### PR TITLE
Handle loading errors in the GUI

### DIFF
--- a/mantidimaging/core/algorithms/size_calculator.py
+++ b/mantidimaging/core/algorithms/size_calculator.py
@@ -77,4 +77,4 @@ def full_size_MB(shape=None, axis=None, dtype=None):
 
 
 def number_of_images_from_indices(start, end, step):
-    return int((end - start) / step)
+    return int((end - start) / step) if step != 0 else 0

--- a/mantidimaging/gui/main_window/load_dialog.py
+++ b/mantidimaging/gui/main_window/load_dialog.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+from logging import getLogger
 
 from PyQt5 import Qt
 
@@ -35,6 +36,8 @@ class MWLoadDialog(Qt.QDialog):
         super(MWLoadDialog, self).__init__(parent)
         gui_compile_ui.execute('gui/ui/load_dialog.ui', self)
 
+        self.parent_view = parent
+
         self.sampleButton.clicked.connect(
             lambda: self.update_dialogue(select_file(self.samplePath, "Sample")))
 
@@ -60,8 +63,15 @@ class MWLoadDialog(Qt.QDialog):
         if not select_file_successful:
             return False
 
-        self.image_format = get_file_extension(str(self.samplePath.text()))
-        self.last_shape = read_in_shape(self.sample_path(), self.image_format)
+        sample_filename = str(self.samplePath.text())
+        self.image_format = get_file_extension(sample_filename)
+
+        try:
+            self.last_shape = read_in_shape(self.sample_path(), self.image_format)
+        except Exception as e:
+            getLogger(__name__).error("Failed to read file %s (%s)", sample_filename, e)
+            self.parent_view.presenter.show_error("Failed to read this file. See log for details.")
+            self.last_shape = (0, 0, 0)
 
         self.update_indices(self.last_shape[0])
         self.update_expected()

--- a/mantidimaging/tests/gui_test/mw_presenter_test.py
+++ b/mantidimaging/tests/gui_test/mw_presenter_test.py
@@ -1,10 +1,14 @@
+import os
+import tempfile
 import unittest
 
 import numpy as np
 
 import mantidimaging.tests.test_helper as th
 
-from mantidimaging.gui.main_window.mw_presenter import MainWindowPresenter
+from mantidimaging.gui.main_window.load_dialog import MWLoadDialog
+from mantidimaging.gui.main_window.mw_presenter import (
+        MainWindowPresenter, Notification)
 from mantidimaging.gui.main_window.mw_view import MainWindowView
 
 mock = th.import_mock()
@@ -17,11 +21,36 @@ class MainWindowPresenterTest(unittest.TestCase):
     def setUp(self):
         self.config = None
         self.view = mock.create_autospec(MainWindowView)
+        self.view.load_dialogue = mock.create_autospec(MWLoadDialog)
         self.presenter = MainWindowPresenter(self.view, self.config)
 
     def test_show_error_message_forwarded_to_view(self):
         self.presenter.show_error("test message")
         self.view.show_error_dialog.assert_called_once_with("test message")
+
+    def test_attempt_to_load_bad_datafile_shows_error(self):
+        with tempfile.NamedTemporaryFile() as f:
+            dirname = os.path.dirname(f.name)
+
+            # Bad data file
+            bad_filename = os.path.join(dirname, 'test_bad_nexus.nxs')
+            with open(bad_filename, 'w') as tf:
+                tf.write('000')
+
+            # Set load parameters
+            self.view.load_dialogue.sample_file = lambda: 'test_bad_nexus'
+            self.view.load_dialogue.sample_path = lambda: dirname
+            self.view.load_dialogue.image_format = 'nxs'
+            self.view.load_dialogue.parallel_load = lambda: False
+            self.view.load_dialogue.indices = lambda: (-1, 0, 0)
+            self.view.load_dialogue.window_title = lambda: 'test_bad_nexus'
+
+            # Ask for load
+            self.presenter.notify(Notification.LOAD)
+
+            # Expect error message
+            self.view.show_error_dialog.assert_called_once_with(
+                    "Failed to read data file. See log for details.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #87

Adds error handling around the data loading stages in the load dialog (where files are inspected for dimensions) and main window presenter (where the data is actually loaded).

There will trigger the error message box (see #72).