### PR TITLE
Stack Visualiser arrow buttons scroll through stack

### DIFF
--- a/mantidimaging/gui/stack_navigation_toolbar.py
+++ b/mantidimaging/gui/stack_navigation_toolbar.py
@@ -2,8 +2,36 @@ from __future__ import absolute_import, division, print_function
 
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
 
+from mantidimaging.gui.stack_visualiser.sv_presenter import Notification \
+        as StackVisualiserNotification
+
 
 class StackNavigationToolbar(NavigationToolbar2QT):
 
-    toolitems = [t for t in NavigationToolbar2QT.toolitems if
-                 t[0] in ('Home', 'Pan', 'Zoom', 'Subplots', 'Save', None)]
+    # See [Matplotlib]/lib/matplotlib/backend_bases.py
+    toolitems = (
+        ('Home', 'Reset original view', 'home', 'home'),
+        ('Pan', 'Pan axes with left mouse, zoom with right', 'move', 'pan'),
+        ('Zoom', 'Zoom to rectangle', 'zoom_to_rect', 'zoom'),
+        (None, None, None, None),
+        ('Subplots', 'Configure subplots', 'subplots', 'configure_subplots'),
+        (None, None, None, None),
+        ('Save', 'Save the figure', 'filesave', 'save_figure'),
+        (None, None, None, None),
+        ('Previous Slice', 'Scroll to the previous image in the stack',
+            'back', 'scroll_stack_back'),
+        ('Next Slice', 'Scroll to the next image in the stack', 'forward',
+            'scroll_stack_forward'),
+      )
+
+    stack_visualiser = None
+
+    def scroll_stack_back(self):
+        if self.stack_visualiser:
+            self.stack_visualiser.presenter.notify(
+                    StackVisualiserNotification.SCROLL_DOWN)
+
+    def scroll_stack_forward(self):
+        if self.stack_visualiser:
+            self.stack_visualiser.presenter.notify(
+                    StackVisualiserNotification.SCROLL_UP)

--- a/mantidimaging/gui/stack_navigation_toolbar.py
+++ b/mantidimaging/gui/stack_navigation_toolbar.py
@@ -1,0 +1,9 @@
+from __future__ import absolute_import, division, print_function
+
+from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
+
+
+class StackNavigationToolbar(NavigationToolbar2QT):
+
+    toolitems = [t for t in NavigationToolbar2QT.toolitems if
+                 t[0] in ('Home', 'Pan', 'Zoom', 'Subplots', 'Save', None)]

--- a/mantidimaging/gui/stack_visualiser/sv_view.py
+++ b/mantidimaging/gui/stack_visualiser/sv_view.py
@@ -44,6 +44,7 @@ class StackVisualiserView(Qt.QMainWindow):
         self._current_roi = None
 
         self.toolbar = StackNavigationToolbar(self.canvas, self, coordinates=True)
+        self.toolbar.stack_visualiser = self
 
         self.initialise_slider()
         self.initialise_image(cmap)

--- a/mantidimaging/gui/stack_visualiser/sv_view.py
+++ b/mantidimaging/gui/stack_visualiser/sv_view.py
@@ -5,13 +5,13 @@ import sys
 from logging import getLogger
 
 from PyQt5 import Qt, QtCore, QtWidgets
-from matplotlib.backends.backend_qt5agg import (FigureCanvasQTAgg,
-                                                NavigationToolbar2QT)
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
 from matplotlib.widgets import RectangleSelector, Slider
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from mantidimaging.core.utility import gui_compile_ui
+from mantidimaging.gui. stack_navigation_toolbar import StackNavigationToolbar
 from mantidimaging.gui.stack_visualiser import sv_histogram
 from mantidimaging.gui.stack_visualiser.sv_presenter import Notification as StackWindowNotification
 from mantidimaging.gui.stack_visualiser.sv_presenter import StackVisualiserPresenter
@@ -43,7 +43,7 @@ class StackVisualiserView(Qt.QMainWindow):
         self.initialise_canvas()
         self._current_roi = None
 
-        self.toolbar = NavigationToolbar2QT(self.canvas, self, coordinates=True)
+        self.toolbar = StackNavigationToolbar(self.canvas, self, coordinates=True)
 
         self.initialise_slider()
         self.initialise_image(cmap)

--- a/mantidimaging/gui/stack_visualiser/sv_view.py
+++ b/mantidimaging/gui/stack_visualiser/sv_view.py
@@ -11,7 +11,7 @@ from matplotlib.widgets import RectangleSelector, Slider
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from mantidimaging.core.utility import gui_compile_ui
-from mantidimaging.gui. stack_navigation_toolbar import StackNavigationToolbar
+from mantidimaging.gui.stack_navigation_toolbar import StackNavigationToolbar
 from mantidimaging.gui.stack_visualiser import sv_histogram
 from mantidimaging.gui.stack_visualiser.sv_presenter import Notification as StackWindowNotification
 from mantidimaging.gui.stack_visualiser.sv_presenter import StackVisualiserPresenter


### PR DESCRIPTION
Rearranges the default Matplotlib toolbar and makes the arrow buttons scroll through the image stack.

Closes #152 

To test:
- Load a stack of multiple images (ideally more than three)
- Use the arrow buttons on the top toolbar, see that they scroll through the image stack
- See that the tooltips are appropriate