### PR TITLE
Record filter params in metadata

### DIFF
--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -66,6 +66,20 @@ class Images(object):
     def metadata_saves(self):
         return json.dumps(self.properties)
 
+    def record_parameters_in_metadata(self, func, *args, **kwargs):
+        if 'operation_history' not in self.properties:
+            self.properties['operation_history'] = []
+
+        def accepted_type(o):
+            return type(o) in [str, int, float, bool, tuple]
+
+        self.properties['operation_history'].append({
+            'name': func,
+            'args': [a if accepted_type(a) else None for a in args],
+            'kwargs': dict([(k, v if accepted_type(v) else None) for
+                           (k, v) in kwargs.items()])
+        })
+
     @staticmethod
     def check_data_stack(data, expected_dims=3, expected_class=np.ndarray):
         h.check_data_stack(data, expected_dims, expected_class)

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -75,3 +75,24 @@ class ImagesTest(unittest.TestCase):
         validate_prop('a_string', 'yes')
         validate_prop('a_int', 42)
         validate_prop('a_arr', ['one', 'two', 'three'])
+
+    def test_record_parameters_in_metadata(self):
+        imgs = Images()
+        imgs.record_parameters_in_metadata(
+                'test_func',
+                56, 9002, np.ndarray((800, 1024, 1024)), 'yes', False,
+                this=765, that=495.0, roi=(1, 2, 3, 4))
+
+        self.assertEquals(imgs.properties, {
+            'operation_history': [
+                {
+                    'name': 'test_func',
+                    'args': [56, 9002, None, 'yes', False],
+                    'kwargs': {
+                        'this': 765,
+                        'that': 495.0,
+                        'roi': (1, 2, 3, 4)
+                    }
+                }
+            ]
+        })

--- a/mantidimaging/gui/dialogs/filters/model.py
+++ b/mantidimaging/gui/dialogs/filters/model.py
@@ -111,9 +111,18 @@ class FiltersDialogModel(object):
         execute_func = self.execute()
 
         # Log execute function parameters
+        log.info("Filter kwargs: {}".format(exec_kwargs))
         if isinstance(execute_func, partial):
-            log.info("Filter args: {}".format(execute_func.args))
-            log.info("Filter kwargs: {}".format(execute_func.keywords))
+            log.info("Filter partial args: {}".format(execute_func.args))
+            log.info("Filter partial kwargs: {}".format(execute_func.keywords))
+
+            all_kwargs = execute_func.keywords.copy()
+            all_kwargs.update(exec_kwargs)
+
+            images.record_parameters_in_metadata(
+                    '{}.{}'.format(execute_func.func.__module__,
+                                   execute_func.func.__name__),
+                    *execute_func.args, **all_kwargs)
 
         # Do preprocessing and save result
         preproc_res = do_before_func(images.sample)
@@ -138,7 +147,7 @@ class FiltersDialogModel(object):
 
     def do_apply_filter(self):
         """
-        Applys the selected filter to the selected stack.
+        Applies the selected filter to the selected stack.
         """
         if not self.stack_presenter:
             raise ValueError('No stack selected')


### PR DESCRIPTION
Saves a very rough history of filters that are applied in the GUI in the image properties.

To test:
- Load some data
- Apply some filters
- Save it
- Open the `.json` file saved alongside the images and see that the operations performed are listed