### PR TITLE
Fix failing tests on Python 2

### DIFF
--- a/mantidimaging/tests/core_test/process_list_test.py
+++ b/mantidimaging/tests/core_test/process_list_test.py
@@ -18,6 +18,9 @@ class ProcessListTest(unittest.TestCase):
         self.pl.store(median_filter.execute, size=55)
         self.pl.store(median_filter.execute, 11, mode='test')
 
+    def tearDown(self):
+        self.pl = None
+
     def test_store(self):
         self.pl.store(median_filter.execute, 3)
         self.pl.store(median_filter.execute, 1)


### PR DESCRIPTION
- Python < 3.3 does not have the `inspect` module, so fall back to `funcsigs`
- Fix unicode string handling with StringIO
- Fix finding package name on Python 2

Fixes #85 