### PR TITLE
Guard filters that require TomoPy

### DIFF
--- a/mantidimaging/core/filters/circular_mask/__init__.py
+++ b/mantidimaging/core/filters/circular_mask/__init__.py
@@ -5,4 +5,6 @@ NAME = 'Circular Mask'
 from .circular_mask import execute, _cli_register  # noqa:F401
 from .circular_mask_gui import _gui_register  # noqa:F401
 
+from mantidimaging.core.utility.optional_imports import tomopy_available as available  # noqa: F401
+
 del absolute_import, division, print_function  # noqa:F821

--- a/mantidimaging/core/filters/minus_log/__init__.py
+++ b/mantidimaging/core/filters/minus_log/__init__.py
@@ -5,4 +5,6 @@ NAME = 'Minus Log'
 from .minus_log import execute, _cli_register  # noqa:F401
 from .minus_log_gui import _gui_register  # noqa:F401
 
+from mantidimaging.core.utility.optional_imports import tomopy_available as available  # noqa: F401
+
 del absolute_import, division, print_function  # noqa:F821

--- a/mantidimaging/core/filters/outliers/__init__.py
+++ b/mantidimaging/core/filters/outliers/__init__.py
@@ -5,4 +5,6 @@ NAME = 'Remove Outliers'
 from .outliers import execute, modes, _cli_register  # noqa:F401
 from .outliers_gui import _gui_register  # noqa: F401
 
+from mantidimaging.core.utility.optional_imports import tomopy_available as available  # noqa: F401
+
 del absolute_import, division, print_function  # noqa:F821

--- a/mantidimaging/core/filters/ring_removal/__init__.py
+++ b/mantidimaging/core/filters/ring_removal/__init__.py
@@ -5,4 +5,6 @@ NAME = 'Ring Removal'
 from .ring_removal import execute, _cli_register  # noqa:F401
 from .ring_removal_gui import _gui_register  # noqa:F401
 
+from mantidimaging.core.utility.optional_imports import tomopy_available as available  # noqa: F401
+
 del absolute_import, division, print_function  # noqa:F821

--- a/mantidimaging/core/filters/ring_removal/ring_removal.py
+++ b/mantidimaging/core/filters/ring_removal/ring_removal.py
@@ -1,8 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
-import tomopy.misc.corr
-
 from mantidimaging import helper as h
+from mantidimaging.core.utility.optional_imports import safe_import
 from mantidimaging.core.utility.progress_reporting import Progress
 
 
@@ -91,12 +90,14 @@ def execute(data,
     progress = Progress.ensure_instance(progress,
                                         task_name='Ring Removal')
 
+    tp = safe_import('tomopy.misc.corr')
+
     if run_ring_removal:
         h.check_data_stack(data)
 
         with progress:
             progress.update(msg="Ring Removal")
-            data = tomopy.misc.corr.remove_ring(
+            data = tp.remove_ring(
                 data,
                 center_x=center_x,
                 center_y=center_y,

--- a/mantidimaging/core/filters/stripe_removal/__init__.py
+++ b/mantidimaging/core/filters/stripe_removal/__init__.py
@@ -5,4 +5,6 @@ NAME = 'Stripe Removal'
 from .stripe_removal import execute, wavelet_names, _cli_register  # noqa:F401
 from .stripe_removal_gui import _gui_register  # noqa:F401
 
+from mantidimaging.core.utility.optional_imports import tomopy_available as available  # noqa: F401
+
 del absolute_import, division, print_function  # noqa:F821

--- a/mantidimaging/core/utility/optional_imports.py
+++ b/mantidimaging/core/utility/optional_imports.py
@@ -1,0 +1,44 @@
+"""
+A place for availability checking and import logic for optional dependencies to
+live.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import importlib
+import traceback
+import warnings
+
+from six import StringIO
+from logging import getLogger
+
+
+def safe_import(name):
+    """
+    Try to import an optional library that may not be present.
+
+    Will fail gracefully by returning None if the library is not available.
+    """
+    try:
+        module = importlib.import_module(name)
+
+    except ImportError:
+        warnings.warn(
+                'Failed to import optional module "{}"'.format(name))
+
+        o = StringIO()
+        traceback.print_stack(file=o)
+        getLogger(__name__).debug(
+                'Module import stack trace: {}'.format(o.getvalue()))
+
+        module = None
+
+    return module
+
+
+def check_availability(name):
+    return safe_import(name) is not None
+
+
+def tomopy_available():
+    return check_availability('tomopy')

--- a/mantidimaging/gui/filters_window/model.py
+++ b/mantidimaging/gui/filters_window/model.py
@@ -65,6 +65,10 @@ class FiltersWindowModel(object):
         loaded_filters = import_items(filter_packages,
                                       ['execute', 'NAME', '_gui_register'])
 
+        loaded_filters = filter(
+                lambda f: f.available() if hasattr(f, 'available') else True,
+                loaded_filters)
+
         def register_filter(filter_list, module):
             filter_list.append((module.NAME, module._gui_register))
 


### PR DESCRIPTION
Closes #176

For context the fact that a new module was added to deal with optional imports rather than just using the existing functionality in `tomopy_tool.py` is that a large refactoring of the `core.tools` package is planned when work starts on TomoPy integration (depending on how tools are handled in the GUI and the outcome of #156 tools may be handled differently to how they are now).

To test:
- Open the GUI in an environment with TomoPy installed, you should see all filters in the filter window
- Do the same in an environment that is missing TomoPy, you should see 5 filters missing