### PR TITLE
Allow Rebin filter to work for all number types

### DIFF
--- a/mantidimaging/core/filters/rebin/rebin.py
+++ b/mantidimaging/core/filters/rebin/rebin.py
@@ -79,7 +79,7 @@ def _execute_par(data, rebin_param, mode, cores=None, chunksize=None,
                                         task_name='Rebin')
 
     resized_data, resized_shape = _create_reshaped_array(
-            data.shape, rebin_param)
+            data.shape, data.dtype, rebin_param)
 
     with progress:
         progress.update(msg="Starting PARALLEL image rebinning.")
@@ -101,7 +101,7 @@ def _execute_seq(data, rebin_param, mode, progress=None):
         progress.update(msg="Starting image rebinning.")
 
         resized_data, resized_shape = _create_reshaped_array(
-                data.shape, rebin_param)
+                data.shape, data.dtype, rebin_param)
 
         num_images = resized_data.shape[0]
         progress.add_estimated_steps(num_images)
@@ -114,7 +114,7 @@ def _execute_seq(data, rebin_param, mode, progress=None):
     return resized_data
 
 
-def _create_reshaped_array(old_shape, rebin_param):
+def _create_reshaped_array(old_shape, dtype, rebin_param):
     num_images = old_shape[0]
 
     # use SciPy's calculation to find the expected dimensions
@@ -128,6 +128,6 @@ def _create_reshaped_array(old_shape, rebin_param):
 
     # allocate memory for images with new dimensions
     shape = (num_images, expected_dimy, expected_dimx)
-    data = pu.create_shared_array(shape)
+    data = pu.create_shared_array(shape, dtype)
 
     return (data, shape)

--- a/mantidimaging/core/filters/rebin/test/rebin_test.py
+++ b/mantidimaging/core/filters/rebin/test/rebin_test.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 import mantidimaging.core.testing.unit_test_helper as th
@@ -70,8 +71,13 @@ class RebinTest(unittest.TestCase):
         self.do_execute_uniform(5.0)
         th.switch_mp_on()
 
-    def do_execute_uniform(self, val=2.0):
-        images = th.gen_img_shared_array()
+    def test_executed_uniform_seq_5_int(self):
+        th.switch_mp_off()
+        self.do_execute_uniform(5.0, np.int32)
+        th.switch_mp_on()
+
+    def do_execute_uniform(self, val=2.0, dtype=np.float32):
+        images = th.gen_img_shared_array(dtype=dtype)
         mode = 'nearest'
 
         expected_x = int(images.shape[1] * val)
@@ -81,6 +87,9 @@ class RebinTest(unittest.TestCase):
 
         npt.assert_equal(result.shape[1], expected_x)
         npt.assert_equal(result.shape[2], expected_y)
+
+        self.assertEquals(images.dtype, dtype)
+        self.assertEquals(result.dtype, dtype)
 
         # TODO: in-place data test
         # npt.assert_equal(images.shape[1], expected_x)

--- a/mantidimaging/core/testing/unit_test_helper.py
+++ b/mantidimaging/core/testing/unit_test_helper.py
@@ -24,8 +24,8 @@ def gen_img_shared_array_and_copy(shape=g_shape):
     return arr, copy
 
 
-def gen_img_shared_array(shape=g_shape):
-    d = pu.create_shared_array(shape)
+def gen_img_shared_array(shape=g_shape, dtype=np.float32):
+    d = pu.create_shared_array(shape, dtype)
     n = np.random.rand(shape[0], shape[1], shape[2])
     # move the data in the shared array
     d[:] = n[:]


### PR DESCRIPTION
Corrects the assumption that data will always be a 32 bit float. (I can't remember why this was an issue for me but it was something I got half way done at the dev meeting)

Reviewing the additional unit test should be sufficient.