### PR TITLE
Add Conda packaging

### DIFF
--- a/buildscripts/conda/build.sh
+++ b/buildscripts/conda/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+conda-build --croot /tmp/mantidimaging-conda mantidimaging

--- a/buildscripts/conda/mantidimaging/bld.bat
+++ b/buildscripts/conda/mantidimaging/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/buildscripts/conda/mantidimaging/build.sh
+++ b/buildscripts/conda/mantidimaging/build.sh
@@ -1,0 +1,1 @@
+$PYTHON setup.py install

--- a/buildscripts/conda/mantidimaging/meta.yaml
+++ b/buildscripts/conda/mantidimaging/meta.yaml
@@ -1,0 +1,39 @@
+package:
+  name: mantidimaging
+  version: "nightly"
+
+source:
+  git_rev: master
+  git_url: https://github.com/mantidproject/mantidimaging.git
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - sphinx
+  run:
+    - python
+    - astropy
+    - numpy
+    - scipy
+    - matplotlib
+    - tomopy
+    - pyqt
+
+test:
+  imports:
+    - mantidimaging
+  requires:
+    - nose
+    - coverage
+    - flake8
+
+about:
+  home: https://github.com/mantidproject/mantidimaging
+  license: GPL-3
+  license_file: LICENSE.txt
+
+app:
+  entry: mantidimaging-gui
+  summary: "GUI for Mantid Imaging toolkit"
+  icon:


### PR DESCRIPTION
Closes #164 

Adds the required files to build a Conda distribution of the `mantidimaging` package.

Can be built using the `buildscripts/conda/build.sh` script (once `conda-build` is installed) (the `--croot` option is to get around the fact `conda-build` does not like encrypted volumes).

If TomoPy is not installed first then nothing will work (see #176), and AFAIK TomoPy can not be automatically installed unless the correct channel is added to `.condarc` first (in which case the user may as well just install it).

To test:
- Create the packages using the `build.sh` script
- On a clean environment install TomoPy then the created package archive
- Run `mantidimaging-gui`, it should open and be usable