### PR TITLE
Show image metadata in GUI

### DIFF
--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 import json
+import pprint
 
 import numpy as np
 
@@ -54,6 +55,11 @@ class Images(object):
     @property
     def filenames(self):
         return self._filenames
+
+    @property
+    def properties_pretty(self):
+        pp = pprint.PrettyPrinter(indent=2)
+        return pp.pformat(self.properties)
 
     def metadata_load(self, f):
         self.properties = json.load(f)

--- a/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
+++ b/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import, division, print_function
+
+from PyQt5 import Qt
+
+
+class MetadataDialog(Qt.QDialog):
+    """
+    Dialog used to show a pretty formatted version of the image metadata.
+    """
+
+    def __init__(self, parent, image):
+        super(MetadataDialog, self).__init__(parent)
+
+        self.setWindowTitle('Image Metadata')
+        self.setSizeGripEnabled(True)
+        self.resize(600, 300)
+
+        metadataText = Qt.QTextEdit()
+        metadataText.setReadOnly(True)
+        metadataText.setText(image.properties_pretty)
+
+        buttons = Qt.QDialogButtonBox(Qt.QDialogButtonBox.Close)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+
+        layout = Qt.QVBoxLayout()
+        layout.addWidget(metadataText)
+        layout.addWidget(buttons)
+        self.setLayout(layout)

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -20,6 +20,7 @@ class Notification(IntEnum):
     STACK_MODE = 6
     SUM_MODE = 7
     REFRESH_IMAGE = 8
+    SHOW_METADATA = 9
 
 
 class Parameters(IntEnum):
@@ -61,6 +62,8 @@ class StackVisualiserPresenter(BasePresenter):
                 self.image_mode = ImageMode.SUM
             elif signal == Notification.REFRESH_IMAGE:
                 self.view.show_current_image()
+            elif signal == Notification.SHOW_METADATA:
+                self.view.show_image_metadata()
         except Exception as e:
             self.show_error(e)
             getLogger(__name__).exception("Notification handler failed")

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -15,6 +15,7 @@ from mantidimaging.gui.utility import BlockQtSignals
 
 from . import histogram
 from .image_selector_widget import ImageSelectorWidget
+from .metadata_dialog import MetadataDialog
 from .navigation_toolbar import StackNavigationToolbar
 from .roi_selector_widget import ROISelectorWidget
 from .presenter import StackVisualiserPresenter
@@ -154,6 +155,12 @@ class StackVisualiserView(BaseMainWindowView):
         add_context_menu_action(
                 "Show Histogram in new window",
                 StackWindowNotification.NEW_WINDOW_HISTOGRAM)
+
+        self.canvas_context_menu.addSeparator()
+
+        add_context_menu_action(
+                "Show metadata",
+                StackWindowNotification.SHOW_METADATA)
 
         # Register mouse release callback
         self.canvas.mpl_connect(
@@ -411,6 +418,12 @@ class StackVisualiserView(BaseMainWindowView):
             self.image_selector_toolbar.index = index
 
         self.show_current_image()
+
+    def show_image_metadata(self):
+        """
+        Shows image metadata in a dialog.
+        """
+        MetadataDialog(self, self.presenter.images).show()
 
 
 def see(data, data_traversal_axis=0, cmap='Greys_r', block=False):


### PR DESCRIPTION
Adds a menu option to show image metadata in GUI.

When testing, be aware of: https://github.com/mantidproject/mantidimaging/issues/224

To test:
- Load some data
- Perform some basic filters on it
- Right click the data in the stack visualiser
- Click "Show Metadata"
- A dialog with image metadata should be shown