### PR TITLE
Allow gradient to be used in reconstruction COR calculations

### DIFF
--- a/mantidimaging/core/cor_tilt/__init__.py
+++ b/mantidimaging/core/cor_tilt/__init__.py
@@ -1,6 +1,5 @@
 from .angles import (  # noqa: F401
-        cors_to_tilt_angle,
-        tilt_angle_to_cors)
+        cors_to_tilt_angle)
 
 from .auto import (  # noqa: F401
         auto_find_cors)

--- a/mantidimaging/core/cor_tilt/angles.py
+++ b/mantidimaging/core/cor_tilt/angles.py
@@ -8,18 +8,3 @@ def cors_to_tilt_angle(slice_upper, m):
     opp = m * slice_upper
     hyp = np.sqrt(adj ** 2 + opp ** 2)
     return np.arcsin(opp / hyp)
-
-
-def tilt_angle_to_cors(theta, cor_zero, slice_range):
-    # Calculate max COR
-    adj = slice_range[-1] - slice_range[0]
-    adj_a = (math.pi / 2) - theta
-    cor_max = ((adj / np.sin(adj_a)) * np.sin(theta)) + cor_zero
-
-    # Interpolate COR over range
-    interpolated_cors = np.interp(
-            slice_range,
-            np.linspace(slice_range[0], slice_range[-1], 2),
-            np.asarray([cor_zero, cor_max]))
-
-    return interpolated_cors

--- a/mantidimaging/core/cor_tilt/test/angles_test.py
+++ b/mantidimaging/core/cor_tilt/test/angles_test.py
@@ -13,10 +13,3 @@ class AnglesTest(TestCase):
     def test_cors_to_tilt_angle(self):
         theta = angles.cors_to_tilt_angle(10, 1)
         self.assertAlmostEqual(theta, math.pi / 4)
-
-    def test_tilt_angle_to_cors(self):
-        theta = math.pi / 4
-        slices = np.linspace(0, 100, 20)
-        cors = angles.tilt_angle_to_cors(theta, 50, slices)
-        self.assertAlmostEqual(cors[0], 50.0)
-        self.assertAlmostEqual(cors[-1], 150.0)

--- a/mantidimaging/core/reconstruct/test/utility_test.py
+++ b/mantidimaging/core/reconstruct/test/utility_test.py
@@ -125,17 +125,20 @@ class UtilityTest(TestCase):
     def test_get_cor_tilt_from_images(self):
         imgs = Images()
         imgs.properties = TEST_PARAMS_1
-        cor, tilt = utility.get_cor_tilt_from_images(imgs)
+        cor, tilt, m = utility.get_cor_tilt_from_images(imgs)
         self.assertEquals(cor, 1427.6 - 821)
         self.assertAlmostEqual(tilt, -0.01238)
+        self.assertAlmostEqual(m, -0.012)
 
     def test_get_cor_tilt_from_images_empty(self):
         imgs = Images()
-        cor, tilt = utility.get_cor_tilt_from_images(imgs)
+        cor, tilt, m = utility.get_cor_tilt_from_images(imgs)
         self.assertEquals(cor, 0)
         self.assertEquals(tilt, 0.0)
+        self.assertEquals(m, 0.0)
 
     def test_get_cor_tilt_from_images_none(self):
-        cor, tilt = utility.get_cor_tilt_from_images(None)
+        cor, tilt, m = utility.get_cor_tilt_from_images(None)
         self.assertEquals(cor, 0)
         self.assertEquals(tilt, 0.0)
+        self.assertEquals(m, 0.0)

--- a/mantidimaging/core/reconstruct/utility.py
+++ b/mantidimaging/core/reconstruct/utility.py
@@ -18,13 +18,14 @@ def get_roi_left_shift(images):
 
 def get_cor_tilt_from_images(images):
     if not images or const.AUTO_COR_TILT not in images.properties:
-        return (0, 0.0)
+        return (0, 0.0, 0.0)
 
     auto_cor_tilt = images.properties[const.AUTO_COR_TILT]
 
     cor = auto_cor_tilt['rotation_centre']
     tilt = auto_cor_tilt['tilt_angle_rad']
+    m = auto_cor_tilt['fitted_gradient']
 
     cor -= get_roi_left_shift(images)
 
-    return (cor, tilt)
+    return (cor, tilt, m)

--- a/mantidimaging/gui/ui/tomopy_recon_window.ui
+++ b/mantidimaging/gui/ui/tomopy_recon_window.ui
@@ -47,30 +47,7 @@
           <item row="4" column="0">
            <widget class="QLabel" name="corLabel">
             <property name="text">
-             <string>Rotation centre:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="tiltLabel">
-            <property name="text">
-             <string>Tilt angle:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="QDoubleSpinBox" name="tilt">
-            <property name="decimals">
-             <number>9</number>
-            </property>
-            <property name="minimum">
-             <double>-6.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>6.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.010000000000000</double>
+             <string>Rotation centre (at top of stack):</string>
             </property>
            </widget>
           </item>
@@ -101,6 +78,29 @@
             </property>
             <property name="singleStep">
              <double>10.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="gradientLabel">
+            <property name="text">
+             <string>Rotation centre gradient:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QDoubleSpinBox" name="gradient">
+            <property name="decimals">
+             <number>9</number>
+            </property>
+            <property name="minimum">
+             <double>-1.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.001000000000000</double>
             </property>
            </widget>
           </item>

--- a/mantidimaging/gui/windows/cor_tilt/view.py
+++ b/mantidimaging/gui/windows/cor_tilt/view.py
@@ -150,13 +150,13 @@ class CORTiltWindowView(BaseMainWindowView):
             self.tableView.setModel(mdl)
         return self.tableView.model()
 
-    def set_results(self, cor, tilt, m):
+    def set_results(self, cor, tilt, gradient):
         """
         Sets the numerical COR and tilt angle results.
         """
         self.resultCor.setValue(cor)
         self.resultTilt.setValue(tilt)
-        self.resultGradient.setValue(m)
+        self.resultGradient.setValue(gradient)
 
     def update_image_preview(self,
                              image_data,

--- a/mantidimaging/gui/windows/tomopy_recon/model.py
+++ b/mantidimaging/gui/windows/tomopy_recon/model.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from mantidimaging.core.utility.projection_angles import \
         generate as generate_projection_angles
-from mantidimaging.core.cor_tilt import tilt_angle_to_cors
 from mantidimaging.core.reconstruct import tomopy_reconstruct
 
 
@@ -36,11 +35,10 @@ class TomopyReconWindowModel(object):
         self.projection = self.sample.swapaxes(0, 1) \
             if stack is not None else None
 
-    def generate_cors(self, cor, tilt):
+    def generate_cors(self, cor, gradient):
         if self.stack is not None:
             num_slices = self.sample.shape[0]
-            self.cors = tilt_angle_to_cors(
-                    tilt, cor, np.arange(0, num_slices, 1))
+            self.cors = (np.arange(0, num_slices, 1) * gradient) + cor
             LOG.debug('Generated CORs: {}'.format(self.cors))
 
     def generate_projection_angles(self, max_angle):

--- a/mantidimaging/gui/windows/tomopy_recon/presenter.py
+++ b/mantidimaging/gui/windows/tomopy_recon/presenter.py
@@ -64,9 +64,9 @@ class TomopyReconWindowPresenter(BasePresenter):
         self.view.update_recon_preview(None)
 
         # Pre-populate COR and tilt options
-        cor, tilt = get_cor_tilt_from_images(self.model.images)
-        self.view.set_cor(cor)
-        self.view.set_tilt(tilt)
+        cor, _, m = get_cor_tilt_from_images(self.model.images)
+        self.view.rotation_centre = cor
+        self.view.cor_gradient = m
 
     def set_preview_slice_idx(self, idx):
         max_idx = \
@@ -84,11 +84,11 @@ class TomopyReconWindowPresenter(BasePresenter):
 
     def prepare_reconstruction(self):
         self.model.generate_cors(
-                self.view.get_cor(),
-                self.view.get_tilt())
+                self.view.rotation_centre,
+                self.view.cor_gradient)
 
         self.model.generate_projection_angles(
-                self.view.get_max_proj_angle())
+                self.view.max_proj_angle)
 
     def do_reconstruct_slice(self):
         self.prepare_reconstruction()

--- a/mantidimaging/gui/windows/tomopy_recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/tomopy_recon/test/presenter_test.py
@@ -18,9 +18,9 @@ class TomopyReconWindowPresenterTest(unittest.TestCase):
     def setUp(self):
         # Mock view
         self.view = mock.create_autospec(TomopyReconWindowView)
-        self.view.get_cor = mock.MagicMock(return_value=500)
-        self.view.get_tilt = mock.MagicMock(return_value=0)
-        self.view.get_max_proj_angle = mock.MagicMock(return_value=360)
+        self.view.rotation_centre = 500
+        self.view.cor_gradient = 0
+        self.view.max_proj_angle = 360
 
         self.presenter = TomopyReconWindowPresenter(self.view, None)
 
@@ -35,8 +35,8 @@ class TomopyReconWindowPresenterTest(unittest.TestCase):
 
         self.view.update_projection_preview.assert_called_once()
         self.view.update_recon_preview.assert_called_once_with(None)
-        self.view.set_cor.assert_called_once_with(0)
-        self.view.set_tilt.assert_called_once_with(0)
+        self.assertEquals(self.view.rotation_centre, 0)
+        self.assertEquals(self.view.cor_gradient, 0.0)
 
     def test_prepare_recon(self):
         self.presenter.set_stack(self.stack)

--- a/mantidimaging/gui/windows/tomopy_recon/view.py
+++ b/mantidimaging/gui/windows/tomopy_recon/view.py
@@ -116,17 +116,22 @@ class TomopyReconWindowView(BaseMainWindowView):
     def set_preview_slice_max_idx(self, max_idx):
         self.previewSlice.setMaximum(max_idx)
 
-    def get_cor(self):
+    @property
+    def rotation_centre(self):
         return self.cor.value()
 
-    def set_cor(self, value):
+    @rotation_centre.setter
+    def rotation_centre(self, value):
         self.cor.setValue(value)
 
-    def get_tilt(self):
-        return self.tilt.value()
+    @property
+    def cor_gradient(self):
+        return self.gradient.value()
 
-    def set_tilt(self, value):
-        self.tilt.setValue(value)
+    @cor_gradient.setter
+    def cor_gradient(self, value):
+        self.gradient.setValue(value)
 
-    def get_max_proj_angle(self):
+    @property
+    def max_proj_angle(self):
         return self.maxProjAngle.value()


### PR DESCRIPTION
Fixes #247.

Swaps from using tilt angle to fitted COR gradient in calculation of rotation centres for reconstruction.

To test:
- Load `Babylon5/Public/DanNixon/sino2`, only a small amount are needed
- Open *Reconstruction* > *TomoPy Reconstruction*
- See that the *Rotation centre gradient* option is pre-populated with the value from the `image.json` file (in the directory from step 1)