### PR TITLE
Parallel COR/tilt finding

### DIFF
--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -11,6 +11,9 @@ def create_shared_array(shape, dtype=np.float32):
     if isinstance(dtype, np.uint16) or dtype == 'uint16':
         ctype = ctypes.c_int16
         dtype = np.uint16
+    elif isinstance(dtype, np.int64) or dtype == 'int64':
+        ctype = ctypes.c_int64
+        dtype = np.int64
     elif isinstance(dtype, np.float32) or dtype == 'float32':
         ctype = ctypes.c_float
         dtype = np.float32
@@ -18,8 +21,11 @@ def create_shared_array(shape, dtype=np.float32):
         ctype = ctypes.c_double
         dtype = np.float64
 
-    shared_array_base = sharedctypes.RawArray(
-            ctype, shape[0] * shape[1] * shape[2])
+    length = 1
+    for axis_length in shape:
+        length *= axis_length
+
+    shared_array_base = sharedctypes.RawArray(ctype, length)
 
     # create a numpy array from shared array
     data = np.frombuffer(shared_array_base, dtype=dtype)


### PR DESCRIPTION
Fixes #186 

Runs COR finding per slice in parallel, reducing the time taken for the longest step of this algorithm.

To test:
- Run `babylon5/DanNixon/cot_tilt_test.py` (correct the `input_path` to wherever you have babylon5 mounted)
- See that it only uses a single CPU core
- Set `cores=None` and run again
- See that all CPU cores are used