### PR TITLE
Avoid GUI imports in core module

### DIFF
--- a/mantidimaging/core/filters/crop_coords/crop_coords_gui.py
+++ b/mantidimaging/core/filters/crop_coords/crop_coords_gui.py
@@ -2,12 +2,11 @@ from __future__ import absolute_import, division, print_function
 
 from functools import partial
 
-from mantidimaging.gui.windows.stack_visualiser import Parameters
-
 from . import crop_coords
 
 
 def _gui_register(form, on_change):
+    from mantidimaging.gui.windows.stack_visualiser import Parameters
     from mantidimaging.gui.utility import add_property_to_form
 
     add_property_to_form(

--- a/mantidimaging/core/filters/roi_normalisation/roi_normalisation_gui.py
+++ b/mantidimaging/core/filters/roi_normalisation/roi_normalisation_gui.py
@@ -1,11 +1,10 @@
 from functools import partial
 
-from mantidimaging.gui.windows.stack_visualiser import Parameters
-
 from . import execute
 
 
 def _gui_register(form, on_change):
+    from mantidimaging.gui.windows.stack_visualiser import Parameters
     from mantidimaging.gui.utility import add_property_to_form
 
     add_property_to_form(


### PR DESCRIPTION
These two imports were causing the `.gui` module to be pulled in cases when only `.core` is needed.