### PR TITLE
Auto fill COT/Tilt params

### DIFF
--- a/mantidimaging/core/data/__init__.py
+++ b/mantidimaging/core/data/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from . import const  # noqa: F401
 from .images import Images  # noqa: F401
 
 del absolute_import, division, print_function

--- a/mantidimaging/core/data/const.py
+++ b/mantidimaging/core/data/const.py
@@ -1,0 +1,4 @@
+from __future__ import (absolute_import, division, print_function)
+
+OPERATION_HISTORY = 'operation_history'
+AUTO_COR_TILT = 'auto_cor_tilt'

--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -4,6 +4,7 @@ import json
 
 import numpy as np
 
+from . import const
 from mantidimaging import helper as h
 
 
@@ -67,13 +68,13 @@ class Images(object):
         return json.dumps(self.properties)
 
     def record_parameters_in_metadata(self, func, *args, **kwargs):
-        if 'operation_history' not in self.properties:
-            self.properties['operation_history'] = []
+        if const.OPERATION_HISTORY not in self.properties:
+            self.properties[const.OPERATION_HISTORY] = []
 
         def accepted_type(o):
             return type(o) in [str, int, float, bool, tuple]
 
-        self.properties['operation_history'].append({
+        self.properties[const.OPERATION_HISTORY].append({
             'name': func,
             'args': [a if accepted_type(a) else None for a in args],
             'kwargs': dict([(k, v if accepted_type(v) else None) for

--- a/mantidimaging/core/reconstruct/cor_tilt.py
+++ b/mantidimaging/core/reconstruct/cor_tilt.py
@@ -47,7 +47,7 @@ def calculate_cor_and_tilt(
 
     progress = Progress.ensure_instance(progress)
     progress.task_name = "Find COR and tilt"
-    progress.add_estimated_steps(2 + indices.size)
+    progress.add_estimated_steps(3 + indices.size)
 
     with progress:
         # Crop to the ROI from which the COR/tilt are calculated
@@ -76,7 +76,8 @@ def calculate_cor_and_tilt(
                                fwd_func=psm.return_fwd_func,
                                sample_data=fliped_data)
 
-        psm.execute(cors, f, cores=cores)
+        progress.update(msg="Rotation centre finding")
+        psm.execute(cors, f, cores=cores, progress=progress)
 
         slices = indices_in_roi_flipped
 

--- a/mantidimaging/core/reconstruct/cor_tilt.py
+++ b/mantidimaging/core/reconstruct/cor_tilt.py
@@ -7,6 +7,7 @@ import math
 import numpy as np
 import scipy as sp
 
+from mantidimaging.core.data import const
 from mantidimaging.core.parallel import shared_mem as psm
 from mantidimaging.core.parallel import utility as pu
 from mantidimaging.core.utility.progress_reporting import Progress
@@ -94,7 +95,7 @@ def calculate_cor_and_tilt(
         log.info("COR={}, tilt={} ({}deg)".format(cor, tilt, np.rad2deg(tilt)))
 
         # Record results in stack properties
-        stack.properties['auto_cor_tilt'] = {
+        stack.properties[const.AUTO_COR_TILT] = {
             'rotation_centre': cor,
             'tilt_angle_rad': tilt,
             'fitted_gradient': m,

--- a/mantidimaging/core/reconstruct/test/utility_test.py
+++ b/mantidimaging/core/reconstruct/test/utility_test.py
@@ -1,0 +1,136 @@
+from unittest import TestCase
+
+from mantidimaging.core.data import Images
+from mantidimaging.core.reconstruct import utility
+
+
+TEST_PARAMS_1 = {
+    "operation_history": [
+        {
+            "args": [],
+            "kwargs": {
+                "region_of_interest": [
+                    61,
+                    31,
+                    2025,
+                    1730
+                ]
+            },
+            "name":
+            "mantidimaging.core.filters.crop_coords.crop_coords.execute_single"
+        },
+        {
+            "args": [],
+            "kwargs": {
+                "threshold": 0.75
+            },
+            "name": "mantidimaging.core.filters.cut_off.cut_off.execute"
+        },
+        {
+            "args": [],
+            "kwargs": {
+                "region_of_interest": [
+                    760,
+                    316,
+                    1939,
+                    1687
+                ]
+            },
+            "name":
+            "mantidimaging.core.filters.crop_coords.crop_coords.execute_single"
+        }
+    ],
+    "auto_cor_tilt": {
+        "fitted_gradient": -0.012,
+        "rotation_centre": 1427.6,
+        "rotation_centres": [
+            1428,
+            1425,
+            1427,
+            1426,
+            1424,
+            1423,
+            1422,
+            1421,
+            1422,
+            1420,
+            1419,
+            1418,
+            1416
+        ],
+        "slice_indices": [
+            1,
+            71,
+            141,
+            211,
+            281,
+            351,
+            421,
+            491,
+            561,
+            631,
+            701,
+            771,
+            841
+        ],
+        "tilt_angle_rad": -0.01238
+    }
+}
+
+
+TEST_PARAMS_2 = {
+    "operation_history": [
+        {
+            "args": [],
+            "kwargs": {
+                "region_of_interest": [
+                    61,
+                    31,
+                    2025,
+                    1730
+                ]
+            },
+            "name":
+            "mantidimaging.core.filters.crop_coords.crop_coords.execute_single"
+        }
+    ]
+}
+
+
+class UtilityTest(TestCase):
+
+    def test_get_roi_left_shift_multiple(self):
+        imgs = Images()
+        imgs.properties = TEST_PARAMS_1
+        roi_offset = utility.get_roi_left_shift(imgs)
+        self.assertEquals(roi_offset, 821)
+
+    def test_get_roi_left_shift_single(self):
+        imgs = Images()
+        imgs.properties = TEST_PARAMS_2
+        roi_offset = utility.get_roi_left_shift(imgs)
+        self.assertEquals(roi_offset, 61)
+
+    def test_get_roi_left_shift_no_hist(self):
+        imgs = Images()
+        imgs.properties = {"operation_history": []}
+        roi_offset = utility.get_roi_left_shift(imgs)
+        self.assertEquals(roi_offset, 0)
+
+    def test_get_roi_left_shift_empty(self):
+        imgs = Images()
+        roi_offset = utility.get_roi_left_shift(imgs)
+        self.assertEquals(roi_offset, 0)
+
+    def test_get_cor_tilt_from_images(self):
+        imgs = Images()
+        imgs.properties = TEST_PARAMS_1
+        cor, tilt = utility.get_cor_tilt_from_images(imgs)
+        self.assertEquals(cor, 1427.6 - 821)
+        self.assertAlmostEqual(tilt, -0.01238)
+
+    def test_get_cor_tilt_from_images_empty(self):
+        imgs = Images()
+        cor, tilt = utility.get_cor_tilt_from_images(imgs)
+        self.assertEquals(cor, 0)
+        self.assertEquals(tilt, 0.0)

--- a/mantidimaging/core/reconstruct/test/utility_test.py
+++ b/mantidimaging/core/reconstruct/test/utility_test.py
@@ -134,3 +134,8 @@ class UtilityTest(TestCase):
         cor, tilt = utility.get_cor_tilt_from_images(imgs)
         self.assertEquals(cor, 0)
         self.assertEquals(tilt, 0.0)
+
+    def test_get_cor_tilt_from_images_none(self):
+        cor, tilt = utility.get_cor_tilt_from_images(None)
+        self.assertEquals(cor, 0)
+        self.assertEquals(tilt, 0.0)

--- a/mantidimaging/core/reconstruct/utility.py
+++ b/mantidimaging/core/reconstruct/utility.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import, division, print_function
+
+from mantidimaging.core.data import const
+
+
+def get_roi_left_shift(images):
+    if const.OPERATION_HISTORY not in images.properties:
+        return 0
+
+    history = images.properties[const.OPERATION_HISTORY]
+    rois = [e['kwargs']['region_of_interest'] for e in history
+            if 'crop_coords' in e['name']]
+
+    roi_offset = 0
+    for r in rois:
+        roi_offset += r[0]
+
+    return roi_offset
+
+
+def get_cor_tilt_from_images(images):
+    if const.AUTO_COR_TILT not in images.properties:
+        return (0, 0.0)
+
+    auto_cor_tilt = images.properties[const.AUTO_COR_TILT]
+
+    cor = auto_cor_tilt['rotation_centre']
+    tilt = auto_cor_tilt['tilt_angle_rad']
+
+    cor -= get_roi_left_shift(images)
+
+    return (cor, tilt)

--- a/mantidimaging/core/reconstruct/utility.py
+++ b/mantidimaging/core/reconstruct/utility.py
@@ -19,7 +19,7 @@ def get_roi_left_shift(images):
 
 
 def get_cor_tilt_from_images(images):
-    if const.AUTO_COR_TILT not in images.properties:
+    if not images or const.AUTO_COR_TILT not in images.properties:
         return (0, 0.0)
 
     auto_cor_tilt = images.properties[const.AUTO_COR_TILT]

--- a/mantidimaging/gui/dialogs/cor_tilt/model.py
+++ b/mantidimaging/gui/dialogs/cor_tilt/model.py
@@ -58,6 +58,7 @@ class CORTiltDialogModel(object):
             upper = self.roi[3]
 
             step = int((upper - lower) / count) if count != 0 else 1
+            step = step if step != 0 else 1
 
             self.slice_indices = np.arange(upper - 1, lower, -step)
 

--- a/mantidimaging/gui/dialogs/tomopy_recon/model.py
+++ b/mantidimaging/gui/dialogs/tomopy_recon/model.py
@@ -28,6 +28,10 @@ class TomopyReconDialogModel(object):
         return self.stack.presenter.images.sample if self.stack is not None \
                 else None
 
+    @property
+    def images(self):
+        return self.stack.presenter.images if self.stack is not None else None
+
     def initial_select_data(self, stack):
         self.stack = stack
 

--- a/mantidimaging/gui/dialogs/tomopy_recon/presenter.py
+++ b/mantidimaging/gui/dialogs/tomopy_recon/presenter.py
@@ -4,6 +4,7 @@ from enum import Enum
 from logging import getLogger
 
 from mantidimaging.core.data import Images
+from mantidimaging.core.reconstruct.utility import get_cor_tilt_from_images
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.dialogs.async_task import AsyncTaskDialogView
 from mantidimaging.gui.mvp_base import BasePresenter
@@ -63,6 +64,11 @@ class TomopyReconDialogPresenter(BasePresenter):
 
         # Remove existing reconstructed preview
         self.view.update_recon_preview(None)
+
+        # Pre-populate COR and tilt options
+        cor, tilt = get_cor_tilt_from_images(self.model.images)
+        self.view.set_cor(cor)
+        self.view.set_tilt(tilt)
 
     def set_preview_slice_idx(self, idx):
         max_idx = \

--- a/mantidimaging/gui/dialogs/tomopy_recon/test/presenter_test.py
+++ b/mantidimaging/gui/dialogs/tomopy_recon/test/presenter_test.py
@@ -37,6 +37,8 @@ class TomopyReconDialogPresenterTest(unittest.TestCase):
 
         self.view.update_projection_preview.assert_called_once()
         self.view.update_recon_preview.assert_called_once_with(None)
+        self.view.set_cor.assert_called_once_with(0)
+        self.view.set_tilt.assert_called_once_with(0)
 
     def test_prepare_recon(self):
         self.presenter.set_stack(self.stack)

--- a/mantidimaging/gui/dialogs/tomopy_recon/view.py
+++ b/mantidimaging/gui/dialogs/tomopy_recon/view.py
@@ -117,8 +117,14 @@ class TomopyReconDialogView(BaseDialogView):
     def get_cor(self):
         return self.cor.value()
 
+    def set_cor(self, value):
+        self.cor.setValue(value)
+
     def get_tilt(self):
         return self.tilt.value()
+
+    def set_tilt(self, value):
+        self.tilt.setValue(value)
 
     def get_max_proj_angle(self):
         return self.maxProjAngle.value()


### PR DESCRIPTION
To test:
- Follow instructions from #185
- Crop the dataset to a ROI that encloses the bottom cylinder with a bit of free space around it (via Filters dialog)
- Save the dataset, checking the "Swap Axes" option
- Load the dataset back in with step = 1 (it should be a a stack of sinograms now)
- Open TomoPy Reconstruction and select the newly loaded data
- You should see a COR and tilt value pre-populated
- Select "Reconstruct Slice", ideally the reconstruction should look reasonable-ish (it isn't prefect)