### PR TITLE
Test both returned and modified in-place filter data

### DIFF
--- a/mantidimaging/tests/filters_test/background_correction_test.py
+++ b/mantidimaging/tests/filters_test/background_correction_test.py
@@ -5,11 +5,18 @@ import unittest
 import numpy as np
 import numpy.testing as npt
 
-from mantidimaging.core.filters import background_correction
 from mantidimaging.tests import test_helper as th
+
+from mantidimaging.core.filters import background_correction
 
 
 class BackgroundCorrectionTest(unittest.TestCase):
+    """
+    Test background correction filter.
+
+    Tests return value and in-place modified data.
+    """
+
     def __init__(self, *args, **kwargs):
         super(BackgroundCorrectionTest, self).__init__(*args, **kwargs)
 
@@ -18,14 +25,18 @@ class BackgroundCorrectionTest(unittest.TestCase):
 
         # empty params
         result = background_correction.execute(images)
+
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
 
     def test_not_executed_no_dark(self):
         images, control = th.gen_img_shared_array_and_copy()
         flat = th.gen_img_shared_array()[0]
 
         # no dark
-        background_correction.execute(images, flat[0])
+        result = background_correction.execute(images, flat[0])
+
+        npt.assert_equal(result, control)
         npt.assert_equal(images, control)
 
     def test_not_executed_no_flat(self):
@@ -33,7 +44,9 @@ class BackgroundCorrectionTest(unittest.TestCase):
         dark = th.gen_img_shared_array()[0]
 
         # no flat
-        background_correction.execute(images, None, dark[0])
+        result = background_correction.execute(images, None, dark[0])
+
+        npt.assert_equal(result, control)
         npt.assert_equal(images, control)
 
     def test_not_executed_bad_flat(self):
@@ -54,9 +67,6 @@ class BackgroundCorrectionTest(unittest.TestCase):
         npt.assert_raises(ValueError, background_correction.execute, images,
                           flat, dark[0])
 
-    # def test_real_result_par(self):
-    #     self.do_real_result()
-
     def test_real_result(self):
         th.switch_mp_off()
         self.do_real_result()
@@ -75,8 +85,12 @@ class BackgroundCorrectionTest(unittest.TestCase):
         expected = np.full(sample.shape, 20.)
 
         # we dont want anything to be cropped out
-        res = background_correction.execute(sample, flat, dark, clip_max=20)
-        npt.assert_almost_equal(res, expected, 7)
+        result = background_correction.execute(sample, flat, dark, clip_max=20)
+
+        npt.assert_almost_equal(result, expected, 7)
+        npt.assert_almost_equal(sample, expected, 7)
+
+        npt.assert_equal(result, sample)
 
     def test_clip_works(self):
         # the calculation here was designed on purpose to have a value
@@ -91,8 +105,12 @@ class BackgroundCorrectionTest(unittest.TestCase):
         expected = np.full(sample.shape, 3.)
 
         # we dont want anything to be cropped out
-        res = background_correction.execute(sample, flat, dark)
-        npt.assert_equal(res, expected)
+        result = background_correction.execute(sample, flat, dark)
+
+        npt.assert_equal(result, expected)
+        npt.assert_equal(sample, expected)
+
+        npt.assert_equal(result, sample)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/tests/filters_test/circular_mask_test.py
+++ b/mantidimaging/tests/filters_test/circular_mask_test.py
@@ -1,12 +1,22 @@
 from __future__ import (absolute_import, division, print_function)
+
 import unittest
+
 import numpy.testing as npt
+
 from mantidimaging import helper as h
 from mantidimaging.tests import test_helper as th
+
 from mantidimaging.core.filters import circular_mask
 
 
 class CircularMaskTest(unittest.TestCase):
+    """
+    Test circular mask filter.
+
+    Tests return value and in-place modified data.
+    """
+
     def __init__(self, *args, **kwargs):
         super(CircularMaskTest, self).__init__(*args, **kwargs)
 
@@ -20,50 +30,71 @@ class CircularMaskTest(unittest.TestCase):
         mask_val = 0.
         result = circular_mask.execute(images, ratio, mask_val)
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
 
         ratio = 1
         result = circular_mask.execute(images, ratio, mask_val)
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
 
         ratio = -1
         result = circular_mask.execute(images, ratio, mask_val)
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
 
         ratio = None
         result = circular_mask.execute(images, ratio, mask_val)
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
 
     def test_executed(self):
         images, control = th.gen_img_shared_array_and_copy()
 
         ratio = 0.001
+
         result = circular_mask.execute(images, ratio)
+
         th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
 
         # reset the input images
         images, control = th.gen_img_shared_array_and_copy()
         ratio = 0.994
+
         result = circular_mask.execute(images, ratio)
+
         th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
 
     def test_memory_change_acceptable(self):
         """
         Expected behaviour for the filter is to be done in place
         without using more memory.
+
         In reality the memory is increased by about 40MB (4 April 2017),
         but this could change in the future.
+
         The reason why a 10% window is given on the expected size is
         to account for any library imports that may happen.
+
         This will still capture if the data is doubled, which is the main goal.
         """
         images, control = th.gen_img_shared_array_and_copy()
-
         ratio = 0.001
+
         cached_memory = h.get_memory_usage_linux(kb=True)[0]
+
         result = circular_mask.execute(images, ratio)
+
         self.assertLess(
             h.get_memory_usage_linux(kb=True)[0], cached_memory * 1.1)
+
         th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/tests/filters_test/clip_values_test.py
+++ b/mantidimaging/tests/filters_test/clip_values_test.py
@@ -1,0 +1,130 @@
+from __future__ import (absolute_import, division, print_function)
+
+import unittest
+
+import numpy.testing as npt
+
+from mantidimaging import helper as h
+from mantidimaging.tests import test_helper as th
+
+from mantidimaging.core.filters import clip_values
+
+
+class ClipValuesTest(unittest.TestCase):
+    """
+    Test clip values filter.
+
+    Tests return value and in-place modified data.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(ClipValuesTest, self).__init__(*args, **kwargs)
+
+    def test_no_execute(self):
+        images, control = th.gen_img_shared_array_and_copy()
+
+        result = clip_values.execute(images)
+
+        npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
+
+    def test_execute_min_only(self):
+        images, control = th.gen_img_shared_array_and_copy()
+
+        result = clip_values.execute(images,
+                                     clip_min=0.2,
+                                     clip_max=None,
+                                     clip_min_new_value=0.1,
+                                     clip_max_new_value=None)
+
+        th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
+
+        npt.assert_approx_equal(result.min(), 0.1)
+
+    def test_execute_max_only(self):
+        images, control = th.gen_img_shared_array_and_copy()
+
+        result = clip_values.execute(images,
+                                     clip_min=None,
+                                     clip_max=0.8,
+                                     clip_min_new_value=None,
+                                     clip_max_new_value=0.9)
+
+        th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
+
+        npt.assert_approx_equal(result.max(), 0.9)
+
+    def test_execute_min_max(self):
+        images, control = th.gen_img_shared_array_and_copy()
+
+        result = clip_values.execute(images,
+                                     clip_min=0.2,
+                                     clip_max=0.8,
+                                     clip_min_new_value=0.1,
+                                     clip_max_new_value=0.9)
+
+        th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
+
+        npt.assert_approx_equal(result.min(), 0.1)
+        npt.assert_approx_equal(result.max(), 0.9)
+
+    def test_execute_min_max_no_new_values(self):
+        images, control = th.gen_img_shared_array_and_copy()
+
+        result = clip_values.execute(images,
+                                     clip_min=0.2,
+                                     clip_max=0.8,
+                                     clip_min_new_value=None,
+                                     clip_max_new_value=None)
+
+        th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
+
+        npt.assert_approx_equal(result.min(), 0.2)
+        npt.assert_approx_equal(result.max(), 0.8)
+
+    def test_memory_change_acceptable(self):
+        """
+        Expected behaviour for the filter is to be done in place
+        without using more memory.
+
+        In reality the memory is increased by about 40MB (4 April 2017),
+        but this could change in the future.
+
+        The reason why a 10% window is given on the expected size is
+        to account for any library imports that may happen.
+
+        This will still capture if the data is doubled, which is the main goal.
+        """
+        images, control = th.gen_img_shared_array_and_copy()
+
+        cached_memory = h.get_memory_usage_linux(kb=True)[0]
+
+        result = clip_values.execute(images,
+                                     clip_min=0.2,
+                                     clip_max=0.8,
+                                     clip_min_new_value=0.1,
+                                     clip_max_new_value=0.9)
+
+        self.assertLess(
+            h.get_memory_usage_linux(kb=True)[0], cached_memory * 1.1)
+
+        th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mantidimaging/tests/filters_test/contrast_normalisation_test.py
+++ b/mantidimaging/tests/filters_test/contrast_normalisation_test.py
@@ -1,12 +1,22 @@
 from __future__ import (absolute_import, division, print_function)
+
 import unittest
+
 import numpy as np
 import numpy.testing as npt
+
 from mantidimaging.tests import test_helper as th
+
 from mantidimaging.core.filters import roi_normalisation
 
 
 class ContrastNormalisationTest(unittest.TestCase):
+    """
+    Test contrast ROI normalisation filter.
+
+    Tests return value and in-place modified data.
+    """
+
     def __init__(self, *args, **kwargs):
         super(ContrastNormalisationTest, self).__init__(*args, **kwargs)
 
@@ -15,7 +25,9 @@ class ContrastNormalisationTest(unittest.TestCase):
 
         air = None
         result = roi_normalisation.execute(images, air)
+
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
 
     def test_not_executed_invalid_shape(self):
         images, control = th.gen_img_shared_array_and_copy()
@@ -38,7 +50,11 @@ class ContrastNormalisationTest(unittest.TestCase):
 
         air = [3, 3, 4, 4]
         result = roi_normalisation.execute(images, air)
+
         th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/tests/filters_test/crop_coords_test.py
+++ b/mantidimaging/tests/filters_test/crop_coords_test.py
@@ -5,11 +5,18 @@ import unittest
 import numpy.testing as npt
 
 from mantidimaging import helper as h
-from mantidimaging.core.filters import crop_coords
 from mantidimaging.tests import test_helper as th
+
+from mantidimaging.core.filters import crop_coords
 
 
 class CropCoordsTest(unittest.TestCase):
+    """
+    Test crop by coordinates filter.
+
+    Tests return value only.
+    """
+
     def __init__(self, *args, **kwargs):
         super(CropCoordsTest, self).__init__(*args, **kwargs)
 
@@ -17,14 +24,19 @@ class CropCoordsTest(unittest.TestCase):
         images, control = th.gen_img_shared_array_and_copy()
         flat = th.shared_deepcopy(images)[0]
         dark = th.shared_deepcopy(images)[0]
-
         roi = [1, 1, 5, 5]
+
         r_sample, r_flat, r_dark = crop_coords.execute(images, roi, flat, dark)
+
         expected_shape_sample = (10, 4, 4)
         expected_shape_flat_dark = (4, 4)
+
         npt.assert_equal(r_sample.shape, expected_shape_sample)
         npt.assert_equal(r_flat.shape, expected_shape_flat_dark)
         npt.assert_equal(r_dark.shape, expected_shape_flat_dark)
+
+        # TODO: in-place data test
+        # npt.assert_equal(images.shape, expected_shape_sample)
 
     def test_executed_with_only_flat_and_no_dark(self):
         """
@@ -33,13 +45,18 @@ class CropCoordsTest(unittest.TestCase):
         images, control = th.gen_img_shared_array_and_copy()
         flat = th.shared_deepcopy(images)[0]
         dark = None
-
         roi = [1, 1, 5, 5]
+
         r_sample, r_flat, r_dark = crop_coords.execute(images, roi, flat, dark)
+
         expected_shape_sample = (10, 4, 4)
+
         npt.assert_equal(r_sample.shape, expected_shape_sample)
         npt.assert_equal(r_flat, None)
         npt.assert_equal(r_dark, None)
+
+        # TODO: in-place data test
+        # npt.assert_equal(images.shape, expected_shape_sample)
 
     def test_executed_with_no_flat_and_only_dark(self):
         """
@@ -48,13 +65,18 @@ class CropCoordsTest(unittest.TestCase):
         images, control = th.gen_img_shared_array_and_copy()
         flat = None
         dark = th.shared_deepcopy(images)[0]
-
         roi = [1, 1, 5, 5]
+
         r_sample, r_flat, r_dark = crop_coords.execute(images, roi, flat, dark)
+
         expected_shape_sample = (10, 4, 4)
+
         npt.assert_equal(r_sample.shape, expected_shape_sample)
         npt.assert_equal(r_flat, None)
         npt.assert_equal(r_dark, None)
+
+        # TODO: in-place data test
+        # npt.assert_equal(images.shape, expected_shape_sample)
 
     def test_executed_only_volume(self):
         # Check that the filter is  executed when:
@@ -67,6 +89,9 @@ class CropCoordsTest(unittest.TestCase):
         expected_shape = (10, 4, 4)
 
         npt.assert_equal(result.shape, expected_shape)
+
+        # TODO: in-place data test
+        # npt.assert_equal(images.shape, expected_shape)
 
     def test_not_executed_no_sample(self):
         # images that will be put through testing
@@ -82,27 +107,41 @@ class CropCoordsTest(unittest.TestCase):
 
         # not executed because no Region of interest is provided
         roi = None
+
         result = crop_coords.execute(images, roi)[0]
+
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
 
     def test_memory_change_acceptable(self):
         """
         Expected behaviour for the filter is to be done in place
         without using more memory.
+
         In reality the memory is increased by about 40MB (4 April 2017),
         but this could change in the future.
+
         The reason why a 10% window is given on the expected size is
         to account for any library imports that may happen.
+
         This will still capture if the data is doubled, which is the main goal.
         """
         images, control = th.gen_img_shared_array_and_copy()
         roi = [1, 1, 5, 5]
+
         cached_memory = h.get_memory_usage_linux(mb=True)[0]
+
         result = crop_coords.execute(images, roi)[0]
+
         self.assertLess(
             h.get_memory_usage_linux(mb=True)[0], cached_memory * 1.1)
+
         expected_shape = (10, 4, 4)
+
         npt.assert_equal(result.shape, expected_shape)
+
+        # TODO: in-place data test
+        # npt.assert_equal(images.shape, expected_shape)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/tests/filters_test/cut_off_test.py
+++ b/mantidimaging/tests/filters_test/cut_off_test.py
@@ -1,0 +1,69 @@
+from __future__ import (absolute_import, division, print_function)
+
+import unittest
+
+import numpy.testing as npt
+
+from mantidimaging import helper as h
+from mantidimaging.tests import test_helper as th
+
+from mantidimaging.core.filters import cut_off
+
+
+class CutOffTest(unittest.TestCase):
+    """
+    Test cut-off filter.
+
+    Tests return value and in-place modified data.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(CutOffTest, self).__init__(*args, **kwargs)
+
+    def test_execute(self):
+        images, control = th.gen_img_shared_array_and_copy()
+        threshold = 0.5
+
+        previous_max = images.max()
+        result = cut_off.execute(images, threshold=threshold)
+        new_max = images.max()
+
+        th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
+
+        self.assertTrue(new_max < previous_max,
+                        "New maximum value should be less than maximum value "
+                        "before processing")
+
+    def test_memory_change_acceptable(self):
+        """
+        Expected behaviour for the filter is to be done in place
+        without using more memory.
+
+        In reality the memory is increased by about 40MB (4 April 2017),
+        but this could change in the future.
+
+        The reason why a 10% window is given on the expected size is
+        to account for any library imports that may happen.
+
+        This will still capture if the data is doubled, which is the main goal.
+        """
+        images, control = th.gen_img_shared_array_and_copy()
+
+        cached_memory = h.get_memory_usage_linux(kb=True)[0]
+
+        result = cut_off.execute(images, threshold=0.5)
+
+        self.assertLess(
+            h.get_memory_usage_linux(kb=True)[0], cached_memory * 1.1)
+
+        th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mantidimaging/tests/filters_test/gaussian_test.py
+++ b/mantidimaging/tests/filters_test/gaussian_test.py
@@ -1,15 +1,26 @@
 from __future__ import (absolute_import, division, print_function)
+
 import unittest
+
 import numpy.testing as npt
+
 from mantidimaging import helper as h
 from mantidimaging.tests import test_helper as th
+
 from mantidimaging.core.filters import gaussian
 
 
 class GaussianTest(unittest.TestCase):
     """
-    Surprisingly sequential Gaussian seems to outperform parallel Gaussian on very small data.
-    This does not scale and parallel execution is always faster on any reasonably sized data (e.g. 143,512,512)
+    Test gaussian filter.
+
+    Tests return value and in-place modified data.
+
+    Surprisingly sequential Gaussian seems to outperform parallel Gaussian on
+    very small data.
+
+    This does not scale and parallel execution is always faster on any
+    reasonably sized data (e.g. 143,512,512)
     """
 
     def __init__(self, *args, **kwargs):
@@ -21,8 +32,11 @@ class GaussianTest(unittest.TestCase):
         size = None
         mode = None
         order = None
+
         result = gaussian.execute(images, size, mode, order)
+
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
 
     def test_executed_parallel(self):
         images, control = th.gen_img_shared_array_and_copy()
@@ -30,8 +44,11 @@ class GaussianTest(unittest.TestCase):
         size = 3
         mode = 'reflect'
         order = 1
+
         result = gaussian.execute(images, size, mode, order)
+
         th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
 
     def test_executed_no_helper_parallel(self):
         images, control = th.gen_img_shared_array_and_copy()
@@ -39,8 +56,11 @@ class GaussianTest(unittest.TestCase):
         size = 3
         mode = 'reflect'
         order = 1
+
         result = gaussian.execute(images, size, mode, order)
+
         th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
 
     def test_executed_no_helper_seq(self):
         images, control = th.gen_img_shared_array_and_copy()
@@ -54,27 +74,35 @@ class GaussianTest(unittest.TestCase):
         th.switch_mp_on()
 
         th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
 
     def test_memory_change_acceptable(self):
         """
         Expected behaviour for the filter is to be done in place
         without using more memory.
+
         In reality the memory is increased by about 40MB (4 April 2017),
         but this could change in the future.
+
         The reason why a 10% window is given on the expected size is
         to account for any library imports that may happen.
+
         This will still capture if the data is doubled, which is the main goal.
         """
         images, control = th.gen_img_shared_array_and_copy()
-
         size = 3
         mode = 'reflect'
         order = 1
+
         cached_memory = h.get_memory_usage_linux(kb=True)[0]
+
         result = gaussian.execute(images, size, mode, order)
+
         self.assertLess(
             h.get_memory_usage_linux(kb=True)[0], cached_memory * 1.1)
+
         th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/tests/filters_test/median_filter_test.py
+++ b/mantidimaging/tests/filters_test/median_filter_test.py
@@ -1,12 +1,22 @@
 from __future__ import (absolute_import, division, print_function)
+
 import unittest
+
 import numpy.testing as npt
+
 from mantidimaging import helper as h
 from mantidimaging.tests import test_helper as th
+
 from mantidimaging.core.filters import median_filter
 
 
 class MedianTest(unittest.TestCase):
+    """
+    Test median filter.
+
+    Tests return value and in-place modified data.
+    """
+
     def __init__(self, *args, **kwargs):
         super(MedianTest, self).__init__(*args, **kwargs)
 
@@ -15,47 +25,68 @@ class MedianTest(unittest.TestCase):
 
         size = None
         mode = None
+
         result = median_filter.execute(images, size, mode)
+
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
 
     def test_executed_no_helper_parallel(self):
         images, control = th.gen_img_shared_array_and_copy()
 
         size = 3
         mode = 'reflect'
+
         result = median_filter.execute(images, size, mode)
+
         th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
 
     def test_executed_no_helper_seq(self):
         images, control = th.gen_img_shared_array_and_copy()
 
         size = 3
         mode = 'reflect'
+
         th.switch_mp_off()
         result = median_filter.execute(images, size, mode)
         th.switch_mp_on()
+
         th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
 
     def test_memory_change_acceptable(self):
         """
         Expected behaviour for the filter is to be done in place
         without using more memory.
+
         In reality the memory is increased by about 40MB (4 April 2017),
         but this could change in the future.
+
         The reason why a 10% window is given on the expected size is
         to account for any library imports that may happen.
+
         This will still capture if the data is doubled, which is the main goal.
         """
         images, control = th.gen_img_shared_array_and_copy()
-
         size = 3
         mode = 'reflect'
+
         cached_memory = h.get_memory_usage_linux(kb=True)[0]
+
         result = median_filter.execute(images, size, mode)
 
         self.assertLess(
             h.get_memory_usage_linux(kb=True)[0], cached_memory * 1.1)
+
         th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/tests/filters_test/minus_log_test.py
+++ b/mantidimaging/tests/filters_test/minus_log_test.py
@@ -1,0 +1,60 @@
+from __future__ import (absolute_import, division, print_function)
+
+import unittest
+
+import numpy.testing as npt
+
+from mantidimaging import helper as h
+from mantidimaging.tests import test_helper as th
+
+from mantidimaging.core.filters import minus_log
+
+
+class MinusLogTest(unittest.TestCase):
+    """
+    Test minus log filter.
+
+    Tests return value and in-place modified data.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(MinusLogTest, self).__init__(*args, **kwargs)
+
+    def test_no_execute(self):
+        images, control = th.gen_img_shared_array_and_copy()
+
+        result = minus_log.execute(images, minus_log=False)
+
+        npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
+
+    def test_memory_change_acceptable(self):
+        """
+        Expected behaviour for the filter is to be done in place
+        without using more memory.
+
+        In reality the memory is increased by about 40MB (4 April 2017),
+        but this could change in the future.
+
+        The reason why a 10% window is given on the expected size is
+        to account for any library imports that may happen.
+
+        This will still capture if the data is doubled, which is the main goal.
+        """
+        images, control = th.gen_img_shared_array_and_copy()
+
+        cached_memory = h.get_memory_usage_linux(kb=True)[0]
+
+        result = minus_log.execute(images, minus_log=True)
+
+        self.assertLess(
+            h.get_memory_usage_linux(kb=True)[0], cached_memory * 1.1)
+
+        th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mantidimaging/tests/filters_test/outliers_test.py
+++ b/mantidimaging/tests/filters_test/outliers_test.py
@@ -1,58 +1,95 @@
 from __future__ import (absolute_import, division, print_function)
+
 import unittest
+
 import numpy.testing as npt
+
 from mantidimaging.tests import test_helper as th
+
 from mantidimaging.core.filters import outliers
 
 
 class OutliersTest(unittest.TestCase):
+    """
+    Test outliers filter.
+
+    Tests return value only.
+    """
+
     def __init__(self, *args, **kwargs):
         super(OutliersTest, self).__init__(*args, **kwargs)
 
     def test_not_executed_no_threshold(self):
         images, control = th.gen_img_shared_array_and_copy()
+
         # invalid thresholds
         threshold = None
         radius = 8
+
         result = outliers.execute(images, threshold, radius, cores=1)
+
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
 
     def test_not_executed_bad_threshold(self):
         images, control = th.gen_img_shared_array_and_copy()
+
         radius = 8
         threshold = 0
+
         result = outliers.execute(images, threshold, radius, cores=1)
+
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
 
     def test_not_executed_bad_threshold2(self):
         images, control = th.gen_img_shared_array_and_copy()
+
         radius = 8
         threshold = -42
+
         result = outliers.execute(images, threshold, radius, cores=1)
+
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
 
     def test_not_executed_no_radius(self):
         images, control = th.gen_img_shared_array_and_copy()
+
         radius = 8
         threshold = 42
         radius = None
+
         result = outliers.execute(images, threshold, radius, cores=1)
+
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
 
     def test_executed(self):
         images, control = th.gen_img_shared_array_and_copy()
+
         radius = 8
         threshold = 0.1
+
         result = outliers.execute(images, threshold, radius, cores=1)
+
         th.assert_not_equals(result, control)
+
+        # TODO: in-place data test
+        # th.assert_not_equals(images, control)
 
     def test_executed_no_helper(self):
         images, control = th.gen_img_shared_array_and_copy()
 
         threshold = 0.1
         radius = 8
+
         result = outliers.execute(images, threshold, radius, cores=1)
+
         npt.assert_raises(AssertionError, npt.assert_equal, result, control)
+
+        # TODO: in-place data test
+        # npt.assert_raises(AssertionError, npt.assert_equal, images, control)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/tests/filters_test/rebin_test.py
+++ b/mantidimaging/tests/filters_test/rebin_test.py
@@ -5,34 +5,53 @@ import unittest
 import numpy.testing as npt
 
 from mantidimaging import helper as h
-from mantidimaging.core.filters import rebin
 from mantidimaging.tests import test_helper as th
+
+from mantidimaging.core.filters import rebin
 
 
 class RebinTest(unittest.TestCase):
+    """
+    Test rebin filter.
+
+    Tests return value only.
+    """
+
     def __init__(self, *args, **kwargs):
         super(RebinTest, self).__init__(*args, **kwargs)
 
     def test_not_executed_rebin_none(self):
         images, control = th.gen_img_shared_array_and_copy()
+
         val = None
         mode = 'nearest'
+
         result = rebin.execute(images, val, mode)
+
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
 
     def test_not_executed_rebin_negative(self):
         images, control = th.gen_img_shared_array_and_copy()
+
         mode = 'nearest'
         val = -1
+
         result = rebin.execute(images, val, mode)
+
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
 
     def test_not_executed_rebin_zero(self):
         images, control = th.gen_img_shared_array_and_copy()
+
         mode = 'nearest'
         val = 0
+
         result = rebin.execute(images, val, mode)
+
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
 
     def test_executed_par_2(self):
         self.do_execute(2.)
@@ -56,27 +75,44 @@ class RebinTest(unittest.TestCase):
 
         expected_x = int(images.shape[1] * val)
         expected_y = int(images.shape[2] * val)
+
         result = rebin.execute(images, val, mode)
+
         npt.assert_equal(result.shape[1], expected_x)
         npt.assert_equal(result.shape[2], expected_y)
 
+        # TODO: in-place data test
+        # npt.assert_equal(images.shape[1], expected_x)
+        # npt.assert_equal(images.shape[2], expected_y)
+
+
     def test_memory_change_acceptable(self):
         """
-        This filter will increase the memory usage
-        as it has to allocate memory for the new resized shape
+        This filter will increase the memory usage as it has to allocate memory
+        for the new resized shape
         """
         images = th.gen_img_shared_array()
+
         mode = 'nearest'
         # This about doubles the memory. Value found from running the test
         val = 100.
+
         expected_x = int(images.shape[1] * val)
         expected_y = int(images.shape[2] * val)
+
         cached_memory = h.get_memory_usage_linux(kb=True)[0]
+
         result = rebin.execute(images, val, mode)
+
         self.assertLess(
             h.get_memory_usage_linux(kb=True)[0], cached_memory * 2)
+
         npt.assert_equal(result.shape[1], expected_x)
         npt.assert_equal(result.shape[2], expected_y)
+
+        # TODO: in-place data test
+        # npt.assert_equal(images.shape[1], expected_x)
+        # npt.assert_equal(images.shape[2], expected_y)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/tests/filters_test/ring_removal_test.py
+++ b/mantidimaging/tests/filters_test/ring_removal_test.py
@@ -7,32 +7,48 @@ import numpy.testing as npt
 from mantidimaging import helper as h
 from mantidimaging.tests import test_helper as th
 
+from mantidimaging.core.filters import ring_removal
+
 
 class RingRemovalTest(unittest.TestCase):
+    """
+    Test ring removal filter.
+
+    Tests return value and in-place modified data.
+    """
+
     def __init__(self, *args, **kwargs):
         super(RingRemovalTest, self).__init__(*args, **kwargs)
-
-        from mantidimaging.core.filters import ring_removal
-        self.alg = ring_removal
 
     def test_not_executed(self):
         images, control = th.gen_img_shared_array_and_copy()
 
         # invalid threshold
         run_ring_removal = False
-        result = self.alg.execute(images, run_ring_removal, cores=1)
+
+        result = ring_removal.execute(images, run_ring_removal, cores=1)
+
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
+
+        npt.assert_equal(result, images)
 
     def test_memory_change_acceptable(self):
         images, control = th.gen_img_shared_array_and_copy()
         # invalid threshold
-
         run_ring_removal = False
+
         cached_memory = h.get_memory_usage_linux(kb=True)[0]
-        result = self.alg.execute(images, run_ring_removal, cores=1)
+
+        result = ring_removal.execute(images, run_ring_removal, cores=1)
+
         self.assertLess(
             h.get_memory_usage_linux(kb=True)[0], cached_memory * 1.1)
+
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
+
+        npt.assert_equal(result, images)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/tests/filters_test/roi_normalisation_test.py
+++ b/mantidimaging/tests/filters_test/roi_normalisation_test.py
@@ -10,7 +10,7 @@ from mantidimaging.tests import test_helper as th
 from mantidimaging.core.filters import roi_normalisation
 
 
-class ContrastNormalisationTest(unittest.TestCase):
+class ROINormalisationTest(unittest.TestCase):
     """
     Test contrast ROI normalisation filter.
 
@@ -18,7 +18,7 @@ class ContrastNormalisationTest(unittest.TestCase):
     """
 
     def __init__(self, *args, **kwargs):
-        super(ContrastNormalisationTest, self).__init__(*args, **kwargs)
+        super(ROINormalisationTest, self).__init__(*args, **kwargs)
 
     def test_not_executed_empty_params(self):
         images, control = th.gen_img_shared_array_and_copy()

--- a/mantidimaging/tests/filters_test/rotate_stack_test.py
+++ b/mantidimaging/tests/filters_test/rotate_stack_test.py
@@ -5,11 +5,18 @@ import unittest
 import numpy.testing as npt
 
 from mantidimaging import helper as h
-from mantidimaging.core.filters import rotate_stack
 from mantidimaging.tests import test_helper as th
+
+from mantidimaging.core.filters import rotate_stack
 
 
 class RotateStackTest(unittest.TestCase):
+    """
+    Test rotate stack filter.
+
+    Tests return value and in-place modified data.
+    """
+
     def __init__(self, *args, **kwargs):
         super(RotateStackTest, self).__init__(*args, **kwargs)
 
@@ -19,7 +26,9 @@ class RotateStackTest(unittest.TestCase):
 
         # empty params
         result = rotate_stack.execute(images, None)[0]
+
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
 
     def test_executed_par(self):
         self.do_execute()
@@ -35,30 +44,45 @@ class RotateStackTest(unittest.TestCase):
 
         rotation = 1  # once clockwise
         images[:, 0, 0] = 42  # set all images at 0,0 to 42
+
         result = rotate_stack.execute(images, rotation)[0]
+
         w = result.shape[2]
         npt.assert_equal(result[:, 0, w - 1], 42.0)
+        npt.assert_equal(images[:, 0, w - 1], 42.0)
+
+        npt.assert_equal(result, images)
 
     def test_memory_change_acceptable(self):
         """
         Expected behaviour for the filter is to be done in place
         without using more memory.
+
         In reality the memory is increased by about 40MB (4 April 2017),
         but this could change in the future.
+
         The reason why a 10% window is given on the expected size is
         to account for any library imports that may happen.
+
         This will still capture if the data is doubled, which is the main goal.
         """
         # only works on square images
         images, control = th.gen_img_shared_array_and_copy((10, 10, 10))
         rotation = 1  # once clockwise
         images[:, 0, 0] = 42  # set all images at 0,0 to 42
+
         cached_memory = h.get_memory_usage_linux(kb=True)[0]
+
         result = rotate_stack.execute(images, rotation)[0]
         w = result.shape[2]
+
         self.assertLess(
             h.get_memory_usage_linux(kb=True)[0], cached_memory * 1.1)
+
         npt.assert_equal(result[:, 0, w - 1], 42.0)
+        npt.assert_equal(images[:, 0, w - 1], 42.0)
+
+        npt.assert_equal(result, images)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/tests/filters_test/stripe_removal_test.py
+++ b/mantidimaging/tests/filters_test/stripe_removal_test.py
@@ -5,11 +5,18 @@ import unittest
 import numpy.testing as npt
 
 from mantidimaging import helper as h
-from mantidimaging.core.filters import stripe_removal
 from mantidimaging.tests import test_helper as th
+
+from mantidimaging.core.filters import stripe_removal
 
 
 class StripeRemovalTest(unittest.TestCase):
+    """
+    Test stripe removal filter.
+
+    Tests return value and in-place modified data.
+    """
+
     def __init__(self, *args, **kwargs):
         super(StripeRemovalTest, self).__init__(*args, **kwargs)
 
@@ -19,8 +26,11 @@ class StripeRemovalTest(unittest.TestCase):
         wf = None
         ti = None
         sf = None
+
         result = stripe_removal.execute(images, wf, ti, sf)
+
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
 
     def test_executed_wf(self):
         images, control = th.gen_img_shared_array_and_copy()
@@ -28,8 +38,13 @@ class StripeRemovalTest(unittest.TestCase):
         wf = ["level=1"]
         ti = None
         sf = None
+
         result = stripe_removal.execute(images, wf, ti, sf)
+
         th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
 
     def test_executed_ti(self):
         images, control = th.gen_img_shared_array_and_copy()
@@ -37,8 +52,13 @@ class StripeRemovalTest(unittest.TestCase):
         wf = None
         ti = ['nblock=2']
         sf = None
+
         result = stripe_removal.execute(images, wf, ti, sf)
+
         th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
 
     def test_executed_sf(self):
         images, control = th.gen_img_shared_array_and_copy()
@@ -46,8 +66,13 @@ class StripeRemovalTest(unittest.TestCase):
         wf = None
         ti = None
         sf = ['size=5']
+
         result = stripe_removal.execute(images, wf, ti, sf)
+
         th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
 
     def test_memory_executed_wf(self):
         images, control = th.gen_img_shared_array_and_copy()
@@ -55,11 +80,18 @@ class StripeRemovalTest(unittest.TestCase):
         wf = ["level=1"]
         ti = None
         sf = None
+
         cached_memory = h.get_memory_usage_linux(kb=True)[0]
+
         result = stripe_removal.execute(images, wf, ti, sf)
+
         self.assertLess(
             h.get_memory_usage_linux(kb=True)[0], cached_memory * 1.1)
+
         th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
 
     def test_memory_executed_ti(self):
         images, control = th.gen_img_shared_array_and_copy()
@@ -67,11 +99,18 @@ class StripeRemovalTest(unittest.TestCase):
         wf = None
         ti = ['nblock=2']
         sf = None
+
         cached_memory = h.get_memory_usage_linux(kb=True)[0]
+
         result = stripe_removal.execute(images, wf, ti, sf)
+
         self.assertLess(
             h.get_memory_usage_linux(kb=True)[0], cached_memory * 1.1)
+
         th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
 
     def test_memory_executed_sf(self):
         images, control = th.gen_img_shared_array_and_copy()
@@ -79,11 +118,18 @@ class StripeRemovalTest(unittest.TestCase):
         wf = None
         ti = None
         sf = ['size=5']
+
         cached_memory = h.get_memory_usage_linux(kb=True)[0]
+
         result = stripe_removal.execute(images, wf, ti, sf)
+
         self.assertLess(
             h.get_memory_usage_linux(kb=True)[0], cached_memory * 1.1)
+
         th.assert_not_equals(result, control)
+        th.assert_not_equals(images, control)
+
+        npt.assert_equal(result, images)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Where possible test both the return value from filters and the data they modify in place (which should be identical).

There are some filters where only the return value contains the processed data, these are noted in the tests.

This was brought about by the fact that wen adding the new filter GUIs several did not work as the dialog expected the data to always be modified in-place.