### PR TITLE
Generate startup scripts with setuptools

### DIFF
--- a/mantidimaging-gui.sh
+++ b/mantidimaging-gui.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-${MANTIDIMAGING_PYTHON_BIN}/python -m "mantidimaging.main" --gui -i . "$@"

--- a/mantidimaging-ipython.sh
+++ b/mantidimaging-ipython.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-mantidimaging_dir=${HOME}/mantidimaging
-
-${MANTIDIMAGING_PYTHON_BIN}/python $mantidimaging_dir/mantidimaging/ipython.py "$@"

--- a/mantidimaging.sh
+++ b/mantidimaging.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-${MANTIDIMAGING_PYTHON_BIN}/python -m "mantidimaging.main" "$@"

--- a/mantidimaging/core/configs/recon_config.py
+++ b/mantidimaging/core/configs/recon_config.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import argparse
 import os
+import sys
 import tempfile
 from argparse import RawTextHelpFormatter
 
@@ -11,7 +12,7 @@ from mantidimaging.core.algorithms import registrator
 from mantidimaging.core.configs.functional_config import FunctionalConfig
 
 
-def grab_full_config():
+def grab_full_config(default_args=None):
     """
     Build the command line at runtime, by parsing all of the filters' parameter. 
     Afterwards parses the arguments passed in from command line, updates the vales and creates the ReconstructionConfig.
@@ -34,7 +35,7 @@ def grab_full_config():
             package='mantidimaging.core.filters')
 
     # parse the real arguments
-    args = parser.parse_args()
+    args = parser.parse_args(default_args if default_args is not None else [] + sys.argv)
 
     # update the configs
     functional_args._update(args)

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -18,10 +18,11 @@ def check_version_info():
             "Version found: {0}".format(python_version))
 
 
-def main():
+def main(default_args):
     h.initialise_logging()
     check_version_info()
-    config = recon_config.grab_full_config()
+
+    config = recon_config.grab_full_config(default_args)
 
     if config.func.debug and config.func.debug_port:
         import pydevd
@@ -63,6 +64,14 @@ def main():
     h.total_execution_timer()
 
     return res
+
+
+def cli_main():
+    main(None)
+
+
+def gui_main():
+    main(['-i', '.', '--gui'])
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,15 @@ setup(
     version='0.9',
     packages=find_packages(),
     py_modules=['mantidimaging'],
+    entry_points={
+        'console_scripts': [
+            'mantidimaging = mantidimaging.main:cli_main',
+            'mantidimaging-ipython = mantidimaging.ipython:main'
+        ],
+        'gui_scripts': [
+            'mantidimaging-gui = mantidimaging.main:gui_main'
+        ]
+    },
     url='https://github.com/mantidproject/mantidimaging',
     license='GPL-3.0',
     author='Dimitar Tasev',


### PR DESCRIPTION
Assumes that the target Python distribution is placed at the higher priority in the `PATH`.

Can use `pip install -e .` to setup locally for development.

Once installed, scripts can then be launched using `mantidimaging`, `mantidimaging-gui` and `mantidimaging-ipython`.

Fixes #35