### PR TITLE
Search groups of similar file extensions

### DIFF
--- a/mantidimaging/tests/core_test/io_test.py
+++ b/mantidimaging/tests/core_test/io_test.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from mantidimaging.core.configs.recon_config import ReconstructionConfig
 from mantidimaging.core.io import loader
+from mantidimaging.core.io import utility
 from mantidimaging.core.io.saver import Saver, generate_names
 from mantidimaging.tests import test_helper as th
 
@@ -534,6 +535,35 @@ class IOTest(unittest.TestCase):
             loaded_images = loader.load_from_config(config)
 
             th.assert_equals(exp_sinograms, loaded_images.get_sample())
+
+    def test_get_candidate_file_extensions(self):
+        self.assertEquals(
+                ['tif', 'tiff'],
+                utility.get_candidate_file_extensions('tif'))
+
+        self.assertEquals(
+                ['tiff', 'tif'],
+                utility.get_candidate_file_extensions('tiff'))
+
+        self.assertEquals(
+                ['png'],
+                utility.get_candidate_file_extensions('png'))
+
+    def test_get_file_names(self):
+        with tempfile.NamedTemporaryFile() as f:
+            # Directory used for testing
+            dirname = os.path.dirname(f.name)
+
+            # Create test file with .tiff extension
+            tiff_filename = os.path.join(dirname, 'test.tiff')
+            with open(tiff_filename, 'wb') as tf:
+                tf.write(b'\0')
+
+            # Search for files with .tif extension
+            found_files = utility.get_file_names(dirname, 'tif')
+
+            # Expect to find the .tiff file
+            self.assertEquals([tiff_filename], found_files)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Searches for files with an ordered list of file extensions based on groups of similar/equivalent extensions (e.g. `.tif` and '.tiff').

If no files are found for the extension that the user specifies the loader will look for files with equivalent extensions.

Fixes #20 