### PR TITLE
Filter GUIs - part 2

### DIFF
--- a/mantidimaging/core/filters/crop_coords/crop_coords_gui.py
+++ b/mantidimaging/core/filters/crop_coords/crop_coords_gui.py
@@ -1,9 +1,31 @@
-from mantidimaging.core.utility import gui_compile_ui as gcu
+from __future__ import absolute_import, division, print_function
+
+from functools import partial
+
 from mantidimaging.gui.algorithm_dialog import AlgorithmDialog
+
+from . import crop_coords
 
 GUI_MENU_NAME = 'Crop Coords'
 
-# def _gui_register(main_window):
-#     dialog = AlgorithmDialog(main_window)
-#     dialog.setWindowTitle(GUI_MENU_NAME)
-#     return dialog
+
+def _gui_register(main_window):
+    dialog = AlgorithmDialog(main_window)
+    dialog.setWindowTitle(GUI_MENU_NAME)
+
+    valid_range = (0, 99999)
+
+    _, left = dialog.add_property('Left', 'int', valid_values=valid_range)
+    _, top = dialog.add_property('Top', 'int', valid_values=valid_range)
+    _, right = dialog.add_property('Right', 'int', valid_values=valid_range)
+    _, bottom = dialog.add_property('Bottom', 'int', valid_values=valid_range)
+
+    def custom_execute():
+        # Get ROI from input fields
+        roi = [left.value(), top.value(), right.value(), bottom.value()]
+
+        return partial(crop_coords._execute, region_of_interest=roi)
+
+    dialog.set_execute(custom_execute)
+
+    return dialog

--- a/mantidimaging/core/filters/rebin/rebin.py
+++ b/mantidimaging/core/filters/rebin/rebin.py
@@ -42,7 +42,7 @@ def execute(data, rebin_param, mode, cores=None, chunksize=None,
     :param rebin_param: int, float or tuple
                         int - Percentage of current size.
                         float - Fraction of current size.
-                        tuple - Size of the output image.
+                        tuple - Size of the output image (x, y).
 
     :param mode: Interpolation to use for re-sizing
                  ('nearest', 'lanczos', 'bilinear', 'bicubic' or 'cubic').
@@ -55,7 +55,15 @@ def execute(data, rebin_param, mode, cores=None, chunksize=None,
     """
     h.check_data_stack(data)
 
-    if rebin_param and 0 < rebin_param:
+    param_valid = False
+    if rebin_param is None:
+        pass
+    elif isinstance(rebin_param, tuple):
+        param_valid = rebin_param[0] > 0 and rebin_param[1] > 0
+    else:
+        param_valid = rebin_param > 0
+
+    if param_valid:
         if pu.multiprocessing_available():
             data = _execute_par(data, rebin_param, mode, cores, chunksize,
                                 progress)
@@ -109,8 +117,12 @@ def _create_reshaped_array(old_shape, rebin_param):
 
     # use SciPy's calculation to find the expected dimensions
     # int to avoid visible deprecation warning
-    expected_dimy = int(rebin_param * old_shape[1])
-    expected_dimx = int(rebin_param * old_shape[2])
+    if isinstance(rebin_param, tuple):
+        expected_dimy = int(rebin_param[0])
+        expected_dimx = int(rebin_param[1])
+    else:
+        expected_dimy = int(rebin_param * old_shape[1])
+        expected_dimx = int(rebin_param * old_shape[2])
 
     # allocate memory for images with new dimensions
     return pu.create_shared_array((num_images, expected_dimy, expected_dimx))

--- a/mantidimaging/core/filters/rebin/rebin.py
+++ b/mantidimaging/core/filters/rebin/rebin.py
@@ -84,7 +84,7 @@ def _execute_par(data, rebin_param, mode, cores=None, chunksize=None,
         progress.update(msg="Starting PARALLEL image rebinning.")
 
         f = pem.create_partial(
-                scipy.misc.imresize, size=rebin_param, interp=mode)
+                scipy.misc.imresize, size=rebin_param, interp=mode, mode='F')
 
         resized_data = pem.execute(
             data, f, cores, chunksize, "Rebinning", output_data=resized_data)
@@ -106,7 +106,7 @@ def _execute_seq(data, rebin_param, mode, progress=None):
 
         for idx in range(num_images):
             resized_data[idx] = scipy.misc.imresize(
-                data[idx], rebin_param, interp=mode)
+                data[idx], rebin_param, interp=mode, mode='F')
             progress.update()
 
     return resized_data

--- a/mantidimaging/core/filters/rebin/rebin_gui.py
+++ b/mantidimaging/core/filters/rebin/rebin_gui.py
@@ -1,0 +1,74 @@
+from functools import partial
+
+from PyQt5 import Qt
+
+from mantidimaging.gui.algorithm_dialog import AlgorithmDialog
+
+from . import rebin
+
+GUI_MENU_NAME = "Rebin"
+
+
+def _gui_register(main_window):
+    dialog = AlgorithmDialog(main_window)
+    dialog.setWindowTitle(GUI_MENU_NAME)
+
+    # Rebin by uniform factor options
+    _, factor = dialog.add_property('Factor', 'float', 0.5, (0.0, 1.0), False)
+    factor.setSingleStep(0.05)
+
+    # Rebin to target shape options
+    shape_range = (0, 9999)
+
+    _, shape_x = dialog.add_property(
+            'X', 'int', valid_values=shape_range, add_to_form=False)
+
+    _, shape_y = dialog.add_property(
+            'Y', 'int', valid_values=shape_range, add_to_form=False)
+
+    shape_fields = Qt.QHBoxLayout()
+    shape_fields.addWidget(shape_x)
+    shape_fields.addWidget(shape_y)
+
+    # Rebin dimension selection options
+    rebin_by_factor_radio = Qt.QRadioButton("Rebin by Factor")
+
+    def size_by_factor_toggled(enabled):
+        factor.setEnabled(enabled)
+    rebin_by_factor_radio.toggled.connect(size_by_factor_toggled)
+
+    rebin_to_dimensions_radio = Qt.QRadioButton("Rebin to Dimensions")
+
+    def size_by_dimensions_toggled(enabled):
+        shape_x.setEnabled(enabled)
+        shape_y.setEnabled(enabled)
+    rebin_to_dimensions_radio.toggled.connect(size_by_dimensions_toggled)
+
+    # Rebin mode options
+    label_mode = Qt.QLabel("Mode")
+    mode_field = Qt.QComboBox()
+    mode_field.addItems(rebin.modes())
+
+    dialog.formLayout.addRow(rebin_to_dimensions_radio, shape_fields)
+    dialog.formLayout.addRow(rebin_by_factor_radio, factor)
+    dialog.formLayout.addRow(label_mode, mode_field)
+
+    # Ensure good default UI state
+    rebin_to_dimensions_radio.setChecked(True)
+    rebin_by_factor_radio.setChecked(True)
+
+    def custom_execute():
+        if rebin_to_dimensions_radio.isChecked():
+            params = (shape_x.value(), shape_y.value())
+        elif rebin_by_factor_radio.isChecked():
+            params = factor.value()
+        else:
+            raise ValueError('Unknown bin dimension mode')
+
+        return partial(rebin.execute,
+                       mode=mode_field.currentText(),
+                       rebin_param=params)
+
+    dialog.set_execute(custom_execute)
+
+    return dialog

--- a/mantidimaging/core/utility/registrator/gui_registrator.py
+++ b/mantidimaging/core/utility/registrator/gui_registrator.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
+from logging import getLogger
+
 from PyQt5.Qt import QMenu, QAction
 
 from mantidimaging.gui.algorithm_dialog import AlgorithmDialog
 from mantidimaging.gui.main_window.mw_view import MainWindowView
+
 from .registrator import do_importing
 
 
@@ -36,6 +39,9 @@ def do_registering(module, module_dir, main_window):
                         for it to be a MainWindowView because of the assertion in gui_register
 
     """
+    log = getLogger(__name__)
+    log.debug("Registering GUI: %s", module)
+
     menu = main_window.menuFilters
 
     # This will call the _gui_register function on each of the filters, where _gui_register is found
@@ -59,7 +65,8 @@ def do_registering(module, module_dir, main_window):
     assert dialog.execute is not None, \
         "The execute function must be set manually! The module {0} has not set execute correctly".format(module_dir)
 
-    action = QAction(getattr(module, 'GUI_MENU_NAME', module_dir), menu)
+    menu_name = getattr(module, 'GUI_MENU_NAME', module_dir)
+    action = QAction(menu_name, menu)
 
     # the captured_dialog=dialog in the lambda captures THE ORIGINAL reference to the dialog
     # and when the user clicks the QAction in the QMenu the correct dialog is shown!

--- a/mantidimaging/gui/stack_visualiser/sv_presenter.py
+++ b/mantidimaging/gui/stack_visualiser/sv_presenter.py
@@ -142,7 +142,7 @@ class StackVisualiserPresenter(object):
         if not isinstance(res_before, tuple):
             res_before = (res_before,)
 
-        algorithm_dialog.execute(self.images.get_sample(), *parameter_value)
+        self.images.sample = algorithm_dialog.execute(self.images.get_sample(), *parameter_value)
 
         # execute the do_after function by passing the results from the do_before
         if do_after:

--- a/mantidimaging/gui/stack_visualiser/sv_view.py
+++ b/mantidimaging/gui/stack_visualiser/sv_view.py
@@ -342,13 +342,26 @@ class StackVisualiserView(Qt.QMainWindow):
 
     def show_current_image(self, val=None):
         """
-        :param val: Unused, but required so that the function has the same signature as the expected one
+        :param val: Unused, but required so that the function has the same
+                    signature as the expected one
         """
         self.set_image_title_to_current_filename()
         self.image.set_data(self.current_image())
 
+        # Update colour bar extents
         self.color_bar.set_clim(self.presenter.get_image_pixel_range())
         self.color_bar.draw_all()
+
+        # Update image extents
+        old_extent = self.image.get_extent()
+        self.image.set_extent((
+            0, self.current_image().shape[1],
+            self.current_image().shape[0], 0)
+        )
+
+        # If the size of the image is different then clear the old ROI
+        if old_extent != self.image.get_extent():
+            self.presenter.do_clear_roi()
 
         self.canvas.draw()
 

--- a/mantidimaging/tests/filters_test/rebin_test.py
+++ b/mantidimaging/tests/filters_test/rebin_test.py
@@ -53,23 +53,23 @@ class RebinTest(unittest.TestCase):
         npt.assert_equal(result, control)
         npt.assert_equal(images, control)
 
-    def test_executed_par_2(self):
-        self.do_execute(2.)
+    def test_executed_uniform_par_2(self):
+        self.do_execute_uniform(2.0)
 
-    def test_executed_par_5(self):
-        self.do_execute(5.)
+    def test_executed_uniform_par_5(self):
+        self.do_execute_uniform(5.0)
 
-    def test_executed_seq_2(self):
+    def test_executed_uniform_seq_2(self):
         th.switch_mp_off()
-        self.do_execute(2.)
+        self.do_execute_uniform(2.0)
         th.switch_mp_on()
 
-    def test_executed_seq_5(self):
+    def test_executed_uniform_seq_5(self):
         th.switch_mp_off()
-        self.do_execute(5.)
+        self.do_execute_uniform(5.0)
         th.switch_mp_on()
 
-    def do_execute(self, val=2.):
+    def do_execute_uniform(self, val=2.0):
         images = th.gen_img_shared_array()
         mode = 'nearest'
 
@@ -77,6 +77,46 @@ class RebinTest(unittest.TestCase):
         expected_y = int(images.shape[2] * val)
 
         result = rebin.execute(images, val, mode)
+
+        npt.assert_equal(result.shape[1], expected_x)
+        npt.assert_equal(result.shape[2], expected_y)
+
+        # TODO: in-place data test
+        # npt.assert_equal(images.shape[1], expected_x)
+        # npt.assert_equal(images.shape[2], expected_y)
+
+    def test_executed_xy_par_128_256(self):
+        self.do_execute_xy((128, 256))
+
+    def test_executed_xy_par_512_256(self):
+        self.do_execute_xy((512, 256))
+
+    def test_executed_xy_par_1024_1024(self):
+        self.do_execute_xy((1024, 1024))
+
+    def test_executed_xy_seq_128_256(self):
+        th.switch_mp_off()
+        self.do_execute_xy((128, 256))
+        th.switch_mp_on()
+
+    def test_executed_xy_seq_512_256(self):
+        th.switch_mp_off()
+        self.do_execute_xy((512, 256))
+        th.switch_mp_on()
+
+    def test_executed_xy_seq_1024_1024(self):
+        th.switch_mp_off()
+        self.do_execute_xy((1024, 1024))
+        th.switch_mp_on()
+
+    def do_execute_xy(self, val=(512, 512)):
+        images = th.gen_img_shared_array()
+        mode = 'nearest'
+
+        expected_x = int(val[0])
+        expected_y = int(val[1])
+
+        result = rebin.execute(images, rebin_param=val, mode=mode)
 
         npt.assert_equal(result.shape[1], expected_x)
         npt.assert_equal(result.shape[2], expected_y)

--- a/mantidimaging/tests/gui_test/sv_presenter_test.py
+++ b/mantidimaging/tests/gui_test/sv_presenter_test.py
@@ -97,8 +97,6 @@ class StackVisualiserPresenterTest(unittest.TestCase):
 
         self.presenter.apply_to_data(mock_algorithm_dialog)
 
-        print(dir(do_before_mock))
-
         do_before_mock.assert_any_call()
         do_after_mock.assert_any_call()
 


### PR DESCRIPTION
Fixes #107

- Allows filters that modify data by return value only to work in the GUI
- Fix an issue with data type conversion happening in rebin
- Add GUIs for crop coordinates and rebin filters

To test:
- Load an image
- Apply crop coordinates and rebin filters (rebin should be fairly self explanatory, the ROI selector can be used to get coordinates for crop coordinates)
- See that the stacks are resized in the GUI as expected