### PR TITLE
Add a context aware execution timer

### DIFF
--- a/mantidimaging/core/utility/__init__.py
+++ b/mantidimaging/core/utility/__init__.py
@@ -13,4 +13,6 @@ from . import (  # noqa: F401
         size_calculator,
         value_scaling)
 
+from .execution_timer import ExecutionTimer  # noqa: F401
+
 del absolute_import, division, print_function

--- a/mantidimaging/core/utility/execution_timer.py
+++ b/mantidimaging/core/utility/execution_timer.py
@@ -1,0 +1,36 @@
+from __future__ import (absolute_import, division, print_function)
+
+import time
+
+
+class ExecutionTimer(object):
+    """
+    Context handler used to time the execution of code in it's context.
+    """
+
+    def __init__(self, msg='Elapsed time'):
+        self.msg = msg
+
+        self.time_start = None
+        self.time_end = None
+
+    def __str__(self):
+        prefix = '{}: '.format(self.msg) if self.msg else ''
+        sec = self.total_seconds
+        return '{}{} seconds'.format(prefix, sec if sec else 'unknown')
+
+    def __enter__(self):
+        self.time_start = time.time()
+        self.time_end = None
+
+    def __exit__(self, *args):
+        self.time_end = time.time()
+
+    @property
+    def total_seconds(self):
+        """
+        Gets the total number of seconds the timer was running for, returns
+        None if the timer has not been run or is still running.
+        """
+        return self.time_end - self.time_start if \
+                self.time_start and self.time_end else None

--- a/mantidimaging/helper.py
+++ b/mantidimaging/helper.py
@@ -19,8 +19,6 @@ _log_formatter = None
 
 _time_start = None
 
-_whole_exec_timer = None
-
 
 def initialise_logging():
     global _log_formatter
@@ -171,21 +169,3 @@ def run_import_checks(config):
         log.info("Multiprocessing not available.")
     else:
         log.info("Running process on {0} cores.".format(config.func.cores))
-
-
-def total_execution_timer(message="Total execution time was "):
-    """
-    This will ONLY be used to time the WHOLE execution time.
-    The first call to this will be in tomo_reconstruct.py and it will start it.
-    The last call will be at the end of find_center or do_recon.
-    """
-    global _whole_exec_timer
-
-    if not _whole_exec_timer:
-        # change type from bool to timer
-        _whole_exec_timer = time.time()
-    else:
-        # change from timer to string
-        _whole_exec_timer = str(time.time() - _whole_exec_timer)
-        message += _whole_exec_timer + " sec"
-        logging.getLogger(__name__).info(message)

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -6,6 +6,7 @@ import warnings
 
 from mantidimaging import helper as h
 from mantidimaging.core.configs import recon_config
+from mantidimaging.core.utility import ExecutionTimer
 
 formatwarning_orig = warnings.formatwarning
 warnings.formatwarning = lambda message, category, filename, lineno, line=None: \
@@ -57,13 +58,14 @@ def main(default_args):
         from mantidimaging.core.configurations import default_run
         thingy_to_execute = default_run.execute
 
-    h.total_execution_timer()
-    if not config.func.split:
-        res = thingy_to_execute(config)
-    else:
-        from mantidimaging.core.utility import execution_splitter
-        res = execution_splitter.execute(config, thingy_to_execute)
-    h.total_execution_timer()
+    exec_timer = ExecutionTimer(msg='Total execution time')
+    with exec_timer:
+        if not config.func.split:
+            res = thingy_to_execute(config)
+        else:
+            from mantidimaging.core.utility import execution_splitter
+            res = execution_splitter.execute(config, thingy_to_execute)
+    print(exec_timer)
 
     return res
 

--- a/mantidimaging/tests/utility_test/execution_timer_test.py
+++ b/mantidimaging/tests/utility_test/execution_timer_test.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import, division, print_function
+
+import unittest
+import time
+
+from mantidimaging.core.utility import ExecutionTimer
+
+
+class ExecutionTimerTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(ExecutionTimerTest, self).__init__(*args, **kwargs)
+
+    def test_execute(self):
+        t = ExecutionTimer()
+        self.assertEquals(t.total_seconds, None)
+        self.assertEquals(str(t), 'Elapsed time: unknown seconds')
+
+        with t:
+            self.assertEquals(t.total_seconds, None)
+            self.assertEquals(str(t), 'Elapsed time: unknown seconds')
+
+            time.sleep(0.01)
+
+        self.assertAlmostEqual(t.total_seconds, 0.01, delta=0.001)
+
+    def test_custom_message(self):
+        t = ExecutionTimer(msg='Task')
+        self.assertEquals(str(t), 'Task: unknown seconds')
+
+    def test_custom_message_empty(self):
+        t = ExecutionTimer(msg='')
+        self.assertEquals(str(t), 'unknown seconds')
+
+    def test_custom_message_none(self):
+        t = ExecutionTimer(msg=None)
+        self.assertEquals(str(t), 'unknown seconds')


### PR DESCRIPTION
- Adds a context based execution timer
- Replaces the total execution timer in `helper.py`

To test:
- Run an operation, any operation. E.g. `mantidimaging -i ~/demoimages/sample/ --imopr cor --indices 0 2 1`