### PR TITLE
Add option to restrict file finding by filename prefix

### DIFF
--- a/mantidimaging/core/configs/functional_config.py
+++ b/mantidimaging/core/configs/functional_config.py
@@ -27,6 +27,7 @@ class FunctionalConfig(object):
         self.input_path = None
         self.input_path_flat = None
         self.input_path_dark = None
+        self.in_prefix = ''
         self.in_format = DEFAULT_IO_FILE_FORMAT
         self.construct_sinograms = False
 
@@ -98,6 +99,7 @@ class FunctionalConfig(object):
         return "Input directory: {0}\n".format(os.path.abspath(str(self.input_path))) \
                + "Flat directory: {0}\n".format(os.path.abspath(str(self.input_path_flat))) \
                + "Dark directory: {0}\n".format(os.path.abspath(str(self.input_path_dark))) \
+               + "Input image prefix: {0}\n".format(str(self.in_prefix)) \
                + "Input image format: {0}\n".format(str(self.in_format)) \
                + "Output directory: {0}\n".format(os.path.abspath(str(self.output_path))) \
                + "Output image format: {0}\n".format(str(self.out_format)) \
@@ -167,6 +169,14 @@ class FunctionalConfig(object):
             default=self.input_path_dark,
             type=str,
             help="Input directory for flat images")
+
+        grp_func.add_argument(
+            "--in-prefix",
+            required=False,
+            default=self.out_format,
+            type=str,
+            help="Filename prefix to use when searching for input image files "
+                 "to load.")
 
         from mantidimaging.core.io import loader
         grp_func.add_argument(

--- a/mantidimaging/core/configs/functional_config.py
+++ b/mantidimaging/core/configs/functional_config.py
@@ -173,7 +173,7 @@ class FunctionalConfig(object):
         grp_func.add_argument(
             "--in-prefix",
             required=False,
-            default=self.out_format,
+            default=self.in_prefix,
             type=str,
             help="Filename prefix to use when searching for input image files "
                  "to load.")

--- a/mantidimaging/core/io/loader/img_loader.py
+++ b/mantidimaging/core/io/loader/img_loader.py
@@ -15,7 +15,8 @@ This module handles the loading of FIT, FITS, TIF, TIFF
 
 
 def execute(load_func, input_file_names, input_path_flat, input_path_dark,
-            img_format, data_dtype, cores, chunksize, parallel_load, indices, construct_sinograms):
+            img_format, data_dtype, cores, chunksize, parallel_load, indices,
+            construct_sinograms):
     """
     Reads a stack of images into memory, assuming dark and flat images
     are in separate directories.
@@ -45,8 +46,9 @@ def execute(load_func, input_file_names, input_path_flat, input_path_dark,
     img_shape = first_sample_img.shape
 
     # forward all arguments to internal class for easy re-usage
-    l = ImageLoader(load_func, input_file_names, input_path_flat, input_path_dark,
-                    img_format, img_shape, data_dtype, cores, chunksize, parallel_load, indices, construct_sinograms)
+    l = ImageLoader(load_func, input_file_names, input_path_flat,
+                    input_path_dark, img_format, img_shape, data_dtype, cores,
+                    chunksize, parallel_load, indices, construct_sinograms)
 
     # we load the flat and dark first, because if they fail we don't want to
     # fail after we've loaded a big stack into memory
@@ -56,7 +58,8 @@ def execute(load_func, input_file_names, input_path_flat, input_path_dark,
 
     sample_data = l.load_sample_data(input_file_names)
 
-    # if this is true, then the loaded sample data was created via the stack_loader
+    # if this is true, then the loaded sample data was created via the
+    # stack_loader
     if isinstance(sample_data, Images):
         sample_data = sample_data.get_sample()
 
@@ -64,8 +67,9 @@ def execute(load_func, input_file_names, input_path_flat, input_path_dark,
 
 
 class ImageLoader(object):
-    def __init__(self, load_func, input_file_names, input_path_flat, input_path_dark,
-                 img_format, img_shape, data_dtype, cores, chunksize, parallel_load, indices, construct_sinograms):
+    def __init__(self, load_func, input_file_names, input_path_flat,
+                 input_path_dark, img_format, img_shape, data_dtype, cores,
+                 chunksize, parallel_load, indices, construct_sinograms):
         self.load_func = load_func
         self.input_file_names = input_file_names
         self.input_path_flat = input_path_flat
@@ -81,9 +85,11 @@ class ImageLoader(object):
 
     def load_sample_data(self, input_file_names):
         # determine what the loaded data was
-        if len(self.img_shape) == 2:  # the loaded file was a single image
+        if len(self.img_shape) == 2:
+            # the loaded file was a single image
             sample_data = self.load_files(input_file_names, "Sample")
-        elif len(self.img_shape) == 3:  # the loaded file was a file containing a stack of images
+        elif len(self.img_shape) == 3:
+            # the loaded file was a file containing a stack of images
             sample_data = stack_loader.execute(
                 self.load_func, input_file_names[0], self.data_dtype, "Sample",
                 self.cores, self.chunksize, self.parallel_load, self.indices)
@@ -110,10 +116,12 @@ class ImageLoader(object):
                 raise ValueError(
                     "An image has different width and/or height dimensions! "
                     "All images must have the same dimensions. "
-                    "Expected dimensions: {0} Error message: {1}".format(self.img_shape, exc))
+                    "Expected dimensions: {0} Error message: {1}".format(
+                        self.img_shape, exc))
             except IOError as exc:
-                raise RuntimeError("Could not load file {0}. Error details: {1}".
-                                   format(in_file, exc))
+                raise RuntimeError(
+                        "Could not load file {0}. Error details: {1}".format(
+                            in_file, exc))
         h.prog_close()
 
         return data
@@ -128,10 +136,12 @@ class ImageLoader(object):
                 raise ValueError(
                     "An image has different width and/or height dimensions! "
                     "All images must have the same dimensions. "
-                    "Expected dimensions: {0} Error message: {1}".format(self.img_shape, exc))
+                    "Expected dimensions: {0} Error message: {1}".format(
+                        self.img_shape, exc))
             except IOError as exc:
-                raise RuntimeError("Could not load file {0}. Error details: {1}".
-                                   format(in_file, exc))
+                raise RuntimeError(
+                        "Could not load file {0}. Error details: {1}".format(
+                            in_file, exc))
         h.prog_close()
 
         return data
@@ -157,9 +167,13 @@ class ImageLoader(object):
 
     def allocate_data(self, num_images):
         if self.construct_sinograms:
-            return pu.create_shared_array((self.img_shape[0], num_images, self.img_shape[1]), dtype=self.data_dtype)
+            return pu.create_shared_array(
+                    (self.img_shape[0], num_images, self.img_shape[1]),
+                    dtype=self.data_dtype)
         else:
-            return pu.create_shared_array((num_images, self.img_shape[0], self.img_shape[1]), dtype=self.data_dtype)
+            return pu.create_shared_array(
+                    (num_images, self.img_shape[0], self.img_shape[1]),
+                    dtype=self.data_dtype)
 
 
 def _inplace_load(data, filename, load_func=None):

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -4,7 +4,8 @@ from logging import getLogger
 
 import numpy as np
 
-from mantidimaging.core.io.utility import get_file_names, DEFAULT_IO_FILE_FORMAT
+from mantidimaging.core.io.utility import (
+        get_file_names, DEFAULT_IO_FILE_FORMAT)
 
 from mantidimaging.core.io.loader import img_loader, stack_loader
 
@@ -41,7 +42,8 @@ def _imread(filename):
 
 
 def supported_formats():
-    # ignore errors for unused import/variable, we are only checking availability
+    # ignore errors for unused import/variable, we are only checking
+    # availability
     try:
         import h5py  # noqa: F401
         h5nxs_available = True
@@ -68,7 +70,11 @@ def supported_formats():
     return avail_list
 
 
-def read_in_shape(input_path, in_format=DEFAULT_IO_FILE_FORMAT, data_dtype=np.float32, cores=None, chunksize=None):
+def read_in_shape(input_path,
+                  in_format=DEFAULT_IO_FILE_FORMAT,
+                  data_dtype=np.float32,
+                  cores=None,
+                  chunksize=None):
     input_file_names = get_file_names(input_path, in_format)
     images = load(input_path, None, None, in_format,
                   data_dtype, cores, chunksize, indices=[0, 1, 1])
@@ -81,15 +87,19 @@ def read_in_shape_from_config(config):
     """
     This function is intended for internal usage.
 
-    Read in ONLY the first image in the specified directory, and return the total shape
-    that all the images in that folder will have after loaded. This is determined by the
-    number of images, and the loaded image's width and height.
+    Read in ONLY the first image in the specified directory, and return the
+    total shape that all the images in that folder will have after loaded. This
+    is determined by the number of images, and the loaded image's width and
+    height.
 
-    It is assumed all images are the same. If they are not the loader will fail on runtime.
+    It is assumed all images are the same. If they are not the loader will fail
+    on runtime.
 
-    :param config: The reconstruction config from which the parameters are read.
+    :param config: The reconstruction config from which the parameters are
+                   read.
 
-    :returns: The full shape of the images in the specified directory in a tuple of (Length, X, Y)
+    :returns: The full shape of the images in the specified directory in a
+              tuple of (Length, X, Y)
     """
     input_path = config.func.input_path
     in_format = config.func.in_format
@@ -155,20 +165,24 @@ def load(input_path=None,
 
     :param chunksize: Default:None (auto calculated), chunk of work per worker
 
-    :param parallel_load: Default: False, if set to true the loading of the data
-                          will be done in parallel.
+    :param parallel_load: Default: False, if set to true the loading of the
+                          data will be done in parallel.
                           This could be faster depending on the IO system.
-                          For local runs (with HDD) recommended setting is False
+                          For local runs (with HDD) recommended setting is
+                          False
 
     :param file_names: Use provided file names for loading
 
     :param indices: Specify which indices are loaded from the found files.
-                    This **DOES NOT** check for the number in the image filename,
-                    but removes all indices from the filenames list that are not selected
+                    This **DOES NOT** check for the number in the image
+                    filename, but removes all indices from the filenames list
+                    that are not selected
 
-    :param construct_sinograms: The loaded images will be used to construct the sinograms during loading
+    :param construct_sinograms: The loaded images will be used to construct the
+                                sinograms during loading
 
-    :return: a tuple with shape 3: (sample, flat, dark), if no flat and dark were loaded, they will be None
+    :return: a tuple with shape 3: (sample, flat, dark), if no flat and dark
+             were loaded, they will be None
     """
     if in_format not in supported_formats():
         raise ValueError("Image format {0} not supported!".format(in_format))
@@ -194,8 +208,9 @@ def load(input_path=None,
             load_func = _imread
 
         images = img_loader.execute(
-            load_func, input_file_names, input_path_flat, input_path_dark, in_format, dtype, cores, chunksize,
-            parallel_load, indices, construct_sinograms)
+            load_func, input_file_names, input_path_flat, input_path_dark,
+            in_format, dtype, cores, chunksize, parallel_load, indices,
+            construct_sinograms)
 
     images.check_data_stack(images)
 
@@ -204,14 +219,19 @@ def load(input_path=None,
 
 def load_sinogram(input_path=None, sinogram_number=0, in_format=DEFAULT_IO_FILE_FORMAT, dtype=np.float32):
     """
-    This function is not be exposed to the CLI. It can only be accessed internally and through IPython interface.
-    The reason is because this function will have a lot slower performance than the normal load.
+    This function is not be exposed to the CLI.
+
+    It can only be accessed internally and through IPython interface.
+
+    The reason is because this function will have a lot slower performance than
+    the normal load.
     """
     if in_format not in supported_formats():
         raise ValueError("Image format {0} not supported!".format(in_format))
 
     if in_format == 'nxs':
-        raise NotImplementedError("This functionality is not yet implemented for NXS files")
+        raise NotImplementedError(
+                "This functionality is not yet implemented for NXS files")
 
     input_file_names = get_file_names(input_path, in_format)
 
@@ -224,7 +244,8 @@ def load_sinogram(input_path=None, sinogram_number=0, in_format=DEFAULT_IO_FILE_
     from mantidimaging.core.parallel import utility as pu
 
     # allocate memory for a single sinogram
-    output_data = pu.create_shared_array((1, num_images, img_shape[1]), dtype=dtype)
+    output_data = pu.create_shared_array(
+            (1, num_images, img_shape[1]), dtype=dtype)
 
     logging.getLogger(__name__).info("Output data shape: {}".format(output_data.shape))
 
@@ -233,7 +254,8 @@ def load_sinogram(input_path=None, sinogram_number=0, in_format=DEFAULT_IO_FILE_
     h.prog_init(num_images, "Loading sinograms")
 
     for idx, input_file in enumerate(input_file_names):
-        # read a single row from each projection, very wasteful but can quickly create a sinogram
+        # read a single row from each projection, very wasteful but can quickly
+        # create a sinogram
         loaded_image = _imread(input_file)
         output_data[0, idx, :] = loaded_image[:, sinogram_number]
         h.prog_update()

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -71,12 +71,13 @@ def supported_formats():
 
 
 def read_in_shape(input_path,
+                  in_prefix='',
                   in_format=DEFAULT_IO_FILE_FORMAT,
                   data_dtype=np.float32,
                   cores=None,
                   chunksize=None):
-    input_file_names = get_file_names(input_path, in_format)
-    images = load(input_path, None, None, in_format,
+    input_file_names = get_file_names(input_path, in_format, in_prefix)
+    images = load(input_path, None, None, in_prefix, in_format,
                   data_dtype, cores, chunksize, indices=[0, 1, 1])
 
     # construct and return the new shape
@@ -102,12 +103,14 @@ def read_in_shape_from_config(config):
               tuple of (Length, X, Y)
     """
     input_path = config.func.input_path
+    in_prefix = config.func.in_prefix
     in_format = config.func.in_format
     data_dtype = config.func.data_dtype
     cores = config.func.cores
     chunksize = config.func.chunksize
 
-    return read_in_shape(input_path, in_format, data_dtype, cores, chunksize)
+    return read_in_shape(
+            input_path, in_prefix, in_format, data_dtype, cores, chunksize)
 
 
 def load_from_config(config):
@@ -123,6 +126,7 @@ def load_from_config(config):
     input_path = config.func.input_path
     input_path_flat = config.func.input_path_flat
     input_path_dark = config.func.input_path_dark
+    img_prefix = config.func.in_prefix
     img_format = config.func.in_format
     data_dtype = config.func.data_dtype
     cores = config.func.cores
@@ -131,14 +135,15 @@ def load_from_config(config):
     indices = config.func.indices
     construct_sinograms = config.func.construct_sinograms
 
-    return load(input_path, input_path_flat, input_path_dark,
-                img_format, data_dtype, cores, chunksize,
-                parallel_load, indices=indices, construct_sinograms=construct_sinograms)
+    return load(input_path, input_path_flat, input_path_dark, img_prefix,
+                img_format, data_dtype, cores, chunksize, parallel_load,
+                indices=indices, construct_sinograms=construct_sinograms)
 
 
 def load(input_path=None,
          input_path_flat=None,
          input_path_dark=None,
+         in_prefix='',
          in_format=DEFAULT_IO_FILE_FORMAT,
          dtype=np.float32,
          cores=None,
@@ -155,6 +160,8 @@ def load(input_path=None,
     :param input_path_flat: Optional: Path for the input Flat images folder
 
     :param input_path_dark: Optional: Path for the input Dark images folder
+
+    :param in_prefix: Optional: Prefix for loaded files
 
     :param img_format: Default:'fits', format for the input images
 
@@ -192,7 +199,7 @@ def load(input_path=None,
             "Indices at this point MUST have 3 elements: [start, stop, step]!")
 
     if not file_names:
-        input_file_names = get_file_names(input_path, in_format)
+        input_file_names = get_file_names(input_path, in_format, in_prefix)
     else:
         input_file_names = file_names
 
@@ -217,7 +224,11 @@ def load(input_path=None,
     return images
 
 
-def load_sinogram(input_path=None, sinogram_number=0, in_format=DEFAULT_IO_FILE_FORMAT, dtype=np.float32):
+def load_sinogram(input_path=None,
+                  sinogram_number=0,
+                  in_prefix='',
+                  in_format=DEFAULT_IO_FILE_FORMAT,
+                  dtype=np.float32):
     """
     This function is not be exposed to the CLI.
 
@@ -233,7 +244,7 @@ def load_sinogram(input_path=None, sinogram_number=0, in_format=DEFAULT_IO_FILE_
         raise NotImplementedError(
                 "This functionality is not yet implemented for NXS files")
 
-    input_file_names = get_file_names(input_path, in_format)
+    input_file_names = get_file_names(input_path, in_format, in_prefix)
 
     num_images = len(input_file_names)
 

--- a/mantidimaging/core/io/loader/stack_loader.py
+++ b/mantidimaging/core/io/loader/stack_loader.py
@@ -57,14 +57,25 @@ def execute(load_func,
 
     On HDD I've found it's about 50% SLOWER, thus not recommended!
 
-    :param file_name :: list of image file paths given as strings
-    :param load_func :: file name extension if fixed (to set the expected image format)
-    :param dtype :: data type for the output numpy array
+    :param file_name: list of image file paths given as strings
+
+    :param load_func: file name extension if fixed (to set the expected image
+                      format)
+
+    :param dtype: data type for the output numpy array
+
     :param cores: Default:1, cores to be used if parallel_load is True
+
     :param chunksize: chunk of work per worker
-    :param parallel_load: Default: False, if set to true the loading of the data will be done in parallel.
-            This could be faster depending on the IO system. For local HDD runs the recommended setting is False
-    :return: stack of images as a 3-elements tuple: numpy array with sample images, white image, and dark image.
+
+    :param parallel_load: Default: False, if set to true the loading of the
+                          data will be done in parallel.
+                          This could be faster depending on the IO
+                          system.
+                          For local HDD runs the recommended setting is False
+
+    :return: stack of images as a 3-elements tuple: numpy array with sample
+             images, white image, and dark image.
     """
     # create shared array
     new_data = load_func(file_name)
@@ -82,5 +93,6 @@ def execute(load_func,
         # loading bar information, and I doubt there's any performance gain
         data = do_stack_load_seq(data, new_data, img_shape, name)
 
-    # Nexus doesn't load flat/dark images yet, if the functionality is requested it should be changed here
+    # Nexus doesn't load flat/dark images yet, if the functionality is
+    # requested it should be changed here
     return Images(data, None, None, file_name)

--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -5,6 +5,8 @@ import itertools
 import os
 import re
 
+from logging import getLogger
+
 DEFAULT_IO_FILE_FORMAT = 'tif'
 
 SIMILAR_FILE_EXTENSIONS = (
@@ -64,11 +66,10 @@ def get_file_names(path, img_format, prefix=''):
 
     :return: All the file names, sorted by ascending
     """
+    log = getLogger(__name__)
 
     path = os.path.abspath(os.path.expanduser(path))
     extensions = get_candidate_file_extensions(img_format)
-
-    # TODO: could do with some logging here
 
     for ext in extensions:
         files_match = glob.glob(
@@ -82,9 +83,11 @@ def get_file_names(path, img_format, prefix=''):
             "Could not find any image files in '{0}' with extensions: {1}".format(
                 path, extensions))
 
-    # this is a necessary step, otherwise the file order is not guaranteed to
+    # This is a necessary step, otherwise the file order is not guaranteed to
     # be sequential and we get randomly ordered stack of names
     files_match.sort(key=_alphanum_key_split)
+
+    log.debug('Found files: {}'.format(files_match))
 
     return files_match
 

--- a/mantidimaging/gui/main_window/load_dialog.py
+++ b/mantidimaging/gui/main_window/load_dialog.py
@@ -67,7 +67,8 @@ class MWLoadDialog(Qt.QDialog):
         self.image_format = get_file_extension(sample_filename)
 
         try:
-            self.last_shape = read_in_shape(self.sample_path(), self.image_format)
+            self.last_shape = read_in_shape(self.sample_path(),
+                                            in_format=self.image_format)
         except Exception as e:
             getLogger(__name__).error("Failed to read file %s (%s)", sample_filename, e)
             self.parent_view.presenter.show_error("Failed to read this file. See log for details.")

--- a/mantidimaging/gui/main_window/mw_model.py
+++ b/mantidimaging/gui/main_window/mw_model.py
@@ -20,7 +20,7 @@ class MainWindowModel(object):
             sample_path,
             None,
             None,
-            image_format,
+            in_format=image_format,
             parallel_load=parallel_load,
             indices=indices)
 

--- a/mantidimaging/tests/core_test/io_test.py
+++ b/mantidimaging/tests/core_test/io_test.py
@@ -423,8 +423,10 @@ class IOTest(FileOutputtingTestCase):
                          'out_preproc_image'), saver._out_format,
             data_as_stack, dark.shape[0], loader_indices or saver_indices)
 
-        loaded_images = loader.load(sample_output_path, flat_output_path, dark_output_path,
-                                    saver._out_format, cores=1, parallel_load=parallel, indices=loader_indices)
+        loaded_images = loader.load(
+                sample_output_path, flat_output_path, dark_output_path,
+                in_format=saver._out_format, cores=1, parallel_load=parallel,
+                indices=loader_indices)
 
         if loader_indices:
             assert len(loaded_images.get_sample()) == expected_len, "The length of the loaded data doesn't " \


### PR DESCRIPTION
Provides an additional option (`--in-prefix`) that allows the a filename prefix to be specified when searching for input files.

For example `--in-prefix s1` would match the first two files in this list but not the last two:
- `s1_1.tiff`
- `s1_2.tiff`
- `s2_1.tiff`
- `s2_2.tiff`

Fixes #19 