### PR TITLE
Add a colour bar to the stack visualiser

### DIFF
--- a/mantidimaging/gui/stack_visualiser/sv_presenter.py
+++ b/mantidimaging/gui/stack_visualiser/sv_presenter.py
@@ -94,6 +94,14 @@ class StackVisualiserPresenter(object):
             axis = self.axis
         return self.images.get_sample().shape[self.axis]
 
+    def get_image_pixel_range(self):
+        """
+        Gets the range of pixel intensities across all images.
+
+        :return: Tuple of (min, max) pixel intensities
+        """
+        return (self.images.get_sample().min(), self.images.get_sample().max())
+
     def do_scroll_stack(self, offset):
         """
         Scrolls through the stack by a given number of images.

--- a/mantidimaging/gui/stack_visualiser/sv_view.py
+++ b/mantidimaging/gui/stack_visualiser/sv_view.py
@@ -9,6 +9,7 @@ from matplotlib.backends.backend_qt5agg import (FigureCanvasQTAgg,
                                                 NavigationToolbar2QT)
 from matplotlib.figure import Figure
 from matplotlib.widgets import RectangleSelector, Slider
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from mantidimaging.core.utility import gui_compile_ui
 from mantidimaging.gui.stack_visualiser import sv_histogram
@@ -63,7 +64,14 @@ class StackVisualiserView(Qt.QMainWindow):
         :param cmap: The color map which is to be used
         """
         self.image_axis = self.figure.add_subplot(111)
-        self.image = self.image_axis.imshow(self.presenter.get_image(0), cmap=cmap)
+        self.image = self.image_axis.imshow(
+                self.presenter.get_image(0), cmap=cmap)
+
+        self.color_bar_axis = make_axes_locatable(self.image_axis).append_axes(
+                "right", size="5%", pad=0.1)
+        self.color_bar = self.figure.colorbar(
+                self.image, cax=self.color_bar_axis)
+
         self.set_image_title_to_current_filename()
 
     def initialise_canvas(self):
@@ -338,6 +346,8 @@ class StackVisualiserView(Qt.QMainWindow):
         """
         self.set_image_title_to_current_filename()
         self.image.set_data(self.current_image())
+        self.color_bar.set_clim(self.current_image().min(), self.current_image().max())
+        self.color_bar.draw_all()
         self.canvas.draw()
 
     def set_image_title_to_current_filename(self):

--- a/mantidimaging/gui/stack_visualiser/sv_view.py
+++ b/mantidimaging/gui/stack_visualiser/sv_view.py
@@ -346,8 +346,10 @@ class StackVisualiserView(Qt.QMainWindow):
         """
         self.set_image_title_to_current_filename()
         self.image.set_data(self.current_image())
-        self.color_bar.set_clim(self.current_image().min(), self.current_image().max())
+
+        self.color_bar.set_clim(self.presenter.get_image_pixel_range())
         self.color_bar.draw_all()
+
         self.canvas.draw()
 
     def set_image_title_to_current_filename(self):
@@ -362,7 +364,7 @@ class StackVisualiserView(Qt.QMainWindow):
 
         :param msg: Error message string
         """
-        QtWidgets.QMessageBox.critical(self, "Error", msg)
+        QtWidgets.QMessageBox.critical(self, "Error", str(msg))
 
 
 def see(data, data_traversal_axis=0, cmap='Greys_r', block=False):


### PR DESCRIPTION
Adds a colour/intensity bar to the stack visualiser.

To test:
- Load a stack of images (`demoimages/sample` will do). See that there is a colour bar.
- Scroll through the stack. See that the colour bar range does not change.
- Resize the window. See that the colour bar resizes correctly relative to the image.
- Apply a filter that changes pixel intensities (e.g. cut off). See that the bar adjusts range correctly.