### PR TITLE
Trigger filter preview update from ROI change

### DIFF
--- a/mantidimaging/gui/dialogs/filters/model.py
+++ b/mantidimaging/gui/dialogs/filters/model.py
@@ -32,7 +32,7 @@ class FiltersDialogModel(object):
         self.preview_image_idx = 0
 
         # Execution info for current filter
-        self.stack_presenter = None
+        self.stack = None
         self.do_before = None
         self.execute = None
         self.do_after = None
@@ -81,6 +81,10 @@ class FiltersDialogModel(object):
         :param filter_idx: Index of the filter in the registry
         """
         return self.filters[filter_idx][1]
+
+    @property
+    def stack_presenter(self):
+        return self.stack.presenter if self.stack else None
 
     @property
     def num_images_in_stack(self):

--- a/mantidimaging/gui/dialogs/filters/model.py
+++ b/mantidimaging/gui/dialogs/filters/model.py
@@ -21,10 +21,8 @@ def ensure_tuple(val):
 
 class FiltersDialogModel(object):
 
-    def __init__(self, main_window):
+    def __init__(self):
         super(FiltersDialogModel, self).__init__()
-
-        self.main_window = main_window
 
         # Update the local filter registry
         self.filters = None
@@ -34,7 +32,7 @@ class FiltersDialogModel(object):
         self.preview_image_idx = 0
 
         # Execution info for current filter
-        self.stack_uuid = None
+        self.stack_presenter = None
         self.do_before = None
         self.execute = None
         self.do_after = None
@@ -84,19 +82,10 @@ class FiltersDialogModel(object):
         """
         return self.filters[filter_idx][1]
 
-    def get_stack(self):
-        """
-        Gets the presenter for the selected stack.
-        """
-        stack = self.main_window.get_stack_visualiser(self.stack_uuid) \
-            if self.stack_uuid else None
-        return stack.presenter if stack is not None else None
-
     @property
     def num_images_in_stack(self):
-        stack = self.get_stack()
-        num_images = stack.images.sample.shape[0] \
-            if stack is not None else 0
+        num_images = self.stack_presenter.images.sample.shape[0] \
+            if self.stack_presenter is not None else 0
         return num_images
 
     def setup_filter(self, filter_specifics):
@@ -147,15 +136,14 @@ class FiltersDialogModel(object):
         """
         Applys the selected filter to the selected stack.
         """
-        # Get stack
-        stack = self.get_stack()
-        if not stack:
+        if not self.stack_presenter:
             raise ValueError('No stack selected')
 
         # Get auto parameters
-        exec_kwargs = get_auto_params_from_stack(stack, self.auto_props)
+        exec_kwargs = get_auto_params_from_stack(
+                self.stack_presenter, self.auto_props)
 
-        self.apply_filter(stack.images, exec_kwargs)
+        self.apply_filter(self.stack_presenter.images, exec_kwargs)
 
         # Refresh the image in the stack visualiser
-        stack.notify(SVNotification.REFRESH_IMAGE)
+        self.stack_presenter.notify(SVNotification.REFRESH_IMAGE)

--- a/mantidimaging/gui/dialogs/filters/presenter.py
+++ b/mantidimaging/gui/dialogs/filters/presenter.py
@@ -10,6 +10,7 @@ from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.core.utility.histogram import (
         generate_histogram_from_image)
 from mantidimaging.gui.mvp_base import BasePresenter
+from mantidimaging.gui.windows.stack_visualiser import Parameters
 from mantidimaging.gui.utility import (
         BlockQtSignals, get_auto_params_from_stack)
 
@@ -74,8 +75,8 @@ class FiltersDialogPresenter(BasePresenter):
         self.view.previewImageIndex.setMaximum(self.max_preview_image_idx)
 
     def handle_roi_selection(self, roi):
-        if roi:
-            self.notify(Notification.UPDATE_PREVIEWS)
+        if roi and self.filter_uses_auto_property(Parameters.ROI):
+            self.view.auto_update_triggered.emit()
 
     def set_preview_image_index(self, image_idx):
         """
@@ -103,6 +104,10 @@ class FiltersDialogPresenter(BasePresenter):
         self.model.setup_filter(
                 register_func(self.view.filterPropertiesLayout,
                               self.view.auto_update_triggered.emit))
+
+    def filter_uses_auto_property(self, prop):
+        return prop in self.model.auto_props.values() if \
+                self.model.auto_props is not None else False
 
     def do_apply_filter(self):
         self.model.do_apply_filter()

--- a/mantidimaging/gui/dialogs/filters/presenter.py
+++ b/mantidimaging/gui/dialogs/filters/presenter.py
@@ -59,11 +59,23 @@ class FiltersDialogPresenter(BasePresenter):
                 if uuid is not None else None)
 
     def set_stack(self, stack):
-        self.model.stack_presenter = stack.presenter
+        # Disconnect ROI update singal from previous stack
+        if self.model.stack:
+            self.model.stack.roi_updated.disconnect(self.handle_roi_selection)
+
+        # Connect ROI update signal to newly selected stack
+        if stack:
+            stack.roi_updated.connect(self.handle_roi_selection)
+
+        self.model.stack = stack
 
         # Update the preview image index
         self.set_preview_image_index(0)
         self.view.previewImageIndex.setMaximum(self.max_preview_image_idx)
+
+    def handle_roi_selection(self, roi):
+        if roi:
+            self.notify(Notification.UPDATE_PREVIEWS)
 
     def set_preview_image_index(self, image_idx):
         """

--- a/mantidimaging/gui/dialogs/filters/presenter.py
+++ b/mantidimaging/gui/dialogs/filters/presenter.py
@@ -29,7 +29,7 @@ class FiltersDialogPresenter(BasePresenter):
     def __init__(self, view, main_window):
         super(FiltersDialogPresenter, self).__init__(view)
 
-        self.model = FiltersDialogModel(main_window)
+        self.model = FiltersDialogModel()
         self.main_window = main_window
 
     def notify(self, signal):
@@ -53,11 +53,13 @@ class FiltersDialogPresenter(BasePresenter):
     def max_preview_image_idx(self):
         return max(self.model.num_images_in_stack - 1, 0)
 
-    def set_stack_uuid(self, stack_uuid):
-        """
-        Sets the UUID of the currently selected stack.
-        """
-        self.model.stack_uuid = stack_uuid
+    def set_stack_uuid(self, uuid):
+        self.set_stack(
+                self.main_window.get_stack_visualiser(uuid)
+                if uuid is not None else None)
+
+    def set_stack(self, stack):
+        self.model.stack_presenter = stack.presenter
 
         # Update the preview image index
         self.set_preview_image_index(0)
@@ -102,7 +104,7 @@ class FiltersDialogPresenter(BasePresenter):
 
         with progress:
             progress.update(msg='Getting stack')
-            stack = self.model.get_stack()
+            stack = self.model.stack_presenter
 
             # If there is no stack then clear the preview area
             if stack is None:

--- a/mantidimaging/gui/dialogs/filters/test/model_test.py
+++ b/mantidimaging/gui/dialogs/filters/test/model_test.py
@@ -31,7 +31,7 @@ class FiltersDialogModelTest(unittest.TestCase):
         self.sv_presenter = StackVisualiserPresenter(
                 self.sv_view, self.test_data, data_traversal_axis=0)
 
-        self.model = FiltersDialogModel(None)
+        self.model = FiltersDialogModel()
 
     def execute_mock(self, data):
         self.assertTrue(isinstance(data, np.ndarray))
@@ -59,7 +59,7 @@ class FiltersDialogModelTest(unittest.TestCase):
         self.assertTrue(len(self.model.filter_names) > 0)
 
     def test_do_apply_filter(self):
-        self.model.get_stack = lambda: self.sv_presenter
+        self.model.stack_presenter = self.sv_presenter
 
         execute = mock.MagicMock(
                 return_value=self.execute_mock)
@@ -70,7 +70,7 @@ class FiltersDialogModelTest(unittest.TestCase):
         execute.assert_called_once()
 
     def test_do_apply_filter_with_roi(self):
-        self.model.get_stack = lambda: self.sv_presenter
+        self.model.stack_presenter = self.sv_presenter
 
         execute = mock.MagicMock(
                 return_value=self.execute_mock_with_roi)
@@ -85,7 +85,7 @@ class FiltersDialogModelTest(unittest.TestCase):
         execute.assert_called_once()
 
     def test_do_apply_filter_pre_post_processing(self):
-        self.model.get_stack = lambda: self.sv_presenter
+        self.model.stack_presenter = self.sv_presenter
 
         execute = mock.MagicMock(
                 return_value=self.execute_mock)

--- a/mantidimaging/gui/dialogs/filters/test/model_test.py
+++ b/mantidimaging/gui/dialogs/filters/test/model_test.py
@@ -30,6 +30,7 @@ class FiltersDialogModelTest(unittest.TestCase):
 
         self.sv_presenter = StackVisualiserPresenter(
                 self.sv_view, self.test_data, data_traversal_axis=0)
+        self.sv_view.presenter = self.sv_presenter
 
         self.model = FiltersDialogModel()
 
@@ -59,7 +60,7 @@ class FiltersDialogModelTest(unittest.TestCase):
         self.assertTrue(len(self.model.filter_names) > 0)
 
     def test_do_apply_filter(self):
-        self.model.stack_presenter = self.sv_presenter
+        self.model.stack = self.sv_presenter.view
 
         execute = mock.MagicMock(
                 return_value=self.execute_mock)
@@ -70,7 +71,7 @@ class FiltersDialogModelTest(unittest.TestCase):
         execute.assert_called_once()
 
     def test_do_apply_filter_with_roi(self):
-        self.model.stack_presenter = self.sv_presenter
+        self.model.stack = self.sv_presenter.view
 
         execute = mock.MagicMock(
                 return_value=self.execute_mock_with_roi)
@@ -85,7 +86,7 @@ class FiltersDialogModelTest(unittest.TestCase):
         execute.assert_called_once()
 
     def test_do_apply_filter_pre_post_processing(self):
-        self.model.stack_presenter = self.sv_presenter
+        self.model.stack = self.sv_presenter.view
 
         execute = mock.MagicMock(
                 return_value=self.execute_mock)

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -22,7 +22,7 @@ from .presenter import Notification as StackWindowNotification
 class StackVisualiserView(BaseMainWindowView):
 
     image_updated = Qt.pyqtSignal()
-    roi_updated = Qt.pyqtSignal()
+    roi_updated = Qt.pyqtSignal('PyQt_PyObject')
 
     def __init__(self, parent, dock, images, data_traversal_axis=0,
                  cmap='Greys_r', block=False):
@@ -182,7 +182,8 @@ class StackVisualiserView(BaseMainWindowView):
         self.roi_selector.extents = (value[0], value[2], value[1], value[3]) \
             if value is not None else (0, 0, 0, 0)
 
-        self.roi_updated.emit()
+        # Notify of new ROI selected
+        self.roi_updated.emit(self.current_roi)
 
     def handle_canvas_scroll_wheel(self, event):
         """

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -22,6 +22,7 @@ from .presenter import Notification as StackWindowNotification
 class StackVisualiserView(BaseMainWindowView):
 
     image_updated = Qt.pyqtSignal()
+    roi_updated = Qt.pyqtSignal()
 
     def __init__(self, parent, dock, images, data_traversal_axis=0,
                  cmap='Greys_r', block=False):
@@ -180,6 +181,8 @@ class StackVisualiserView(BaseMainWindowView):
         # Update ROI selector
         self.roi_selector.extents = (value[0], value[2], value[1], value[3]) \
             if value is not None else (0, 0, 0, 0)
+
+        self.roi_updated.emit()
 
     def handle_canvas_scroll_wheel(self, event):
         """


### PR DESCRIPTION
Fixes #196

Triggers a filter preview refresh when the ROI on the data stack is changed and the selected filter makes use of the ROI auto parameter.

To test:
- Load two datasets (ideally obviously different ones)
- Open the filters window
- Select a filter that does not use ROI (e.g. intensity cut off)
- Select an ROI on the data stack and see that the filter does not refresh
- Select the crop coordinates filter and select an ROI
- See that the preview updates every time the ROI is changed
- Swap between input stacks and see that only the selected stack triggers a refresh