### PR TITLE
Improved temporary file/directory handling in unit tests

### DIFF
--- a/mantidimaging/tests/core_test/aggregate_test.py
+++ b/mantidimaging/tests/core_test/aggregate_test.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 import os
-import tempfile
 import unittest
 
 import numpy as np
@@ -11,10 +10,12 @@ from mantidimaging.core.aggregate import aggregate
 from mantidimaging.core.configs.recon_config import ReconstructionConfig
 from mantidimaging.core.io import loader
 from mantidimaging.core.io.saver import Saver
+from mantidimaging.tests.file_outputting_test_case import (
+        FileOutputtingTestCase)
 from mantidimaging.tests import test_helper as th
 
 
-class AggregateTest(unittest.TestCase):
+class AggregateTest(FileOutputtingTestCase):
     def __init__(self, *args, **kwargs):
         super(AggregateTest, self).__init__(*args, **kwargs)
 
@@ -24,39 +25,6 @@ class AggregateTest(unittest.TestCase):
 
     def create_saver(self):
         return Saver(self.config)
-
-    def tearDown(self):
-        """
-        Cleanup, Make sure all files are deleted from tmp
-        """
-        try:
-            th.delete_files(folder='pre_processed')
-        except OSError:
-            # no preprocessed images were saved
-            pass
-        try:
-            th.delete_files(folder='reconstructed')
-        except OSError:
-            # no reconstructed images were saved
-            pass
-
-        try:
-            th.delete_files(folder='converted')
-        except OSError:
-            # no reconstructed images were saved
-            pass
-
-        try:
-            th.delete_files(folder='aggregated')
-        except OSError:
-            # no reconstructed images were saved
-            pass
-
-        try:
-            th.delete_files(folder='aggregate')
-        except OSError:
-            # no reconstructed images were saved
-            pass
 
     def test_aggregate_single_folder_sum_fits(self):
         self.do_aggregate_single_folder('fits', 'fits', 'sum')
@@ -86,47 +54,47 @@ class AggregateTest(unittest.TestCase):
         parallel = False
         saver = self.create_saver()
 
-        with tempfile.NamedTemporaryFile() as f:
-            aggregate_path = os.path.dirname(f.name) + '/aggregate'
-            # save out 5 'angles'
-            for i in range(aggregate_angles):
-                angle_path = aggregate_path + '/angle' + str(i)
-                saver._output_path = angle_path
-                saver._out_format = img_format
-                saver._data_as_stack = stack
-                # do the actual saving out, directories will be created here
-                saver.save(
-                    images,
-                    angle_path,
-                    'out_angle',
-                    out_format=saver._out_format)
+        aggregate_path = os.path.join(self.output_directory, 'aggregate')
+        # save out 5 'angles'
+        for i in range(aggregate_angles):
+            angle_path = aggregate_path + '/angle' + str(i)
+            saver._output_path = angle_path
+            saver._out_format = img_format
+            saver._data_as_stack = stack
+            # do the actual saving out, directories will be created here
+            saver.save(
+                images,
+                angle_path,
+                'out_angle',
+                out_format=saver._out_format)
 
-            # aggregate them
-            conf = self.config
-            conf.func.aggregate = ['0', '10', mode]
-            # select angles 0 - 4 (aggregate_angles is 5 so we subtract 1)
-            conf.func.aggregate_angles = ['0', str(aggregate_angles - 1)]
-            conf.func.aggregate_single_folder_output = True
-            conf.func.input_path = aggregate_path
-            conf.func.in_format = saver._out_format
-            conf.func.out_format = convert_format
-            aggregate_output_path = os.path.dirname(f.name) + '/aggregated'
-            conf.func.output_path = aggregate_output_path
-            # because we need to write in the same folder
-            conf.func.overwrite_all = True
-            conf.func.convert_prefix = 'aggregated'
-            aggregate.execute(conf)
+        # aggregate them
+        conf = self.config
+        conf.func.aggregate = ['0', '10', mode]
+        # select angles 0 - 4 (aggregate_angles is 5 so we subtract 1)
+        conf.func.aggregate_angles = ['0', str(aggregate_angles - 1)]
+        conf.func.aggregate_single_folder_output = True
+        conf.func.input_path = aggregate_path
+        conf.func.in_format = saver._out_format
+        conf.func.out_format = convert_format
+        aggregate_output_path = os.path.join(self.output_directory,
+                                             'aggregated')
+        conf.func.output_path = aggregate_output_path
+        # because we need to write in the same folder
+        conf.func.overwrite_all = True
+        conf.func.convert_prefix = 'aggregated'
+        aggregate.execute(conf)
 
-            # load them back
-            # compare data to original
-            # this does not load any flats or darks as they were not saved out
-            images = loader.load(
-                aggregate_output_path,
-                in_format=saver._out_format,
-                parallel_load=parallel)
+        # load them back
+        # compare data to original
+        # this does not load any flats or darks as they were not saved out
+        images = loader.load(
+            aggregate_output_path,
+            in_format=saver._out_format,
+            parallel_load=parallel)
 
-            for i in images.get_sample():
-                th.assert_equals(i, expected)
+        for i in images.get_sample():
+            th.assert_equals(i, expected)
 
     def test_aggregate_not_single_folder_sum_fits(self):
         self.do_aggregate_not_single_folder('fits', 'fits', 'sum')
@@ -156,54 +124,54 @@ class AggregateTest(unittest.TestCase):
         parallel = False
         saver = self.create_saver()
 
-        with tempfile.NamedTemporaryFile() as f:
-            aggregate_path = os.path.dirname(f.name) + '/aggregate'
-            # keep the angle paths for the load later
-            angle_paths = []
-            # save out 5 'angles'
-            for i in range(aggregate_angles):
-                angle_paths.append(aggregate_path + '/angle' + str(i))
-                saver._output_path = angle_paths[i]
-                saver._out_format = img_format
-                saver._data_as_stack = stack
-                saver._overwrite_all = True
-                # do the actual saving out, directories will be created here
-                saver.save(
-                    images,
-                    angle_paths[i],
-                    'out_angle',
-                    swap_axes=False,
-                    out_format=saver._out_format)
+        aggregate_path = os.path.join(self.output_directory, 'aggregate')
+        # keep the angle paths for the load later
+        angle_paths = []
+        # save out 5 'angles'
+        for i in range(aggregate_angles):
+            angle_paths.append(aggregate_path + '/angle' + str(i))
+            saver._output_path = angle_paths[i]
+            saver._out_format = img_format
+            saver._data_as_stack = stack
+            saver._overwrite_all = True
+            # do the actual saving out, directories will be created here
+            saver.save(
+                images,
+                angle_paths[i],
+                'out_angle',
+                swap_axes=False,
+                out_format=saver._out_format)
 
-            # aggregate them
-            conf = self.config
-            conf.func.aggregate = ['0', '10', mode]
-            # select angles 0 - 4 (starts from 0 so -1)
-            conf.func.aggregate_angles = ['0', str(aggregate_angles - 1)]
-            conf.func.aggregate_single_folder_output = False
-            conf.func.input_path = aggregate_path
-            conf.func.in_format = saver._out_format
-            conf.func.out_format = convert_format
-            aggregate_output_path = os.path.dirname(f.name) + '/aggregated'
-            conf.func.output_path = aggregate_output_path
-            conf.func.overwrite_all = True
-            conf.func.convert_prefix = 'aggregated'
-            aggregate.execute(conf)
+        # aggregate them
+        conf = self.config
+        conf.func.aggregate = ['0', '10', mode]
+        # select angles 0 - 4 (starts from 0 so -1)
+        conf.func.aggregate_angles = ['0', str(aggregate_angles - 1)]
+        conf.func.aggregate_single_folder_output = False
+        conf.func.input_path = aggregate_path
+        conf.func.in_format = saver._out_format
+        conf.func.out_format = convert_format
+        aggregate_output_path = os.path.join(self.output_directory,
+                                             'aggregated')
+        conf.func.output_path = aggregate_output_path
+        conf.func.overwrite_all = True
+        conf.func.convert_prefix = 'aggregated'
+        aggregate.execute(conf)
 
-            # load them back
-            # compare data to original
-            # this does not load any flats or darks as they were not saved out
-            for i in range(aggregate_angles):
-                angle_path = os.path.dirname(
-                    f.name) + '/aggregated/angle_' + mode + str(i)
+        # load them back
+        # compare data to original
+        # this does not load any flats or darks as they were not saved out
+        for i in range(aggregate_angles):
+            angle_path = os.path.join(self.output_directory,
+                                      'aggregated/angle_' + mode + str(i))
 
-                images = loader.load(
-                    angle_path,
-                    in_format=saver._out_format,
-                    parallel_load=parallel)
+            images = loader.load(
+                angle_path,
+                in_format=saver._out_format,
+                parallel_load=parallel)
 
-                for i in images.get_sample():
-                    th.assert_equals(i, expected)
+            for i in images.get_sample():
+                th.assert_equals(i, expected)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/tests/core_test/io_test.py
+++ b/mantidimaging/tests/core_test/io_test.py
@@ -10,10 +10,12 @@ import numpy as np
 from mantidimaging.core.configs.recon_config import ReconstructionConfig
 from mantidimaging.core.io import loader
 from mantidimaging.core.io.saver import Saver, generate_names
+from mantidimaging.tests.file_outputting_test_case import (
+        FileOutputtingTestCase)
 from mantidimaging.tests import test_helper as th
 
 
-class IOTest(unittest.TestCase):
+class IOTest(FileOutputtingTestCase):
     def __init__(self, *args, **kwargs):
         super(IOTest, self).__init__(*args, **kwargs)
 
@@ -45,33 +47,6 @@ class IOTest(unittest.TestCase):
         else:
             filename = base_name + '.' + file_format
             self.assertTrue(os.path.isfile(filename))
-
-    def tearDown(self):
-        """
-        Cleanup, Make sure all files are deleted from tmp
-        """
-        try:
-            th.delete_files(folder='pre_processed')
-        except OSError:
-            # no preprocessed images were saved
-            pass
-        try:
-            # delete files from test_load_sample_flat_and_dark
-            th.delete_files(folder='imgIOTest_flat')
-        except OSError:
-            # no preprocessed images were saved
-            pass
-        try:
-            # delete files from test_load_sample_flat_and_dark
-            th.delete_files(folder='imgIOTest_dark')
-        except OSError:
-            # no preprocessed images were saved
-            pass
-        try:
-            th.delete_files(folder='reconstructed')
-        except OSError:
-            # no reconstructed images were saved
-            pass
 
     def test_preproc_fits_par(self):
         self.do_preproc('fits', parallel=True)
@@ -228,43 +203,42 @@ class IOTest(unittest.TestCase):
                    saver_indices=None):
         expected_images = th.gen_img_shared_array_with_val(42.)
         saver = self.create_saver()
-        with tempfile.NamedTemporaryFile() as f:
-            saver._output_path = os.path.dirname(f.name)
-            saver._out_format = img_format
-            saver._save_preproc = True
-            saver._swap_axes = False
-            # this only affects enumeration
-            saver._indices = saver_indices
-            data_as_stack = False
+        saver._output_path = self. output_directory
+        saver._out_format = img_format
+        saver._save_preproc = True
+        saver._swap_axes = False
+        # this only affects enumeration
+        saver._indices = saver_indices
+        data_as_stack = False
 
-            # saver indices only affects the enumeration of the data
-            if saver_indices:
-                # crop the original images to make sure the tests is correct
-                expected_images = expected_images[saver_indices[0]:saver_indices[1]]
+        # saver indices only affects the enumeration of the data
+        if saver_indices:
+            # crop the original images to make sure the tests is correct
+            expected_images = expected_images[saver_indices[0]:saver_indices[1]]
 
-            saver.save_preproc_images(expected_images)
+        saver.save_preproc_images(expected_images)
 
-            # create the same path as the saved out preproc images
-            preproc_output_path = saver._output_path + '/pre_processed/'
+        # create the same path as the saved out preproc images
+        preproc_output_path = saver._output_path + '/pre_processed/'
 
-            self.assert_files_exist(os.path.join(preproc_output_path, 'out_preproc_image'),
-                                    saver._out_format, data_as_stack,
-                                    expected_images.shape[0], saver_indices)
+        self.assert_files_exist(os.path.join(preproc_output_path, 'out_preproc_image'),
+                                saver._out_format, data_as_stack,
+                                expected_images.shape[0], saver_indices)
 
-            # this does not load any flats or darks as they were not saved out
-            loaded_images = loader.load(preproc_output_path, in_format=saver._out_format,
-                                        cores=1, parallel_load=parallel, indices=loader_indices)
+        # this does not load any flats or darks as they were not saved out
+        loaded_images = loader.load(preproc_output_path, in_format=saver._out_format,
+                                    cores=1, parallel_load=parallel, indices=loader_indices)
 
-            if loader_indices:
-                assert len(loaded_images.get_sample()) == expected_len, "The length of the loaded data does not " \
-                    "match the expected length! Expected: {0}, " \
-                    "Got {1}".format(expected_len, len(
-                        loaded_images.get_sample()))
+        if loader_indices:
+            assert len(loaded_images.get_sample()) == expected_len, "The length of the loaded data does not " \
+                "match the expected length! Expected: {0}, " \
+                "Got {1}".format(expected_len, len(
+                    loaded_images.get_sample()))
 
-                # crop the original images to make sure the tests is correct
-                expected_images = expected_images[loader_indices[0]:loader_indices[1]]
+            # crop the original images to make sure the tests is correct
+            expected_images = expected_images[loader_indices[0]:loader_indices[1]]
 
-            th.assert_equals(loaded_images.get_sample(), expected_images)
+        th.assert_equals(loaded_images.get_sample(), expected_images)
 
     def test_save_nxs_seq(self):
         self.do_preproc_nxs(parallel=False)
@@ -301,48 +275,46 @@ class IOTest(unittest.TestCase):
         """
         expected_images = th.gen_img_shared_array_with_val(42.)
         saver = self.create_saver()
+        saver._output_path = self.output_directory
+        saver._save_preproc = True
+        saver._out_format = save_out_img_format
+        saver._swap_axes = False
+        data_as_stack = True
 
-        with tempfile.NamedTemporaryFile() as f:
-            saver._output_path = os.path.dirname(f.name)
-            saver._save_preproc = True
-            saver._out_format = save_out_img_format
-            saver._swap_axes = False
-            data_as_stack = True
+        saver.save_preproc_images(expected_images)
 
-            saver.save_preproc_images(expected_images)
+        # create the same path as the saved out preproc images
+        preproc_output_path = os.path.join(
+            saver._output_path, 'pre_processed/')
 
-            # create the same path as the saved out preproc images
-            preproc_output_path = os.path.join(
-                saver._output_path, 'pre_processed/')
+        self.assert_files_exist(os.path.join(preproc_output_path, 'out_preproc_image'),
+                                saver._out_format, data_as_stack,
+                                expected_images.shape[0])
 
-            self.assert_files_exist(os.path.join(preproc_output_path, 'out_preproc_image'),
-                                    saver._out_format, data_as_stack,
-                                    expected_images.shape[0])
+        # this does not load any flats or darks as they were not saved out!
+        # this is a race condition versus the saving from the saver
+        # when load is executed in parallel, the 8 threads try to
+        # load the data too fast, and the data loaded is corrupted
+        # hard coded 1 core to avoid race condition
+        images = loader.load(preproc_output_path, in_format=saver._out_format, cores=1,
+                             parallel_load=parallel, indices=loader_indices)
 
-            # this does not load any flats or darks as they were not saved out!
-            # this is a race condition versus the saving from the saver
-            # when load is executed in parallel, the 8 threads try to
-            # load the data too fast, and the data loaded is corrupted
-            # hard coded 1 core to avoid race condition
-            images = loader.load(preproc_output_path, in_format=saver._out_format, cores=1,
-                                 parallel_load=parallel, indices=loader_indices)
+        if loader_indices:
+            assert len(
+                images.get_sample()
+            ) == expected_len, "The length of the loaded data does not " \
+                               "match the expected length! Expected: {0}, " \
+                               "Got {1}".format(
+                expected_len, len(images.get_sample()))
 
-            if loader_indices:
-                assert len(
-                    images.get_sample()
-                ) == expected_len, "The length of the loaded data does not " \
-                                   "match the expected length! Expected: {0}, " \
-                                   "Got {1}".format(
-                    expected_len, len(images.get_sample()))
+            # crop the original images to make sure the tests is correct
+            expected_images = expected_images[loader_indices[0]:loader_indices[1]]
 
-                # crop the original images to make sure the tests is correct
-                expected_images = expected_images[loader_indices[0]:loader_indices[1]]
+        th.assert_equals(images.get_sample(), expected_images)
 
-            th.assert_equals(images.get_sample(), expected_images)
-
-            self.assert_files_exist(os.path.join(preproc_output_path, 'out_preproc_image'),
-                                    saver._out_format, data_as_stack,
-                                    expected_images.shape[0])
+        self.assert_files_exist(os.path.join(preproc_output_path, 'out_preproc_image'),
+                                saver._out_format, data_as_stack,
+                                expected_images.shape[0])
 
     def test_do_recon_fits(self):
         self.do_recon(img_format='fits', horiz_slices=False)
@@ -370,30 +342,29 @@ class IOTest(unittest.TestCase):
         """
         images = th.gen_img_shared_array()
         saver = self.create_saver()
-        with tempfile.NamedTemporaryFile() as f:
-            saver._output_path = os.path.dirname(f.name)
-            saver._out_format = img_format
-            saver._swap_axes = False
-            saver._save_horiz_slices = horiz_slices
-            # this only affects enumeration
-            saver._indices = saver_indices
-            data_as_stack = False
+        saver._output_path = self.output_directory
+        saver._out_format = img_format
+        saver._swap_axes = False
+        saver._save_horiz_slices = horiz_slices
+        # this only affects enumeration
+        saver._indices = saver_indices
+        data_as_stack = False
 
-            saver.save_recon_output(images)
+        saver.save_recon_output(images)
 
-            recon_output_path = os.path.join(
-                saver._output_path, 'reconstructed/')
+        recon_output_path = os.path.join(
+            saver._output_path, 'reconstructed/')
 
-            self.assert_files_exist(os.path.join(recon_output_path, 'recon_slice'),
-                                    saver._out_format, data_as_stack,
-                                    images.shape[0], saver_indices)
+        self.assert_files_exist(os.path.join(recon_output_path, 'recon_slice'),
+                                saver._out_format, data_as_stack,
+                                images.shape[0], saver_indices)
 
-            if horiz_slices:
-                self.assert_files_exist(
-                    os.path.join(recon_output_path,
-                                 'horiz_slices/recon_horiz'),
-                    saver._out_format, data_as_stack, images.shape[1],
-                    saver_indices)
+        if horiz_slices:
+            self.assert_files_exist(
+                os.path.join(recon_output_path,
+                             'horiz_slices/recon_horiz'),
+                saver._out_format, data_as_stack, images.shape[1],
+                saver_indices)
 
     def test_load_sample_flat_and_dark(self,
                                        img_format='tiff',
@@ -409,65 +380,64 @@ class IOTest(unittest.TestCase):
         dark[:] = 3
 
         saver = self.create_saver()
-        with tempfile.NamedTemporaryFile() as f:
-            saver._output_path = os.path.dirname(f.name)
-            saver._out_format = img_format
-            saver._save_preproc = True
-            saver._swap_axes = False
-            # this only affects enumeration
-            saver._indices = saver_indices
-            data_as_stack = False
+        saver._output_path = self.output_directory
+        saver._out_format = img_format
+        saver._save_preproc = True
+        saver._swap_axes = False
+        # this only affects enumeration
+        saver._indices = saver_indices
+        data_as_stack = False
 
-            # saver indices only affects the enumeration of the data
-            if saver_indices:
-                # crop the original images to make sure the tests is correct
-                images = images[saver_indices[0]:saver_indices[1]]
+        # saver indices only affects the enumeration of the data
+        if saver_indices:
+            # crop the original images to make sure the tests is correct
+            images = images[saver_indices[0]:saver_indices[1]]
 
-            saver.save_preproc_images(images)
-            saver._preproc_dir = "imgIOTest_flat"
-            saver.save_preproc_images(flat)
-            saver._preproc_dir = "imgIOTest_dark"
-            saver.save_preproc_images(dark)
+        saver.save_preproc_images(images)
+        saver._preproc_dir = "imgIOTest_flat"
+        saver.save_preproc_images(flat)
+        saver._preproc_dir = "imgIOTest_dark"
+        saver.save_preproc_images(dark)
 
-            # create the same path as the saved out preproc images
-            sample_output_path = os.path.join(
-                saver._output_path, 'pre_processed')
-            flat_output_path = os.path.join(
-                saver._output_path, 'imgIOTest_flat')
-            dark_output_path = os.path.join(
-                saver._output_path, 'imgIOTest_dark')
+        # create the same path as the saved out preproc images
+        sample_output_path = os.path.join(
+            saver._output_path, 'pre_processed')
+        flat_output_path = os.path.join(
+            saver._output_path, 'imgIOTest_flat')
+        dark_output_path = os.path.join(
+            saver._output_path, 'imgIOTest_dark')
 
-            self.assert_files_exist(os.path.join(sample_output_path, 'out_preproc_image'),
-                                    saver._out_format, data_as_stack,
-                                    images.shape[0], loader_indices or
-                                    saver_indices)
+        self.assert_files_exist(os.path.join(sample_output_path, 'out_preproc_image'),
+                                saver._out_format, data_as_stack,
+                                images.shape[0], loader_indices or
+                                saver_indices)
 
-            self.assert_files_exist(
-                os.path.join(flat_output_path,
-                             'out_preproc_image'), saver._out_format,
-                data_as_stack, flat.shape[0], loader_indices or saver_indices)
+        self.assert_files_exist(
+            os.path.join(flat_output_path,
+                         'out_preproc_image'), saver._out_format,
+            data_as_stack, flat.shape[0], loader_indices or saver_indices)
 
-            self.assert_files_exist(
-                os.path.join(dark_output_path,
-                             'out_preproc_image'), saver._out_format,
-                data_as_stack, dark.shape[0], loader_indices or saver_indices)
+        self.assert_files_exist(
+            os.path.join(dark_output_path,
+                         'out_preproc_image'), saver._out_format,
+            data_as_stack, dark.shape[0], loader_indices or saver_indices)
 
-            loaded_images = loader.load(sample_output_path, flat_output_path, dark_output_path,
-                                        saver._out_format, cores=1, parallel_load=parallel, indices=loader_indices)
+        loaded_images = loader.load(sample_output_path, flat_output_path, dark_output_path,
+                                    saver._out_format, cores=1, parallel_load=parallel, indices=loader_indices)
 
-            if loader_indices:
-                assert len(loaded_images.get_sample()) == expected_len, "The length of the loaded data doesn't " \
-                    "match the expected length: {0}, " \
-                    "Got: {1}".format(expected_len, len(loaded_images.get_sample()))
+        if loader_indices:
+            assert len(loaded_images.get_sample()) == expected_len, "The length of the loaded data doesn't " \
+                "match the expected length: {0}, " \
+                "Got: {1}".format(expected_len, len(loaded_images.get_sample()))
 
-                # crop the original images to make sure the tests is correct
-                images = images[loader_indices[0]:loader_indices[1]]
+            # crop the original images to make sure the tests is correct
+            images = images[loader_indices[0]:loader_indices[1]]
 
-            th.assert_equals(loaded_images.get_sample(), images)
-            # we only check the first image because they will be
-            # averaged out when loaded! The initial images are only 3s
-            th.assert_equals(loaded_images.get_flat(), flat[0])
-            th.assert_equals(loaded_images.get_dark(), dark[0])
+        th.assert_equals(loaded_images.get_sample(), images)
+        # we only check the first image because they will be
+        # averaged out when loaded! The initial images are only 3s
+        th.assert_equals(loaded_images.get_flat(), flat[0])
+        th.assert_equals(loaded_images.get_dark(), dark[0])
 
     def test_raise_on_invalid_format(self):
         self.assertRaises(ValueError, loader.load, "/some/path",
@@ -478,63 +448,60 @@ class IOTest(unittest.TestCase):
 
         expected_shape = images.shape
         saver = self.create_saver()
-        with tempfile.NamedTemporaryFile() as f:
-            saver._output_path = os.path.dirname(f.name)
-            saver._out_format = "tiff"
-            saver._save_preproc = True
-            saver._swap_axes = False
+        saver._output_path = self.output_directory
+        saver._out_format = "tiff"
+        saver._save_preproc = True
+        saver._swap_axes = False
 
-            config = ReconstructionConfig.empty_init()
-            config.func.input_path = os.path.join(
-                saver._output_path, saver._preproc_dir)
-            config.func.in_format = saver._out_format
-            saver.save_preproc_images(images)
+        config = ReconstructionConfig.empty_init()
+        config.func.input_path = os.path.join(
+            saver._output_path, saver._preproc_dir)
+        config.func.in_format = saver._out_format
+        saver.save_preproc_images(images)
 
-            shape = loader.read_in_shape_from_config(config)
+        shape = loader.read_in_shape_from_config(config)
 
-            self.assertEqual(shape, expected_shape)
+        self.assertEqual(shape, expected_shape)
 
     def test_load_from_config(self):
         images = th.gen_img_shared_array_with_val(42.)
 
         saver = self.create_saver()
-        with tempfile.NamedTemporaryFile() as f:
-            saver._output_path = os.path.dirname(f.name)
-            saver._out_format = "tiff"
-            saver._save_preproc = True
-            saver._swap_axes = False
+        saver._output_path = self.output_directory
+        saver._out_format = "tiff"
+        saver._save_preproc = True
+        saver._swap_axes = False
 
-            config = ReconstructionConfig.empty_init()
-            config.func.input_path = os.path.join(
-                saver._output_path, saver._preproc_dir)
-            config.func.in_format = saver._out_format
-            saver.save_preproc_images(images)
+        config = ReconstructionConfig.empty_init()
+        config.func.input_path = os.path.join(
+            saver._output_path, saver._preproc_dir)
+        config.func.in_format = saver._out_format
+        saver.save_preproc_images(images)
 
-            loaded_images = loader.load_from_config(config)
+        loaded_images = loader.load_from_config(config)
 
-            th.assert_equals(images, loaded_images.get_sample())
+        th.assert_equals(images, loaded_images.get_sample())
 
     def test_construct_sinograms(self):
         images = th.gen_img_shared_array_with_val(42.)
         exp_sinograms = np.swapaxes(images, 0, 1)
 
         saver = self.create_saver()
-        with tempfile.NamedTemporaryFile() as f:
-            saver._output_path = os.path.dirname(f.name)
-            saver._out_format = "tiff"
-            saver._save_preproc = True
-            saver._swap_axes = False
+        saver._output_path = self.output_directory
+        saver._out_format = "tiff"
+        saver._save_preproc = True
+        saver._swap_axes = False
 
-            config = ReconstructionConfig.empty_init()
-            config.func.input_path = os.path.join(
-                saver._output_path, saver._preproc_dir)
-            config.func.in_format = saver._out_format
-            saver.save_preproc_images(images)
+        config = ReconstructionConfig.empty_init()
+        config.func.input_path = os.path.join(
+            saver._output_path, saver._preproc_dir)
+        config.func.in_format = saver._out_format
+        saver.save_preproc_images(images)
 
-            config.func.construct_sinograms = True
-            loaded_images = loader.load_from_config(config)
+        config.func.construct_sinograms = True
+        loaded_images = loader.load_from_config(config)
 
-            th.assert_equals(exp_sinograms, loaded_images.get_sample())
+        th.assert_equals(exp_sinograms, loaded_images.get_sample())
 
 
 if __name__ == '__main__':

--- a/mantidimaging/tests/core_test/process_list_test.py
+++ b/mantidimaging/tests/core_test/process_list_test.py
@@ -1,24 +1,29 @@
 from __future__ import absolute_import, division, print_function
 
-import tempfile
-import unittest
+import os
 
 from mantidimaging.core import process_list
 from mantidimaging.core.filters import median_filter
+from mantidimaging.tests.file_outputting_test_case import (
+        FileOutputtingTestCase)
 from mantidimaging.tests import test_helper as th
 
 PACKAGE_LOCATION_STRING = 'mantidimaging.core.filters.median_filter'
 FUNC_NAME = 'execute'
 
 
-class ProcessListTest(unittest.TestCase):
+class ProcessListTest(FileOutputtingTestCase):
     def setUp(self):
+        super(ProcessListTest, self).setUp()
+
         self.pl = process_list.ProcessList()
         self.pl.store(median_filter.execute, 3)
         self.pl.store(median_filter.execute, size=55)
         self.pl.store(median_filter.execute, 11, mode='test')
 
     def tearDown(self):
+        super(ProcessListTest, self).tearDown()
+
         self.pl = None
 
     def test_store(self):
@@ -49,16 +54,16 @@ class ProcessListTest(unittest.TestCase):
         self.assertEqual(func_tuple[3], {'mode': 'test'})
 
     def test_save(self):
-        with tempfile.NamedTemporaryFile() as f:
-            self.pl.save(f.name)
-            th.assert_files_exist(
-                self, f.name, file_extension='', file_extension_separator='')
+        filename = os.path.join(self.output_directory, 'test_process_list.txt')
+        self.pl.save(filename)
+        th.assert_files_exist(
+            self, filename, file_extension='', file_extension_separator='')
 
     def test_load(self):
-        with tempfile.NamedTemporaryFile() as f:
-            self.pl.save(f.name)
-            process_list2 = process_list.load(f.name)
-            self.assertTrue(self.pl == process_list2)
+        filename = os.path.join(self.output_directory, 'test_process_list.txt')
+        self.pl.save(filename)
+        process_list2 = process_list.load(filename)
+        self.assertTrue(self.pl == process_list2)
 
     def test_to_string(self):
         res = self.pl.to_string()

--- a/mantidimaging/tests/file_outputting_test_case.py
+++ b/mantidimaging/tests/file_outputting_test_case.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import, division, print_function
+
+import shutil
+import tempfile
+import unittest
+
+
+class FileOutputtingTestCase(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(FileOutputtingTestCase, self).__init__(*args, **kwargs)
+
+        self.output_directory = None
+
+    def setUp(self):
+        self.output_directory = tempfile.mkdtemp(
+                prefix='mantidimaging_test_tmp_')
+
+    def tearDown(self):
+        shutil.rmtree(path=self.output_directory, ignore_errors=True)

--- a/mantidimaging/tests/test_helper.py
+++ b/mantidimaging/tests/test_helper.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-import shutil
 import sys
-import tempfile
 
 import numpy as np
 import numpy.testing as npt
@@ -134,15 +132,6 @@ def switch_mp_on():
     pu.multiprocessing_available = backup_mp_avail
 
 
-def delete_files(folder=None):
-    """
-    Deletes the test files in a specified folder.
-    """
-    with tempfile.NamedTemporaryFile() as f:
-        full_path = os.path.join(os.path.dirname(f.name), folder)
-        shutil.rmtree(full_path)
-
-
 def assert_files_exist(cls, base_name, file_extension, file_extension_separator='.', single_file=True, num_images=1):
     """
     Asserts that the
@@ -170,18 +159,6 @@ def assert_files_exist(cls, base_name, file_extension, file_extension_separator=
     else:
         filename = base_name + file_extension_separator + file_extension
         cls.assertTrue(os.path.isfile(filename))
-
-
-def delete_folder_from_temp(subdir=''):
-    """
-    Use with caution, this deletes things!
-    """
-    import shutil
-    import tempfile
-    with tempfile.NamedTemporaryFile() as f:
-        full_path = os.path.join(os.path.dirname(f.name), subdir)
-        if os.path.isdir(full_path):
-            shutil.rmtree(full_path)
 
 
 def import_mock():


### PR DESCRIPTION
Adds a subclass of `unittest.testCase` (`FileOutputtingTestCase`) that deals with creating and destroying a temporary directory for each test to operate in.

Tests now no longer reuse temporary directories and should be safe to run in parallel (each individual test gets it's own temporary directory).

Fixes #89