### PR TITLE
Update the stack list in algorithm dialogs

### DIFF
--- a/mantidimaging/core/utility/registrator/gui_registrator.py
+++ b/mantidimaging/core/utility/registrator/gui_registrator.py
@@ -42,6 +42,10 @@ def do_registering(module, module_dir, main_window):
     # We pass in the main_window reference to use it as the dialog's parent
     dialog = module._gui_register(main_window)
 
+    # Refresh the stack list in the algorithm dialog whenever the active stacks
+    # change
+    main_window.active_stacks_changed.connect(dialog.refresh_stack_list)
+
     assert isinstance(
         dialog, AlgorithmDialog), "Function _gui_register of {0} did not return the expected type. Check that the " \
                                   "dialog is of type AlgorithmDialog and is returned at the end of the _gui_register " \

--- a/mantidimaging/gui/algorithm_dialog.py
+++ b/mantidimaging/gui/algorithm_dialog.py
@@ -216,7 +216,7 @@ class AlgorithmDialog(Qt.QDialog):
         if self.selected_stack:
             self.main_window.algorithm_accepted(self.selected_stack, self)
 
-    def update_and_show(self):
+    def refresh_stack_list(self):
         # clear the previous entries from the drop down menu
         self.stackNames.clear()
 
@@ -225,5 +225,7 @@ class AlgorithmDialog(Qt.QDialog):
         if stack_list:  # run away if no stacks are loaded
             self.stack_uuids, user_friendly_names = zip(*stack_list)
             self.stackNames.addItems(user_friendly_names)
-        # show the dialogue with the updated stacks
+
+    def update_and_show(self):
+        self.refresh_stack_list()
         self.show()

--- a/mantidimaging/gui/main_window/mw_presenter.py
+++ b/mantidimaging/gui/main_window/mw_presenter.py
@@ -36,7 +36,7 @@ class MainWindowPresenter(object):
 
     def remove_stack(self, uuid):
         self.model.do_remove_stack(uuid)
-        self.view.update_shortcuts()
+        self.view.active_stacks_changed.emit()
 
     def load_stack(self):
         log = getLogger(__name__)
@@ -64,7 +64,7 @@ class MainWindowPresenter(object):
             dock_widget = self.view.create_stack_window(data, title=name)
             stack_visualiser = dock_widget.widget()
             self.model.add_stack(stack_visualiser, dock_widget)
-            self.view.update_shortcuts()
+            self.view.active_stacks_changed.emit()
 
     def save(self, indices=None):
         stack_uuid = self.view.save_dialogue.selected_stack

--- a/mantidimaging/gui/main_window/mw_view.py
+++ b/mantidimaging/gui/main_window/mw_view.py
@@ -15,11 +15,12 @@ from .save_dialog import MWSaveDialog
 
 
 class MainWindowView(Qt.QMainWindow):
+
+    active_stacks_changed = Qt.pyqtSignal()
+
     def __init__(self, config):
         super(MainWindowView, self).__init__()
         gui_compile_ui.execute('gui/ui/main_window.ui', self)
-
-        self.setup_shortcuts()
 
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
         self.setWindowTitle("MantidImaging")
@@ -27,6 +28,7 @@ class MainWindowView(Qt.QMainWindow):
         # filter and algorithm communications will be funneled through this
         self.presenter = MainWindowPresenter(self, config)
 
+        self.setup_shortcuts()
         self.update_shortcuts()
 
     def setup_shortcuts(self):
@@ -38,6 +40,8 @@ class MainWindowView(Qt.QMainWindow):
 
         self.actionExit.setShortcut('Ctrl+Q')
         self.actionExit.triggered.connect(Qt.qApp.quit)
+
+        self.active_stacks_changed.connect(self.update_shortcuts)
 
     def update_shortcuts(self):
         self.actionSave.setEnabled(len(self.presenter.stack_names()) > 0)


### PR DESCRIPTION
Ensures that the stack list shown in algorithm dialogs is kept up to date when stacks are loaded or closed whilst algorithm/filter dialogs are open.

Fixes #98 

To test:
- Open Filters > Background Corrections
- Load and close several image stacks (sample, flat or dark images in `demoimages`)
- See that the stack selection drop down in the filter dialog remains up to date with the loaded stacks