### PR TITLE
Allow nested context for progress reporting

### DIFF
--- a/mantidimaging/core/utility/progress_reporting/progress.py
+++ b/mantidimaging/core/utility/progress_reporting/progress.py
@@ -60,6 +60,9 @@ class Progress(object):
         # Handers that receive notifications when progress updates occur
         self.progress_handlers = []
 
+        # Levels of nesting when used as a context manager
+        self.context_nesting_level = 0
+
         # Add initial step to history
         self.update(0, 'init')
 
@@ -72,10 +75,15 @@ class Progress(object):
         return 'Progress(\n{})'.format('\n'.join(self.progress_history))
 
     def __enter__(self):
+        self.context_nesting_level += 1
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.mark_complete()
+        self.context_nesting_level -= 1
+
+        # Only when we have left the context at all levels is the task complete
+        if self.context_nesting_level == 0:
+            self.mark_complete()
 
     def is_started(self):
         """

--- a/mantidimaging/core/utility/progress_reporting/test/progress_test.py
+++ b/mantidimaging/core/utility/progress_reporting/test/progress_test.py
@@ -200,6 +200,33 @@ class ProgressTest(unittest.TestCase):
         self.assertEquals(len(p.progress_history), 3)
         self.assertEquals(p.completion(), 1.0)
 
+    def test_context_nested(self):
+        p = Progress()
+
+        self.assertFalse(p.is_started())
+        self.assertFalse(p.is_completed())
+        self.assertEquals(len(p.progress_history), 1)
+        self.assertEquals(p.completion(), 0.0)
+
+        with p:
+            p.update(msg='do a thing')
+            self.assertEquals(len(p.progress_history), 2)
+
+            for i in range(5):
+                with p:
+                    p.update(
+                        msg='do a thing in a loop nested in the other thing')
+
+                self.assertEquals(len(p.progress_history), 3 + i)
+                self.assertFalse(p.is_completed())
+
+            self.assertEquals(len(p.progress_history), 7)
+            self.assertFalse(p.is_completed())
+
+        self.assertTrue(p.is_completed())
+        self.assertEquals(len(p.progress_history), 8)
+        self.assertEquals(p.completion(), 1.0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds a nesting level so that progress instances can be passed to child
operations that use the context management feature of the progress
reporter.

This ensures that task is not marked as complete until the parent task
has left the progress reporting context.