### PR TITLE
Ensure shared array memory is freed

### DIFF
--- a/buildscripts/create_conda_environment.sh
+++ b/buildscripts/create_conda_environment.sh
@@ -14,7 +14,8 @@ then
   echo "Creating environment ${env_name}..."
   ${anaconda_dir}/bin/conda env create -n ${env_name} -f ${env_file}
 else
-  echo "Environment ${env_name} already exists"
+  echo "Environment ${env_name} already exists, eupdating..."
+  ${anaconda_dir}/bin/conda env update -n ${env_name} -f ${env_file}
 fi
 
 echo "Environment directory: ${env_dir}"

--- a/environment.yml
+++ b/environment.yml
@@ -21,3 +21,4 @@ dependencies:
     - GitPython
     - sphinx
     - coverage>=4.5.0
+    - git+https://github.com/mrsmn/hazelnut.git

--- a/mantidimaging/core/filters/stripe_removal/test/stripe_removal_test.py
+++ b/mantidimaging/core/filters/stripe_removal/test/stripe_removal_test.py
@@ -14,7 +14,7 @@ class StripeRemovalTest(unittest.TestCase):
     """
     Test stripe removal filter.
 
-    Tests return value and in-place modified data.
+    Tests return value only.
     """
 
     def __init__(self, *args, **kwargs):
@@ -42,9 +42,6 @@ class StripeRemovalTest(unittest.TestCase):
         result = stripe_removal.execute(images, wf, ti, sf)
 
         th.assert_not_equals(result, control)
-        th.assert_not_equals(images, control)
-
-        npt.assert_equal(result, images)
 
     def test_executed_wf_dict(self):
         images, control = th.gen_img_shared_array_and_copy()
@@ -65,9 +62,6 @@ class StripeRemovalTest(unittest.TestCase):
         result = stripe_removal.execute(images, wf, ti, sf)
 
         th.assert_not_equals(result, control)
-        th.assert_not_equals(images, control)
-
-        npt.assert_equal(result, images)
 
     def test_executed_ti_dict(self):
         images, control = th.gen_img_shared_array_and_copy()
@@ -88,9 +82,6 @@ class StripeRemovalTest(unittest.TestCase):
         result = stripe_removal.execute(images, wf, ti, sf)
 
         th.assert_not_equals(result, control)
-        th.assert_not_equals(images, control)
-
-        npt.assert_equal(result, images)
 
     def test_executed_sf_dict(self):
         images, control = th.gen_img_shared_array_and_copy()
@@ -116,9 +107,6 @@ class StripeRemovalTest(unittest.TestCase):
             get_memory_usage_linux(kb=True)[0], cached_memory * 1.1)
 
         th.assert_not_equals(result, control)
-        th.assert_not_equals(images, control)
-
-        npt.assert_equal(result, images)
 
     def test_memory_executed_ti(self):
         images, control = th.gen_img_shared_array_and_copy()
@@ -135,9 +123,6 @@ class StripeRemovalTest(unittest.TestCase):
             get_memory_usage_linux(kb=True)[0], cached_memory * 1.1)
 
         th.assert_not_equals(result, control)
-        th.assert_not_equals(images, control)
-
-        npt.assert_equal(result, images)
 
     def test_memory_executed_sf(self):
         images, control = th.gen_img_shared_array_and_copy()
@@ -154,9 +139,6 @@ class StripeRemovalTest(unittest.TestCase):
             get_memory_usage_linux(kb=True)[0], cached_memory * 1.1)
 
         th.assert_not_equals(result, control)
-        th.assert_not_equals(images, control)
-
-        npt.assert_equal(result, images)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/parallel/test/utility_test.py
+++ b/mantidimaging/core/parallel/test/utility_test.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import, division, print_function
+
+import unittest
+
+import numpy as np
+from hazelnut import MemInfo
+
+from mantidimaging.core.parallel import utility as pu
+
+
+class UtilityTest(unittest.TestCase):
+
+    def test_shared_memory_is_freed(self):
+        mapped_before = MemInfo().get('Mapped')
+
+        a = pu.create_shared_array((10, 1024, 1024), np.float32)
+        del a
+
+        mapped_after = MemInfo().get('Mapped')
+
+        self.assertLess(mapped_after, mapped_before + 1024)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -66,6 +66,7 @@ class MainWindowPresenter(BasePresenter):
             title = task.kwargs['selected_file'] if not custom_name \
                 else custom_name
             self.create_new_stack(task.result, title)
+            del task.result
 
         else:
             log.error("Failed to load stack: %s", str(task.error))


### PR DESCRIPTION
Requires #260 to be merged first.

Fixes the bug where memory allocated via `sharedctypes.RawArray` was never being free'd until the program exits.

Also corrects a bug where the `Images` instance holding the allocated array would never get out of scope (at least for loaded images).

To test:
- Review alternative implementation
- Validate memory is being freed when images are closed
  - Load a large image stack (ideally one that just fits in memory twice)
  - Check mapped memory usage (`cat /proc/meminfo | grep Mapped`)
  - Close the image
  - Check mapped memory usage (`cat /proc/meminfo | grep Mapped`)
  - (it should be lower by approximately the size of the dataset)
- Try a few workflows (from recent PRs) and try to make something break
  - Following the steps of #213 and #242 is a good start