### PR TITLE
Refactor image storage

### DIFF
--- a/mantidimaging/core/aggregate/aggregate.py
+++ b/mantidimaging/core/aggregate/aggregate.py
@@ -122,7 +122,7 @@ def do_aggregating(angle_image_paths, img_format, agg_method, energies_label,
                                  in_format=img_format,
                                  parallel_load=parallel_load)
 
-            images = images.get_sample()
+            images = images.sample
             # sum or average them
             if 'sum' == agg_method:
                 aggregated_images = images.sum(axis=0, dtype=np.float32)

--- a/mantidimaging/core/aggregate/test/aggregate_test.py
+++ b/mantidimaging/core/aggregate/test/aggregate_test.py
@@ -94,7 +94,7 @@ class AggregateTest(FileOutputtingTestCase):
             in_format=saver._out_format,
             parallel_load=parallel)
 
-        for i in images.get_sample():
+        for i in images.sample:
             npt.assert_equal(i, expected)
 
     def test_aggregate_not_single_folder_sum_fits(self):
@@ -171,7 +171,7 @@ class AggregateTest(FileOutputtingTestCase):
                 in_format=saver._out_format,
                 parallel_load=parallel)
 
-            for i in images.get_sample():
+            for i in images.sample:
                 npt.assert_equal(i, expected)
 
 

--- a/mantidimaging/core/configurations/default_run.py
+++ b/mantidimaging/core/configurations/default_run.py
@@ -58,7 +58,7 @@ def execute(config):
     images = loader.load_from_config(config)
 
     sample, flat, dark = default_filtering.execute(
-            config, images.get_sample(), images.get_flat(), images.get_dark())
+            config, images.sample, images.flat, images.dark)
 
     if not config.func.reconstruction:
         saver_class.save_preproc_images(sample)

--- a/mantidimaging/core/convert/convert.py
+++ b/mantidimaging/core/convert/convert.py
@@ -23,11 +23,10 @@ def execute(config):
     saver.make_dirs_if_needed(output_dir, config.func.overwrite_all)
 
     images = loader.load_from_config(config)
-    sample = images.get_sample()
 
     # save out in the main output directory
     saver.save(
-        sample,
+        images.sample,
         output_dir,
         config.func.convert_prefix,
         config.func.swap_axes,

--- a/mantidimaging/core/convert/test/convert_test.py
+++ b/mantidimaging/core/convert/test/convert_test.py
@@ -80,7 +80,7 @@ class ConvertTest(FileOutputtingTestCase):
             in_format=convert_format,
             parallel_load=parallel)
 
-        npt.assert_equal(loaded_images.get_sample(), expected_images)
+        npt.assert_equal(loaded_images.sample, expected_images)
 
     def test_convert_fits_nxs_stack(self):
         # NXS is only supported for stack
@@ -127,7 +127,7 @@ class ConvertTest(FileOutputtingTestCase):
             in_format=convert_format,
             parallel_load=parallel)
 
-        npt.assert_equal(loaded_images.get_sample(), expected_images)
+        npt.assert_equal(loaded_images.sample, expected_images)
 
     def test_convert_nxs_fits_nostack(self):
         self.do_convert_from_nxs(
@@ -173,7 +173,7 @@ class ConvertTest(FileOutputtingTestCase):
                                     in_format=convert_format,
                                     parallel_load=parallel)
 
-        npt.assert_equal(loaded_images.get_sample(), expected_images)
+        npt.assert_equal(loaded_images.sample, expected_images)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/data/__init__.py
+++ b/mantidimaging/core/data/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
+from .images import Images  # noqa: F401
+
+del absolute_import, division, print_function

--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -14,11 +14,15 @@ class Images(object):
 
         self._filenames = filenames
 
+        self.properties = {}
+
     def __str__(self):
-        return 'Image Stack: sample={}, flat={}, dark={}'.format(
+        return \
+            'Image Stack: sample={}, flat={}, dark={}, |properties|={}'.format(
                 self.sample.shape if self.sample is not None else None,
                 self.flat.shape if self.flat is not None else None,
-                self.dark.shape if self.dark is not None else None)
+                self.dark.shape if self.dark is not None else None,
+                len(self.properties))
 
     @property
     def sample(self):

--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -1,15 +1,18 @@
 from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
+
 from mantidimaging import helper as h
 
 
 class Images(object):
     def __init__(self, sample=None, flat=None, dark=None, filenames=None):
-        self.sample = sample
-        self.flat = flat
-        self.dark = dark
-        self.filenames = filenames
+
+        self._sample = sample
+        self._flat = flat
+        self._dark = dark
+
+        self._filenames = filenames
 
     def __str__(self):
         return 'Image Stack: sample={}, flat={}, dark={}'.format(
@@ -17,17 +20,33 @@ class Images(object):
                 self.flat.shape if self.flat is not None else None,
                 self.dark.shape if self.dark is not None else None)
 
-    def get_sample(self):
-        return self.sample
+    @property
+    def sample(self):
+        return self._sample
 
-    def get_flat(self):
-        return self.flat
+    @sample.setter
+    def sample(self, imgs):
+        self._sample = imgs
 
-    def get_dark(self):
-        return self.dark
+    @property
+    def flat(self):
+        return self._flat
 
-    def get_filenames(self):
-        return self.filenames
+    @flat.setter
+    def flat(self, imgs):
+        self._flat = imgs
+
+    @property
+    def dark(self):
+        return self._dark
+
+    @dark.setter
+    def dark(self, imgs):
+        self._dark = imgs
+
+    @property
+    def filenames(self):
+        return self._filenames
 
     @staticmethod
     def check_data_stack(data, expected_dims=3, expected_class=np.ndarray):

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -13,11 +13,13 @@ class ImagesTest(unittest.TestCase):
         imgs = Images()
         self.assertEquals(
                 str(imgs),
-                'Image Stack: sample=None, flat=None, dark=None')
+                'Image Stack: sample=None, flat=None, dark=None, '
+                '|properties|=0')
 
     def test_to_string_with_sample(self):
         sample = np.ndarray(shape=(2, 64, 64))
         imgs = Images(sample)
         self.assertEquals(
                 str(imgs),
-                'Image Stack: sample=(2, 64, 64), flat=None, dark=None')
+                'Image Stack: sample=(2, 64, 64), flat=None, dark=None, '
+                '|properties|=0')

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from mantidimaging.core.io.loader import Images
+from mantidimaging.core.data import Images
 
 
 class ImagesTest(unittest.TestCase):

--- a/mantidimaging/core/filters/background_correction/background_correction_gui.py
+++ b/mantidimaging/core/filters/background_correction/background_correction_gui.py
@@ -28,13 +28,13 @@ def _gui_register(form):
 
         # this will be put in the 'sample' attribute, because we load a single
         # volume
-        flat = images_flat_only.get_sample().mean(axis=0)
+        flat = images_flat_only.sample.mean(axis=0)
 
         images_dark_only = io.loader.load(dark_dir, in_format=dark_extension)
 
         # this will be put in the 'sample' attribute, because we load a single
         # volume
-        dark = images_dark_only.get_sample().mean(axis=0)
+        dark = images_dark_only.sample.mean(axis=0)
 
         par = partial(execute, flat=flat, dark=dark)
 

--- a/mantidimaging/core/imopr/imopr.py
+++ b/mantidimaging/core/imopr/imopr.py
@@ -69,10 +69,10 @@ def execute(config):
     images = loader.load_from_config(config)
 
     getLogger(__name__).info(
-            "Data shape {0}".format(images.get_sample().shape))
+            "Data shape {0}".format(images.sample.shape))
 
     return module.execute(
-            images.get_sample(), images.get_flat(), images.get_dark(),
+            images.sample, images.flat, images.dark,
             config, indices)
 
 

--- a/mantidimaging/core/io/__init__.py
+++ b/mantidimaging/core/io/__init__.py
@@ -27,6 +27,4 @@ from . import (  # noqa: F401
         loader,
         utility)
 
-from .loader.images import Images  # noqa: F401
-
 del absolute_import, division, print_function

--- a/mantidimaging/core/io/loader/__init__.py
+++ b/mantidimaging/core/io/loader/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from .images import Images  # noqa: F401
-
 from .loader import (  # noqa: F401
         load,
         load_from_config,

--- a/mantidimaging/core/io/loader/img_loader.py
+++ b/mantidimaging/core/io/loader/img_loader.py
@@ -6,13 +6,13 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
+from mantidimaging.core.data import Images
 from mantidimaging.core.io.utility import get_file_names
 from mantidimaging.core.parallel import two_shared_mem as ptsm
 from mantidimaging.core.parallel import utility as pu
 from mantidimaging.core.utility.progress_reporting import Progress
 
 from . import stack_loader
-from .images import Images
 
 
 def execute(load_func, input_file_names, input_path_flat, input_path_dark,

--- a/mantidimaging/core/io/loader/img_loader.py
+++ b/mantidimaging/core/io/loader/img_loader.py
@@ -63,7 +63,7 @@ def execute(load_func, input_file_names, input_path_flat, input_path_dark,
     # if this is true, then the loaded sample data was created via the
     # stack_loader
     if isinstance(sample_data, Images):
-        sample_data = sample_data.get_sample()
+        sample_data = sample_data.sample
 
     return Images(sample_data, flat_avg, dark_avg, input_file_names)
 

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -81,7 +81,7 @@ def read_in_shape(input_path,
                   data_dtype, cores, chunksize, indices=[0, 1, 1])
 
     # construct and return the new shape
-    return (len(input_file_names),) + images.get_sample().shape[1:]
+    return (len(input_file_names),) + images.sample.shape[1:]
 
 
 def read_in_shape_from_config(config):

--- a/mantidimaging/core/io/loader/stack_loader.py
+++ b/mantidimaging/core/io/loader/stack_loader.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
+from mantidimaging.core.data import Images
 from mantidimaging.core.parallel import two_shared_mem as ptsm
 from mantidimaging.core.parallel import utility as pu
 from mantidimaging.core.utility.progress_reporting import Progress
-from .images import Images
 
 
 def parallel_move_data(input_data, output_data):

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -90,7 +90,7 @@ def save(data,
                                         task_name='Save')
 
     if isinstance(data, Images):
-        data = data.get_sample()
+        data = data.sample
 
     # expand the path for plugins that don't do it themselves
     output_dir = os.path.abspath(os.path.expanduser(output_dir))

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -7,9 +7,9 @@ import os
 import numpy as np
 
 from mantidimaging.core.utility.progress_reporting import Progress
+from mantidimaging.core.data import Images
 
 from .utility import DEFAULT_IO_FILE_FORMAT
-from .loader.images import Images
 
 DEFAULT_ZFILL_LENGTH = 6
 DEFAULT_NAME_PREFIX = 'image'

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -237,17 +237,17 @@ class IOTest(FileOutputtingTestCase):
                                     indices=loader_indices)
 
         if loader_indices:
-            assert len(loaded_images.get_sample()) == expected_len, \
+            assert len(loaded_images.sample) == expected_len, \
                 "The length of the loaded data does not " \
                 "match the expected length! Expected: {0}, " \
                 "Got {1}".format(expected_len, len(
-                    loaded_images.get_sample()))
+                    loaded_images.sample))
 
             # crop the original images to make sure the tests is correct
             expected_images = \
                 expected_images[loader_indices[0]:loader_indices[1]]
 
-        npt.assert_equal(loaded_images.get_sample(), expected_images)
+        npt.assert_equal(loaded_images.sample, expected_images)
 
     def test_save_nxs_seq(self):
         self.do_preproc_nxs(parallel=False)
@@ -314,17 +314,17 @@ class IOTest(FileOutputtingTestCase):
 
         if loader_indices:
             assert len(
-                images.get_sample()
+                images.sample
             ) == expected_len, "The length of the loaded data does not " \
                                "match the expected length! Expected: {0}, " \
                                "Got {1}".format(
-                expected_len, len(images.get_sample()))
+                expected_len, len(images.sample))
 
             # crop the original images to make sure the tests is correct
             expected_images = \
                 expected_images[loader_indices[0]:loader_indices[1]]
 
-        npt.assert_equal(images.get_sample(), expected_images)
+        npt.assert_equal(images.sample, expected_images)
 
         self.assert_files_exist(os.path.join(preproc_output_path,
                                              'out_preproc_image'),
@@ -444,20 +444,20 @@ class IOTest(FileOutputtingTestCase):
                 indices=loader_indices)
 
         if loader_indices:
-            assert len(loaded_images.get_sample()) == expected_len, \
+            assert len(loaded_images.sample) == expected_len, \
                 "The length of the loaded data doesn't " \
                 "match the expected length: {0}, " \
                 "Got: {1}".format(
-                        expected_len, len(loaded_images.get_sample()))
+                        expected_len, len(loaded_images.sample))
 
             # crop the original images to make sure the tests is correct
             images = images[loader_indices[0]:loader_indices[1]]
 
-        npt.assert_equal(loaded_images.get_sample(), images)
+        npt.assert_equal(loaded_images.sample, images)
         # we only check the first image because they will be
         # averaged out when loaded! The initial images are only 3s
-        npt.assert_equal(loaded_images.get_flat(), flat[0])
-        npt.assert_equal(loaded_images.get_dark(), dark[0])
+        npt.assert_equal(loaded_images.flat, flat[0])
+        npt.assert_equal(loaded_images.dark, dark[0])
 
     def test_read_in_shape_from_config(self):
         images = th.gen_img_shared_array_with_val(42.)
@@ -496,7 +496,7 @@ class IOTest(FileOutputtingTestCase):
 
         loaded_images = loader.load_from_config(config)
 
-        npt.assert_equal(images, loaded_images.get_sample())
+        npt.assert_equal(images, loaded_images.sample)
 
     def test_construct_sinograms(self):
         images = th.gen_img_shared_array_with_val(42.)
@@ -517,7 +517,7 @@ class IOTest(FileOutputtingTestCase):
         config.func.construct_sinograms = True
         loaded_images = loader.load_from_config(config)
 
-        npt.assert_equal(exp_sinograms, loaded_images.get_sample())
+        npt.assert_equal(exp_sinograms, loaded_images.sample)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/testing/unit_test_helper.py
+++ b/mantidimaging/core/testing/unit_test_helper.py
@@ -34,7 +34,7 @@ def gen_img_shared_array(shape=g_shape):
 
 
 def generate_images_class_random_shared_array(shape=g_shape):
-    from mantidimaging.core.io.loader.images import Images
+    from mantidimaging.core.data import Images
     d = pu.create_shared_array(shape)
     n = np.random.rand(shape[0], shape[1], shape[2])
     # move the data in the shared array

--- a/mantidimaging/gui/filters_window/model.py
+++ b/mantidimaging/gui/filters_window/model.py
@@ -99,7 +99,7 @@ class FiltersWindowModel(object):
     @property
     def num_images_in_stack(self):
         stack = self.get_stack()
-        num_images = stack.images.get_sample().shape[0] \
+        num_images = stack.images.sample.shape[0] \
             if stack is not None else 0
         return num_images
 
@@ -127,11 +127,11 @@ class FiltersWindowModel(object):
             log.info("Filter kwargs: {}".format(execute_func.keywords))
 
         # Do preprocessing and save result
-        preproc_res = do_before_func(images.get_sample())
+        preproc_res = do_before_func(images.sample)
         preproc_res = ensure_tuple(preproc_res)
 
         # Run filter
-        ret_val = execute_func(images.get_sample(), **exec_kwargs)
+        ret_val = execute_func(images.sample, **exec_kwargs)
 
         # Handle the return value from the algorithm dialog
         if isinstance(ret_val, tuple):
@@ -145,7 +145,7 @@ class FiltersWindowModel(object):
             log.debug('Unknown execute return value: {}'.format(type(ret_val)))
 
         # Do postprocessing using return value of preprocessing as parameter
-        do_after_func(images.get_sample(), *preproc_res)
+        do_after_func(images.sample, *preproc_res)
 
     def do_apply_filter(self):
         """

--- a/mantidimaging/gui/filters_window/presenter.py
+++ b/mantidimaging/gui/filters_window/presenter.py
@@ -154,7 +154,7 @@ class FiltersWindowPresenter(object):
             try:
                 sub_images = Images(np.asarray([before_image_data]))
                 self.model.apply_filter(sub_images, exec_kwargs)
-                filtered_image_data = sub_images.get_sample()[0]
+                filtered_image_data = sub_images.sample[0]
             except Exception:
                 log.exception("Error applying filter for preview")
 

--- a/mantidimaging/gui/filters_window/presenter.py
+++ b/mantidimaging/gui/filters_window/presenter.py
@@ -5,7 +5,7 @@ from logging import getLogger
 
 import numpy as np
 
-from mantidimaging.core.io.loader import Images
+from mantidimaging.core.data import Images
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.core.utility.histogram import (
         generate_histogram_from_image)

--- a/mantidimaging/gui/main_window/model.py
+++ b/mantidimaging/gui/main_window/model.py
@@ -32,7 +32,7 @@ class MainWindowModel(object):
                   overwrite, swap_axes, indices, progress):
         svp = self.get_stack_visualiser(stack_uuid).presenter
         saver.save(
-            data=svp.images.get_sample(),
+            data=svp.images.sample,
             output_dir=output_dir,
             name_prefix=name_prefix,
             swap_axes=swap_axes,

--- a/mantidimaging/gui/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/stack_visualiser/presenter.py
@@ -122,11 +122,11 @@ class StackVisualiserPresenter(object):
     def get_image(self, index):
         if self.mode == ImageMode.STACK:
             if self.axis == 0:
-                return self.images.get_sample()[index, :, :]
+                return self.images.sample[index, :, :]
             elif self.axis == 1:
-                return self.images.get_sample()[:, index, :]
+                return self.images.sample[:, index, :]
             elif self.axis == 2:
-                return self.images.get_sample()[:, :, index]
+                return self.images.sample[:, :, index]
 
         elif self.mode == ImageMode.SUM:
             return self.summed_image
@@ -134,11 +134,11 @@ class StackVisualiserPresenter(object):
         raise ValueError('Unknown image mode')
 
     def get_image_fullpath(self, index):
-        filenames = self.images.get_filenames()
+        filenames = self.images.filenames
         return filenames[index] if filenames is not None else ""
 
     def get_image_filename(self, index):
-        filenames = self.images.get_filenames()
+        filenames = self.images.filenames
         return os.path.basename(
                 filenames[index] if filenames is not None else "")
 
@@ -150,7 +150,7 @@ class StackVisualiserPresenter(object):
         """
         if axis is None:
             axis = self.axis
-        return self.images.get_sample().shape[self.axis]
+        return self.images.sample.shape[self.axis]
 
     def get_image_pixel_range(self):
         """
@@ -158,7 +158,7 @@ class StackVisualiserPresenter(object):
 
         :return: Tuple of (min, max) pixel intensities
         """
-        return (self.images.get_sample().min(), self.images.get_sample().max())
+        return (self.images.sample.min(), self.images.sample.max())
 
     def do_scroll_stack(self, offset):
         """

--- a/mantidimaging/gui/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/stack_visualiser/test/presenter_test.py
@@ -46,7 +46,7 @@ class StackVisualiserPresenterTest(unittest.TestCase):
     def test_get_image(self):
         index = 3
 
-        test_data = self.test_data.get_sample()
+        test_data = self.test_data.sample
 
         img = self.presenter.get_image(index)
         npt.assert_equal(test_data[index], img)
@@ -87,7 +87,7 @@ class StackVisualiserPresenterTest(unittest.TestCase):
     def test_get_image_count_on_axis(self):
         self.assertEquals(
                 self.presenter.get_image_count_on_axis(),
-                self.test_data.get_sample().shape[self.presenter.axis])
+                self.test_data.sample.shape[self.presenter.axis])
 
     def test_scroll_stack(self):
         self.view.current_index = mock.MagicMock(return_value=3)
@@ -105,7 +105,7 @@ class StackVisualiserPresenterTest(unittest.TestCase):
         self.view.set_index.assert_called_once_with(2)
 
     def test_summed_image_creation(self):
-        test_data = self.test_data.get_sample()
+        test_data = self.test_data.sample
 
         # No summed image by default
         self.assertEquals(self.presenter.image_mode, ImageMode.STACK)

--- a/mantidimaging/gui/stack_visualiser/view.py
+++ b/mantidimaging/gui/stack_visualiser/view.py
@@ -26,10 +26,10 @@ class StackVisualiserView(Qt.QMainWindow):
     def __init__(self, parent, dock, images, data_traversal_axis=0,
                  cmap='Greys_r', block=False):
         # enforce not showing a single image
-        assert images.get_sample().ndim == 3, \
+        assert images.sample.ndim == 3, \
                 "Data does NOT have 3 dimensions! Dimensions found: \
                 {0}".format(
-            images.get_sample().ndim)
+            images.sample.ndim)
 
         # We set the main window as the parent, the effect is the same as
         # having no parent, the window will be inside the QDockWidget. If the

--- a/mantidimaging/helper.py
+++ b/mantidimaging/helper.py
@@ -140,7 +140,7 @@ def check_data_stack(data, expected_dims=3, expected_class=np.ndarray):
     if isinstance(data, expected_class):
         to_check = data
     else:
-        to_check = data.get_sample()
+        to_check = data.sample
 
     # the data must be a np array, otherwise most functionality won't work
     if not isinstance(to_check, expected_class):


### PR DESCRIPTION
- Moves image storage container to a generic `core.data` package
- Use property getters/setters to access images
- Add storage for parameters that may be stored during processing (eventually these will be loaded and saved with images, see #166)