### PR TITLE
Reduce memory usage in COR/TIlt finding

### DIFF
--- a/mantidimaging/gui/dialogs/cor_tilt/model.py
+++ b/mantidimaging/gui/dialogs/cor_tilt/model.py
@@ -12,6 +12,7 @@ class CORTiltDialogModel(object):
         self.preview_idx = 0
         self.roi = None
         self.slice_indices = None
+        self.projection_indices = None
 
         self.slices = None
         self.cors = None
@@ -62,6 +63,15 @@ class CORTiltDialogModel(object):
 
             self.slice_indices = np.arange(upper - 1, lower, -step)
 
+    def calculate_projections(self, count):
+        self.reset_results()
+        if self.sample is not None:
+            sample_proj_count = self.sample.shape[0]
+            downsample_proj_count = min(sample_proj_count, count)
+            self.projection_indices = \
+                np.linspace(0, sample_proj_count - 1, downsample_proj_count,
+                            dtype=int)
+
     def run_finding(self, progress):
         if self.stack is None:
             raise ValueError('No image stack is provided')
@@ -75,7 +85,7 @@ class CORTiltDialogModel(object):
         self.tilt, self.cor, self.slices, self.cors, self.m = \
             calculate_cor_and_tilt(
                     self.images, self.roi, self.slice_indices,
-                    progress=progress)
+                    self.projection_indices, progress=progress)
 
         return True
 

--- a/mantidimaging/gui/dialogs/cor_tilt/presenter.py
+++ b/mantidimaging/gui/dialogs/cor_tilt/presenter.py
@@ -53,7 +53,7 @@ class CORTiltDialogPresenter(BasePresenter):
         self.notify(Notification.UPDATE_PREVIEWS)
         self.notify(Notification.UPDATE_INDICES)
         self.view.set_results(0, 0)
-        self.view.set_max_preview_idx(self.model.num_projections - 1)
+        self.view.set_num_projections(self.model.num_projections)
 
     def set_preview_idx(self, idx):
         self.model.preview_idx = idx

--- a/mantidimaging/gui/dialogs/cor_tilt/presenter.py
+++ b/mantidimaging/gui/dialogs/cor_tilt/presenter.py
@@ -14,7 +14,8 @@ class Notification(Enum):
     CROP_TO_ROI = 1
     UPDATE_PREVIEWS = 2
     UPDATE_INDICES = 3
-    RUN = 4
+    UPDATE_PROJECTIONS = 4
+    RUN = 5
 
 
 class CORTiltDialogPresenter(BasePresenter):
@@ -32,6 +33,8 @@ class CORTiltDialogPresenter(BasePresenter):
                 self.do_update_previews()
             elif signal == Notification.UPDATE_INDICES:
                 self.do_update_indices()
+            elif signal == Notification.UPDATE_PROJECTIONS:
+                self.do_update_projections()
             elif signal == Notification.RUN:
                 self.do_execute()
 
@@ -76,6 +79,9 @@ class CORTiltDialogPresenter(BasePresenter):
 
     def do_update_indices(self):
         self.model.calculate_slices(self.view.slice_count)
+
+    def do_update_projections(self):
+        self.model.calculate_projections(self.view.projection_count)
 
     def do_execute(self):
         atd = AsyncTaskDialogView(self.view, auto_close=True)

--- a/mantidimaging/gui/dialogs/cor_tilt/view.py
+++ b/mantidimaging/gui/dialogs/cor_tilt/view.py
@@ -39,6 +39,9 @@ class CORTiltDialogView(BaseDialogView):
         # Handle index definition
         self.sliceCount.valueChanged[int].connect(
                 lambda: self.presenter.notify(PresNotification.UPDATE_INDICES))
+        self.projectionCount.valueChanged[int].connect(
+                lambda: self.presenter.notify(
+                    PresNotification.UPDATE_PROJECTIONS))
 
         def add_mpl_figure(layout):
             figure = Figure()
@@ -107,3 +110,7 @@ class CORTiltDialogView(BaseDialogView):
     @property
     def slice_count(self):
         return self.sliceCount.value()
+
+    @property
+    def projection_count(self):
+        return self.projectionCount.value()

--- a/mantidimaging/gui/dialogs/cor_tilt/view.py
+++ b/mantidimaging/gui/dialogs/cor_tilt/view.py
@@ -36,12 +36,13 @@ class CORTiltDialogView(BaseDialogView):
         self.previewStackIndex.valueChanged[int].connect(
                 self.presenter.set_preview_idx)
 
-        # Handle index definition
+        # Handle calculation parameters
         self.sliceCount.valueChanged[int].connect(
                 lambda: self.presenter.notify(PresNotification.UPDATE_INDICES))
         self.projectionCount.valueChanged[int].connect(
                 lambda: self.presenter.notify(
                     PresNotification.UPDATE_PROJECTIONS))
+        self.projectionCountReset.clicked.connect(self.reset_projection_count)
 
         def add_mpl_figure(layout):
             figure = Figure()
@@ -114,6 +115,12 @@ class CORTiltDialogView(BaseDialogView):
         # Projection downsample control
         self.projectionCount.setMaximum(count)
         self.projectionCount.setValue(count)
+
+    def reset_projection_count(self):
+        """
+        Resets the number of projections to the maximum available.
+        """
+        self.projectionCount.setValue(self.projectionCount.maximum())
 
     @property
     def slice_count(self):

--- a/mantidimaging/gui/dialogs/cor_tilt/view.py
+++ b/mantidimaging/gui/dialogs/cor_tilt/view.py
@@ -103,9 +103,17 @@ class CORTiltDialogView(BaseDialogView):
 
         self.fit_canvas.draw()
 
-    def set_max_preview_idx(self, max_idx):
+    def set_num_projections(self, count):
+        """
+        Set the number of projections in the input dataset.
+        """
+        # Preview image control
         self.previewStackIndex.setValue(0)
-        self.previewStackIndex.setMaximum(max_idx)
+        self.previewStackIndex.setMaximum(count - 1)
+
+        # Projection downsample control
+        self.projectionCount.setMaximum(count)
+        self.projectionCount.setValue(count)
 
     @property
     def slice_count(self):

--- a/mantidimaging/gui/ui/cor_tilt_dialog.ui
+++ b/mantidimaging/gui/ui/cor_tilt_dialog.ui
@@ -87,6 +87,9 @@
             <property name="maximum">
              <number>9999</number>
             </property>
+            <property name="value">
+             <number>25</number>
+            </property>
            </widget>
           </item>
           <item row="0" column="1">

--- a/mantidimaging/gui/ui/cor_tilt_dialog.ui
+++ b/mantidimaging/gui/ui/cor_tilt_dialog.ui
@@ -62,6 +62,13 @@
           <property name="fieldGrowthPolicy">
            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
           </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="projectionCountLabel">
+            <property name="text">
+             <string>Number of projections:</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="0">
            <widget class="QLabel" name="sliceCountLabel">
             <property name="text">
@@ -71,30 +78,55 @@
           </item>
           <item row="1" column="1">
            <widget class="QSpinBox" name="sliceCount">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Number of slices at which rotation centre will be calculated.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
             <property name="minimum">
              <number>1</number>
             </property>
             <property name="maximum">
              <number>9999</number>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="projectionCountLabel">
-            <property name="text">
-             <string>Number of projections:</string>
             </property>
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QSpinBox" name="projectionCount">
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>9999</number>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QSpinBox" name="projectionCount">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Number of projections to be used in the rotation centre calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>9999</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="projectionCountReset">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the number of projections used to all in the stack.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>All</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>
@@ -207,7 +239,6 @@
   <tabstop>stackSelector</tabstop>
   <tabstop>setRoi</tabstop>
   <tabstop>previewStackIndex</tabstop>
-  <tabstop>projectionCount</tabstop>
   <tabstop>sliceCount</tabstop>
   <tabstop>calculateButton</tabstop>
   <tabstop>resultCor</tabstop>

--- a/mantidimaging/gui/ui/cor_tilt_dialog.ui
+++ b/mantidimaging/gui/ui/cor_tilt_dialog.ui
@@ -62,15 +62,35 @@
           <property name="fieldGrowthPolicy">
            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
           </property>
-          <item row="0" column="0">
+          <item row="1" column="0">
            <widget class="QLabel" name="sliceCountLabel">
             <property name="text">
              <string>Number of slices:</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
+          <item row="1" column="1">
            <widget class="QSpinBox" name="sliceCount">
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>9999</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="projectionCountLabel">
+            <property name="text">
+             <string>Number of projections:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="projectionCount">
+            <property name="minimum">
+             <number>1</number>
+            </property>
             <property name="maximum">
              <number>9999</number>
             </property>
@@ -183,6 +203,17 @@
    <header>mantidimaging.gui.widgets.stack_selector</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>stackSelector</tabstop>
+  <tabstop>setRoi</tabstop>
+  <tabstop>previewStackIndex</tabstop>
+  <tabstop>projectionCount</tabstop>
+  <tabstop>sliceCount</tabstop>
+  <tabstop>calculateButton</tabstop>
+  <tabstop>resultCor</tabstop>
+  <tabstop>resultTilt</tabstop>
+  <tabstop>buttonBox</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Fixes #217.

Allows the dataset used for COR/Tilt finding to be downsampled in the GUI.

This allows a full dataset to be loaded, preprocessed, COR/Tilt finding run then saved as sinograms. This is now important as the full crop history and COR/Tilt results is expected to be found in the image metadata, which will only happen if the operations are carried out on a single dataset.

To test:
- Open your resource monitor of choice (`htop` sorted by memory usage will do)
- Open GUI
- Load `babylon5/DanNixon/PSI_Cylinder/Sample`, all images (step size = 1) (adjust this to a higher value if memory is limited on your system)
- At this point just over `16 / step size` GB should be consumed
- Select a region of interest that encloses one of the two large cylinders (that contain the several thinner cylinders), exceed the cylinder on the X axis but remain within the cylinder on the Y axis
- Open the Find COR and Tilt UI and click Set ROI from stack, the image preview should show the ROI you selected on the stack visualiser
- Enter 45 projections
- Enter 25 slices
- Click OK, memory usage should increase slightly here but definitely be less than `(16 / step size) + 2` GB
- You should see the COR per slice plotted in blue with a linear fit in red and a yellow line showing the sample tilt over the image
  
  