### PR TITLE
Add spacing to parameter panels

### DIFF
--- a/mantidimaging/gui/ui/cor_tilt_window.ui
+++ b/mantidimaging/gui/ui/cor_tilt_window.ui
@@ -22,8 +22,8 @@
       </property>
       <widget class="QWidget" name="formLayoutWidget">
        <layout class="QVBoxLayout" name="verticalLayout">
-        <property name="spacing">
-         <number>0</number>
+        <property name="margin">
+         <number>9</number>
         </property>
         <item>
          <widget class="QTabWidget" name="tabWidget">

--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -31,6 +31,9 @@
         <property name="sizeConstraint">
          <enum>QLayout::SetDefaultConstraint</enum>
         </property>
+        <property name="margin">
+         <number>9</number>
+        </property>
         <item>
          <layout class="QFormLayout" name="optionsLayout">
           <property name="fieldGrowthPolicy">

--- a/mantidimaging/gui/ui/tomopy_recon_window.ui
+++ b/mantidimaging/gui/ui/tomopy_recon_window.ui
@@ -22,6 +22,9 @@
       </property>
       <widget class="QWidget" name="verticalLayoutWidget_2">
        <layout class="QVBoxLayout" name="paramsLayout">
+        <property name="margin">
+         <number>9</number>
+        </property>
         <item>
          <layout class="QGridLayout" name="optionsLayout">
           <item row="3" column="1">


### PR DESCRIPTION
Fixes #231

See commit message for description.

To test:
- Open each of the following GUIs and see that the spacing looks normal:
  - Filters
  - COR/Tilt
  - TomoPy recon