### PR TITLE
Output and load COR files

### DIFF
--- a/mantidimaging/core/configs/functional_config.py
+++ b/mantidimaging/core/configs/functional_config.py
@@ -463,7 +463,10 @@ class FunctionalConfig(object):
             nargs='*',
             type=str,  # will be converted to floats in self.update()
             default=self.cors,
-            help="Provide the CORs for the selected slices with --cor-slices.\n"
+            help="Either a list of CORs or a file containing CORs.\n"
+            "If a file is used it must be a text file with a pair of slice"
+            "index and COR on each line.\n"
+            "Provide the CORs for the selected slices with --cor-slices.\n"
             "If no slices are provided a SINGLE COR is expected, "
             "that will be used for the whole stack.\n"
             "If slices are provided, the number of CORs provided "

--- a/mantidimaging/core/configs/recon_config.py
+++ b/mantidimaging/core/configs/recon_config.py
@@ -4,7 +4,9 @@ import argparse
 import os
 import sys
 import tempfile
+
 from argparse import RawTextHelpFormatter
+from logging import getLogger
 
 import numpy as np
 
@@ -73,6 +75,8 @@ class ReconstructionConfig(object):
             self.handle_special_arguments()
 
     def handle_special_arguments(self):
+        log = getLogger(__name__)
+
         if self.args.region_of_interest:
             if len(self.args.region_of_interest) != 4:
                 raise ValueError(
@@ -133,9 +137,8 @@ class ReconstructionConfig(object):
                     "Slice Indices (len {1})!".format(len_cors,
                                                       len_cor_slices))
 
-        # TODO
-        print(self.func.cors)
-        print(self.func.cor_slices)
+        log.debug("CORs: {}".format(self.func.cors))
+        log.debug("COR slices: {}".format(self.func.cor_slices))
 
         # if the reconstruction is ran on already cropped images, then no ROI
         # should be provided, however if we have a ROI then the Centers of Rotation

--- a/mantidimaging/core/configs/recon_config.py
+++ b/mantidimaging/core/configs/recon_config.py
@@ -106,13 +106,23 @@ class ReconstructionConfig(object):
             raise ValueError("If running a reconstruction a Center of "
                              "Rotation MUST be provided")
 
-        # Convert the centers of rotation (if provided) to floats
-        if self.func.cors:
-            self.func.cors = [float(cor) for cor in self.func.cors]
+        if self.func.cors and os.path.exists(self.func.cors[0]):
+            # If the provided cors is a filename then load COR from file
+            from mantidimaging.core.imopr.helper import load_cors_from_file
+            cors = load_cors_from_file(self.func.cors[0])
+            self.func.cors = []
+            self.func.cor_slices = []
+            for c in cors:
+                self.func.cor_slices.append(int(c[0]))
+                self.func.cors.append(float(c[1]))
+        else:
+            # Convert the centers of rotation (if provided) to floats
+            if self.func.cors:
+                self.func.cors = [float(cor) for cor in self.func.cors]
 
-        # Convert the slices for the center of rotation centers of rotation (if provided) to ints
-        if self.func.cor_slices:
-            self.func.cor_slices = [int(slice_id) for slice_id in self.func.cor_slices]
+            # Convert the slices for the center of rotation centers of rotation (if provided) to ints
+            if self.func.cor_slices:
+                self.func.cor_slices = [int(slice_id) for slice_id in self.func.cor_slices]
 
         if self.func.cors and self.func.cor_slices:
             len_cors = len(self.func.cors)
@@ -122,6 +132,10 @@ class ReconstructionConfig(object):
                     "Centers of Rotation (len {0}) doesn't match length of "
                     "Slice Indices (len {1})!".format(len_cors,
                                                       len_cor_slices))
+
+        # TODO
+        print(self.func.cors)
+        print(self.func.cor_slices)
 
         # if the reconstruction is ran on already cropped images, then no ROI
         # should be provided, however if we have a ROI then the Centers of Rotation

--- a/mantidimaging/core/imopr/helper.py
+++ b/mantidimaging/core/imopr/helper.py
@@ -1,5 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
+import numpy as np
+
 # TODO should change the name of this file so its not confused with
 # the other helper.py that's not in imopr
 
@@ -24,3 +26,15 @@ def handle_indices(indices, retstep=False):
             return indices[0], indices[1]
         else:
             return indices[0], indices[1], indices[2]
+
+
+def new_cor_array(num_cors):
+    return np.ndarray(shape=(num_cors), dtype='int, float')
+
+
+def save_cors_to_file(filename, cors):
+    np.savetxt(filename, cors, fmt='%i %f', header='slice_index cor')
+
+
+def load_cors_from_file(filename):
+    return np.loadtxt(filename, dtype='int, float')

--- a/mantidimaging/core/imopr/helper.py
+++ b/mantidimaging/core/imopr/helper.py
@@ -37,4 +37,4 @@ def save_cors_to_file(filename, cors):
 
 
 def load_cors_from_file(filename):
-    return np.loadtxt(filename, dtype='int, float')
+    return np.loadtxt(filename, dtype='int, float', ndmin=1)

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -176,7 +176,6 @@ class Saver(object):
         return supported_formats()
 
     def __init__(self, config):
-
         self._output_path = config.func.output_path
         if self._output_path is not None:
             self._output_path = os.path.abspath(
@@ -198,6 +197,9 @@ class Saver(object):
         # assign package functions for ease of access
         self.save = save
         self.make_dirs_if_needed = make_dirs_if_needed
+
+    def should_save_output(self):
+        return self._output_path is not None
 
     def get_output_path(self):
         return self._output_path

--- a/mantidimaging/tests/core_test/imopr_test.py
+++ b/mantidimaging/tests/core_test/imopr_test.py
@@ -1,0 +1,64 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+import tempfile
+import unittest
+import numpy.testing as npt
+
+from mantidimaging.core.imopr.helper import (
+        new_cor_array, save_cors_to_file, load_cors_from_file)
+
+
+class ImoprTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(ImoprTest, self).__init__(*args, **kwargs)
+
+    def test_save_cor_file(self):
+        expected = (
+                '# slice_index cor\n' +
+                '0 0.000000\n' +
+                '2 5.500000\n' +
+                '4 11.000000\n' +
+                '6 16.500000\n' +
+                '8 22.000000\n')
+
+        cors = new_cor_array(5)
+        for i in range(5):
+            cors[i] = (i * 2, i * 5.5)
+
+        with tempfile.NamedTemporaryFile() as f:
+            output_path = os.path.dirname(f.name)
+            filename = os.path.join(output_path, 'cors.txt')
+
+            save_cors_to_file(filename, cors)
+
+            with open(filename) as tf:
+                text = tf.read()
+                self.assertEqual(text, expected)
+
+    def test_load_cor_file(self):
+        text_data = (
+                '0 0.000000\n' +
+                '2 5.500000\n' +
+                '4 11.000000\n' +
+                '6 16.500000\n' +
+                '8 22.000000\n')
+
+        expected = new_cor_array(5)
+        for i in range(5):
+            expected[i] = (i * 2, i * 5.5)
+
+        with tempfile.NamedTemporaryFile() as f:
+            output_path = os.path.dirname(f.name)
+            filename = os.path.join(output_path, 'cors.txt')
+
+            with open(filename, 'w') as tf:
+                tf.write(text_data)
+
+            cors = load_cors_from_file(filename)
+
+            npt.assert_array_equal(cors, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mantidimaging/tests/core_test/imopr_test.py
+++ b/mantidimaging/tests/core_test/imopr_test.py
@@ -59,6 +59,24 @@ class ImoprTest(unittest.TestCase):
 
             npt.assert_array_equal(cors, expected)
 
+    def test_load_cor_file_single_cor(self):
+        text_data = '5 1.230000\n'
+
+        expected = new_cor_array(1)
+        expected[0] = (5, 1.23)
+
+        with tempfile.NamedTemporaryFile() as f:
+            output_path = os.path.dirname(f.name)
+            filename = os.path.join(output_path, 'cors.txt')
+
+            with open(filename, 'w') as tf:
+                tf.write(text_data)
+
+            cors = load_cors_from_file(filename)
+
+            self.assertEquals(cors.shape, (1,))
+            npt.assert_array_equal(cors, expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Allows output and loading back of centres of rotation to/from files. The files in question are simple space separated text files containing pairs of slice index and COR.

The file is generated when an output directory is specified when running automatic COR finding (i.e. `--imopr cor`) and is loaded back by specifying a filename to the `--cor` parameter when performing reconstruction.

Fixes #64 