### PR TITLE
Metadata loading and saving

### DIFF
--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -57,8 +57,14 @@ class Images(object):
     def metadata_load(self, f):
         self.properties = json.load(f)
 
+    def metadata_loads(self, s):
+        self.properties = json.loads(s)
+
     def metadata_save(self, f):
         json.dump(self.properties, f)
+
+    def metadata_saves(self):
+        return json.dumps(self.properties)
 
     @staticmethod
     def check_data_stack(data, expected_dims=3, expected_class=np.ndarray):

--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -1,5 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
+import json
+
 import numpy as np
 
 from mantidimaging import helper as h
@@ -51,6 +53,12 @@ class Images(object):
     @property
     def filenames(self):
         return self._filenames
+
+    def metadata_load(self, f):
+        self.properties = json.load(f)
+
+    def metadata_save(self, f):
+        json.dump(self.properties, f)
 
     @staticmethod
     def check_data_stack(data, expected_dims=3, expected_class=np.ndarray):

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -37,17 +37,36 @@ class ImagesTest(unittest.TestCase):
             for k in imgs.properties.keys():
                 self.assertTrue(k in s)
 
+        s = imgs.metadata_saves()
+        validate_str(s)
+
         f = StringIO()
         imgs.metadata_save(f)
         validate_str(f.getvalue())
 
-    def test_parse_metadata_str(self):
+    def test_parse_metadata_file(self):
         json_file = StringIO(
                 '{"a_int": 42, "a_string": "yes", "a_arr": ["one", "two", '
                 '"three"], "a_float": 3.65e-05, "a_bool": true}')
 
         imgs = Images()
         imgs.metadata_load(json_file)
+
+        def validate_prop(k, v):
+            self.assertEquals(imgs.properties[k], v)
+
+        validate_prop('a_bool', True)
+        validate_prop('a_string', 'yes')
+        validate_prop('a_int', 42)
+        validate_prop('a_arr', ['one', 'two', 'three'])
+
+    def test_parse_metadata_str(self):
+        json_str = \
+                '{"a_int": 42, "a_string": "yes", "a_arr": ["one", "two", ' \
+                '"three"], "a_float": 3.65e-05, "a_bool": true}'
+
+        imgs = Images()
+        imgs.metadata_loads(json_str)
 
         def validate_prop(k, v):
             self.assertEquals(imgs.properties[k], v)

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import unittest
 
+from six import StringIO
 import numpy as np
 
 from mantidimaging.core.data import Images
@@ -23,3 +24,35 @@ class ImagesTest(unittest.TestCase):
                 str(imgs),
                 'Image Stack: sample=(2, 64, 64), flat=None, dark=None, '
                 '|properties|=0')
+
+    def test_serialise_metadata(self):
+        imgs = Images()
+        imgs.properties['a_bool'] = True
+        imgs.properties['a_string'] = 'yes'
+        imgs.properties['a_float'] = 3.65e-5
+        imgs.properties['a_int'] = 42
+        imgs.properties['a_arr'] = ['one', 'two', 'three']
+
+        def validate_str(s):
+            for k in imgs.properties.keys():
+                self.assertTrue(k in s)
+
+        f = StringIO()
+        imgs.metadata_save(f)
+        validate_str(f.getvalue())
+
+    def test_parse_metadata_str(self):
+        json_file = StringIO(
+                '{"a_int": 42, "a_string": "yes", "a_arr": ["one", "two", '
+                '"three"], "a_float": 3.65e-05, "a_bool": true}')
+
+        imgs = Images()
+        imgs.metadata_load(json_file)
+
+        def validate_prop(k, v):
+            self.assertEquals(imgs.properties[k], v)
+
+        validate_prop('a_bool', True)
+        validate_prop('a_string', 'yes')
+        validate_prop('a_int', 42)
+        validate_prop('a_arr', ['one', 'two', 'three'])

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-import os
-
 from logging import getLogger
 
 import numpy as np
@@ -233,12 +231,12 @@ def load(input_path=None,
     metadata_filename = get_file_names(input_path, 'json', in_prefix,
                                        essential=False)
     metadata_filename = metadata_filename[0] if metadata_filename else None
-    if metadata_filename and os.path.exists(metadata_filename):
+    if metadata_filename:
         with open(metadata_filename) as f:
             images.metadata_load(f)
             LOG.debug('Loaded metadata from: {}'.format(metadata_filename))
     else:
-        LOG.debug('No metadata file found: {}'.format(metadata_filename))
+        LOG.debug('No metadata file found')
 
     return images
 

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import os
+
 from logging import getLogger
 
 import numpy as np
@@ -8,6 +10,8 @@ from mantidimaging.core.io.loader import img_loader, stack_loader
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.core.io.utility import (
         get_file_names, DEFAULT_IO_FILE_FORMAT)
+
+LOG = getLogger(__name__)
 
 
 def _fitsread(filename):
@@ -225,6 +229,17 @@ def load(input_path=None,
 
     images.check_data_stack(images)
 
+    # Search for and load metadata file
+    metadata_filename = get_file_names(input_path, 'json', in_prefix,
+                                       essential=False)
+    metadata_filename = metadata_filename[0] if metadata_filename else None
+    if metadata_filename and os.path.exists(metadata_filename):
+        with open(metadata_filename) as f:
+            images.metadata_load(f)
+            LOG.debug('Loaded metadata from: {}'.format(metadata_filename))
+    else:
+        LOG.debug('No metadata file found: {}'.format(metadata_filename))
+
     return images
 
 
@@ -267,7 +282,7 @@ def load_sinogram(input_path=None,
     output_data = pu.create_shared_array(
             (1, num_images, img_shape[1]), dtype=dtype)
 
-    getLogger(__name__).info("Output data shape: {}".format(output_data.shape))
+    LOG.info("Output data shape: {}".format(output_data.shape))
 
     with progress:
         for idx, input_file in enumerate(input_file_names):

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -91,17 +91,18 @@ def save(data,
     progress = Progress.ensure_instance(progress,
                                         task_name='Save')
 
-    if isinstance(data, Images):
-        metadata_filename = os.path.join(output_dir, name_prefix + '.json')
-        LOG.debug('Metadata filename: {}'.format(metadata_filename))
-        with open(metadata_filename, 'w') as f:
-            data.metadata_save(f)
-
-        data = data.sample
-
     # expand the path for plugins that don't do it themselves
     output_dir = os.path.abspath(os.path.expanduser(output_dir))
     make_dirs_if_needed(output_dir, overwrite_all)
+
+    if isinstance(data, Images):
+        # Save metadata
+        metadata_filename = os.path.join(output_dir, name_prefix + '.json')
+        LOG.debug('Metadata filename: {}'.format(metadata_filename))
+        with open(metadata_filename, 'w+') as f:
+            data.metadata_save(f)
+
+        data = data.sample
 
     if swap_axes:
         data = np.swapaxes(data, 0, 1)

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -11,6 +11,8 @@ from mantidimaging.core.data import Images
 
 from .utility import DEFAULT_IO_FILE_FORMAT
 
+LOG = getLogger(__name__)
+
 DEFAULT_ZFILL_LENGTH = 6
 DEFAULT_NAME_PREFIX = 'image'
 DEFAULT_NAME_POSTFIX = ''
@@ -90,6 +92,11 @@ def save(data,
                                         task_name='Save')
 
     if isinstance(data, Images):
+        metadata_filename = os.path.join(output_dir, name_prefix + '.json')
+        LOG.debug('Metadata filename: {}'.format(metadata_filename))
+        with open(metadata_filename, 'w') as f:
+            data.metadata_save(f)
+
         data = data.sample
 
     # expand the path for plugins that don't do it themselves
@@ -254,7 +261,7 @@ class Saver(object):
         # reshape so that it works with the internals
         data = data.reshape(1, data.shape[0], data.shape[1])
         if self._output_path is None:
-            getLogger(__name__).info(
+            LOG.info(
                 "Not saving a single image, "
                 "because no output path is specified."
             )
@@ -327,7 +334,7 @@ class Saver(object):
                                             task_name='Save Reconstruction')
 
         if self._output_path is None:
-            getLogger(__name__).warning(
+            LOG.warning(
                 "Not saving reconstruction output, "
                 "because no output path is specified."
             )
@@ -348,7 +355,7 @@ class Saver(object):
                 out_horiz_dir = os.path.join(out_recon_dir,
                                              self._out_horiz_slices_subdir)
 
-                getLogger(__name__).info(
+                LOG.info(
                     "Saving horizontal slices in: {0}".format(out_horiz_dir))
 
                 # save out the horizontal slices by flipping the axes

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -519,6 +519,9 @@ class IOTest(FileOutputtingTestCase):
 
         npt.assert_equal(exp_sinograms, loaded_images.sample)
 
+    def test_metadata_round_trip(self):
+        self.fail('TODO: write this test')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -11,8 +11,9 @@ import mantidimaging.core.testing.unit_test_helper as th
 
 from mantidimaging.helper import initialise_logging
 from mantidimaging.core.configs.recon_config import ReconstructionConfig
+from mantidimaging.core.data import Images
 from mantidimaging.core.io import loader
-from mantidimaging.core.io.saver import Saver, generate_names
+from mantidimaging.core.io.saver import Saver, save, generate_names
 from mantidimaging.core.testing import FileOutputtingTestCase
 
 
@@ -520,7 +521,19 @@ class IOTest(FileOutputtingTestCase):
         npt.assert_equal(exp_sinograms, loaded_images.sample)
 
     def test_metadata_round_trip(self):
-        self.fail('TODO: write this test')
+        # Create dummy image stack
+        sample = th.gen_img_shared_array_with_val(42.)
+        images = Images(sample)
+        images.properties['message'] = 'hello, world!'
+
+        # Save image stack
+        save(images, self.output_directory)
+
+        # Load image stack back
+        loaded_images = loader.load(self.output_directory)
+
+        # Ensure properties have been preserved
+        self.assertEquals(loaded_images.properties, images.properties)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -55,7 +55,7 @@ def get_candidate_file_extensions(ext):
     return [ext] + candidates
 
 
-def get_file_names(path, img_format, prefix=''):
+def get_file_names(path, img_format, prefix='', essential=True):
     """
     Get all file names in a directory with a specific format.
     :param path: The path to be checked.
@@ -63,6 +63,9 @@ def get_file_names(path, img_format, prefix=''):
     :param img_format: The image format used as a postfix after the .
 
     :param prefix: A specific prefix for the images
+
+    :param essential: Flag indicating if failure to find file should raise and
+                      exception
 
     :return: All the file names, sorted by ascending
     """
@@ -78,7 +81,7 @@ def get_file_names(path, img_format, prefix=''):
         if len(files_match) > 0:
             break
 
-    if len(files_match) <= 0:
+    if len(files_match) <= 0 and essential:
         raise RuntimeError(
             "Could not find any image files in '{0}' with extensions: "
             "{1}".format(path, extensions))

--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -71,6 +71,10 @@ def get_file_names(path, img_format, prefix='', essential=True):
     """
     log = getLogger(__name__)
 
+    # Return no found files on None path
+    if path is None:
+        return []
+
     path = os.path.abspath(os.path.expanduser(path))
     extensions = get_candidate_file_extensions(img_format)
 

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -32,7 +32,7 @@ class MainWindowModel(object):
                   overwrite, swap_axes, indices, progress):
         svp = self.get_stack_visualiser(stack_uuid).presenter
         saver.save(
-            data=svp.images.sample,
+            data=svp.images,
             output_dir=output_dir,
             name_prefix=name_prefix,
             swap_axes=swap_axes,


### PR DESCRIPTION
Fixes #198 

To test:
- Review added unit test
- Run this script (adjust paths as required), see that the properties are preserved through the load/save cycle:

```
import time
from mantidimaging.core.io.loader import load
from mantidimaging.core.io.saver import save

stack = load('~/demoimages/sample/')
stack.properties['load_time'] = time.time()

save(stack, '~/test/')

reloaded_stack = load('~/test/')

print(reloaded_stack)
print(reloaded_stack.properties)
```