### PR TITLE
Address COR/Tilt finder UI issues

### DIFF
--- a/mantidimaging/external/tomopy_rotation.py
+++ b/mantidimaging/external/tomopy_rotation.py
@@ -65,6 +65,7 @@ from tomopy.recon.algorithm import recon
 import tomopy.util.dtype as dtype
 import os.path
 import logging
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -237,8 +238,9 @@ def find_center_vo(tomo, ind=None, smin=-50, smax=50, srad=6, step=0.5,
         ind = tomo.shape[1] // 2
     _tomo = tomo[:, ind, :]
 
-    # Enable cache for FFTW.
-    pyfftw.interfaces.cache.enable()
+    if sys.version_info <= (3, 0):
+        # Enable cache for FFTW.
+        pyfftw.interfaces.cache.enable()
 
     # Reduce noise by smooth filters. Use different filters for coarse and fine search
     _tomo_cs = ndimage.filters.gaussian_filter(_tomo, (3, 1))

--- a/mantidimaging/gui/dialogs/cor_tilt/model.py
+++ b/mantidimaging/gui/dialogs/cor_tilt/model.py
@@ -57,10 +57,13 @@ class CORTiltDialogModel(object):
 
             self.slice_indices = np.arange(upper - 1, lower, -step)
 
-    def run_finding(self):
+    def run_finding(self, progress):
         self.tilt, self.cor, self.slices, self.cors, self.m = \
                 calculate_cor_and_tilt(
-                        self.sample, self.roi, self.slice_indices)
+                        self.sample, self.roi, self.slice_indices,
+                        progress=progress)
+
+        return True
 
     @property
     def preview_tilt_line_data(self):

--- a/mantidimaging/gui/dialogs/cor_tilt/model.py
+++ b/mantidimaging/gui/dialogs/cor_tilt/model.py
@@ -9,6 +9,7 @@ class CORTiltDialogModel(object):
 
     def __init__(self):
         self.stack = None
+        self.preview_idx = 0
         self.roi = None
         self.slice_indices = None
 
@@ -27,10 +28,16 @@ class CORTiltDialogModel(object):
     def sample(self):
         return self.stack.presenter.images.sample if self.stack else None
 
+    @property
+    def num_projections(self):
+        s = self.sample
+        return s.shape[0] if s is not None else 0
+
     def initial_select_data(self, stack):
         self.reset_results()
 
         self.stack = stack
+        self.preview_idx = 0
 
         if stack is not None:
             image_shape = self.sample[0].shape

--- a/mantidimaging/gui/dialogs/cor_tilt/model.py
+++ b/mantidimaging/gui/dialogs/cor_tilt/model.py
@@ -58,10 +58,19 @@ class CORTiltDialogModel(object):
             self.slice_indices = np.arange(upper - 1, lower, -step)
 
     def run_finding(self, progress):
+        if self.stack is None:
+            raise ValueError('No image stack is provided')
+
+        if self.roi is None:
+            raise ValueError('No region of interest is defined')
+
+        if self.slice_indices is None:
+            raise ValueError('No slices are defined')
+
         self.tilt, self.cor, self.slices, self.cors, self.m = \
-                calculate_cor_and_tilt(
-                        self.sample, self.roi, self.slice_indices,
-                        progress=progress)
+            calculate_cor_and_tilt(
+                    self.sample, self.roi, self.slice_indices,
+                    progress=progress)
 
         return True
 

--- a/mantidimaging/gui/dialogs/cor_tilt/presenter.py
+++ b/mantidimaging/gui/dialogs/cor_tilt/presenter.py
@@ -45,6 +45,12 @@ class CORTiltDialogPresenter(BasePresenter):
         self.notify(Notification.UPDATE_PREVIEWS)
         self.notify(Notification.UPDATE_INDICES)
         self.view.set_results(0, 0)
+        self.view.previewStackIndex.setMaximum(self.model.num_projections - 1)
+        self.view.previewStackIndex.setValue(0)
+
+    def set_preview_idx(self, idx):
+        self.model.preview_idx = idx
+        self.notify(Notification.UPDATE_PREVIEWS)
 
     def do_crop_to_roi(self):
         self.model.update_roi_from_stack()
@@ -54,8 +60,8 @@ class CORTiltDialogPresenter(BasePresenter):
         self.view.set_results(0, 0)
 
     def do_update_previews(self):
-        img_data = self.model.sample[0] if self.model.sample is not None \
-                else None
+        img_data = self.model.sample[self.model.preview_idx] \
+                if self.model.sample is not None else None
 
         self.view.update_image_preview(
                 img_data, self.model.preview_tilt_line_data, self.model.roi)

--- a/mantidimaging/gui/dialogs/cor_tilt/view.py
+++ b/mantidimaging/gui/dialogs/cor_tilt/view.py
@@ -34,6 +34,10 @@ class CORTiltDialogView(BaseDialogView):
         self.setRoi.clicked.connect(
                 lambda: self.presenter.notify(PresNotification.CROP_TO_ROI))
 
+        # Handle preview image selection
+        self.previewStackIndex.valueChanged[int].connect(
+                self.presenter.set_preview_idx)
+
         # Handle index definition
         self.sliceCount.valueChanged[int].connect(
                 lambda: self.presenter.notify(PresNotification.UPDATE_INDICES))

--- a/mantidimaging/gui/ui/cor_tilt_dialog.ui
+++ b/mantidimaging/gui/ui/cor_tilt_dialog.ui
@@ -29,14 +29,24 @@
          <property name="title">
           <string>Data</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <item>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0" colspan="2">
            <widget class="StackSelectorWidgetView" name="stackSelector"/>
           </item>
-          <item>
+          <item row="1" column="0" colspan="2">
            <widget class="QPushButton" name="setRoi">
             <property name="text">
              <string>Set ROI from stack</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QSpinBox" name="previewStackIndex"/>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="previewStackIndexLabel">
+            <property name="text">
+             <string>Preview stack index:</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Fixes #187 

- Preview can now scroll through stack
- Processing is done async

To test:
- Follow instructions for #185
- Notice the additional option to select the index of the projection shown in the preview window
- When Calculate is clicked the GUI thread should not be blocked (e.g. windows can be moved and resized correctly, the main window will still work) and a progress bar will be shown (in the GUI)