### PR TITLE
Add Tomopy recon preview function

### DIFF
--- a/mantidimaging/core/reconstruct/__init__.py
+++ b/mantidimaging/core/reconstruct/__init__.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 from .cor_tilt import calculate_cor_and_tilt  # noqa: F401
 
 from .tomopy_reconstruction import (  # noqa: F401
-        reconstruct as tomopy_reconstruct)
+        reconstruct as tomopy_reconstruct,
+        reconstruct_single_preview as tomopy_reconstruct_preview)
 
 del absolute_import, division, print_function


### PR DESCRIPTION
Adds a function to run a preview reconstruction with a single sinogram.

Data is provided as projections and the single slice is extracted and converted to a single sinogram.

Script for testing (adjust paths as appropriate, note that the COR value is not correct for this sinogram and the reconstruction will not be of good quality):
```
import logging
import timeit
import numpy as np
import matplotlib.pyplot as plt
from mantidimaging.helper import initialise_logging
from mantidimaging.core.io.loader import load
from mantidimaging.core.filters.crop_coords import execute as crop
from mantidimaging.core.reconstruct import tomopy_reconstruct_preview
from mantidimaging.core.utility.projection_angles import \
        generate as generate_projection_angles

# initialise_logging(logging.INFO)

d = load('/home/dan/psi_sample/sample/', indices=(0, 940, 5)).sample

angles = generate_projection_angles(360, d.shape[0])

roi = (810, 750, 2009, 1500)
d = crop(d, roi)[0]

def test():
    return tomopy_reconstruct_preview(d, 0, 560, angles)

plt.imshow(test())
plt.show()

print()

print('Testing performance...')
count = 250
total_time = timeit.timeit('test()', setup='from __main__ import test', number=count)
print()
print('Average time:', total_time / count, 'seconds')

```