### PR TITLE
COR/Tilt UI redesign

### DIFF
--- a/mantidimaging/gui/ui/cor_tilt_window.ui
+++ b/mantidimaging/gui/ui/cor_tilt_window.ui
@@ -7,14 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>800</width>
-    <height>400</height>
+    <height>600</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>COT &amp; Tilt Finding</string>
+   <string>Find COR and Tilt</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QVBoxLayout" name="verticalLayout_2">
+   <layout class="QVBoxLayout" name="verticalLayout_3">
     <item>
      <widget class="QSplitter" name="splitter">
       <property name="orientation">
@@ -22,179 +22,332 @@
       </property>
       <widget class="QWidget" name="formLayoutWidget">
        <layout class="QVBoxLayout" name="verticalLayout">
+        <property name="spacing">
+         <number>0</number>
+        </property>
         <item>
-         <widget class="QGroupBox" name="dataGroup">
-          <property name="title">
-           <string>Data</string>
+         <widget class="QTabWidget" name="tabWidget">
+          <property name="currentIndex">
+           <number>0</number>
           </property>
-          <layout class="QFormLayout" name="formLayout">
-           <item row="0" column="0" colspan="2">
-            <widget class="StackSelectorWidgetView" name="stackSelector"/>
-           </item>
-           <item row="1" column="0" colspan="2">
-            <widget class="QPushButton" name="setRoi">
-             <property name="text">
-              <string>Set ROI from stack</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QSpinBox" name="previewStackIndex"/>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="previewStackIndexLabel">
-             <property name="text">
-              <string>Preview stack index:</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="parametersGroup">
-          <property name="title">
-           <string>Calculation</string>
-          </property>
-          <layout class="QFormLayout" name="formLayout_2">
-           <property name="fieldGrowthPolicy">
-            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-           </property>
-           <item row="0" column="0">
-            <widget class="QLabel" name="projectionCountLabel">
-             <property name="text">
-              <string>Number of projections:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="sliceCountLabel">
-             <property name="text">
-              <string>Number of slices:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QSpinBox" name="sliceCount">
-             <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Number of slices at which rotation centre will be calculated.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>9999</number>
-             </property>
-             <property name="value">
-              <number>25</number>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <layout class="QHBoxLayout" name="horizontalLayout">
-             <item>
-              <widget class="QSpinBox" name="projectionCount">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
+          <widget class="QWidget" name="inputTab">
+           <attribute name="title">
+            <string>Input</string>
+           </attribute>
+           <layout class="QVBoxLayout" name="verticalLayout_2">
+            <item>
+             <widget class="QGroupBox" name="dataGroup">
+              <property name="title">
+               <string>Data</string>
+              </property>
+              <layout class="QFormLayout" name="formLayout">
+               <item row="0" column="0" colspan="2">
+                <widget class="StackSelectorWidgetView" name="stackSelector"/>
+               </item>
+               <item row="1" column="0" colspan="2">
+                <widget class="QPushButton" name="setRoi">
+                 <property name="text">
+                  <string>Set ROI from stack</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="autoParametersGroup">
+              <property name="title">
+               <string>Automatic Calculation</string>
+              </property>
+              <layout class="QFormLayout" name="formLayout_2">
+               <property name="fieldGrowthPolicy">
+                <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                </property>
-               <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Number of projections to be used in the rotation centre calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-               </property>
-               <property name="minimum">
-                <number>1</number>
-               </property>
-               <property name="maximum">
-                <number>9999</number>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="projectionCountReset">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the number of projections used to all in the stack.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-               </property>
-               <property name="text">
-                <string>All</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="calculateButton">
-          <property name="text">
-           <string>Calculate</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="resultGroup">
-          <property name="title">
-           <string>Result</string>
-          </property>
-          <layout class="QFormLayout" name="formLayout_3">
-           <item row="0" column="0">
-            <widget class="QLabel" name="resultCorLabel">
-             <property name="text">
-              <string>Centre of Rotation:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QDoubleSpinBox" name="resultCor">
-             <property name="readOnly">
-              <bool>true</bool>
-             </property>
-             <property name="buttonSymbols">
-              <enum>QAbstractSpinBox::NoButtons</enum>
-             </property>
-             <property name="decimals">
-              <number>0</number>
-             </property>
-             <property name="maximum">
-              <double>99999.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="resultTiltLabel">
-             <property name="text">
-              <string>Tilt angle:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QDoubleSpinBox" name="resultTilt">
-             <property name="readOnly">
-              <bool>true</bool>
-             </property>
-             <property name="buttonSymbols">
-              <enum>QAbstractSpinBox::NoButtons</enum>
-             </property>
-             <property name="decimals">
-              <number>9</number>
-             </property>
-             <property name="minimum">
-              <double>-90.000000000000000</double>
-             </property>
-             <property name="maximum">
-              <double>90.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-          </layout>
+               <item row="0" column="0">
+                <widget class="QLabel" name="projectionCountLabel">
+                 <property name="text">
+                  <string>Number of projections:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="sliceCountLabel">
+                 <property name="text">
+                  <string>Number of slices:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QSpinBox" name="sliceCount">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Number of slices at which rotation centre will be calculated.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="minimum">
+                  <number>1</number>
+                 </property>
+                 <property name="maximum">
+                  <number>9999</number>
+                 </property>
+                 <property name="value">
+                  <number>20</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <layout class="QHBoxLayout" name="horizontalLayout">
+                 <item>
+                  <widget class="QSpinBox" name="projectionCount">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Number of projections to be used in the rotation centre calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="minimum">
+                    <number>1</number>
+                   </property>
+                   <property name="maximum">
+                    <number>9999</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="projectionCountReset">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the number of projections used to all in the stack.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="text">
+                    <string>All</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item row="2" column="0" colspan="2">
+                <widget class="QPushButton" name="autoCalculateButton">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Perform automatic centre of rotation and tilt angle finding.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Calculate</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="resultsTab">
+           <attribute name="title">
+            <string>Results</string>
+           </attribute>
+           <layout class="QVBoxLayout" name="verticalLayout_4">
+            <item>
+             <widget class="QGroupBox" name="resultGroup">
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>150</height>
+               </size>
+              </property>
+              <property name="title">
+               <string>Result</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_2">
+               <item>
+                <layout class="QFormLayout" name="numericalResults">
+                 <property name="fieldGrowthPolicy">
+                  <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                 </property>
+                 <item row="1" column="0">
+                  <widget class="QLabel" name="resultCorLabel">
+                   <property name="toolTip">
+                    <string>Centre of Rotation, relative to full image coordinates.</string>
+                   </property>
+                   <property name="text">
+                    <string>COR:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
+                  <widget class="QDoubleSpinBox" name="resultCor">
+                   <property name="readOnly">
+                    <bool>true</bool>
+                   </property>
+                   <property name="buttonSymbols">
+                    <enum>QAbstractSpinBox::NoButtons</enum>
+                   </property>
+                   <property name="decimals">
+                    <number>0</number>
+                   </property>
+                   <property name="maximum">
+                    <double>99999.000000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="3" column="1">
+                  <widget class="QDoubleSpinBox" name="resultGradient">
+                   <property name="readOnly">
+                    <bool>true</bool>
+                   </property>
+                   <property name="buttonSymbols">
+                    <enum>QAbstractSpinBox::NoButtons</enum>
+                   </property>
+                   <property name="decimals">
+                    <number>6</number>
+                   </property>
+                   <property name="minimum">
+                    <double>-99.000000000000000</double>
+                   </property>
+                   <property name="maximum">
+                    <double>99.000000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="1">
+                  <widget class="QDoubleSpinBox" name="resultTilt">
+                   <property name="readOnly">
+                    <bool>true</bool>
+                   </property>
+                   <property name="buttonSymbols">
+                    <enum>QAbstractSpinBox::NoButtons</enum>
+                   </property>
+                   <property name="prefix">
+                    <string/>
+                   </property>
+                   <property name="suffix">
+                    <string/>
+                   </property>
+                   <property name="decimals">
+                    <number>6</number>
+                   </property>
+                   <property name="minimum">
+                    <double>-90.000000000000000</double>
+                   </property>
+                   <property name="maximum">
+                    <double>90.000000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="0">
+                  <widget class="QLabel" name="resultTiltLabel">
+                   <property name="toolTip">
+                    <string>Tilt angle in degrees.</string>
+                   </property>
+                   <property name="text">
+                    <string>Tilt:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="3" column="0">
+                  <widget class="QLabel" name="resultGradientLabel">
+                   <property name="text">
+                    <string>Gradient:</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QVBoxLayout" name="fitLayout"/>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="manualGroup">
+              <property name="title">
+               <string>Manual</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_5">
+               <item>
+                <widget class="RemovableRowTableView" name="tableView"/>
+               </item>
+               <item>
+                <layout class="QGridLayout" name="gridLayout">
+                 <item row="0" column="2">
+                  <widget class="QPushButton" name="manualAddButton">
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a new row to the table.&lt;/p&gt;&lt;p&gt;Slice index defaults to the current preview slice index.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="text">
+                    <string>Add</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="2">
+                  <widget class="QPushButton" name="manualFitButton">
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Performs linear fit of rows/points in the table.&lt;/p&gt;&lt;p&gt;Requires at least two rows.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="text">
+                    <string>Fit</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="0">
+                  <widget class="QPushButton" name="manualRemoveButton">
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Removes the selected row from the table.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="text">
+                    <string>Remove</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QPushButton" name="manualClearAllButton">
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Removes all rows from the table.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="text">
+                    <string>Clear All</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
          </widget>
         </item>
         <item>
@@ -210,13 +363,46 @@
           </property>
          </spacer>
         </item>
+        <item>
+         <widget class="QGroupBox" name="previewGroup">
+          <property name="title">
+           <string>Preview</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_2">
+           <item row="0" column="0">
+            <widget class="QLabel" name="previewProjectionIndexLabel">
+             <property name="text">
+              <string>Projection index:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="previewProjectionIndex"/>
+           </item>
+           <item row="1" column="1">
+            <widget class="QSpinBox" name="previewSliceIndex">
+             <property name="maximum">
+              <number>9999</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="previewSliceIndexLabel">
+             <property name="text">
+              <string>Slice index:</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
        </layout>
       </widget>
       <widget class="QWidget" name="verticalLayoutWidget">
        <layout class="QVBoxLayout" name="imageLayout"/>
       </widget>
       <widget class="QWidget" name="verticalLayoutWidget_2">
-       <layout class="QVBoxLayout" name="fitLayout"/>
+       <layout class="QVBoxLayout" name="reconPreviewLayout"/>
       </widget>
      </widget>
     </item>
@@ -228,6 +414,11 @@
    <class>StackSelectorWidgetView</class>
    <extends>QComboBox</extends>
    <header>mantidimaging.gui.widgets.stack_selector</header>
+  </customwidget>
+  <customwidget>
+   <class>RemovableRowTableView</class>
+   <extends>QTableView</extends>
+   <header>mantidimaging.gui.widgets</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/mantidimaging/gui/widgets/__init__.py
+++ b/mantidimaging/gui/widgets/__init__.py
@@ -1,1 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
+
+from .mpl_navigation_toolbar_simple import (  # noqa: F401
+        NavigationToolbarSimple)
+
+from .removable_row_table_view import (  # noqs: F401
+        RemovableRowTableView)

--- a/mantidimaging/gui/widgets/mpl_navigation_toolbar_simple.py
+++ b/mantidimaging/gui/widgets/mpl_navigation_toolbar_simple.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import, division, print_function
+
+from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
+
+
+class NavigationToolbarSimple(NavigationToolbar2QT):
+
+    # See [Matplotlib]/lib/matplotlib/backend_bases.py
+    toolitems = (
+        ('Home', 'Reset original view', 'home', 'home'),
+        ('Pan', 'Pan axes with left mouse, zoom with right', 'move', 'pan'),
+        ('Zoom', 'Zoom to rectangle', 'zoom_to_rect', 'zoom'),
+      )

--- a/mantidimaging/gui/widgets/removable_row_table_view.py
+++ b/mantidimaging/gui/widgets/removable_row_table_view.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import, division, print_function
+
+from PyQt5.QtCore import Qt, QModelIndex
+from PyQt5.QtWidgets import QTableView
+
+
+class RemovableRowTableView(QTableView):
+
+    def keyPressEvent(self, e):
+        super(RemovableRowTableView, self).keyPressEvent(e)
+
+        # Handle deletion of a row from the table by pressing the [Delete] key
+        if e.key() == Qt.Key_Delete:
+            self.removeSelectedRows()
+
+    def removeSelectedRows(self):
+        """
+        Removes all selected rows from the table.
+        """
+        for row in self.selectionModel().selectedRows():
+            self.model().removeRows(row.row(), 1, QModelIndex())

--- a/mantidimaging/gui/windows/cor_tilt/__init__.py
+++ b/mantidimaging/gui/windows/cor_tilt/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from .model import CORTiltWindowModel  # noqa: F401
+from .point_table_model import CorTiltPointQtModel  # noqa: F401
 from .presenter import CORTiltWindowPresenter  # noqa: F401
 from .view import CORTiltWindowView  # noqa: F401
 

--- a/mantidimaging/gui/windows/cor_tilt/point_table_model.py
+++ b/mantidimaging/gui/windows/cor_tilt/point_table_model.py
@@ -1,0 +1,136 @@
+from __future__ import (absolute_import, division, print_function)
+
+from PyQt5.QtCore import Qt, QAbstractTableModel, QModelIndex
+
+from mantidimaging.core.cor_tilt import (
+        CorTiltDataModel, Field, FIELD_NAMES)
+
+
+class CorTiltPointQtModel(QAbstractTableModel, CorTiltDataModel):
+    """
+    Qt data model for COR/Tilt finding.
+    """
+
+    def populate_slice_indices(self, begin, end, count, cor=0.0):
+        self.beginResetModel()
+        super(CorTiltPointQtModel, self).populate_slice_indices(begin, end, count, cor)
+        self.endResetModel()
+
+    def sort_points(self):
+        self.layoutAboutToBeChanged.emit()
+        super(CorTiltPointQtModel, self).sort_points()
+        self.layoutChanged.emit()
+
+    def set_point(self, idx, slice_idx=None, cor=None):
+        super(CorTiltPointQtModel, self).set_point(idx, slice_idx, cor)
+        self.dataChanged.emit(self.index(idx, 0), self.index(idx, 1))
+
+    def columnCount(self, parent=None):
+        return len(Field)
+
+    def rowCount(self, parent):
+        if parent.isValid():
+            return 0
+        return self.num_points
+
+    def flags(self, index):
+        flags = super(CorTiltPointQtModel, self).flags(index)
+        flags |= Qt.ItemIsEditable
+        return flags
+
+    def data(self, index, role=Qt.DisplayRole):
+        if not index.isValid():
+            return None
+
+        col = index.column()
+
+        if role == Qt.DisplayRole:
+            return self._points[index.row()][col]
+
+        elif role == Qt.ToolTipRole:
+            col_field = Field(col)
+            if col_field == Field.SLICE_INDEX:
+                return 'Slice index (y coordinate of projection)'
+            elif col_field == Field.CENTRE_OF_ROTATION:
+                return 'Centre of rotation for specific slice'
+            return ''
+
+    def setData(self, index, val, role=Qt.EditRole):
+        if role != Qt.EditRole:
+            return False
+
+        self.clear_results()
+
+        col = index.column()
+        col_field = Field(col)
+
+        proper_value = None
+        try:
+            if col_field == Field.SLICE_INDEX:
+                proper_value = int(val)
+            elif col_field == Field.CENTRE_OF_ROTATION:
+                proper_value = float(val)
+        except ValueError:
+            return False
+
+        self._points[index.row()][col] = proper_value
+
+        self.dataChanged.emit(index, index)
+
+        self.sort_points()
+
+        return True
+
+    def insertRows(self, row, count, parent=None):
+        self.beginInsertRows(
+                parent if parent is not None else QModelIndex(),
+                row,
+                row + count - 1)
+
+        for _ in range(count):
+            self.add_point(row)
+
+        self.endInsertRows()
+
+    def removeRows(self, row, count, parent=None):
+        if self.empty:
+            return
+
+        self.beginRemoveRows(
+                parent if parent is not None else QModelIndex(),
+                row,
+                row + count - 1)
+
+        for _ in range(count):
+            self.remove_point(row)
+
+        self.endRemoveRows()
+
+    def removeAllRows(self, parent=None):
+        if self.empty:
+            return
+
+        self.beginRemoveRows(
+                parent if parent else QModelIndex(),
+                0,
+                self.num_points - 1)
+
+        self.clear_points()
+
+        self.endRemoveRows()
+
+    def appendNewRow(self, slice_idx):
+        self.insertRows(self.num_points, 1)
+
+        self.setData(
+                self.index(self.num_points - 1, Field.SLICE_INDEX.value),
+                slice_idx)
+
+    def headerData(self, section, orientation, role):
+        if orientation != Qt.Horizontal:
+            return None
+
+        if role != Qt.DisplayRole:
+            return None
+
+        return FIELD_NAMES[Field(section)]

--- a/mantidimaging/gui/windows/cor_tilt/presenter.py
+++ b/mantidimaging/gui/windows/cor_tilt/presenter.py
@@ -10,17 +10,24 @@ from mantidimaging.gui.mvp_base import BasePresenter
 from .model import CORTiltWindowModel
 
 
+LOG = getLogger(__name__)
+
+
 class Notification(Enum):
     CROP_TO_ROI = 1
     UPDATE_PREVIEWS = 2
-    RUN = 3
+    RUN_AUTOMATIC = 3
+    RUN_MANUAL = 4
+    PREVIEW_RECONSTRUCTION = 5
+    PREVIEW_RECONSTRUCTION_SET_COR = 6
+    ADD_NEW_COR_TABLE_ROW = 7
 
 
 class CORTiltWindowPresenter(BasePresenter):
 
     def __init__(self, view, main_window):
         super(CORTiltWindowPresenter, self).__init__(view)
-        self.model = CORTiltWindowModel()
+        self.model = CORTiltWindowModel(self.view.point_model)
         self.main_window = main_window
 
     def notify(self, signal):
@@ -29,12 +36,20 @@ class CORTiltWindowPresenter(BasePresenter):
                 self.do_crop_to_roi()
             elif signal == Notification.UPDATE_PREVIEWS:
                 self.do_update_previews()
-            elif signal == Notification.RUN:
-                self.do_execute()
+            elif signal == Notification.RUN_AUTOMATIC:
+                self.do_execute_automatic()
+            elif signal == Notification.RUN_MANUAL:
+                self.do_execute_manual()
+            elif signal == Notification.PREVIEW_RECONSTRUCTION:
+                self.do_preview_reconstruction()
+            elif signal == Notification.PREVIEW_RECONSTRUCTION_SET_COR:
+                self.do_preview_reconstruction_set_cor()
+            elif signal == Notification.ADD_NEW_COR_TABLE_ROW:
+                self.do_add_manual_cor_table_row()
 
         except Exception as e:
             self.show_error(e)
-            getLogger(__name__).exception("Notification handler failed")
+            LOG.exception("Notification handler failed")
 
     def set_stack_uuid(self, uuid):
         self.set_stack(
@@ -43,31 +58,67 @@ class CORTiltWindowPresenter(BasePresenter):
 
     def set_stack(self, stack):
         self.model.initial_select_data(stack)
-        self.view.set_results(0, 0)
+        self.view.set_results(0, 0, 0)
         self.view.set_num_projections(self.model.num_projections)
+        self.view.set_num_slices(self.model.num_slices)
         self.notify(Notification.UPDATE_PREVIEWS)
 
-    def set_preview_idx(self, idx):
-        self.model.preview_idx = idx
+    def set_preview_projection_idx(self, idx):
+        self.model.preview_projection_idx = idx
         self.notify(Notification.UPDATE_PREVIEWS)
+
+    def set_preview_slice_idx(self, idx):
+        self.model.preview_slice_idx = idx
+        self.notify(Notification.UPDATE_PREVIEWS)
+        self.notify(Notification.PREVIEW_RECONSTRUCTION)
+
+    def handle_cor_manually_changed(self, slice_idx):
+        if slice_idx == self.model.preview_slice_idx:
+            self.notify(Notification.PREVIEW_RECONSTRUCTION_SET_COR)
 
     def do_crop_to_roi(self):
         self.model.update_roi_from_stack()
-        self.view.set_results(0, 0)
+        self.view.set_results(0, 0, 0)
         self.notify(Notification.UPDATE_PREVIEWS)
 
     def do_update_previews(self):
-        img_data = self.model.sample[self.model.preview_idx] \
+        img_data = self.model.sample[self.model.preview_projection_idx] \
                 if self.model.sample is not None else None
 
         self.view.update_image_preview(
-                img_data, self.model.preview_tilt_line_data, self.model.roi)
+                img_data,
+                self.model.preview_slice_idx,
+                self.model.preview_tilt_line_data,
+                self.model.roi)
 
-        self.view.update_fit_plot(self.model.model.slices,
-                                  self.model.model.cors,
-                                  self.model.preview_fit_y_data)
+        self.view.update_fit_plot(
+                self.model.model.slices,
+                self.model.model.cors,
+                self.model.preview_fit_y_data)
 
-    def do_execute(self):
+    def do_preview_reconstruction(self, cor=None):
+        data = None
+
+        # If no COR is provided and there are regression results then calculate
+        # the COR for the selected preview slice
+        if self.model.has_results and cor is None:
+            cor = self.model.model.get_cor_for_slice_from_regression(
+                    self.model.preview_slice_idx)
+
+        if cor is not None:
+            data = self.model.run_preview_recon(
+                    self.model.preview_slice_idx, cor)
+            self.view.update_image_recon_preview(data)
+
+    def do_preview_reconstruction_set_cor(self):
+        cor = self.model.cor_for_current_preview_slice
+        self.do_preview_reconstruction(cor)
+
+    def do_add_manual_cor_table_row(self):
+        idx = self.model.preview_slice_idx
+        self.view.add_cor_table_row(idx)
+
+    def do_execute_automatic(self):
         self.model.calculate_slices(self.view.slice_count)
         self.model.calculate_projections(self.view.projection_count)
 
@@ -75,7 +126,17 @@ class CORTiltWindowPresenter(BasePresenter):
         kwargs = {'progress': Progress()}
         kwargs['progress'].add_progress_handler(atd.presenter)
 
-        atd.presenter.set_task(self.model.run_finding)
+        atd.presenter.set_task(self.model.run_finding_automatic)
+        atd.presenter.set_on_complete(self._on_finding_done)
+        atd.presenter.set_parameters(**kwargs)
+        atd.presenter.do_start_processing()
+
+    def do_execute_manual(self):
+        atd = AsyncTaskDialogView(self.view, auto_close=True)
+        kwargs = {'progress': Progress()}
+        kwargs['progress'].add_progress_handler(atd.presenter)
+
+        atd.presenter.set_task(self.model.run_finding_manual)
         atd.presenter.set_on_complete(self._on_finding_done)
         atd.presenter.set_parameters(**kwargs)
         atd.presenter.do_start_processing()
@@ -86,8 +147,11 @@ class CORTiltWindowPresenter(BasePresenter):
         if task.was_successful():
             self.view.set_results(
                     self.model.model.c,
-                    self.model.model.angle_rad)
+                    self.model.model.angle_rad,
+                    self.model.model.m)
+            self.view.show_results()
             self.notify(Notification.UPDATE_PREVIEWS)
+            self.notify(Notification.PREVIEW_RECONSTRUCTION)
         else:
             log.error("COR/Tilt finding failed: %s", str(task.error))
             self.show_error("COR/Tilt finding failed. See log for details.")

--- a/mantidimaging/gui/windows/cor_tilt/test/model_test.py
+++ b/mantidimaging/gui/windows/cor_tilt/test/model_test.py
@@ -7,7 +7,8 @@ import numpy as np
 from mantidimaging.core.data import Images
 from mantidimaging.core.utility.special_imports import import_mock
 
-from mantidimaging.gui.windows.cor_tilt import CORTiltWindowModel
+from mantidimaging.gui.windows.cor_tilt import (
+        CORTiltWindowModel, CorTiltPointQtModel)
 from mantidimaging.gui.windows.stack_visualiser import (
         StackVisualiserView, StackVisualiserPresenter)
 
@@ -17,7 +18,7 @@ mock = import_mock()
 class CORTiltWindowModelTest(unittest.TestCase):
 
     def setUp(self):
-        self.model = CORTiltWindowModel()
+        self.model = CORTiltWindowModel(CorTiltPointQtModel(None))
 
         # Mock stack
         self.stack = mock.create_autospec(StackVisualiserView)
@@ -28,7 +29,7 @@ class CORTiltWindowModelTest(unittest.TestCase):
         self.model.initial_select_data(self.stack)
 
     def test_empty_init(self):
-        m = CORTiltWindowModel()
+        m = CORTiltWindowModel(CorTiltPointQtModel(None))
         self.assertIsNone(m.stack)
         self.assertIsNone(m.sample)
 

--- a/mantidimaging/gui/windows/cor_tilt/test/presenter_test.py
+++ b/mantidimaging/gui/windows/cor_tilt/test/presenter_test.py
@@ -34,8 +34,14 @@ class CORTiltWindowPresenterTest(unittest.TestCase):
 
         self.view.update_image_preview.assert_called_once()
 
-    def test_set_preview_index(self):
+    def test_set_slice_preview_index(self):
         self.presenter.set_stack(self.stack)
 
-        self.presenter.set_preview_idx(5)
-        self.assertEquals(self.presenter.model.preview_idx, 5)
+        self.presenter.set_preview_slice_idx(5)
+        self.assertEquals(self.presenter.model.preview_slice_idx, 5)
+
+    def test_set_projection_preview_index(self):
+        self.presenter.set_stack(self.stack)
+
+        self.presenter.set_preview_projection_idx(5)
+        self.assertEquals(self.presenter.model.preview_projection_idx, 5)

--- a/mantidimaging/gui/windows/cor_tilt/view.py
+++ b/mantidimaging/gui/windows/cor_tilt/view.py
@@ -2,11 +2,15 @@ from __future__ import absolute_import, division, print_function
 
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
+from PyQt5.QtWidgets import QAbstractItemView
 
+from mantidimaging.core.cor_tilt import Field
 from mantidimaging.gui.mvp_base import BaseMainWindowView
+from mantidimaging.gui.widgets import NavigationToolbarSimple
 
 from .presenter import CORTiltWindowPresenter
 from .presenter import Notification as PresNotification
+from .point_table_model import CorTiltPointQtModel
 
 
 class CORTiltWindowView(BaseMainWindowView):
@@ -20,8 +24,8 @@ class CORTiltWindowView(BaseMainWindowView):
         self.cmap = cmap
 
         # Handle calculate button click
-        self.calculateButton.clicked.connect(
-                lambda: self.presenter.notify(PresNotification.RUN))
+        self.autoCalculateButton.clicked.connect(
+                lambda: self.presenter.notify(PresNotification.RUN_AUTOMATIC))
 
         # Handle stack selection
         self.stackSelector.stack_selected_uuid.connect(
@@ -32,52 +36,152 @@ class CORTiltWindowView(BaseMainWindowView):
                 lambda: self.presenter.notify(PresNotification.CROP_TO_ROI))
 
         # Handle preview image selection
-        self.previewStackIndex.valueChanged[int].connect(
-                self.presenter.set_preview_idx)
+        self.previewProjectionIndex.valueChanged[int].connect(
+                self.presenter.set_preview_projection_idx)
+        self.previewSliceIndex.valueChanged[int].connect(
+                self.presenter.set_preview_slice_idx)
 
         # Handle calculation parameters
         self.projectionCountReset.clicked.connect(self.reset_projection_count)
 
-        def add_mpl_figure(layout):
+        def add_mpl_figure(layout, toolbar=None):
             figure = Figure()
             canvas = FigureCanvasQTAgg(figure)
             canvas.setParent(self)
+            if toolbar is not None:
+                toolbar = toolbar(canvas, self)
+                layout.addWidget(toolbar)
             layout.addWidget(canvas)
-            return (figure, canvas)
+            return (figure, canvas, toolbar)
 
         # Image plot
-        self.image_figure, self.image_canvas = add_mpl_figure(self.imageLayout)
+        self.image_figure, self.image_canvas, _ = \
+            add_mpl_figure(self.imageLayout)
         self.image_plot = self.image_figure.add_subplot(111)
+        self.image_canvas.mpl_connect(
+            'button_press_event', self.preview_image_on_button_press)
+
+        # Reconstruction preview plot
+        self.recon_figure, self.recon_canvas, self.recon_toolbar = \
+            add_mpl_figure(self.reconPreviewLayout, NavigationToolbarSimple)
+        self.recon_plot = self.recon_figure.add_subplot(111)
 
         # Linear fit plot
-        self.fit_figure, self.fit_canvas = add_mpl_figure(self.fitLayout)
+        self.fit_figure, self.fit_canvas, _ = add_mpl_figure(self.fitLayout)
         self.fit_plot = self.fit_figure.add_subplot(111)
         self.update_fit_plot(None, None, None)
 
-        self.set_results(0, 0)
+        # Point table
+        self.tableView.horizontalHeader().setStretchLastSection(True)
+        self.tableView.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.tableView.setSelectionMode(QAbstractItemView.SingleSelection)
+
+        self.tableView.model().rowsInserted.connect(
+                self.on_table_row_count_change)
+        self.tableView.model().rowsRemoved.connect(
+                self.on_table_row_count_change)
+        self.tableView.model().modelReset.connect(
+                self.on_table_row_count_change)
+
+        # Update previews when data in table changes
+        def on_data_change(tl, br, _):
+            self.presenter.notify(PresNotification.UPDATE_PREVIEWS)
+            if tl == br and tl.column() == Field.CENTRE_OF_ROTATION.value:
+                mdl = self.tableView.model()
+                slice_idx = mdl.data(mdl.index(tl.row(), Field.SLICE_INDEX.value))
+                self.presenter.handle_cor_manually_changed(slice_idx)
+
+        self.tableView.model().rowsRemoved.connect(
+                lambda: self.presenter.notify(
+                    PresNotification.UPDATE_PREVIEWS))
+        self.tableView.model().dataChanged.connect(on_data_change)
+
+        self.manualClearAllButton.clicked.connect(
+                self.tableView.model().removeAllRows)
+        self.manualRemoveButton.clicked.connect(
+                self.tableView.removeSelectedRows)
+        self.manualAddButton.clicked.connect(
+                lambda: self.presenter.notify(
+                    PresNotification.ADD_NEW_COR_TABLE_ROW))
+        self.manualFitButton.clicked.connect(
+                lambda: self.presenter.notify(PresNotification.RUN_MANUAL))
+
+        def on_row_change(item, _):
+            """
+            Handles setting preview slice index from the currently selected row
+            in the manual COR table.
+            """
+            if item.isValid():
+                slice_idx = item.model().point(item.row())[
+                        Field.SLICE_INDEX.value]
+                self.presenter.set_preview_slice_idx(slice_idx)
+                self.presenter.notify(
+                        PresNotification.PREVIEW_RECONSTRUCTION_SET_COR)
+
+        self.tableView.selectionModel().currentRowChanged.connect(
+                on_row_change)
+
+        # Update initial UI state
+        self.on_table_row_count_change()
+        self.set_results(0, 0, 0)
 
         self.stackSelector.subscribe_to_main_window(main_window)
 
     def cleanup(self):
         self.stackSelector.unsubscribe_from_main_window()
 
-    def set_results(self, cor, tilt):
+    @property
+    def point_model(self):
+        if self.tableView.model() is None:
+            mdl = CorTiltPointQtModel(self.tableView)
+            self.tableView.setModel(mdl)
+        return self.tableView.model()
+
+    def set_results(self, cor, tilt, m):
+        """
+        Sets the numerical COR and tilt angle results.
+        """
         self.resultCor.setValue(cor)
         self.resultTilt.setValue(tilt)
+        self.resultGradient.setValue(m)
 
     def update_image_preview(self,
                              image_data,
+                             preview_slice_index,
                              tilt_line_points=None,
                              roi=None):
+        """
+        Updates the preview projection image and associated annotations.
+
+        Region of interest sets the bounds of the image axes, it does not
+        resize the data itself. The advantage of this is that the coordinates
+        do not change.
+
+        :param image_data: Projection image data (single/2D image)
+        :param preview_slice_index: Y coordinate at which to draw the preview
+                                    slice indicator
+        :param tilt_line_points: Tuple of (X, Y) data points for tilt preview
+                                 line
+        :param roi: Region of interest to crop the image to
+        """
         self.image_plot.cla()
+
+        self.previewSliceIndex.setValue(preview_slice_index)
 
         # Plot image
         if image_data is not None:
             self.image_plot.imshow(image_data, cmap=self.cmap)
 
+            # Plot preview slice line
+            x_max = image_data.shape[1] - 1
+            self.image_plot.plot(
+                    [0, x_max],
+                    [preview_slice_index, preview_slice_index],
+                    c='y')
+
         # Plot tilt line
         if tilt_line_points is not None:
-            self.image_plot.plot(*tilt_line_points, lw=2, c='y')
+            self.image_plot.plot(*tilt_line_points, lw=1, c='r')
 
         # Set zoom level to ROI
         if roi is not None:
@@ -86,12 +190,38 @@ class CORTiltWindowView(BaseMainWindowView):
 
         self.image_canvas.draw()
 
-    def update_fit_plot(self, x_axis, cor_data, fit_data):
-        self.fit_plot.cla()
+    def preview_image_on_button_press(self, event):
+        """
+        Handles mouse button presses on the preview projection image.
 
-        # Set axes labels
-        self.fit_plot.set_xlabel('Slice')
-        self.fit_plot.set_ylabel('COR')
+        Used to set the preview slice when a user clicks on a given part of the
+        image.
+        """
+        if event.button == 1 and event.ydata is not None:
+            self.presenter.set_preview_slice_idx(int(event.ydata))
+
+    def update_image_recon_preview(self, image_data):
+        """
+        Updates the reconstruction preview image with new data.
+        """
+        self.recon_plot.cla()
+
+        # Plot image
+        if image_data is not None:
+            self.recon_plot.imshow(image_data, cmap=self.cmap)
+
+        self.recon_canvas.draw()
+
+    def update_fit_plot(self, x_axis, cor_data, fit_data):
+        """
+        Updates the fit result preview plot with the data provided.
+
+        :param x_axis: Common x axis data (slice index)
+        :param cor_data: Centre of rotation determined per slice
+        :param fit_data: Result of linear fitting of per slice centre of
+                         rotation
+        """
+        self.fit_plot.cla()
 
         # Plot COR data
         if cor_data is not None:
@@ -101,6 +231,14 @@ class CORTiltWindowView(BaseMainWindowView):
         if fit_data is not None:
             self.fit_plot.plot(x_axis, fit_data)
 
+        # Remove axes ticks to save screen space
+        self.fit_plot.set_xticks([])
+        self.fit_plot.set_yticks([])
+
+        # Use tight layout to reduce unused canvas space
+        # https://matplotlib.org/users/tight_layout_guide.html
+        self.fit_figure.tight_layout()
+
         self.fit_canvas.draw()
 
     def set_num_projections(self, count):
@@ -108,12 +246,21 @@ class CORTiltWindowView(BaseMainWindowView):
         Set the number of projections in the input dataset.
         """
         # Preview image control
-        self.previewStackIndex.setValue(0)
-        self.previewStackIndex.setMaximum(count - 1)
+        self.previewProjectionIndex.setValue(0)
+        self.previewProjectionIndex.setMaximum(max(count - 1, 0))
 
         # Projection downsample control
         self.projectionCount.setMaximum(count)
-        self.projectionCount.setValue(count)
+        self.projectionCount.setValue(int(count * 0.1))
+
+    def set_num_slices(self, count):
+        """
+        Sets the number of slices (projection Y axis size) of the full input
+        image.
+        """
+        # Preview image control
+        self.previewSliceIndex.setValue(0)
+        self.previewSliceIndex.setMaximum(max(count - 1, 0))
 
     def reset_projection_count(self):
         """
@@ -121,10 +268,52 @@ class CORTiltWindowView(BaseMainWindowView):
         """
         self.projectionCount.setValue(self.projectionCount.maximum())
 
+    def show_results(self):
+        """
+        Shows results after finding is complete.
+
+        Specifically switch to the "Results" tab.
+        """
+        self.tabWidget.setCurrentWidget(self.resultsTab)
+
+    def on_table_row_count_change(self):
+        """
+        Called when rows have been added or removed from the point table.
+
+        Used to conditionally enable UI controls that depend on a certain
+        amount of entries in the table.
+        """
+        # Disable clear buttons when there are no rows in the table
+        empty = self.tableView.model().empty
+        self.manualRemoveButton.setEnabled(not empty)
+        self.manualClearAllButton.setEnabled(not empty)
+
+        # Update previews when no data is left
+        if empty:
+            self.presenter.notify(PresNotification.UPDATE_PREVIEWS)
+
+        # Disable fit button when there are less than 2 rows (points)
+        enough_to_fit = self.tableView.model().num_points >= 2
+        self.manualFitButton.setEnabled(enough_to_fit)
+
+    def add_cor_table_row(self, idx):
+        """
+        Adds a row to the manual COR table with a specified slice index.
+        """
+        self.tableView.model().appendNewRow(idx)
+
     @property
     def slice_count(self):
+        """
+        The number of slices/sinograms the user has selected for automatic
+        COR/Tilt finding.
+        """
         return self.sliceCount.value()
 
     @property
     def projection_count(self):
+        """
+        The number of projections the user has selected for automatic COR/Tilt
+        finding.
+        """
         return self.projectionCount.value()


### PR DESCRIPTION
Adds the ability to manually change the COR/Tilt finding results or perform finding by manual inspection of individual reconstructed slices.

To test:
- Load all images from `babylon5/DanNixon/sample_intensity_cutoff_crop/`
- Open *Reconstruct* > *Find COR and Tilt*
- (no cropping is needed as the dataset is already cropped to a correct region)
- Set 45 projections and 10 slices
- Click *Calculate*
- (*Results* tab should be automatically shown)
- Click *Clear All*
- Select somewhere near the top of the projection preview and click *Add*, enter a COR of around 610 (try to remove the halo around the small cylinders)
- Do the last step two or three more times at even intervals down the image
- Click *Fit*
- Click anywhere on the image and you should get a reasonable reconstruction (at least as reasonable as it was when you selected the CORs)
- Right click on the image and view its metadata
- Ensure the COR/Tilt data reflects the last entry in the *Results* tab