### PR TITLE
Reuse image object when replotting COR/Tilt recon preview

### DIFF
--- a/mantidimaging/gui/windows/cor_tilt/presenter.py
+++ b/mantidimaging/gui/windows/cor_tilt/presenter.py
@@ -52,6 +52,7 @@ class CORTiltWindowPresenter(BasePresenter):
             LOG.exception("Notification handler failed")
 
     def set_stack_uuid(self, uuid):
+        self.view.reset_image_recon_preview()
         self.set_stack(
                 self.main_window.get_stack_visualiser(uuid)
                 if uuid is not None else None)

--- a/mantidimaging/gui/windows/cor_tilt/view.py
+++ b/mantidimaging/gui/windows/cor_tilt/view.py
@@ -65,6 +65,7 @@ class CORTiltWindowView(BaseMainWindowView):
         self.recon_figure, self.recon_canvas, self.recon_toolbar = \
             add_mpl_figure(self.reconPreviewLayout, NavigationToolbarSimple)
         self.recon_plot = self.recon_figure.add_subplot(111)
+        self.recon_image = None
 
         # Linear fit plot
         self.fit_figure, self.fit_canvas, _ = add_mpl_figure(self.fitLayout)
@@ -204,13 +205,26 @@ class CORTiltWindowView(BaseMainWindowView):
         """
         Updates the reconstruction preview image with new data.
         """
-        self.recon_plot.cla()
-
         # Plot image
         if image_data is not None:
-            self.recon_plot.imshow(image_data, cmap=self.cmap)
+            # Cache image
+            # Saves time when drawing and maintains image extents
+            if self.recon_image is None:
+                self.recon_image = self.recon_plot.imshow(
+                        image_data, cmap=self.cmap)
+            else:
+                self.recon_image.set_data(image_data)
+                self.recon_image.autoscale()
 
         self.recon_canvas.draw()
+
+    def reset_image_recon_preview(self):
+        """
+        Resets the recon preview image, forcing a complete redraw next time it
+        is updated.
+        """
+        self.recon_plot.cla()
+        self.recon_image = None
 
     def update_fit_plot(self, x_axis, cor_data, fit_data):
         """


### PR DESCRIPTION
Sets new data on existing Image object when plotting the slice reconstruction preview on the COR/Tilt UI.

Maintains the current image extents (pan/zoom) for inspection of individual features across the volume and speeds up plotting a little bit.

Fixes #243 

To test:
- Load all images from `babylon5/DanNixon/sample_intensity_cutoff_crop/`
- Open *Reconstruct* > *Find COR and Tilt*
- (no cropping is needed as the dataset is already cropped to a correct region)
- Switch to *Manual* tab
- Click somewhere on the projection preview
- Click *Add*
- Select the newly added row on the table
- (an initial reconstruction will be shown, as no existing COR exists it will default to zero and be poor quality)
- Change the COR values
- (the image should be updated correctly and be noticeably faster than before)
- Zoom in on one of the features and change the COR value again
- (the preview image should stay zoomed in on the same area)