### PR TITLE
Ensure unique stack name when loading in GUI

### DIFF
--- a/mantidimaging/gui/main_window/mw_model.py
+++ b/mantidimaging/gui/main_window/mw_model.py
@@ -38,11 +38,16 @@ class MainWindowModel(object):
             out_format=image_format,
             indices=indices)
 
-    def create_title(self, file):
-        # TODO can add more processing of the file, e.g. remove the numbers from the file and convert to
-        # 'image_name_xxx' or simply strip all numbers, but we can't be sure the last underscore in the string
-        # will be right before the number
-        return file
+    def create_title(self, filename):
+        name = filename
+
+        current_names = self.stack_names()
+        num = 1
+        while name in current_names:
+            num += 1
+            name = filename + '_{}'.format(num)
+
+        return name
 
     def stack_list(self):
         stacks = []

--- a/mantidimaging/gui/main_window/mw_model.py
+++ b/mantidimaging/gui/main_window/mw_model.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
+import os
 import uuid
 
 from logging import getLogger
@@ -39,8 +40,11 @@ class MainWindowModel(object):
             indices=indices)
 
     def create_title(self, filename):
-        name = filename
+        # Avoid file extensions in names
+        filename = os.path.splitext(filename)[0]
 
+        # Avoid duplicate names
+        name = filename
         current_names = self.stack_names()
         num = 1
         while name in current_names:

--- a/mantidimaging/gui/main_window/mw_model.py
+++ b/mantidimaging/gui/main_window/mw_model.py
@@ -4,7 +4,6 @@ import os
 import uuid
 
 from logging import getLogger
-from PyQt5.QtWidgets import QDockWidget
 
 from mantidimaging.core.io import loader, saver
 
@@ -39,7 +38,10 @@ class MainWindowModel(object):
             out_format=image_format,
             indices=indices)
 
-    def create_title(self, filename):
+    def create_name(self, filename):
+        """
+        Creates a suitable name for a newly loaded stack.
+        """
         # Avoid file extensions in names
         filename = os.path.splitext(filename)[0]
 
@@ -65,20 +67,23 @@ class MainWindowModel(object):
         return sorted(stacks, key=lambda x: x[1])
 
     def stack_names(self):
-        # unpacks the tuple and only gives the correctly sorted human readable names
+        # unpacks the tuple and only gives the correctly sorted human readable
+        # names
         return list(zip(*self.stack_list()))[1] if self.active_stacks else []
 
     def add_stack(self, stack_visualiser, dock_widget):
         # generate unique ID for this stack
         stack_visualiser.uuid = uuid.uuid1()
         self.active_stacks[stack_visualiser.uuid] = dock_widget
-        getLogger(__name__).debug("Active stacks {}".format(self.active_stacks))
+        getLogger(__name__).debug(
+                "Active stacks {}".format(self.active_stacks))
 
     def get_stack(self, stack_uuid):
         """
         :param stack_uuid: The unique ID of the stack that will be retrieved.
-        :return The QDockWidget that contains the Stack Visualiser. For direct access to the
-                Stack Visualiser widget use get_stack_visualiser
+        :return The QDockWidget that contains the Stack Visualiser.
+                For direct access to the Stack Visualiser widget use
+                get_stack_visualiser
         """
         return self.active_stacks[stack_uuid]
 

--- a/mantidimaging/gui/main_window/mw_presenter.py
+++ b/mantidimaging/gui/main_window/mw_presenter.py
@@ -46,7 +46,7 @@ class MainWindowPresenter(object):
         image_format = self.view.load_dialogue.image_format
         parallel_load = self.view.load_dialogue.parallel_load()
         indices = self.view.load_dialogue.indices()
-        window_title = self.view.load_dialogue.window_title()
+        custom_name = self.view.load_dialogue.window_title()
 
         if not sample_path:
             log.debug("No sample path provided, cannot load anything")
@@ -60,8 +60,8 @@ class MainWindowPresenter(object):
             data = None
 
         if data is not None:
-            title = self.model.create_title(selected_file) if not window_title else window_title
-            dock_widget = self.view.create_stack_window(data, title=title)
+            name = self.model.create_name(selected_file) if not custom_name else custom_name
+            dock_widget = self.view.create_stack_window(data, title=name)
             stack_visualiser = dock_widget.widget()
             self.model.add_stack(stack_visualiser, dock_widget)
             self.view.update_shortcuts()

--- a/mantidimaging/tests/gui_test/mw_model_test.py
+++ b/mantidimaging/tests/gui_test/mw_model_test.py
@@ -1,0 +1,58 @@
+import unittest
+
+from mantidimaging.core.algorithms.special_imports import import_mock
+
+from mantidimaging.gui.main_window.mw_model import MainWindowModel
+
+mock = import_mock()
+
+
+class MainWindowModelTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(MainWindowModelTest, self).__init__(*args, **kwargs)
+
+    def setUp(self):
+        self.model = MainWindowModel(None)
+
+    def test_initial_stack_list(self):
+        self.assertEquals(self.model.stack_names(),
+                          [])
+
+    def test_create_title_no_stacks_loaded(self):
+        # Mock the stack list function (this depends on Qt)
+        self.model.stack_list = mock.MagicMock(return_value=[])
+
+        self.assertEquals(self.model.create_title("test"),
+                          "test")
+
+    def test_create_title_one_duplicate_stack_loaded(self):
+        # Mock the stack list function (this depends on Qt)
+        self.model.stack_list = mock.MagicMock(return_value=[
+            ('aaa', 'test')
+        ])
+
+        # Fake items in the active stacks list (required to trigger a check
+        # when returning stack lists)
+        self.model.active_stacks = [0]
+
+        self.assertEquals(self.model.create_title("test"),
+                          "test_2")
+
+    def test_create_title_multiple_duplicate_stacks_loaded(self):
+        # Mock the stack list function (this depends on Qt)
+        self.model.stack_list = mock.MagicMock(return_value=[
+            ('aaa', 'test'),
+            ('aaa', 'test_2'),
+            ('aaa', 'test_3')
+        ])
+
+        # Fake items in the active stacks list (required to trigger a check
+        # when returning stack lists)
+        self.model.active_stacks = [0]
+
+        self.assertEquals(self.model.create_title("test"),
+                          "test_4")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mantidimaging/tests/gui_test/mw_model_test.py
+++ b/mantidimaging/tests/gui_test/mw_model_test.py
@@ -18,14 +18,14 @@ class MainWindowModelTest(unittest.TestCase):
         self.assertEquals(self.model.stack_names(),
                           [])
 
-    def test_create_title_no_stacks_loaded(self):
+    def test_create_name_no_stacks_loaded(self):
         # Mock the stack list function (this depends on Qt)
         self.model.stack_list = mock.MagicMock(return_value=[])
 
-        self.assertEquals(self.model.create_title("test"),
+        self.assertEquals(self.model.create_name("test"),
                           "test")
 
-    def test_create_title_one_duplicate_stack_loaded(self):
+    def test_create_name_one_duplicate_stack_loaded(self):
         # Mock the stack list function (this depends on Qt)
         self.model.stack_list = mock.MagicMock(return_value=[
             ('aaa', 'test')
@@ -35,10 +35,10 @@ class MainWindowModelTest(unittest.TestCase):
         # when returning stack lists)
         self.model.active_stacks = [0]
 
-        self.assertEquals(self.model.create_title("test"),
+        self.assertEquals(self.model.create_name("test"),
                           "test_2")
 
-    def test_create_title_multiple_duplicate_stacks_loaded(self):
+    def test_create_name_multiple_duplicate_stacks_loaded(self):
         # Mock the stack list function (this depends on Qt)
         self.model.stack_list = mock.MagicMock(return_value=[
             ('aaa', 'test'),
@@ -50,14 +50,14 @@ class MainWindowModelTest(unittest.TestCase):
         # when returning stack lists)
         self.model.active_stacks = [0]
 
-        self.assertEquals(self.model.create_title("test"),
+        self.assertEquals(self.model.create_name("test"),
                           "test_4")
 
-    def test_create_title_strips_extension(self):
+    def test_create_name_strips_extension(self):
         # Mock the stack list function (this depends on Qt)
         self.model.stack_list = mock.MagicMock(return_value=[])
 
-        self.assertEquals(self.model.create_title("test.tif"),
+        self.assertEquals(self.model.create_name("test.tif"),
                           "test")
 
 

--- a/mantidimaging/tests/gui_test/mw_model_test.py
+++ b/mantidimaging/tests/gui_test/mw_model_test.py
@@ -53,6 +53,13 @@ class MainWindowModelTest(unittest.TestCase):
         self.assertEquals(self.model.create_title("test"),
                           "test_4")
 
+    def test_create_title_strips_extension(self):
+        # Mock the stack list function (this depends on Qt)
+        self.model.stack_list = mock.MagicMock(return_value=[])
+
+        self.assertEquals(self.model.create_title("test.tif"),
+                          "test")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/tests/gui_test/mw_presenter_test.py
+++ b/mantidimaging/tests/gui_test/mw_presenter_test.py
@@ -52,9 +52,6 @@ class MainWindowPresenterTest(FileOutputtingTestCase):
         self.view.show_error_dialog.assert_called_once_with(
                 "Failed to read data file. See log for details.")
 
-    def test_initial_stack_list(self):
-        self.assertEquals(self.presenter.model.stack_names(), [])
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #122 

To test:
- Load the same image multiple times
- See that a sensible replacement name is used for the window title (the title of the dockable window not the plot)