### PR TITLE
Add first cut of a TomoPy reconstruction UI

### DIFF
--- a/mantidimaging/core/reconstruct/test/cor_tilt_test.py
+++ b/mantidimaging/core/reconstruct/test/cor_tilt_test.py
@@ -1,0 +1,21 @@
+from unittest import TestCase
+
+import math
+
+import numpy as np
+
+from mantidimaging.core.reconstruct import cor_tilt
+
+
+class CorTiltTest(TestCase):
+
+    def test_cors_to_tilt_angle(self):
+        theta = cor_tilt.cors_to_tilt_angle(10, 1)
+        self.assertAlmostEqual(theta, math.pi / 4)
+
+    def test_tilt_angle_to_cors(self):
+        theta = math.pi / 4
+        slices = np.linspace(0, 100, 20)
+        cors = cor_tilt.tilt_angle_to_cors(theta, 50, slices)
+        self.assertAlmostEqual(cors[0], 50.0)
+        self.assertAlmostEqual(cors[-1], 150.0)

--- a/mantidimaging/core/reconstruct/tomopy_reconstruction.py
+++ b/mantidimaging/core/reconstruct/tomopy_reconstruction.py
@@ -20,7 +20,6 @@ def reconstruct(sample,
                 proj_angles=None,
                 ncores=None,
                 progress=None):
-
     progress = Progress.ensure_instance(progress)
 
     if ncores is None:
@@ -29,7 +28,7 @@ def reconstruct(sample,
 
     volume = None
     with progress:
-        # TODO
+        progress.update(msg='TomoPy reconstruction')
         volume = tomopy.recon(
                 ncore=ncores,
                 tomo=sample,

--- a/mantidimaging/core/reconstruct/tomopy_reconstruction.py
+++ b/mantidimaging/core/reconstruct/tomopy_reconstruction.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import, division, print_function
+
+from logging import getLogger
+
+from mantidimaging.core.utility.progress_reporting import Progress
+
+# This import is used to provide the available() function which is used to
+# check if the functionality of a module is available based on the presence of
+# optional libraries
+from mantidimaging.core.utility.optional_imports import (  # noqa: F401
+        safe_import,
+        tomopy_available as available)
+
+LOG = getLogger(__name__)
+tomopy = safe_import('tomopy')
+
+
+def reconstruct(sample,
+                cor=None,
+                proj_angles=None,
+                ncores=None,
+                progress=None):
+
+    progress = Progress.ensure_instance(progress)
+
+    if ncores is None:
+        import multiprocessing
+        ncores = multiprocessing.cpu_count()
+
+    volume = None
+    with progress:
+        # TODO
+        volume = tomopy.recon(
+                ncore=ncores,
+                tomo=sample,
+                sinogram_order=True,
+                theta=proj_angles,
+                center=cor,
+                algorithm='gridrec')
+
+        LOG.info('Reconstructed 3D volume with shape: {0}'.format(
+            volume.shape))
+
+    return volume

--- a/mantidimaging/core/tools/tomopy_tool.py
+++ b/mantidimaging/core/tools/tomopy_tool.py
@@ -146,9 +146,9 @@ class TomoPyTool(AbstractTool):
                          "Algorithm: {2}...".format(
                              np.mean(cors), len(cors), alg))
 
-                # TODO need to expose the filters to CLI
-                # filter_name='parzen',
-                # filter_par=[5.],
+            # TODO need to expose the filters to CLI
+            # filter_name='parzen',
+            # filter_par=[5.],
             recon = self._tomopy.recon(
                 tomo=sample,
                 theta=proj_angles,

--- a/mantidimaging/core/utility/projection_angles.py
+++ b/mantidimaging/core/utility/projection_angles.py
@@ -1,4 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
+
+from logging import getLogger
+
 import numpy as np
 
 
@@ -17,6 +20,8 @@ def generate(max_angle, number_radiograms, radians=True):
     inc = float(max_angle) / number_radiograms
     # arrange from angle 0 to the maximum angle, with a step of the increment
     proj_angles = np.arange(0, number_radiograms * inc, inc)
+    getLogger(__name__).debug(
+            'Generated projection angles: {}'.format(proj_angles))
     if radians:
         return np.radians(proj_angles)
     else:

--- a/mantidimaging/gui/dialogs/async_task/model.py
+++ b/mantidimaging/gui/dialogs/async_task/model.py
@@ -81,6 +81,10 @@ class AsyncTaskDialogModel(Qt.QObject):
         """
         self.task.start()
 
+    @property
+    def task_is_running(self):
+        return self.task.isRunning()
+
     def _on_task_exit(self):
         """
         Handler for task thread completion.

--- a/mantidimaging/gui/dialogs/async_task/presenter.py
+++ b/mantidimaging/gui/dialogs/async_task/presenter.py
@@ -49,6 +49,10 @@ class AsyncTaskDialogPresenter(Qt.QObject, ProgressHandler):
         self.model.do_execute_async()
         self.view.show()
 
+    @property
+    def task_is_running(self):
+        return self.model.task_is_running
+
     def progress_update(self):
         self.progress_updated.emit(self.progress.completion(),
                                    self.progress.last_status_message())

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -20,6 +20,11 @@ class AsyncTaskDialogView(BaseDialogView):
 
         self.progress_text = self.infoText.text()
 
+    def reject(self):
+        # Do not close the dialog when processing is still ongoing
+        if not self.presenter.task_is_running:
+            super(AsyncTaskDialogView, self).reject()
+
     def handle_completion(self, successful):
         """
         Updates the UI after the task has been completed.

--- a/mantidimaging/gui/dialogs/tomopy_recon/__init__.py
+++ b/mantidimaging/gui/dialogs/tomopy_recon/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import, division, print_function
+
+from .model import TomopyReconDialogModel  # noqa: F401
+from .presenter import TomopyReconDialogPresenter  # noqa: F401
+from .view import TomopyReconDialogView  # noqa: F401
+
+del absolute_import, division, print_function  # noqa:F821

--- a/mantidimaging/gui/dialogs/tomopy_recon/model.py
+++ b/mantidimaging/gui/dialogs/tomopy_recon/model.py
@@ -46,16 +46,18 @@ class TomopyReconDialogModel(object):
             self.projection_angles = \
                 generate_projection_angles(max_angle, num_radiograms)
 
-    def reconstruct_slice(self):
+    def reconstruct_slice(self, progress):
         data = np.asarray([self.sample[self.preview_slice_idx]])
 
         return reconstruct(
                 sample=data,
                 cor=self.cors[self.preview_slice_idx],
-                proj_angles=self.projection_angles)
+                proj_angles=self.projection_angles,
+                progress=progress)
 
-    def reconstruct_volume(self):
+    def reconstruct_volume(self, progress):
         return reconstruct(
                 sample=self.sample,
                 cor=self.cors,
-                proj_angles=self.projection_angles)
+                proj_angles=self.projection_angles,
+                progress=progress)

--- a/mantidimaging/gui/dialogs/tomopy_recon/model.py
+++ b/mantidimaging/gui/dialogs/tomopy_recon/model.py
@@ -1,0 +1,61 @@
+from __future__ import (absolute_import, division, print_function)
+
+from logging import getLogger
+
+import numpy as np
+
+from mantidimaging.core.utility.projection_angles import \
+        generate as generate_projection_angles
+from mantidimaging.core.reconstruct.cor_tilt import tilt_angle_to_cors
+from mantidimaging.core.reconstruct.tomopy_reconstruction import reconstruct
+
+
+LOG = getLogger(__name__)
+
+
+class TomopyReconDialogModel(object):
+
+    def __init__(self):
+        self.stack = None
+        self.projection = None
+        self.preview_slice_idx = 0
+
+        self.cors = None
+        self.projection_angles = None
+
+    @property
+    def sample(self):
+        return self.stack.presenter.images.sample if self.stack else None
+
+    def initial_select_data(self, stack):
+        self.stack = stack
+
+        self.projection = self.sample.swapaxes(0, 1) \
+            if stack is not None else None
+
+    def generate_cors(self, cor, tilt):
+        if self.stack is not None:
+            num_slices = self.sample.shape[0]
+            self.cors = tilt_angle_to_cors(
+                    tilt, cor, np.arange(0, num_slices, 1))
+            LOG.debug('Generated CORs: {}'.format(self.cors))
+
+    def generate_projection_angles(self, max_angle):
+        if self.stack is not None:
+            num_radiograms = self.sample.shape[1]
+            self.projection_angles = \
+                generate_projection_angles(max_angle, num_radiograms)
+
+    def reconstruct_slice(self):
+        data = np.asarray([self.sample[self.preview_slice_idx]])
+
+        return reconstruct(
+                sample=data,
+                cor=self.cors[self.preview_slice_idx],
+                proj_angles=self.projection_angles)
+
+    def reconstruct_volume(self):
+        return reconstruct(
+                sample=self.sample,
+                cor=self.cors,
+                proj_angles=self.projection_angles)

--- a/mantidimaging/gui/dialogs/tomopy_recon/navigation_toolbar.py
+++ b/mantidimaging/gui/dialogs/tomopy_recon/navigation_toolbar.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import, division, print_function
+
+from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
+
+
+class TomopyReconNavigationToolbar(NavigationToolbar2QT):
+
+    # See [Matplotlib]/lib/matplotlib/backend_bases.py
+    toolitems = (
+        ('Home', 'Reset original view', 'home', 'home'),
+        ('Pan', 'Pan axes with left mouse, zoom with right', 'move', 'pan'),
+        ('Zoom', 'Zoom to rectangle', 'zoom_to_rect', 'zoom'),
+        (None, None, None, None),
+        ('Subplots', 'Configure subplots', 'subplots', 'configure_subplots'),
+        (None, None, None, None),
+        ('Save', 'Save the figure', 'filesave', 'save_figure'),
+      )

--- a/mantidimaging/gui/dialogs/tomopy_recon/presenter.py
+++ b/mantidimaging/gui/dialogs/tomopy_recon/presenter.py
@@ -1,0 +1,93 @@
+from __future__ import absolute_import, division, print_function
+
+from enum import Enum
+from logging import getLogger
+
+from mantidimaging.core.data import Images
+from mantidimaging.gui.mvp_base import BasePresenter
+from mantidimaging.gui.utility import BlockQtSignals
+
+from .model import TomopyReconDialogModel
+
+
+class Notification(Enum):
+    UPDATE_PROJECTION_PREVIEW = 1
+    PREVIEW_SLICE_NEXT = 2
+    PREVIEW_SLICE_PREVIOUS = 3
+    RECONSTRUCT_SLICE = 4
+    RECONSTRUCT_VOLUME = 5
+
+
+class TomopyReconDialogPresenter(BasePresenter):
+
+    def __init__(self, view, main_window):
+        super(TomopyReconDialogPresenter, self).__init__(view)
+        self.model = TomopyReconDialogModel()
+        self.main_window = main_window
+
+    def notify(self, signal):
+        try:
+            if signal == Notification.UPDATE_PROJECTION_PREVIEW:
+                self.do_update_previews()
+            elif signal == Notification.PREVIEW_SLICE_NEXT:
+                self.set_preview_slice_idx(self.model.preview_slice_idx - 1)
+            elif signal == Notification.PREVIEW_SLICE_PREVIOUS:
+                self.set_preview_slice_idx(self.model.preview_slice_idx + 1)
+            elif signal == Notification.RECONSTRUCT_SLICE:
+                self.do_reconstruct_slice()
+            elif signal == Notification.RECONSTRUCT_VOLUME:
+                self.do_reconstruct_volume()
+
+        except Exception as e:
+            self.show_error(e)
+            getLogger(__name__).exception("Notification handler failed")
+
+    def set_stack_uuid(self, uuid):
+        self.model.initial_select_data(
+                self.main_window.get_stack_visualiser(uuid)
+                if uuid is not None else None)
+
+        self.view.previewSlice.setValue(0)
+        if self.model.sample is not None:
+            self.view.previewSlice.setMaximum(self.model.sample.shape[0] - 1)
+
+        # Update projection preview
+        self.notify(Notification.UPDATE_PROJECTION_PREVIEW)
+
+        # Remove existing reconstructed preview
+        self.view.update_recon_preview(None)
+
+    def set_preview_slice_idx(self, idx):
+        max_idx = \
+            self.model.sample.shape[0] if self.model.sample is not None else 0
+        idx = max(0, min(max_idx, idx))
+        self.model.preview_slice_idx = idx
+        with BlockQtSignals([self.view.previewSlice]):
+            self.view.previewSlice.setValue(idx)
+        self.notify(Notification.UPDATE_PROJECTION_PREVIEW)
+
+    def do_update_previews(self):
+        proj = self.model.projection
+        self.view.update_projection_preview(
+                proj[0] if proj is not None else None,
+                self.model.preview_slice_idx)
+
+    def prepare_reconstruction(self):
+        self.model.generate_cors(
+                self.view.cor.value(),
+                self.view.tilt.value())
+
+        self.model.generate_projection_angles(
+                self.view.maxProjAngle.value())
+
+    def do_reconstruct_slice(self):
+        self.prepare_reconstruction()
+        slice_data = self.model.reconstruct_slice()
+        self.view.update_recon_preview(slice_data[0])
+
+    def do_reconstruct_volume(self):
+        self.prepare_reconstruction()
+        volume_data = self.model.reconstruct_volume()
+        volume_stack = Images(volume_data)
+        name = '{}_recon'.format(self.model.stack.name)
+        self.main_window.presenter.create_new_stack(volume_stack, name)

--- a/mantidimaging/gui/dialogs/tomopy_recon/view.py
+++ b/mantidimaging/gui/dialogs/tomopy_recon/view.py
@@ -1,0 +1,107 @@
+from __future__ import absolute_import, division, print_function
+
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
+from matplotlib.figure import Figure
+
+from mantidimaging.gui.mvp_base import BaseDialogView
+
+from .navigation_toolbar import TomopyReconNavigationToolbar
+from .presenter import TomopyReconDialogPresenter
+from .presenter import Notification as PresNotification
+
+
+class TomopyReconDialogView(BaseDialogView):
+
+    def __init__(self, main_window, cmap='Greys_r'):
+        super(TomopyReconDialogView, self).__init__(
+                main_window, 'gui/ui/tomopy_recon_dialog.ui')
+
+        self.presenter = TomopyReconDialogPresenter(self, main_window)
+
+        self.cmap = cmap
+
+        # Handle stack selection
+        self.stackSelector.subscribe_to_main_window(main_window)
+        self.stackSelector.stack_selected_uuid.connect(
+                self.presenter.set_stack_uuid)
+
+        # Handle reconstruct buttons
+        self.reconstructSlice.clicked.connect(
+                lambda: self.presenter.notify(
+                    PresNotification.RECONSTRUCT_SLICE))
+        self.reconstructVolume.clicked.connect(
+                lambda: self.presenter.notify(
+                    PresNotification.RECONSTRUCT_VOLUME))
+
+        # Handle preview slice selection
+        self.previewSlice.valueChanged[int].connect(
+                self.presenter.set_preview_slice_idx)
+
+        def add_mpl_figure(layout, add_toolbar=False):
+            figure = Figure()
+            canvas = FigureCanvasQTAgg(figure)
+            canvas.setParent(self)
+            if add_toolbar:
+                toolbar = TomopyReconNavigationToolbar(canvas, self)
+                layout.addWidget(toolbar)
+            layout.addWidget(canvas)
+            return (figure, canvas)
+
+        # Projection image
+        self.proj_figure, self.proj_canvas = \
+            add_mpl_figure(self.projectionLayout)
+        self.proj_plot = self.proj_figure.add_subplot(111)
+        self.proj_canvas.mpl_connect(
+                'button_press_event', self.proj_on_button_press)
+        self.proj_canvas.mpl_connect(
+                'scroll_event', self.proj_handle_scroll_wheel)
+
+        # Reconstructed slice image
+        self.recon_figure, self.recon_canvas = \
+            add_mpl_figure(self.reconLayout, True)
+        self.recon_plot = self.recon_figure.add_subplot(111)
+
+    def proj_on_button_press(self, event):
+        if event.button == 1 and event.ydata is not None:
+            self.presenter.set_preview_slice_idx(int(event.ydata))
+
+    def proj_handle_scroll_wheel(self, event):
+        if event.button == 'up':
+            self.presenter.notify(PresNotification.PREVIEW_SLICE_NEXT)
+        elif event.button == 'down':
+            self.presenter.notify(PresNotification.PREVIEW_SLICE_PREVIOUS)
+
+    def update_projection_preview(self,
+                                  proj_image_data=None,
+                                  indicated_slice=None):
+        self.proj_plot.cla()
+
+        if proj_image_data is not None:
+            # Plot the image data
+            self.proj_plot.imshow(proj_image_data, cmap=self.cmap)
+
+            if indicated_slice is not None:
+                # Plot the slice indicator
+                x_max = proj_image_data.shape[1] - 1
+                self.proj_plot.plot(
+                        [0, x_max], [indicated_slice, indicated_slice],
+                        c='y')
+
+        self.proj_canvas.draw()
+
+    def update_recon_preview(self, recon_image_data=None):
+        # Record the image axis range from the existing preview image
+        image_axis_ranges = (
+            self.recon_plot.get_xlim(), self.recon_plot.get_ylim()
+        ) if self.recon_plot.images else None
+
+        self.recon_plot.cla()
+
+        if recon_image_data is not None:
+            self.recon_plot.imshow(recon_image_data, cmap=self.cmap)
+
+        if image_axis_ranges:
+            self.recon_plot.set_xlim(image_axis_ranges[0])
+            self.recon_plot.set_ylim(image_axis_ranges[1])
+
+        self.recon_canvas.draw()

--- a/mantidimaging/gui/ui/main_window.ui
+++ b/mantidimaging/gui/ui/main_window.ui
@@ -40,6 +40,7 @@
      <string>Reconstruct</string>
     </property>
     <addaction name="actionCorTilt"/>
+    <addaction name="actionTomopyRecon"/>
    </widget>
    <widget class="QMenu" name="menuProcessing">
     <property name="title">
@@ -109,6 +110,11 @@
    </property>
    <property name="shortcut">
     <string>F1</string>
+   </property>
+  </action>
+  <action name="actionTomopyRecon">
+   <property name="text">
+    <string>TomoPy Reconstruction</string>
    </property>
   </action>
  </widget>

--- a/mantidimaging/gui/ui/tomopy_recon_dialog.ui
+++ b/mantidimaging/gui/ui/tomopy_recon_dialog.ui
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>400</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <widget class="QWidget" name="verticalLayoutWidget_2">
+      <layout class="QVBoxLayout" name="paramsLayout">
+       <item>
+        <layout class="QGridLayout" name="optionsLayout">
+         <item row="3" column="1">
+          <widget class="QDoubleSpinBox" name="maxProjAngle">
+           <property name="maximum">
+            <double>9999.000000000000000</double>
+           </property>
+           <property name="value">
+            <double>360.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="maxProjAngleLebsl">
+           <property name="text">
+            <string>Maximum projection angle</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="corLabel">
+           <property name="text">
+            <string>Rotation centre:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="tiltLabel">
+           <property name="text">
+            <string>Tilt angle:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="QDoubleSpinBox" name="tilt">
+           <property name="decimals">
+            <number>9</number>
+           </property>
+           <property name="minimum">
+            <double>-6.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>6.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.010000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="stackSelectorLabel">
+           <property name="text">
+            <string>Stack:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="StackSelectorWidgetView" name="stackSelector"/>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="previewSliceLabel">
+           <property name="text">
+            <string>Preview slice:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QSpinBox" name="previewSlice"/>
+         </item>
+         <item row="4" column="1">
+          <widget class="QDoubleSpinBox" name="cor">
+           <property name="maximum">
+            <double>9999.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>10.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="reconButtonGroup">
+         <item>
+          <widget class="QPushButton" name="reconstructSlice">
+           <property name="text">
+            <string>Reconstruct Slice</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="reconstructVolume">
+           <property name="text">
+            <string>Reconstruct Volume</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QDialogButtonBox" name="buttonBox">
+         <property name="standardButtons">
+          <set>QDialogButtonBox::Close</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="verticalLayoutWidget">
+      <layout class="QVBoxLayout" name="projectionLayout"/>
+     </widget>
+     <widget class="QWidget" name="verticalLayoutWidget_3">
+      <layout class="QVBoxLayout" name="reconLayout"/>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>StackSelectorWidgetView</class>
+   <extends>QComboBox</extends>
+   <header>mantidimaging.gui.widgets.stack_selector</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>stackSelector</tabstop>
+  <tabstop>maxProjAngle</tabstop>
+  <tabstop>tilt</tabstop>
+  <tabstop>reconstructSlice</tabstop>
+  <tabstop>reconstructVolume</tabstop>
+  <tabstop>buttonBox</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>123</x>
+     <y>324</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>357</x>
+     <y>173</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/mantidimaging/gui/ui/tomopy_recon_dialog.ui
+++ b/mantidimaging/gui/ui/tomopy_recon_dialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Dialog</class>
- <widget class="QDialog" name="Dialog">
+ <class>TomoPyReconstructionDialog</class>
+ <widget class="QDialog" name="TomoPyReconstructionDialog">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>TomoPy Reconstruction</string>
   </property>
   <property name="sizeGripEnabled">
    <bool>true</bool>
@@ -175,7 +175,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
-   <receiver>Dialog</receiver>
+   <receiver>TomoPyReconstructionDialog</receiver>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -65,19 +65,20 @@ class MainWindowPresenter(BasePresenter):
 
         if task.was_successful():
             custom_name = task.kwargs['custom_name']
-            title = self.model.create_name(task.kwargs['selected_file']) if \
-                not custom_name else custom_name
-
-            dock_widget = self.view.create_stack_window(
-                    task.result, title=title)
-
-            stack_visualiser = dock_widget.widget()
-            self.model.add_stack(stack_visualiser, dock_widget)
-            self.view.active_stacks_changed.emit()
+            title = task.kwargs['selected_file'] if not custom_name \
+                else custom_name
+            self.create_new_stack(task.result, title)
 
         else:
             log.error("Failed to load stack: %s", str(task.error))
             self.show_error("Failed to load stack. See log for details.")
+
+    def create_new_stack(self, data, title):
+        title = self.model.create_name(title)
+        dock_widget = self.view.create_stack_window(data, title=title)
+        stack_visualiser = dock_widget.widget()
+        self.model.add_stack(stack_visualiser, dock_widget)
+        self.view.active_stacks_changed.emit()
 
     def save(self, indices=None):
         kwargs = {}

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -8,6 +8,7 @@ from PyQt5 import Qt, QtCore, QtGui
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.dialogs.cor_tilt import CORTiltDialogView
 from mantidimaging.gui.dialogs.filters import FiltersDialogView
+from mantidimaging.gui.dialogs.tomopy_recon import TomopyReconDialogView
 from mantidimaging.gui.windows.stack_visualiser import StackVisualiserView
 
 from .load_dialog import MWLoadDialog
@@ -31,6 +32,7 @@ class MainWindowView(BaseMainWindowView):
 
         self.filters_window = FiltersDialogView(self)
         self.cor_tilt_window = CORTiltDialogView(self)
+        self.tomopy_recon_window = TomopyReconDialogView(self)
 
         self.setup_shortcuts()
         self.update_shortcuts()
@@ -45,6 +47,7 @@ class MainWindowView(BaseMainWindowView):
 
         self.actionCorTilt.triggered.connect(self.show_cor_tilt_window)
         self.actionFilters.triggered.connect(self.show_filters_window)
+        self.actionTomopyRecon.triggered.connect(self.show_tomopy_recon_window)
 
         self.active_stacks_changed.connect(self.update_shortcuts)
 
@@ -74,6 +77,9 @@ class MainWindowView(BaseMainWindowView):
 
     def show_filters_window(self):
         self.filters_window.show()
+
+    def show_tomopy_recon_window(self):
+        self.tomopy_recon_window.show()
 
     def stack_list(self):
         return self.presenter.stack_list()

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -156,6 +156,10 @@ class StackVisualiserView(BaseMainWindowView):
                 self.slider_axis, self.presenter.get_image_count_on_axis() - 1)
 
     @property
+    def name(self):
+        return self.dock.windowTitle()
+
+    @property
     def current_roi(self):
         return self._current_roi
 


### PR DESCRIPTION
Re #119 

To test:
- Load `babylon5/DanNixon/bg_corr_crop_sinogram`, all sinograms (step = 1)
- Open TomoPy Reconstruction
- Select a slice from the bottom cylinder
- Enter 590 in Rotation Centre (this is the COR relative to the cropped sinogram)
- Enter -0.003 in tilt angle
- Reconstruct a single slice, you should see a relatively OK reconstruction (most likely you'd have a better reconstructed slice if you selected a slice near the bottom of the cylinder)
- Reconstruct the entire volume (you'd need at least 16GB of RAM to do this)

There are a couple of UX issues with this so far:
- The COR is assumed to be at the bottom of the image, which here is not the case
- The COR is also assumed to be relative to the image given to the reconstruction UI, when it is measured relative to the entire image

(there are several "easy" solutions to these, choosing the best one will probably need more discussion)