### PR TITLE
Add help menu

### DIFF
--- a/mantidimaging/gui/main_window/mw_view.py
+++ b/mantidimaging/gui/main_window/mw_view.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import matplotlib
 
 from logging import getLogger
-from PyQt5 import Qt, QtCore, QtWidgets
+from PyQt5 import Qt, QtCore, QtGui, QtWidgets
 
 from mantidimaging.core.utility import gui_compile_ui
 from mantidimaging.gui.stack_visualiser.sv_view import StackVisualiserView
@@ -32,19 +32,21 @@ class MainWindowView(Qt.QMainWindow):
         self.update_shortcuts()
 
     def setup_shortcuts(self):
-        self.actionLoad.setShortcut('F1')
         self.actionLoad.triggered.connect(self.show_load_dialogue)
-
-        self.actionSave.setShortcut('Ctrl+S')
         self.actionSave.triggered.connect(self.show_save_dialogue)
-
-        self.actionExit.setShortcut('Ctrl+Q')
         self.actionExit.triggered.connect(Qt.qApp.quit)
+
+        self.actionOnlineDocumentation.triggered.connect(
+                self.open_online_documentation)
 
         self.active_stacks_changed.connect(self.update_shortcuts)
 
     def update_shortcuts(self):
         self.actionSave.setEnabled(len(self.presenter.stack_names()) > 0)
+
+    def open_online_documentation(self):
+        url = QtCore.QUrl('https://mantidproject.github.io/mantidimaging/')
+        QtGui.QDesktopServices.openUrl(url)
 
     def show_load_dialogue(self):
         self.load_dialogue = MWLoadDialog(self)

--- a/mantidimaging/gui/ui/main_window.ui
+++ b/mantidimaging/gui/ui/main_window.ui
@@ -32,6 +32,7 @@
     </property>
     <addaction name="actionLoad"/>
     <addaction name="actionSave"/>
+    <addaction name="separator"/>
     <addaction name="actionExit"/>
    </widget>
    <widget class="QMenu" name="menuFilters">
@@ -49,24 +50,40 @@
     <addaction name="separator"/>
     <addaction name="actionTomopy"/>
    </widget>
+   <widget class="QMenu" name="menuHelp">
+    <property name="title">
+     <string>Help</string>
+    </property>
+    <addaction name="actionOnlineDocumentation"/>
+   </widget>
    <addaction name="menuFile"/>
    <addaction name="menuFilters"/>
    <addaction name="menuReconstruct"/>
+   <addaction name="menuHelp"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
   <action name="actionLoad">
    <property name="text">
     <string>Load</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+O</string>
+   </property>
   </action>
   <action name="actionSave">
    <property name="text">
     <string>Save</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+S</string>
+   </property>
   </action>
   <action name="actionExit">
    <property name="text">
     <string>Exit</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Q</string>
    </property>
   </action>
   <action name="actionTomopy">
@@ -82,6 +99,14 @@
   <action name="actionManual_Center_of_Rotation">
    <property name="text">
     <string>Manual Center of Rotation</string>
+   </property>
+  </action>
+  <action name="actionOnlineDocumentation">
+   <property name="text">
+    <string>Online Documentation</string>
+   </property>
+   <property name="shortcut">
+    <string>F1</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
- Adds a help menu with a link to the online documentation
- Moves keyboard shortcuts to `.ui` file

To test:
- See that the menus look OK
- Check keyboard shortcuts work
- Check *Online Documentation* option opens the docs in a new browser tab