### PR TITLE
Manually refine rotation centres on COR/TIlt UI

### DIFF
--- a/mantidimaging/core/cor_tilt/data_model.py
+++ b/mantidimaging/core/cor_tilt/data_model.py
@@ -66,6 +66,16 @@ class CorTiltDataModel(object):
         if cor is not None:
             self._points[idx][Field.CENTRE_OF_ROTATION.value] = float(cor)
 
+    def _get_data_idx_from_slice_idx(self, slice_idx):
+        for i, p in enumerate(self._points):
+            if int(p[Field.SLICE_INDEX.value]) == slice_idx:
+                return i
+        return None
+
+    def set_cor_at_slice(self, slice_idx, cor):
+        data_idx = self._get_data_idx_from_slice_idx(slice_idx)
+        self.set_point(data_idx, cor=cor)
+
     def remove_point(self, idx):
         self.clear_results()
         del self._points[idx]

--- a/mantidimaging/core/cor_tilt/test/data_model_test.py
+++ b/mantidimaging/core/cor_tilt/test/data_model_test.py
@@ -205,3 +205,23 @@ class CorTiltDataModelTest(TestCase):
         self.assertEquals(m.get_cor_for_slice_from_regression(0), 4.0)
         self.assertEquals(m.get_cor_for_slice_from_regression(10), 5.0)
         self.assertEquals(m.get_cor_for_slice_from_regression(50), 9.0)
+
+    def test_get_data_idx_for_slice_idx(self):
+        m = CorTiltDataModel()
+        m.add_point(None, 10, 5.0)
+        m.add_point(None, 20, 6.0)
+        m.add_point(None, 30, 7.0)
+        m.add_point(None, 40, 8.0)
+
+        self.assertEquals(m._get_data_idx_from_slice_idx(10), 0)
+        self.assertIsNone(m._get_data_idx_from_slice_idx(100))
+
+    def test_set_cor_at_slice(self):
+        m = CorTiltDataModel()
+        m.add_point(None, 10, 5.0)
+        m.add_point(None, 20, 6.0)
+        m.add_point(None, 30, 7.0)
+        m.add_point(None, 40, 8.0)
+
+        m.set_cor_at_slice(30, 15)
+        self.assertEquals(m.cors, [5.0, 6.0, 15.0, 8.0])

--- a/mantidimaging/gui/ui/cor_tilt_window.ui
+++ b/mantidimaging/gui/ui/cor_tilt_window.ui
@@ -288,26 +288,6 @@
                </item>
                <item>
                 <layout class="QGridLayout" name="gridLayout">
-                 <item row="0" column="2">
-                  <widget class="QPushButton" name="manualAddButton">
-                   <property name="toolTip">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a new row to the table.&lt;/p&gt;&lt;p&gt;Slice index defaults to the current preview slice index.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="text">
-                    <string>Add</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="2">
-                  <widget class="QPushButton" name="manualFitButton">
-                   <property name="toolTip">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Performs linear fit of rows/points in the table.&lt;/p&gt;&lt;p&gt;Requires at least two rows.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="text">
-                    <string>Fit</string>
-                   </property>
-                  </widget>
-                 </item>
                  <item row="0" column="0">
                   <widget class="QPushButton" name="manualRemoveButton">
                    <property name="toolTip">
@@ -325,6 +305,36 @@
                    </property>
                    <property name="text">
                     <string>Clear All</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
+                  <widget class="QPushButton" name="manualRefineCorButton">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="text">
+                    <string>Refine</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="1">
+                  <widget class="QPushButton" name="manualAddButton">
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a new row to the table.&lt;/p&gt;&lt;p&gt;Slice index defaults to the current preview slice index.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="text">
+                    <string>Add</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="0" colspan="2">
+                  <widget class="QPushButton" name="manualFitButton">
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Performs linear fit of rows/points in the table.&lt;/p&gt;&lt;p&gt;Requires at least two rows.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="text">
+                    <string>Fit</string>
                    </property>
                   </widget>
                  </item>

--- a/mantidimaging/gui/windows/cor_tilt/view.py
+++ b/mantidimaging/gui/windows/cor_tilt/view.py
@@ -104,8 +104,12 @@ class CORTiltWindowView(BaseMainWindowView):
         self.manualAddButton.clicked.connect(
                 lambda: self.presenter.notify(
                     PresNotification.ADD_NEW_COR_TABLE_ROW))
+        self.manualRefineCorButton.clicked.connect(
+                lambda: self.presenter.notify(
+                    PresNotification.REFINE_SELECTED_COR))
         self.manualFitButton.clicked.connect(
-                lambda: self.presenter.notify(PresNotification.RUN_MANUAL))
+                lambda: self.presenter.notify(
+                    PresNotification.RUN_MANUAL))
 
         def on_row_change(item, _):
             """
@@ -118,6 +122,10 @@ class CORTiltWindowView(BaseMainWindowView):
                 self.presenter.set_preview_slice_idx(slice_idx)
                 self.presenter.notify(
                         PresNotification.PREVIEW_RECONSTRUCTION_SET_COR)
+
+            # Only allow the refine button to be clicked when a valid row is
+            # selected
+            self.manualRefineCorButton.setEnabled(item.isValid())
 
         self.tableView.selectionModel().currentRowChanged.connect(
                 on_row_change)


### PR DESCRIPTION
See commit messages for descriptions.

Closes #237 

To test:
- Load all images from `babylon5/DanNixon/sample_intensity_cutoff_crop/`
- Open *Reconstruct* > *Find COR and Tilt*
- (no cropping is needed as the dataset is already cropped to a correct region)
- Switch to *Manual* tab
- Click somewhere on the projection preview
- Click *Add*
- Select the newly added row on the table
- Click *Refine*
- Follow instructions on UI
- (you should now see the final rotation centre populated on the table and the reconstruction preview updated)