### PR TITLE
Add proper log level selection and tidy logging code

### DIFF
--- a/mantidimaging/core/configs/functional_config.py
+++ b/mantidimaging/core/configs/functional_config.py
@@ -55,7 +55,7 @@ class FunctionalConfig(object):
         # cor_interpolate
         self.cor_slices = [0]
 
-        self.verbosity = logging.INFO
+        self.log_level = logging.INFO
 
         self.overwrite_all = False
 
@@ -120,7 +120,7 @@ class FunctionalConfig(object):
              "Data type: {c.data_dtype}\n"
              "Provided center of rotation: {c.cors}\n"
              "Slice IDs for CORs: {c.cor_slices}\n"
-             "Log level: {c.verbosity}\n"
+             "Log level: {c.log_level}\n"
              "Overwrite files in output directory: {c.overwrite_all}\n"
              "Debug: {c.debug}\n"
              "Debug port: {c.debug_port}\n"
@@ -303,16 +303,11 @@ class FunctionalConfig(object):
             "Supported: float32, float64")
 
         grp_func.add_argument(
-            "-v",
-            "--verbosity",
-            type=int,
-            default=self.verbosity,
-            help="Default: %(default)s\n"
-            "30 - Low verbosity, will only output warnings\n"
-            "20 (recommended) - Normal verbosity, will output step name "
-            "and execution time\n"
-            "10 - High verbosity, will output step name, execution time "
-            "and memory usage before and after each step\n")
+            "--log-level",
+            type=str,
+            default='INFO',
+            help="Log verbosity level.\n"
+                 "Available options are: TRACE, DEBUG, INFO, WARN, CRITICAL")
 
         grp_func.add_argument(
             "-w",

--- a/mantidimaging/core/configs/functional_config.py
+++ b/mantidimaging/core/configs/functional_config.py
@@ -6,6 +6,7 @@ import os
 import numpy as np
 
 from mantidimaging.core.io.utility import DEFAULT_IO_FILE_FORMAT
+from mantidimaging.helper import set_logging_from_func_config
 
 
 class FunctionalConfig(object):
@@ -558,3 +559,5 @@ class FunctionalConfig(object):
         # update all the arguments
         for arg in all_args:
             setattr(self, arg, getattr(args, arg))
+
+        set_logging_from_func_config(self)

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 from logging import getLogger
 
 import os
-import warnings
 
 import numpy as np
 
@@ -26,10 +25,7 @@ def write_fits(data, filename, overwrite=False):
 def write_img(data, filename, overwrite=False):
     from mantidimaging.core.utility.special_imports import import_skimage_io
     skio = import_skimage_io()
-    with warnings.catch_warnings(record=True) as warn_messages:
-        skio.imsave(filename, data)
-        for w in warn_messages:
-            getLogger(__name__).warn('skimage warning: %s', str(w))
+    skio.imsave(filename, data)
 
 
 def write_nxs(data, filename, projection_angles=None, overwrite=False):

--- a/mantidimaging/core/utility/registrator/registrator.py
+++ b/mantidimaging/core/utility/registrator/registrator.py
@@ -101,7 +101,6 @@ def do_importing(module_dir,
 
     # try registering, and if it fails, show warning to the user
     try:
-
         # If the module has this attribute, it is the function defined in the .py file
         if hasattr(module, name_of_register_function):
 

--- a/mantidimaging/helper.py
+++ b/mantidimaging/helper.py
@@ -4,7 +4,9 @@ import logging
 import os
 import sys
 import time
+
 from time import gmtime, strftime
+from logging import getLogger
 
 import numpy as np
 
@@ -26,7 +28,8 @@ _progress_bar = None
 
 def initialise_logging():
     global _log_formatter
-    _log_formatter = logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
+    _log_formatter = logging.Formatter(
+            "%(asctime)s %(name)s %(levelname)s %(message)s")
 
     # Add a very verbose logging level
     logging.addLevelName(5, 'TRACE')
@@ -49,12 +52,12 @@ def initialise_logging():
     # Don't ever print all the debug logging from Qt
     logging.getLogger('PyQt5').setLevel(logging.INFO)
 
-    logging.getLogger(__name__).debug("Logging initialised")
 
-
-def set_logging_from_config(config):
+def set_logging_from_func_config(config):
     root_logger = logging.getLogger()
-    root_logger.setLevel(logging.getLevelName(config.func.log_level))
+    root_logger.setLevel(logging.getLevelName(config.log_level))
+
+    getLogger(__name__).debug('Log level set to {}'.format(config.log_level))
 
 
 def check_config_class(config):
@@ -67,7 +70,7 @@ def check_config_class(config):
 def initialise(config, saver=None):
     root_logger = logging.getLogger()
 
-    set_logging_from_config(config)
+    set_logging_from_func_config(config.func)
 
     # File handler
     global _log_file_handler

--- a/mantidimaging/helper.py
+++ b/mantidimaging/helper.py
@@ -26,8 +26,15 @@ _progress_bar = None
 
 def initialise_logging():
     global _log_formatter
-    _log_formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+    _log_formatter = logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
 
+    # Add a very verbose logging level
+    logging.addLevelName(5, 'TRACE')
+
+    # Capture all warnings
+    logging.captureWarnings(True)
+
+    # Remove default handlers
     root_logger = logging.getLogger()
     root_logger.handlers = []
 
@@ -39,12 +46,15 @@ def initialise_logging():
     # Default log level
     root_logger.setLevel(logging.DEBUG)
 
+    # Don't ever print all the debug logging from Qt
+    logging.getLogger('PyQt5').setLevel(logging.INFO)
+
     logging.getLogger(__name__).debug("Logging initialised")
 
 
 def set_logging_from_config(config):
     root_logger = logging.getLogger()
-    root_logger.setLevel(config.func.verbosity)
+    root_logger.setLevel(logging.getLevelName(config.func.log_level))
 
 
 def check_config_class(config):

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -26,8 +26,6 @@ def main(default_args):
 
     config = recon_config.grab_full_config(default_args)
 
-    h.set_logging_from_config(config)
-
     if config.func.debug and config.func.debug_port:
         import pydevd
         pydevd.settrace(

--- a/mantidimaging/tests/core_test/aggregate_test.py
+++ b/mantidimaging/tests/core_test/aggregate_test.py
@@ -22,7 +22,7 @@ class AggregateTest(FileOutputtingTestCase):
 
         # force silent outputs
         self.config = ReconstructionConfig.empty_init()
-        self.config.func.verbosity = logging.CRITICAL
+        self.config.func.log_level = logging.CRITICAL
 
     def create_saver(self):
         return Saver(self.config)

--- a/mantidimaging/tests/core_test/convert_test.py
+++ b/mantidimaging/tests/core_test/convert_test.py
@@ -25,7 +25,7 @@ class ConvertTest(FileOutputtingTestCase):
         from mantidimaging.core.configs.recon_config import (
                 ReconstructionConfig)
         self.config = ReconstructionConfig.empty_init()
-        self.config.func.verbosity = logging.CRITICAL
+        self.config.func.log_level = logging.CRITICAL
 
     def create_saver(self):
         from mantidimaging.core.io.saver import Saver

--- a/mantidimaging/tests/core_test/importer_test.py
+++ b/mantidimaging/tests/core_test/importer_test.py
@@ -11,7 +11,7 @@ class ImporterTest(unittest.TestCase):
         # force silent outputs
         from mantidimaging.core.configs.recon_config import ReconstructionConfig
         self.config = ReconstructionConfig.empty_init()
-        self.config.func.verbosity = logging.CRITICAL
+        self.config.func.log_level = logging.CRITICAL
 
     # that's the only supported tool right now, Astra is used through TomoPy
     def test_tomopy(self):

--- a/mantidimaging/tests/core_test/io_test.py
+++ b/mantidimaging/tests/core_test/io_test.py
@@ -7,6 +7,7 @@ import unittest
 import numpy as np
 import numpy.testing as npt
 
+from mantidimaging.helper import initialise_logging
 from mantidimaging.core.configs.recon_config import ReconstructionConfig
 from mantidimaging.core.io import loader
 from mantidimaging.core.io import utility
@@ -21,8 +22,9 @@ class IOTest(FileOutputtingTestCase):
         super(IOTest, self).__init__(*args, **kwargs)
 
         # force silent outputs
+        initialise_logging()
         self.config = ReconstructionConfig.empty_init()
-        self.config.func.verbosity = logging.CRITICAL
+        self.config.func.log_level = logging.CRITICAL
 
     def create_saver(self):
         return Saver(self.config)


### PR DESCRIPTION
- Replaces the `--verbosity` option with `--log-level` which accepts any of the standard Python log levels plus `TRACE`
- Adds the logger name to the output
- Removes special handing of `warnings`

To test:
- Run `mantidimaging-gui --log-level DEBUG` and compare it to `mantidimaging-gui --log-level INFO`