### PR TITLE
Stack visualiser context menu

### DIFF
--- a/mantidimaging/gui/stack_visualiser/sv_presenter.py
+++ b/mantidimaging/gui/stack_visualiser/sv_presenter.py
@@ -60,6 +60,12 @@ class StackVisualiserPresenter(object):
         """
         self.view.show_histogram_of_current_image(new_window=True)
 
+    def do_clear_roi(self):
+        """
+        Clears the active ROI selection.
+        """
+        self.view.deselect_current_roi()
+
     def delete_data(self):
         del self.images
 

--- a/mantidimaging/gui/stack_visualiser/sv_view.py
+++ b/mantidimaging/gui/stack_visualiser/sv_view.py
@@ -72,10 +72,17 @@ class StackVisualiserView(Qt.QMainWindow):
 
         # Create context menu
         self.canvas_context_menu = Qt.QMenu(self)
+
+        def add_context_menu_action(text, func):
+            action = Qt.QAction(text, self.canvas)
+            action.triggered.connect(func)
+            self.canvas_context_menu.addAction(action)
+
         # Add context menu items
-        self.canvas_context_menu.addAction(Qt.QAction('A', self.canvas))
-        self.canvas_context_menu.addAction(Qt.QAction('B', self.canvas))
-        self.canvas_context_menu.addAction(Qt.QAction('C', self.canvas))
+        add_context_menu_action("Show Histogram", self.presenter.do_histogram)
+        add_context_menu_action(
+                "Show Histogram in new window",
+                self.presenter.do_new_window_histogram)
 
         # Register mouse release callback
         self.canvas.mpl_connect('button_press_event', self.on_button_press)
@@ -142,13 +149,13 @@ class StackVisualiserView(Qt.QMainWindow):
             self.current_roi = None
 
         if event.button == 3:
-            # Get the mouse position on the canvas widget, converting from figure space to Qt space
-            point_on_canvas = Qt.QPoint(event.x, self.canvas.get_width_height()[1] - event.y)
+            # Get the mouse position on the canvas widget, converting from
+            # figure space to Qt space
+            point_on_canvas = Qt.QPoint(
+                    event.x, self.canvas.get_width_height()[1] - event.y)
             # Show the context menu at (or near to) the mouse position
-            action = self.canvas_context_menu.exec_(self.canvas.mapToGlobal(point_on_canvas))
-
-            # TODO
-            print(action)
+            self.canvas_context_menu.exec_(
+                    self.canvas.mapToGlobal(point_on_canvas))
 
     def region_select_callback(self, eclick, erelease):
         # eclick and erelease are the press and release events

--- a/mantidimaging/gui/stack_visualiser/sv_view.py
+++ b/mantidimaging/gui/stack_visualiser/sv_view.py
@@ -79,6 +79,7 @@ class StackVisualiserView(Qt.QMainWindow):
             self.canvas_context_menu.addAction(action)
 
         # Add context menu items
+        add_context_menu_action("Clear ROI", self.presenter.do_clear_roi)
         add_context_menu_action("Show Histogram", self.presenter.do_histogram)
         add_context_menu_action(
                 "Show Histogram in new window",
@@ -122,6 +123,10 @@ class StackVisualiserView(Qt.QMainWindow):
         elif event.button == 'down':
             self.presenter.notify(StackWindowNotification.SCROLL_DOWN)
 
+    def deselect_current_roi(self):
+        self.current_roi = None
+        self.rectangle_selector.extents = (0, 0, 0, 0)
+
     def on_button_press(self, event):
         """
         Handles mouse button release events.
@@ -143,8 +148,6 @@ class StackVisualiserView(Qt.QMainWindow):
 
         On right click (mouse button 2) this opens the context menu.
         """
-        print(event)
-
         if event.button == 1:
             self.current_roi = None
 
@@ -163,8 +166,7 @@ class StackVisualiserView(Qt.QMainWindow):
         bottom, right = erelease.xdata, erelease.ydata
 
         self.current_roi = (int(left), int(top), int(right), int(bottom))
-        region = "%i %i %i %i" % self.current_roi
-        getLogger(__name__).info(region)
+        getLogger(__name__).info("ROI: %i %i %i %i", *self.current_roi)
 
     def update_title_event(self):
         text, okPressed = Qt.QInputDialog.getText(


### PR DESCRIPTION
Adds a context menu to the canvas on the stack visualiser.

Currently this only contains option to clear active ROI and to show the histogram but can easily be added to in the future.

Fixes #58 