### PR TITLE
Fix GUI tests on Python 3.5

### DIFF
--- a/mantidimaging/tests/gui_test/sv_presenter_test.py
+++ b/mantidimaging/tests/gui_test/sv_presenter_test.py
@@ -1,6 +1,24 @@
+import sys
 import unittest
 
-import mock
+if sys.version_info >= (3, 3):
+    # Use unittest.mock on Python 3.3 and above
+    import unittest.mock as mock
+
+    if sys.version_info < (3, 6):
+        # If on Python 3.5 and below then need to monkey patch this function in
+        # It is available as standard on Python 3.6 and above
+        def assert_called_once(_mock_self):
+            self = _mock_self
+            if not self.call_count == 1:
+                msg = ("Expected '%s' to have been called once. Called %s times." %
+                        (self._mock_name or 'mock', self.call_count))
+                raise AssertionError(msg)
+        unittest.mock.Mock.assert_called_once = assert_called_once
+else:
+    # Use mock on Python < 3.3
+    import mock
+
 import numpy as np
 
 import mantidimaging.tests.test_helper as th


### PR DESCRIPTION
On Python 3.5 `mock.create_autospec` was causing the stack visualiser presenter test to error, this appeared to be related to it being derived from a PyQt class.