### PR TITLE
Filter GUIs - part 1

### DIFF
--- a/mantidimaging/core/filters/cut_off/cut_off.py
+++ b/mantidimaging/core/filters/cut_off/cut_off.py
@@ -1,5 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
+
 from mantidimaging import helper as h
+
 import numpy as np
 
 
@@ -16,38 +18,14 @@ def _cli_register(parser):
     return parser
 
 
-def _gui_register(main_window):
-    from mantidimaging.core.utility import gui_compile_ui as gcu
-    from mantidimaging.gui.algorithm_dialog import AlgorithmDialog
-    from PyQt5 import Qt
-    dialog = AlgorithmDialog(main_window)
-    gcu.execute("gui/ui/alg_dialog.ui", dialog)
-    dialog.setWindowTitle("Cut Off")
-
-    label_radius = Qt.QLabel("Threshold")
-    radius_field = Qt.QDoubleSpinBox()
-    radius_field.setMinimum(0)
-    radius_field.setMaximum(1)
-    radius_field.setValue(0.95)
-
-    dialog.formLayout.addRow(label_radius, radius_field)
-
-    def decorate_execute():
-        from functools import partial
-        return partial(execute, threshold=radius_field.value())
-
-    # replace dialog function with this one
-    dialog.decorate_execute = decorate_execute
-    return dialog
-
-
 def execute(data, threshold):
     """
     Cut off values above threshold relative to the max pixels.
 
     :param data: Input data as a 3D numpy.ndarray
 
-    :param threshold: The threshold related to the minimum pixel value that will be clipped
+    :param threshold: The threshold related to the minimum pixel value that
+                      will be clipped
 
     :return: The processed 3D numpy.ndarray
     """

--- a/mantidimaging/core/filters/cut_off/cut_off_gui.py
+++ b/mantidimaging/core/filters/cut_off/cut_off_gui.py
@@ -1,9 +1,23 @@
-from mantidimaging.core.utility import gui_compile_ui as gcu
+from functools import partial
+
 from mantidimaging.gui.algorithm_dialog import AlgorithmDialog
+
+from . import cut_off
 
 GUI_MENU_NAME = 'Cut Off'
 
-# def _gui_register(main_window):
-#     dialog = AlgorithmDialog(main_window)
-#     dialog.setWindowTitle(GUI_MENU_NAME)
-#     return dialog
+
+def _gui_register(main_window):
+    dialog = AlgorithmDialog(main_window)
+    dialog.setWindowTitle("Cut Off")
+
+    _, threshold_field = dialog.add_property(
+            'Threshold', 'float', 0.95, (0.0, 1.0))
+    threshold_field.setSingleStep(0.05)
+
+    def custom_execute():
+        return partial(cut_off.execute, threshold=threshold_field.value())
+
+    dialog.set_execute(custom_execute)
+
+    return dialog

--- a/mantidimaging/core/filters/minus_log/minus_log.py
+++ b/mantidimaging/core/filters/minus_log/minus_log.py
@@ -1,4 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
+
 from mantidimaging import helper as h
 from mantidimaging.core.tools import importer
 

--- a/mantidimaging/core/filters/minus_log/minus_log_gui.py
+++ b/mantidimaging/core/filters/minus_log/minus_log_gui.py
@@ -1,0 +1,21 @@
+from functools import partial
+
+from mantidimaging.gui.algorithm_dialog import AlgorithmDialog
+
+from . import minus_log
+
+GUI_MENU_NAME = "Minus Log"
+
+
+def _gui_register(main_window):
+    dialog = AlgorithmDialog(main_window)
+    dialog.setWindowTitle(GUI_MENU_NAME)
+
+    # Not much here, this filter does one thing and one thing only.
+
+    def custom_execute():
+        return partial(minus_log.execute, minus_log=True)
+
+    dialog.set_execute(custom_execute)
+
+    return dialog

--- a/mantidimaging/core/filters/rotate_stack/rotate_stack.py
+++ b/mantidimaging/core/filters/rotate_stack/rotate_stack.py
@@ -1,5 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
+
 import numpy as np
+
 from mantidimaging import helper as h
 from mantidimaging.core.parallel import shared_mem as psm
 from mantidimaging.core.parallel import utility as pu
@@ -46,7 +48,8 @@ def execute(data, rotation, flat=None, dark=None, cores=None, chunksize=None):
     """
     h.check_data_stack(data)
     if rotation:
-        # rot90 rotates counterclockwise; config.args.rotation rotates clockwise
+        # rot90 rotates counterclockwise; config.args.rotation rotates
+        # clockwise
         clockwise_rotations = 4 - rotation
 
         if pu.multiprocessing_available():
@@ -60,7 +63,11 @@ def execute(data, rotation, flat=None, dark=None, cores=None, chunksize=None):
             dark = _rotate_image(dark, clockwise_rotations)
 
     h.check_data_stack(data)
-    return data, flat, dark
+
+    if flat is None and dark is None:
+        return data
+    else:
+        return data, flat, dark
 
 
 def _execute_seq(data, rotation):

--- a/mantidimaging/core/filters/rotate_stack/rotate_stack_gui.py
+++ b/mantidimaging/core/filters/rotate_stack/rotate_stack_gui.py
@@ -1,0 +1,23 @@
+from functools import partial
+
+from mantidimaging.gui.algorithm_dialog import AlgorithmDialog
+
+from . import rotate_stack
+
+GUI_MENU_NAME = 'Rotate Stack'
+
+
+def _gui_register(main_window):
+    dialog = AlgorithmDialog(main_window)
+    dialog.setWindowTitle(GUI_MENU_NAME)
+
+    _, rotation_count = dialog.add_property(
+            'Number of rotations', 'int', 1, (0, 99))
+
+    def custom_execute():
+        num_rotations = rotation_count.value()
+        return partial(rotate_stack.execute, rotation=num_rotations)
+
+    dialog.set_execute(custom_execute)
+
+    return dialog

--- a/mantidimaging/core/filters/stripe_removal/stripe_removal.py
+++ b/mantidimaging/core/filters/stripe_removal/stripe_removal.py
@@ -111,8 +111,16 @@ def execute(data, wf, ti, sf, cores=None, chunksize=None):
     return data
 
 
+def _get_params(params):
+    if isinstance(params, dict):
+        return params
+    else:
+        return dict(map(lambda p: p.split('='), params))
+
+
 def _wf(data, params, cores, chunksize):
     tomopy = importer.do_importing('tomopy')
+
     # creating a dictionary with all possible params for this func
     kwargs = dict(
         level=None,
@@ -123,7 +131,7 @@ def _wf(data, params, cores, chunksize):
         nchunk=chunksize)
 
     # process the input parameters
-    params = dict(map(lambda p: p.split('='), params))
+    params = _get_params(params)
 
     # dict.get returns a None if the keyword arg is not found
     # this means if the user hasn't passed anything that matches the string
@@ -148,8 +156,9 @@ def _ti(data, params, cores, chunksize):
 
     # creating a dictionary with all possible params for this func
     kwargs = dict(nblock=0, alpha=1.5, ncore=cores, nchunk=chunksize)
+
     # process the input parameters
-    params = dict(map(lambda p: p.split('='), params))
+    params = _get_params(params)
 
     # dict.get returns a None if the keyword arg is not found
     # this means if the user hasn't passed anything that matches the string
@@ -167,8 +176,9 @@ def _sf(data, params, cores, chunksize):
 
     # creating a dictionary with all possible params for this func
     kwargs = dict(size=5, ncore=cores, nchunk=chunksize)
+
     # process the input parameters
-    params = dict(map(lambda p: p.split('='), params))
+    params = _get_params(params)
 
     # dict.get returns a None if the keyword arg is not found
     # this means if the user hasn't passed anything that matches the string

--- a/mantidimaging/core/filters/stripe_removal/stripe_removal.py
+++ b/mantidimaging/core/filters/stripe_removal/stripe_removal.py
@@ -49,11 +49,18 @@ def methods():
     ]
 
 
+def wavelet_names():
+    return [
+        'haar', 'db5', 'sym5'
+    ]
+
+
 def execute(data, wf, ti, sf, cores=None, chunksize=None):
     """
     Execute stripe removal filters.
 
-    Multiple filters can be executed, if they are specified on the command line.
+    Multiple filters can be executed, if they are specified on the command
+    line.
 
     The order for that execution will always be: wavelett-fourier, titarenko,
     smoothing-filter.

--- a/mantidimaging/core/filters/stripe_removal/stripe_removal_gui.py
+++ b/mantidimaging/core/filters/stripe_removal/stripe_removal_gui.py
@@ -1,0 +1,74 @@
+from functools import partial
+
+from mantidimaging.gui.algorithm_dialog import AlgorithmDialog
+
+from . import stripe_removal
+
+GUI_MENU_NAME = 'Stripe Removal'
+
+
+def _gui_register(main_window):
+    dialog = AlgorithmDialog(main_window)
+    dialog.setWindowTitle(GUI_MENU_NAME)
+
+    # Filter type option
+    _, value_filter_type = dialog.add_property('Filter Type', 'list')
+
+    # Wavelet options
+    _, value_wf_level = dialog.add_property(
+            'Level', 'int', valid_values=(0, 100))
+    _, value_wf_wname = dialog.add_property(
+            'Wavelet Filter', 'list',
+            valid_values=stripe_removal.wavelet_names())
+    _, value_wf_sigma = dialog.add_property(
+            'Sigma', 'float', 2.0, (0.0, 100.0))
+
+    # Titarenko options
+    _, value_ti_nblock = dialog.add_property(
+            'Number of Blocks', 'int', 0, (0, 100))
+    _, value_ti_alpha = dialog.add_property('Alpha', 'float', 1.5)
+
+    # Smoothing filter options
+    _, value_sf_size = dialog.add_property('Size', 'int', 5, (0, 100))
+
+    filters = [
+            ('wavelet-fourier',
+                [value_wf_level, value_wf_wname, value_wf_sigma]),
+            ('titarenko',
+                [value_ti_nblock, value_ti_alpha]),
+            ('smoothing-filter',
+                [value_sf_size])
+            ]
+
+    def on_filter_type_change(name):
+        for f in filters:
+            enabled = name == f[0]
+            for ui_item in f[1]:
+                ui_item.setEnabled(enabled)
+
+    value_filter_type.addItems([f[0] for f in filters])
+    value_filter_type.currentIndexChanged[str].connect(on_filter_type_change)
+    on_filter_type_change(value_filter_type.currentText())
+
+    def custom_execute():
+        filter_type = value_filter_type.currentText()
+        wf = None
+        ti = None
+        sf = None
+
+        if filter_type == 'wavelett-fourier':
+            wf = {'level': value_wf_level.value(),
+                  'wname': value_wf_wname.currentText(),
+                  'sigma': value_wf_sigma.value(),
+                  'pad': False}
+        elif filter_type == 'titarenko':
+            ti = {'nblock': value_ti_nblock.value(),
+                  'alpha': value_ti_alpha.value()}
+        elif filter_type == 'smoothing-filter':
+            sf = {'size': value_sf_size.value()}
+
+        return partial(stripe_removal.execute, wf=wf, ti=ti, sf=sf)
+
+    dialog.set_execute(custom_execute)
+
+    return dialog

--- a/mantidimaging/core/utility/registrator/gui_registrator.py
+++ b/mantidimaging/core/utility/registrator/gui_registrator.py
@@ -42,6 +42,11 @@ def do_registering(module, module_dir, main_window):
     # We pass in the main_window reference to use it as the dialog's parent
     dialog = module._gui_register(main_window)
 
+    # Make the UI fit the added components and prevent it from being resized
+    # any smaller than this size
+    dialog.adjustSize()
+    dialog.setMinimumSize(dialog.size())
+
     # Refresh the stack list in the algorithm dialog whenever the active stacks
     # change
     main_window.active_stacks_changed.connect(dialog.refresh_stack_list)

--- a/mantidimaging/gui/algorithm_dialog.py
+++ b/mantidimaging/gui/algorithm_dialog.py
@@ -197,7 +197,8 @@ class AlgorithmDialog(Qt.QDialog):
         elif dtype == 'list':
             right_widget = Qt.QComboBox()
             assign_tooltip([right_widget])
-            right_widget.addItems(valid_values)
+            if valid_values:
+                right_widget.addItems(valid_values)
         else:
             raise ValueError("Unknown data type")
 

--- a/mantidimaging/gui/stack_visualiser/sv_view.py
+++ b/mantidimaging/gui/stack_visualiser/sv_view.py
@@ -204,6 +204,11 @@ class StackVisualiserView(Qt.QMainWindow):
                 horizontalalignment='center', verticalalignment='top',
                 **common_kwargs)
 
+        region_pretty = \
+            "Top left  (x, y): %i, %i   Bottom right (x, y): %i, %i" % \
+            self.current_roi
+        getLogger(__name__).info(region_pretty)
+
     def update_title_event(self):
         text, okPressed = Qt.QInputDialog.getText(
             self, "Rename window", "Enter new name", Qt.QLineEdit.Normal, "")

--- a/mantidimaging/gui/ui/alg_dialog.ui
+++ b/mantidimaging/gui/ui/alg_dialog.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>200</height>
+    <height>80</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>300</width>
-    <height>150</height>
+    <height>80</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/mantidimaging/tests/filters_test/rotate_stack_test.py
+++ b/mantidimaging/tests/filters_test/rotate_stack_test.py
@@ -25,7 +25,7 @@ class RotateStackTest(unittest.TestCase):
         images, control = th.gen_img_shared_array_and_copy((10, 10, 10))
 
         # empty params
-        result = rotate_stack.execute(images, None)[0]
+        result = rotate_stack.execute(images, None)
 
         npt.assert_equal(result, control)
         npt.assert_equal(images, control)
@@ -45,7 +45,7 @@ class RotateStackTest(unittest.TestCase):
         rotation = 1  # once clockwise
         images[:, 0, 0] = 42  # set all images at 0,0 to 42
 
-        result = rotate_stack.execute(images, rotation)[0]
+        result = rotate_stack.execute(images, rotation)
 
         w = result.shape[2]
         npt.assert_equal(result[:, 0, w - 1], 42.0)
@@ -73,7 +73,8 @@ class RotateStackTest(unittest.TestCase):
 
         cached_memory = h.get_memory_usage_linux(kb=True)[0]
 
-        result = rotate_stack.execute(images, rotation)[0]
+        result = rotate_stack.execute(images, rotation)
+
         w = result.shape[2]
 
         self.assertLess(

--- a/mantidimaging/tests/filters_test/stripe_removal_test.py
+++ b/mantidimaging/tests/filters_test/stripe_removal_test.py
@@ -46,6 +46,15 @@ class StripeRemovalTest(unittest.TestCase):
 
         npt.assert_equal(result, images)
 
+    def test_executed_wf_dict(self):
+        images, control = th.gen_img_shared_array_and_copy()
+
+        wf = {"level": 1}
+        ti = None
+        sf = None
+        result = stripe_removal.execute(images, wf, ti, sf)
+        th.assert_not_equals(result, control)
+
     def test_executed_ti(self):
         images, control = th.gen_img_shared_array_and_copy()
 
@@ -60,6 +69,15 @@ class StripeRemovalTest(unittest.TestCase):
 
         npt.assert_equal(result, images)
 
+    def test_executed_ti_dict(self):
+        images, control = th.gen_img_shared_array_and_copy()
+
+        wf = None
+        ti = {"nblock": 2}
+        sf = None
+        result = stripe_removal.execute(images, wf, ti, sf)
+        th.assert_not_equals(result, control)
+
     def test_executed_sf(self):
         images, control = th.gen_img_shared_array_and_copy()
 
@@ -73,6 +91,15 @@ class StripeRemovalTest(unittest.TestCase):
         th.assert_not_equals(images, control)
 
         npt.assert_equal(result, images)
+
+    def test_executed_sf_dict(self):
+        images, control = th.gen_img_shared_array_and_copy()
+
+        wf = None
+        ti = None
+        sf = {"size": 5}
+        result = stripe_removal.execute(images, wf, ti, sf)
+        th.assert_not_equals(result, control)
 
     def test_memory_executed_wf(self):
         images, control = th.gen_img_shared_array_and_copy()


### PR DESCRIPTION
Re #107 

Requires ~~#111~~ to be merged first.

- Adds a simple way of adding fields to a filter dialog
- Add GUIs for the following filters:
    - Cut off
    - Minus log
    - Rotate stack
    - Stripe removal
- Ensures that filter dialogs are created the correct size for the widgets they contain

To test:
  - Load a sample image (see `demoimages`)
  - Run some filters on it (all except stripe removal are pretty trivial)