### PR TITLE
Default to using astropy.io.fits as the FITS loader

### DIFF
--- a/mantidimaging/core/algorithms/special_imports.py
+++ b/mantidimaging/core/algorithms/special_imports.py
@@ -10,22 +10,6 @@ from __future__ import absolute_import, division, print_function
 import sys
 
 
-def import_pyfits():
-    try:
-        import pyfits
-    except ImportError:
-        # In Anaconda python, the pyfits package is in a different place,
-        # and this is what you frequently find on windows.
-        try:
-            import astropy.io.fits as pyfits
-        except ImportError:
-            raise ImportError(
-                "Cannot find the package 'pyfits' which is required to "
-                "read/write FITS image files")
-
-    return pyfits
-
-
 def import_skimage_io():
     """
     To import skimage io only when it is/can be used

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -16,9 +16,8 @@ def _fitsread(filename):
     :param filename :: name of the image file, can be relative or absolute path
     :param img_format: format of the image ('fits')
     """
-    from mantidimaging.core.algorithms.special_imports import import_pyfits
-    pyfits = import_pyfits()
-    image = pyfits.open(filename)
+    import astropy.io.fits as fits
+    image = fits.open(filename)
     if len(image) < 1:
         raise RuntimeError(
             "Could not load at least one FITS image/table file from: {0}".
@@ -56,15 +55,14 @@ def supported_formats():
         skio_available = False
 
     try:
-        from mantidimaging.core.algorithms.special_imports import import_pyfits
-        pyfits = import_pyfits()  # noqa: F841
-        pyfits_available = True
+        import astropy.io.fits as fits  # noqa: F401
+        fits_available = True
     except ImportError:
-        pyfits_available = False
+        fits_available = False
 
     avail_list = \
         (['nxs'] if h5nxs_available else []) + \
-        (['fits', 'fit'] if pyfits_available else []) + \
+        (['fits', 'fit'] if fits_available else []) + \
         (['tif', 'tiff', 'png', 'jpg'] if skio_available else [])
 
     return avail_list

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -17,8 +17,7 @@ DEFAULT_NAME_POSTFIX = ''
 
 
 def write_fits(data, filename, overwrite=False):
-    from mantidimaging.core.algorithms.special_imports import import_pyfits
-    fits = import_pyfits()
+    import astropy.io.fits as fits
     hdu = fits.PrimaryHDU(data)
     hdulist = fits.HDUList([hdu])
     hdulist.writeto(filename, clobber=overwrite)


### PR DESCRIPTION
Removes the special importing logic for PyFITS and default to using Astropy's `astropy.io.fits`.

Fixes #113