### PR TITLE
Prefill the COR on newly added rows in COR/Tilt UI

### DIFF
--- a/mantidimaging/gui/windows/cor_tilt/model.py
+++ b/mantidimaging/gui/windows/cor_tilt/model.py
@@ -21,6 +21,7 @@ class CORTiltWindowModel(object):
         self.roi = None
         self.projection_indices = None
         self.model = model
+        self.last_result = None
 
     @property
     def has_results(self):
@@ -96,6 +97,9 @@ class CORTiltWindowModel(object):
                 self.projection_indices,
                 progress=progress)
 
+        # Cache last result
+        self.last_result = self.model.stack_properties
+
         # Async task needs a non-None result of some sort
         return True
 
@@ -109,6 +113,9 @@ class CORTiltWindowModel(object):
 
         self.model.linear_regression()
         self.images.properties.update(self.model.stack_properties)
+
+        # Cache last result
+        self.last_result = self.model.stack_properties
 
         # Async task needs a non-None result of some sort
         return True

--- a/mantidimaging/gui/windows/cor_tilt/point_table_model.py
+++ b/mantidimaging/gui/windows/cor_tilt/point_table_model.py
@@ -119,12 +119,14 @@ class CorTiltPointQtModel(QAbstractTableModel, CorTiltDataModel):
 
         self.endRemoveRows()
 
-    def appendNewRow(self, slice_idx):
+    def appendNewRow(self, slice_idx, cor=0):
         self.insertRows(self.num_points, 1)
 
         self.setData(
                 self.index(self.num_points - 1, Field.SLICE_INDEX.value),
                 slice_idx)
+
+        self.set_cor_at_slice(slice_idx, cor)
 
     def headerData(self, section, orientation, role):
         if orientation != Qt.Horizontal:

--- a/mantidimaging/gui/windows/cor_tilt/presenter.py
+++ b/mantidimaging/gui/windows/cor_tilt/presenter.py
@@ -5,6 +5,7 @@ from logging import getLogger
 
 import matplotlib.pyplot as plt
 
+from mantidimaging.core.data import const as data_const
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.dialogs.async_task import AsyncTaskDialogView
 from mantidimaging.gui.dialogs.cor_inspection import CORInspectionDialogView
@@ -126,7 +127,9 @@ class CORTiltWindowPresenter(BasePresenter):
 
     def do_add_manual_cor_table_row(self):
         idx = self.model.preview_slice_idx
-        self.view.add_cor_table_row(idx)
+        cor = self.model.last_result[data_const.AUTO_COR_TILT]['rotation_centre'] if \
+            self.model.last_result else 0
+        self.view.add_cor_table_row(idx, cor)
 
     def do_refine_selected_cor(self):
         slice_idx = self.model.preview_slice_idx

--- a/mantidimaging/gui/windows/cor_tilt/test/model_test.py
+++ b/mantidimaging/gui/windows/cor_tilt/test/model_test.py
@@ -32,6 +32,7 @@ class CORTiltWindowModelTest(unittest.TestCase):
         m = CORTiltWindowModel(CorTiltPointQtModel(None))
         self.assertIsNone(m.stack)
         self.assertIsNone(m.sample)
+        self.assertIsNone(m.last_result)
 
     def test_init(self):
         self.assertEquals(self.model.sample.shape, (10, 128, 128))

--- a/mantidimaging/gui/windows/cor_tilt/view.py
+++ b/mantidimaging/gui/windows/cor_tilt/view.py
@@ -335,11 +335,11 @@ class CORTiltWindowView(BaseMainWindowView):
         enough_to_fit = self.tableView.model().num_points >= 2
         self.manualFitButton.setEnabled(enough_to_fit)
 
-    def add_cor_table_row(self, idx):
+    def add_cor_table_row(self, idx, cor):
         """
         Adds a row to the manual COR table with a specified slice index.
         """
-        self.tableView.model().appendNewRow(idx)
+        self.tableView.model().appendNewRow(idx, cor)
 
     @property
     def slice_count(self):


### PR DESCRIPTION
When a previous COR/Tilt finding has been run (either automatic or manual) the result is cached and the common rotation centre then used as the default COR value when adding a new row to the manual finding table.

To test:
- Load all images from `babylon5/DanNixon/sample_intensity_cutoff_crop/`
- Open *Reconstruct* > *Find COR and Tilt*
- (no cropping is needed as the dataset is already cropped to a correct region)
- Set 45 projections and 10 slices
- Click *Calculate*
- (*Results* tab should be automatically shown)
- Click *Clear All*
- Select somewhere on the projection preview and click *Add*
- (the COR value should be pre-populated with the rotation centre from the automatic finding run)