### PR TITLE
Unit test verbosity

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
       steps {
         timeout(2) {
           sh 'cd mantidimaging && git clean -xdf'
-          sh '${WORKSPACE}/anaconda3/envs/py35/bin/nosetests --xunit-file=${WORKSPACE}/python35_nosetests.xml --xunit-testsuite-name=python35_nosetests'
+          sh '${WORKSPACE}/anaconda3/envs/py35/bin/nosetests --xunit-file=${WORKSPACE}/python35_nosetests.xml --xunit-testsuite-name=python35_nosetests -v'
           junit '**/python35_nosetests.xml'
         }
       }
@@ -27,7 +27,7 @@ pipeline {
       steps {
         timeout(2) {
           sh 'cd mantidimaging && git clean -xdf'
-          sh '${WORKSPACE}/anaconda2/bin/nosetests --xunit-file=${WORKSPACE}/python27_nosetests.xml --xunit-testsuite-name=python27_nosetests'
+          sh '${WORKSPACE}/anaconda2/bin/nosetests --xunit-file=${WORKSPACE}/python27_nosetests.xml --xunit-testsuite-name=python27_nosetests -v'
           junit '**/python27_nosetests.xml'
         }
       }

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 from logging import getLogger
 
 import os
+import warnings
 
 import numpy as np
 
@@ -26,7 +27,10 @@ def write_fits(data, filename, overwrite=False):
 def write_img(data, filename, overwrite=False):
     from mantidimaging.core.io.loader.imports import import_skimage_io
     skio = import_skimage_io()
-    skio.imsave(filename, data)
+    with warnings.catch_warnings(record=True) as warn_messages:
+        skio.imsave(filename, data)
+        for w in warn_messages:
+            getLogger(__name__).warn('skimage warning: %s', str(w))
 
 
 def write_nxs(data, filename, projection_angles=None, overwrite=False):

--- a/mantidimaging/tests/core_test/configs_test.py
+++ b/mantidimaging/tests/core_test/configs_test.py
@@ -7,6 +7,8 @@ import unittest
 
 import numpy.testing as npt
 
+import mantidimaging.tests.test_helper as th
+
 from mantidimaging.core.algorithms import registrator
 from mantidimaging.core.configs.functional_config import FunctionalConfig
 from mantidimaging.core.configs.recon_config import ReconstructionConfig
@@ -28,18 +30,20 @@ class ConfigsTest(unittest.TestCase):
                                   str(self.func_config), FunctionalConfig)
 
     def test_no_input_path_error(self):
-        # the error is thrown from handle_special_arguments
-        try:
-            # don't add input path, which is supposed to be mandatory
-            fake_args_list = ['--cors', '42']
-            fake_args = self.parser.parse_args(fake_args_list)
-            self.func_config._update(fake_args)
-            ReconstructionConfig(self.func_config, fake_args)
-            assert False, "If we reached this point we have failed the test, \
-                          because we were supposed to crash without --input--path specified"
-        except SystemExit:
-            # it was supposed to fail, it's fine
-            pass
+        # Ignore output to stdout/stderr
+        with th.IgnoreOutputStreams():
+            # the error is thrown from handle_special_arguments
+            try:
+                # don't add input path, which is supposed to be mandatory
+                fake_args_list = ['--cors', '42']
+                fake_args = self.parser.parse_args(fake_args_list)
+                self.func_config._update(fake_args)
+                ReconstructionConfig(self.func_config, fake_args)
+                assert False, "If we reached this point we have failed the test, \
+                              because we were supposed to crash without --input--path specified"
+            except SystemExit:
+                # it was supposed to fail, it's fine
+                pass
 
     def test_missing_cors_error(self):
         # don't add CORS, which is mandatory if running reconstruction

--- a/mantidimaging/tests/test_helper.py
+++ b/mantidimaging/tests/test_helper.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 import os
 import sys
 
+from six import StringIO
+
 import numpy as np
 import numpy.testing as npt
 
@@ -190,8 +192,8 @@ def import_mock():
 
 def mock_property(obj, object_property, property_return_value=None):
     """
-    Mock a property of the object. This is a helper function to work around the limitations
-    of mocking a property with different return values.
+    Mock a property of the object. This is a helper function to work around the
+    limitations of mocking a property with different return values.
 
     :param obj: The object whose property will be mocked.
 
@@ -205,3 +207,23 @@ def mock_property(obj, object_property, property_return_value=None):
     temp_property_mock = mock.PropertyMock(return_value=property_return_value)
     setattr(type(obj), object_property, temp_property_mock)
     return temp_property_mock
+
+
+class IgnoreOutputStreams(object):
+    def __init__(self):
+        self.stdout = None
+        self.stderr = None
+
+    def __enter__(self):
+        # Record the default streams
+        self.stdout = sys.stdout
+        self.stderr = sys.stderr
+
+        # Replace them with string IO "dummy" buffers
+        sys.stdout = StringIO()
+        sys.stderr = StringIO()
+
+    def __exit__(self, type, value, traceback):
+        # Restore the default streams
+        sys.stdout = self.stdout
+        sys.stderr = self.stderr


### PR DESCRIPTION
Removes unintentional output to `stderr` in unit tests and increases nose verbosity for Jenkins builds.