### PR TITLE
Add dialog for manual rotation centre refinement

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ channels:
 
 dependencies:
   - python=3.5
+  - matplotlib>=2.1.0
   - tomopy=1.1.2
   - pyfftw
   - astropy

--- a/mantidimaging/core/reconstruct/__init__.py
+++ b/mantidimaging/core/reconstruct/__init__.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 
 from .tomopy_reconstruction import (  # noqa: F401
         reconstruct as tomopy_reconstruct,
-        reconstruct_single_preview as tomopy_reconstruct_preview)
+        reconstruct_single_preview as tomopy_reconstruct_preview,
+        reconstruct_single_preview_from_sinogram as tomopy_reconstruct_preview_from_sinogram)
 
 del absolute_import, division, print_function

--- a/mantidimaging/core/reconstruct/tomopy_reconstruction.py
+++ b/mantidimaging/core/reconstruct/tomopy_reconstruction.py
@@ -51,6 +51,33 @@ def reconstruct_single_preview(sample,
     return volume[0]
 
 
+def reconstruct_single_preview_from_sinogram(sample,
+                                             cor,
+                                             proj_angles,
+                                             progress=None):
+    """
+
+    :param sample: 2D sinogram data
+    :param cor: Centre of rotation value
+    :param proj_angles: Array of projection angles
+    :param progress: Optional progress reporter
+    :return: 2D image data for reconstructed slice
+    """
+    progress = Progress.ensure_instance(progress,
+                                        task_name='Tomopy reconstruction')
+
+    volume = [None]
+    with progress:
+        volume = tomopy.recon(
+                tomo=[sample],
+                sinogram_order=True,
+                theta=proj_angles,
+                center=cor,
+                algorithm='gridrec')
+
+    return volume[0]
+
+
 def reconstruct(sample,
                 cor=None,
                 proj_angles=None,

--- a/mantidimaging/gui/dialogs/cor_inspection/__init__.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import, division, print_function
+
+from .model import CORInspectionDialogModel  # noqa: F401
+from .view import CORInspectionDialogView  # noqa: F401
+from .types import ImageType  # noqa: F401
+from .presenter import CORInspectionDialogPresenter  # noqa: F401
+
+del absolute_import, division, print_function  # noqa:F821

--- a/mantidimaging/gui/dialogs/cor_inspection/model.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/model.py
@@ -1,0 +1,72 @@
+from __future__ import (absolute_import, division, print_function)
+
+from logging import getLogger
+
+import numpy as np
+
+from mantidimaging.core.reconstruct import (
+        tomopy_reconstruct_preview_from_sinogram)
+from mantidimaging.core.utility.projection_angles import (
+        generate as generate_projection_angles)
+
+from .types import ImageType
+
+LOG = getLogger(__name__)
+
+
+class CORInspectionDialogModel(object):
+
+    def __init__(self, data, slice_idx=None, initial_cor=None, initial_step=50, max_angle=360):
+        # Extract the sinogram
+        if slice_idx is None:
+            self.sino = data
+        else:
+            LOG.debug('Extracting sinogram at index {}'.format(slice_idx))
+            self.sino = np.swapaxes(data, 0, 1)[slice_idx]
+        LOG.debug('Sinogram shape: {}'.format(self.sino.shape))
+
+        # Initial parameters
+        self.centre_cor = self.cor_extents[1] / 2 if \
+            initial_cor is None else initial_cor
+        self.cor_step = initial_step
+
+        # Cache projection angles
+        self.proj_angles = generate_projection_angles(
+                max_angle, self.sino.shape[0])
+
+    def adjust_cor(self, image):
+        """
+        Adjusts the rotation centre and step after an image is selected as the
+        optimal of an iteration.
+        """
+        if image == ImageType.LESS:
+            self.centre_cor -= self.cor_step
+        elif image == ImageType.MORE:
+            self.centre_cor += self.cor_step
+        elif image == ImageType.CURRENT:
+            self.cor_step /= 2
+
+    def cor(self, image):
+        """
+        Gets the rotation centre for a given image in the current iteration.
+        """
+        if image == ImageType.LESS:
+            return max(self.cor_extents[0], self.centre_cor - self.cor_step)
+        elif image == ImageType.CURRENT:
+            return self.centre_cor
+        elif image == ImageType.MORE:
+            return min(self.cor_extents[1], self.centre_cor + self.cor_step)
+
+    def recon_preview(self, image):
+        cor = self.cor(image)
+        # TODO
+        # Only two images should need to be reconstructed per iteration
+        # (currently all three are).
+        # Look for a way to cache them after the iteration step has been
+        # finalised with scientists.
+        return tomopy_reconstruct_preview_from_sinogram(
+               self.sino, cor, self.proj_angles)
+
+    @property
+    def cor_extents(self):
+        return (0, self.sino.shape[1] - 1)

--- a/mantidimaging/gui/dialogs/cor_inspection/presenter.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/presenter.py
@@ -1,0 +1,84 @@
+from __future__ import absolute_import, division, print_function
+
+from logging import getLogger
+from enum import Enum
+from PyQt5 import Qt
+
+from mantidimaging.core.utility.progress_reporting import ProgressHandler
+from mantidimaging.gui.mvp_base import BasePresenter
+
+from .model import CORInspectionDialogModel
+from .types import ImageType
+
+LOG = getLogger(__name__)
+
+
+class Notification(Enum):
+    IMAGE_CLICKED_LESS = 1
+    IMAGE_CLICKED_CURRENT = 2
+    IMAGE_CLICKED_MORE = 3
+    FULL_UPDATE = 4
+    UPDATE_PARAMETERS_FROM_UI = 5
+    LOADED = 6
+
+
+class CORInspectionDialogPresenter(BasePresenter):
+    progress_updated = Qt.pyqtSignal(float, str)
+
+    def __init__(self, view, **args):
+        super(CORInspectionDialogPresenter, self).__init__(view)
+
+        self.model = CORInspectionDialogModel(**args)
+
+    def notify(self, signal):
+        try:
+            if signal == Notification.IMAGE_CLICKED_LESS:
+                self.on_select_image(ImageType.LESS)
+            elif signal == Notification.IMAGE_CLICKED_CURRENT:
+                self.on_select_image(ImageType.CURRENT)
+            elif signal == Notification.IMAGE_CLICKED_MORE:
+                self.on_select_image(ImageType.MORE)
+            elif signal == Notification.FULL_UPDATE:
+                self.do_full_ui_update()
+            elif signal == Notification.UPDATE_PARAMETERS_FROM_UI:
+                self.do_update_ui_parameters()
+            elif signal == Notification.LOADED:
+                self.on_load()
+
+        except Exception as e:
+            self.show_error(e)
+            getLogger(__name__).exception("Notification handler failed")
+
+    def on_load(self):
+        self.view.set_maximum_cor(self.model.cor_extents[1])
+        self.notify(Notification.FULL_UPDATE)
+
+    def on_select_image(self, img):
+        LOG.debug('Image selected: {}'.format(img))
+
+        # Adjust COR step
+        self.model.adjust_cor(img)
+
+        # Update UI
+        self.notify(Notification.FULL_UPDATE)
+
+    def do_full_ui_update(self):
+        # Parameters
+        self.view.step_size = self.model.cor_step
+
+        # Images
+        for i in ImageType:
+            title = 'COR: {}'.format(self.model.cor(i))
+            self.view.set_image(i, self.model.recon_preview(i), title)
+
+        self.view.image_canvas_draw()
+
+    def do_update_ui_parameters(self):
+        self.model.cor_step = self.view.step_size
+
+        # Update UI
+        self.notify(Notification.FULL_UPDATE)
+
+    @property
+    def optimal_rotation_centre(self):
+        return self.model.centre_cor

--- a/mantidimaging/gui/dialogs/cor_inspection/test/model_test.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/test/model_test.py
@@ -1,0 +1,66 @@
+from __future__ import (absolute_import, division, print_function)
+
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from mantidimaging.gui.dialogs.cor_inspection import (
+        CORInspectionDialogModel, ImageType)
+
+
+class CORInspectionDialogModelTest(unittest.TestCase):
+
+    def test_construct_from_sinogram(self):
+        sino = np.ones(shape=(128, 64), dtype=np.float32)
+        m = CORInspectionDialogModel(sino)
+        npt.assert_equal(m.sino, sino)
+        self.assertEquals(m.cor_extents, (0, 63))
+        self.assertEquals(m.proj_angles.shape, (128,))
+
+    def test_construct_from_projections(self):
+        proj = np.ones(shape=(128, 64, 64), dtype=np.float32)
+        m = CORInspectionDialogModel(proj, slice_idx=5)
+        self.assertEquals(m.sino.shape, (128, 64))
+        self.assertEquals(m.cor_extents, (0, 63))
+        self.assertEquals(m.proj_angles.shape, (128,))
+
+    def test_construct_from_sinogram_defaults(self):
+        sino = np.ones(shape=(128, 64), dtype=np.float32)
+        m = CORInspectionDialogModel(sino)
+        self.assertEquals(m.centre_cor, (64 - 1) / 2)
+
+    def test_current_cor(self):
+        sino = np.ones(shape=(128, 64), dtype=np.float32)
+        m = CORInspectionDialogModel(sino)
+        m.centre_cor = 30
+        m.cor_step = 10
+        self.assertEquals(m.cor(ImageType.LESS), 20)
+        self.assertEquals(m.cor(ImageType.CURRENT), 30)
+        self.assertEquals(m.cor(ImageType.MORE), 40)
+
+    def test_adjust_cor(self):
+        sino = np.ones(shape=(128, 64), dtype=np.float32)
+        m = CORInspectionDialogModel(sino)
+        m.centre_cor = 30
+        m.cor_step = 10
+
+        m.adjust_cor(ImageType.CURRENT)
+        self.assertEquals(m.centre_cor, 30)
+        self.assertEquals(m.cor_step, 5)
+
+        m.adjust_cor(ImageType.LESS)
+        self.assertEquals(m.centre_cor, 25)
+        self.assertEquals(m.cor_step, 5)
+
+        m.adjust_cor(ImageType.CURRENT)
+        self.assertEquals(m.centre_cor, 25)
+        self.assertEquals(m.cor_step, 2.5)
+
+        m.adjust_cor(ImageType.MORE)
+        self.assertEquals(m.centre_cor, 27.5)
+        self.assertEquals(m.cor_step, 2.5)
+
+        m.adjust_cor(ImageType.CURRENT)
+        self.assertEquals(m.centre_cor, 27.5)
+        self.assertEquals(m.cor_step, 1.25)

--- a/mantidimaging/gui/dialogs/cor_inspection/types.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/types.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import, division, print_function
+
+from enum import Enum
+
+class ImageType(Enum):
+    LESS = 0
+    CURRENT = 1
+    MORE = 2

--- a/mantidimaging/gui/dialogs/cor_inspection/view.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/view.py
@@ -1,0 +1,96 @@
+from __future__ import absolute_import, division, print_function
+
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
+from matplotlib.figure import Figure
+
+from mantidimaging.gui.mvp_base import BaseDialogView
+from mantidimaging.gui.utility import BlockQtSignals
+from mantidimaging.gui.widgets import NavigationToolbarSimple
+
+from .presenter import (
+        CORInspectionDialogPresenter,
+        Notification as PresNotification)
+
+
+class CORInspectionDialogView(BaseDialogView):
+    def __init__(self, parent, cmap='Greys_r', **args):
+        super(CORInspectionDialogView, self).__init__(
+                parent, 'gui/ui/cor_inspection_dialog.ui')
+
+        self.presenter = CORInspectionDialogPresenter(self, **args)
+        self.cmap = cmap
+
+        # Completed button action
+        self.finishButton.clicked.connect(self.accept)
+
+        # Image canvas
+        self.image_figure = Figure(tight_layout=True)
+        self.image_canvas = FigureCanvasQTAgg(self.image_figure)
+        self.image_canvas.setParent(self)
+        self.imagePlotLayout.addWidget(self.image_canvas)
+        self.image_plots = self.image_figure.subplots(
+                1, 3, sharex=True, sharey=True)
+
+        # Common image toolbar (attached to centre image)
+        self.plot_toolbar = NavigationToolbarSimple(self.image_canvas, self)
+        self.plotToolbarLayout.addWidget(self.plot_toolbar)
+
+        # Handle best image selection
+        self.lessButton.pressed.connect(
+                lambda: self.presenter.notify(
+                    PresNotification.IMAGE_CLICKED_LESS))
+        self.currentButton.pressed.connect(
+                lambda: self.presenter.notify(
+                    PresNotification.IMAGE_CLICKED_CURRENT))
+        self.moreButton.pressed.connect(
+                lambda: self.presenter.notify(
+                    PresNotification.IMAGE_CLICKED_MORE))
+
+        # Handle parameter updates
+        self.step.valueChanged.connect(
+                lambda: self.presenter.notify(
+                    PresNotification.UPDATE_PARAMETERS_FROM_UI))
+
+        self._image_cache = [None, None, None]
+
+        # Ensure initial state
+        self.presenter.notify(PresNotification.LOADED)
+
+    def set_image(self, image_type, data, title):
+        """
+        Sets the image displayed in a given position and it's title.
+        """
+        plot = self.image_plots[image_type.value]
+        image = self._image_cache[image_type.value]
+
+        # Cache the image object so that subsequent plots only have to replace
+        # the data
+        if image is None:
+            self._image_cache[image_type.value] = \
+                    plot.imshow(data, cmap=self.cmap)
+        else:
+            image.set_data(data)
+
+        plot.set_title(title)
+
+    def image_canvas_draw(self):
+        self.image_canvas.draw()
+
+    def set_maximum_cor(self, cor):
+        """
+        Set the maximum valid rotation centre.
+        """
+        self.step.setMaximum(cor)
+
+    @property
+    def step_size(self):
+        return self.step.value()
+
+    @step_size.setter
+    def step_size(self, value):
+        with BlockQtSignals([self.step]):
+            self.step.setValue(value)
+
+    @property
+    def optimal_rotation_centre(self):
+        return self.presenter.optimal_rotation_centre

--- a/mantidimaging/gui/ui/cor_inspection_dialog.ui
+++ b/mantidimaging/gui/ui/cor_inspection_dialog.ui
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CORInspectionDialog</class>
+ <widget class="QDialog" name="CORInspectionDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1000</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>COR Inspection</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="mainLayout">
+     <item row="5" column="0">
+      <widget class="QPushButton" name="lessButton">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>52</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Select</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QPushButton" name="currentButton">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>52</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Select</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="2">
+      <widget class="QPushButton" name="moreButton">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>52</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Select</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0" colspan="3">
+      <layout class="QVBoxLayout" name="imagePlotLayout"/>
+     </item>
+     <item row="7" column="1">
+      <widget class="QPushButton" name="finishButton">
+       <property name="text">
+        <string>Finish</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QDoubleSpinBox" name="step">
+       <property name="prefix">
+        <string>step: </string>
+       </property>
+       <property name="decimals">
+        <number>3</number>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0" colspan="3">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <layout class="QVBoxLayout" name="plotToolbarLayout"/>
+       </item>
+       <item>
+        <widget class="QLabel" name="instructionText">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select the best reconstruction.&lt;br/&gt;Selecting the left or right image centres the search space on their rotation centre.&lt;br/&gt;Step size is halved by selecting the centre image.&lt;br/&gt;Once sufficient quality is reached on the centre image click &amp;quot;Finish&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>lessButton</tabstop>
+  <tabstop>currentButton</tabstop>
+  <tabstop>moreButton</tabstop>
+  <tabstop>step</tabstop>
+  <tabstop>finishButton</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Part of the work required for #237

Implements a GUI that allows manual rotation centre refinement by iteratively selecting the best reconstruction out of three possibilities.

To test, run this script (change path to data as required):
```
import logging
import sys

from PyQt5.Qt import QApplication

from mantidimaging.helper import initialise_logging
from mantidimaging.core.io.loader import load
from mantidimaging.gui.dialogs.cor_inspection import CORInspectionDialogView

initialise_logging(logging.DEBUG)

d = load('/home/dan/datasets/psi_cylinder/sample_intensity_cutoff_crop/', indices=(0, 940, 5))
print(d.sample.shape)

app = QApplication(sys.argv)

cid = CORInspectionDialogView(None, data=d.sample, slice_idx=5)
res = cid.exec()
print(res)
print('Found COR:', cid.optimal_rotation_centre)
```