### PR TITLE
Add the ability to open a large COR vs slice plot

### DIFF
--- a/mantidimaging/gui/windows/cor_tilt/view.py
+++ b/mantidimaging/gui/windows/cor_tilt/view.py
@@ -71,6 +71,11 @@ class CORTiltWindowView(BaseMainWindowView):
         self.fit_figure, self.fit_canvas, _ = add_mpl_figure(self.fitLayout)
         self.fit_plot = self.fit_figure.add_subplot(111)
         self.update_fit_plot(None, None, None)
+        self.fit_canvas.mpl_connect(
+                'button_press_event', self.handle_fit_plot_button_press)
+        self.fit_canvas.setToolTip(
+                'Double click to open a larger plot (requires at least '
+                '2 points)')
 
         # Point table
         self.tableView.horizontalHeader().setStretchLastSection(True)
@@ -89,7 +94,8 @@ class CORTiltWindowView(BaseMainWindowView):
             self.presenter.notify(PresNotification.UPDATE_PREVIEWS)
             if tl == br and tl.column() == Field.CENTRE_OF_ROTATION.value:
                 mdl = self.tableView.model()
-                slice_idx = mdl.data(mdl.index(tl.row(), Field.SLICE_INDEX.value))
+                slice_idx = mdl.data(
+                        mdl.index(tl.row(), Field.SLICE_INDEX.value))
                 self.presenter.handle_cor_manually_changed(slice_idx)
 
         self.tableView.model().rowsRemoved.connect(
@@ -262,6 +268,17 @@ class CORTiltWindowView(BaseMainWindowView):
         self.fit_figure.tight_layout()
 
         self.fit_canvas.draw()
+
+    def handle_fit_plot_button_press(self, event):
+        """
+        Handle mouse button presses on the fit plot preview.
+
+        Currently opens a larger version of the plot in a new window when the
+        plot is double (left) clicked.
+        """
+        # Double left click
+        if event.button == 1 and event.dblclick:
+            self.presenter.notify(PresNotification.SHOW_COR_VS_SLICE_PLOT)
 
     def set_num_projections(self, count):
         """


### PR DESCRIPTION
See commit messages for descriptions.

Fixes #235

To test:
- Load some data (anything will do here)
- Open *Find COR and Tilt* window
- Switch to *Results* tab
- Open the larger COR vs slice plot by double clicking on the mini plot at the top of the *Results* tab
  - When less than 2 points are added no plot is opened
  - When 2 or more points are added only the data line is shown
  - When 2 or more points are added and the fit has been run the data and fit lines are shown