### PR TITLE
Change image index via mouse scroll

### DIFF
--- a/mantidimaging/gui/stack_visualiser/sv_presenter.py
+++ b/mantidimaging/gui/stack_visualiser/sv_presenter.py
@@ -82,6 +82,14 @@ class StackVisualiserPresenter(object):
             axis = self.axis
         return self.images.get_sample().shape[self.axis]
 
+    def do_scroll_stack(self, offset):
+        """
+        Scrolls through the stack by a given number of images.
+        :param offset: Number of images to scroll through stack
+        """
+        idx = self.view.current_index() + offset
+        self.view.set_index(idx)
+
     def handle_algorithm_dialog_request(self, parameter):
         # Developer note: Parameters need to be checked for both here and in algorithm_dialog.py
         if parameter == Parameters.ROI:

--- a/mantidimaging/gui/stack_visualiser/sv_presenter.py
+++ b/mantidimaging/gui/stack_visualiser/sv_presenter.py
@@ -73,6 +73,15 @@ class StackVisualiserPresenter(object):
         filenames = self.images.get_filenames()
         return os.path.basename(filenames[index] if filenames is not None else "")
 
+    def get_image_count_on_axis(self, axis=None):
+        """
+        Returns the number of images on a given axis.
+        :param axis: Axis on which to count images (defaults to data traversal axis)
+        """
+        if axis is None:
+            axis = self.axis
+        return self.images.get_sample().shape[self.axis]
+
     def handle_algorithm_dialog_request(self, parameter):
         # Developer note: Parameters need to be checked for both here and in algorithm_dialog.py
         if parameter == Parameters.ROI:

--- a/mantidimaging/gui/stack_visualiser/sv_presenter.py
+++ b/mantidimaging/gui/stack_visualiser/sv_presenter.py
@@ -13,6 +13,8 @@ class Notification(IntEnum):
     RENAME_WINDOW = 0
     HISTOGRAM = 1
     NEW_WINDOW_HISTOGRAM = 2
+    SCROLL_UP = 3
+    SCROLL_DOWN = 4
 
 
 class StackVisualiserPresenter(object):
@@ -30,6 +32,10 @@ class StackVisualiserPresenter(object):
                 self.do_histogram()
             elif signal == Notification.NEW_WINDOW_HISTOGRAM:
                 self.do_new_window_histogram()
+            elif signal == Notification.SCROLL_UP:
+                self.do_scroll_stack(1)
+            elif signal == Notification.SCROLL_DOWN:
+                self.do_scroll_stack(-1)
         except Exception as e:
             self.show_error(e)
             raise  # re-raise for full stack trace

--- a/mantidimaging/gui/stack_visualiser/sv_presenter.py
+++ b/mantidimaging/gui/stack_visualiser/sv_presenter.py
@@ -94,6 +94,7 @@ class StackVisualiserPresenter(object):
         :param offset: Number of images to scroll through stack
         """
         idx = self.view.current_index() + offset
+        print('idx ', idx)
         self.view.set_index(idx)
 
     def handle_algorithm_dialog_request(self, parameter):

--- a/mantidimaging/gui/stack_visualiser/sv_view.py
+++ b/mantidimaging/gui/stack_visualiser/sv_view.py
@@ -104,9 +104,9 @@ class StackVisualiserView(Qt.QMainWindow):
         :param event: Mouse scroll wheel event
         """
         if event.button == 'up':
-            self.presenter.do_scroll_stack(1)
+            self.presenter.notify(StackWindowNotification.SCROLL_UP)
         elif event.button == 'down':
-            self.presenter.do_scroll_stack(-1)
+            self.presenter.notify(StackWindowNotification.SCROLL_DOWN)
 
     def remove_any_selected_roi(self, event):
         """

--- a/mantidimaging/gui/stack_visualiser/sv_view.py
+++ b/mantidimaging/gui/stack_visualiser/sv_view.py
@@ -103,12 +103,10 @@ class StackVisualiserView(Qt.QMainWindow):
 
         :param event: Mouse scroll wheel event
         """
-        current_idx = self.current_index();
         if event.button == 'up':
-            current_idx += 1
+            self.presenter.do_scroll_stack(1)
         elif event.button == 'down':
-            current_idx -= 1
-        self.set_index(current_idx)
+            self.presenter.do_scroll_stack(-1)
 
     def remove_any_selected_roi(self, event):
         """

--- a/mantidimaging/tests/gui_test/sv_presenter_test.py
+++ b/mantidimaging/tests/gui_test/sv_presenter_test.py
@@ -171,6 +171,11 @@ class StackVisualiserPresenterTest(unittest.TestCase):
         self.presenter.show_error("test message")
         self.view.show_error_dialog.assert_called_once_with("test message")
 
+    def test_get_image_count_on_axis(self):
+        self.assertEquals(
+                self.presenter.get_image_count_on_axis(),
+                self.test_data.get_sample().shape[self.presenter.axis])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/tests/gui_test/sv_presenter_test.py
+++ b/mantidimaging/tests/gui_test/sv_presenter_test.py
@@ -176,6 +176,21 @@ class StackVisualiserPresenterTest(unittest.TestCase):
                 self.presenter.get_image_count_on_axis(),
                 self.test_data.get_sample().shape[self.presenter.axis])
 
+    def test_scroll_stack(self):
+        self.view.current_index = mock.MagicMock(return_value=3)
+        self.presenter.do_scroll_stack(2)
+        self.view.set_index.assert_called_once_with(5)
+
+    def test_do_scroll_up(self):
+        self.view.current_index = mock.MagicMock(return_value=3)
+        self.presenter.notify(PresenterNotifications.SCROLL_UP)
+        self.view.set_index.assert_called_once_with(4)
+
+    def test_do_scroll_down(self):
+        self.view.current_index = mock.MagicMock(return_value=3)
+        self.presenter.notify(PresenterNotifications.SCROLL_DOWN)
+        self.view.set_index.assert_called_once_with(2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Allows the index of the image displayed in the stack visualiser to be changed via mouse scroll when the cursor is over the canvas area (figure and slider).

Requires #71 to be merged first.

Fixes #42 