### PR TITLE
Redraw canvas when showing current image

### DIFF
--- a/mantidimaging/gui/stack_visualiser/sv_view.py
+++ b/mantidimaging/gui/stack_visualiser/sv_view.py
@@ -240,6 +240,7 @@ class StackVisualiserView(Qt.QMainWindow):
         """
         self.set_image_title_to_current_filename()
         self.image.set_data(self.current_image())
+        self.canvas.draw()
 
     def set_image_title_to_current_filename(self):
         self.image_axis.set_title(self.presenter.get_image_filename(self.current_index()))


### PR DESCRIPTION
Ensures that the image represents the latest data (e.g. after running a filter).

Fixes #74