### PR TITLE
Handle rotation centre parameters as an image operation

### DIFF
--- a/mantidimaging/core/cor_tilt/__init__.py
+++ b/mantidimaging/core/cor_tilt/__init__.py
@@ -10,4 +10,5 @@ from .data_model import (  # noqa: F401
         FIELD_NAMES)
 
 from .workflow import (  # noqa: F401
-        run_auto_finding_on_images)
+        run_auto_finding_on_images,
+        update_image_operations)

--- a/mantidimaging/core/cor_tilt/data_model.py
+++ b/mantidimaging/core/cor_tilt/data_model.py
@@ -139,11 +139,9 @@ class CorTiltDataModel(object):
     @property
     def stack_properties(self):
         return {
-            const.AUTO_COR_TILT: {
-                'rotation_centre': self.c,
-                'fitted_gradient': self.m,
-                'tilt_angle_rad': self.angle_rad,
-                'slice_indices': self.slices,
-                'rotation_centres': self.cors
-            }
+            'rotation_centre': float(self.c),
+            'fitted_gradient': float(self.m),
+            'tilt_angle_rad': float(self.angle_rad),
+            'slice_indices': self.slices,
+            'rotation_centres': self.cors
         }

--- a/mantidimaging/core/cor_tilt/test/data_model_test.py
+++ b/mantidimaging/core/cor_tilt/test/data_model_test.py
@@ -138,9 +138,6 @@ class CorTiltDataModelTest(TestCase):
         m.linear_regression()
 
         d = m.stack_properties
-        self.assertTrue('auto_cor_tilt' in d)
-
-        d = d['auto_cor_tilt']
         self.assertEqual(len(d), 5)
 
         self.assertEqual(d['fitted_gradient'], m.m)

--- a/mantidimaging/core/cor_tilt/test/workflow_test.py
+++ b/mantidimaging/core/cor_tilt/test/workflow_test.py
@@ -32,15 +32,18 @@ class WorkflowTest(TestCase):
         self.assertEquals(len(model.slices), 5)
         self.assertEquals(len(model.cors), 5)
 
-        auto_cor_tilt = images.properties['auto_cor_tilt']
+        auto_cor_tilt = images.properties['operation_history'][-1]
+        self.assertEquals(auto_cor_tilt['name'], 'cor_tilt_finding')
 
+        auto_cor_tilt_kwargs = auto_cor_tilt['kwargs']
+        print(auto_cor_tilt)
         self.assertAlmostEqual(
-                auto_cor_tilt['rotation_centre'], model.c)
+                auto_cor_tilt_kwargs['rotation_centre'], model.c)
         self.assertAlmostEqual(
-                auto_cor_tilt['fitted_gradient'], model.m)
+                auto_cor_tilt_kwargs['fitted_gradient'], model.m)
         self.assertAlmostEqual(
-                auto_cor_tilt['tilt_angle_rad'], model.angle_rad)
+                auto_cor_tilt_kwargs['tilt_angle_rad'], model.angle_rad)
         self.assertTrue(isinstance(
-            auto_cor_tilt['slice_indices'], list))
+            auto_cor_tilt_kwargs['slice_indices'], list))
         self.assertTrue(isinstance(
-            auto_cor_tilt['rotation_centres'], list))
+            auto_cor_tilt_kwargs['rotation_centres'], list))

--- a/mantidimaging/core/cor_tilt/workflow.py
+++ b/mantidimaging/core/cor_tilt/workflow.py
@@ -13,4 +13,11 @@ def run_auto_finding_on_images(
     """
     auto_find_cors(images.sample, roi, model, projections, cores, progress)
     model.linear_regression()
-    images.properties.update(model.stack_properties)
+    update_image_operations(images, model)
+
+
+def update_image_operations(images, model):
+    """
+    Updates the image operation history with the results in the given model.
+    """
+    images.record_parameters_in_metadata('cor_tilt_finding', **model.stack_properties)

--- a/mantidimaging/core/data/const.py
+++ b/mantidimaging/core/data/const.py
@@ -1,2 +1,1 @@
 OPERATION_HISTORY = 'operation_history'
-AUTO_COR_TILT = 'auto_cor_tilt'

--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -55,6 +55,10 @@ class Images(object):
         return self._filenames
 
     @property
+    def has_history(self):
+        return const.OPERATION_HISTORY in self.properties
+
+    @property
     def properties_pretty(self):
         pp = pprint.PrettyPrinter(indent=2)
         return pp.pformat(self.properties)
@@ -76,7 +80,7 @@ class Images(object):
             self.properties[const.OPERATION_HISTORY] = []
 
         def accepted_type(o):
-            return type(o) in [str, int, float, bool, tuple]
+            return type(o) in [str, int, float, bool, tuple, list]
 
         self.properties[const.OPERATION_HISTORY].append({
             'name': func,

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -76,10 +76,14 @@ class ImagesTest(unittest.TestCase):
 
     def test_record_parameters_in_metadata(self):
         imgs = Images()
+        self.assertFalse(imgs.has_history)
+
         imgs.record_parameters_in_metadata(
                 'test_func',
                 56, 9002, np.ndarray((800, 1024, 1024)), 'yes', False,
                 this=765, that=495.0, roi=(1, 2, 3, 4))
+
+        self.assertTrue(imgs.has_history)
 
         self.assertEquals(imgs.properties, {
             'operation_history': [

--- a/mantidimaging/core/reconstruct/utility.py
+++ b/mantidimaging/core/reconstruct/utility.py
@@ -1,31 +1,79 @@
+from logging import getLogger
+
 from mantidimaging.core.data import const
 
 
-def get_roi_left_shift(images):
-    if const.OPERATION_HISTORY not in images.properties:
-        return 0
+LOG = getLogger(__name__)
 
-    history = images.properties[const.OPERATION_HISTORY]
-    rois = [e['kwargs']['region_of_interest'] for e in history
-            if 'crop_coords' in e['name']]
 
-    roi_offset = 0
-    for r in rois:
-        roi_offset += r[0]
+def get_last_cor_tilt_find(images):
+    """
+    Gets the properties from the last instance of COR/Tilt finding that was run
+    on a given image stack.
+    """
+    if not images.has_history:
+        return None, None
 
-    return roi_offset
+    # Copy the history and reverse it
+    history = images.properties[const.OPERATION_HISTORY][:]
+    history.reverse()
+
+    # Iterate over history and find the first instance of COR/Tilt finding
+    # (which is the last given that the history was reversed)
+    for i, e in enumerate(history):
+        if 'cor_tilt_finding' in e['name']:
+            return e['kwargs'], len(history) - 1 - i
+
+    return None, None
+
+
+def get_crop_operations(images, start=None, end=None):
+    """
+    Gets a list of crop operations that happened between two points in the
+    image operation history.
+    """
+    if not images.has_history:
+        return []
+
+    history = images.properties[const.OPERATION_HISTORY][start:end]
+    crops = [e for e in history if 'crop_coords' in e['name']]
+    return crops
+
+
+def get_crop(images, axis, start=None, end=None):
+    """
+    Gets a sum along a given axis of all crop operations that happened between
+    two points in the image operation history.
+    """
+    total_crop = 0.0
+    for crop in get_crop_operations(images, start, end):
+        total_crop += crop['kwargs']['region_of_interest'][axis]
+    return total_crop
 
 
 def get_cor_tilt_from_images(images):
-    if not images or const.AUTO_COR_TILT not in images.properties:
+    """
+    Gets rotation centre at top of image and gradient with which to calculate
+    rotation centre arrays for reconstruction.
+    """
+    if not images or not images.has_history:
         return (0, 0.0, 0.0)
 
-    auto_cor_tilt = images.properties[const.AUTO_COR_TILT]
+    last_find, last_find_idx = get_last_cor_tilt_find(images)
 
-    cor = auto_cor_tilt['rotation_centre']
-    tilt = auto_cor_tilt['tilt_angle_rad']
-    m = auto_cor_tilt['fitted_gradient']
+    cor = last_find['rotation_centre']
+    tilt = last_find['tilt_angle_rad']
+    m = last_find['fitted_gradient']
 
-    cor -= get_roi_left_shift(images)
+    cor -= get_crop(images, 0, start=last_find_idx)
 
-    return (cor, tilt, m)
+    # Get total offset from linear regression origin from total crop length on
+    # top edge
+    top = get_crop(images, 1, start=last_find_idx)
+    LOG.debug('Total top crop: {}'.format(top))
+
+    # Calculate new rotation centre at new top of image
+    new_cor = (top * m) + cor
+    LOG.debug('New COR corrected for top crop: {}'.format(new_cor))
+
+    return (new_cor, tilt, m)

--- a/mantidimaging/gui/windows/cor_tilt/model.py
+++ b/mantidimaging/gui/windows/cor_tilt/model.py
@@ -2,7 +2,8 @@ from logging import getLogger
 
 import numpy as np
 
-from mantidimaging.core.cor_tilt import run_auto_finding_on_images
+from mantidimaging.core.cor_tilt import (
+        run_auto_finding_on_images, update_image_operations)
 from mantidimaging.core.reconstruct import tomopy_reconstruct_preview
 from mantidimaging.core.utility.projection_angles import (
         generate as generate_projection_angles)
@@ -110,7 +111,7 @@ class CORTiltWindowModel(object):
             raise ValueError('No region of interest is defined')
 
         self.model.linear_regression()
-        self.images.properties.update(self.model.stack_properties)
+        update_image_operations(self.images, self.model)
 
         # Cache last result
         self.last_result = self.model.stack_properties


### PR DESCRIPTION
See commit messages for description.

Fixes #248.

To test:
- Load every 5th image from `babylon5/Public/DanNixon/PSI_Cylinder/Sample`
- (optional) Apply the *Intensity Cutoff* filter to make the sample easier to view
- Crop the image to slightly wider and slightly shorter than the bottom cylinder (800, 700, 2000, 1600 is about right)
- Open *Reconstruct* > *Find COR and Tilt*
- Select *Results* tab
- Repeat these steps three times at equal positions down the image:
  - Click somewhere on the projection preview
  - Click *Add*
  - Select the newly added row on the table
  - Click *Refine*
  - Follow instructions on UI
- Click *Fit*
- Close the *Find COR and Tilt* UI
- Select *File* > *Save*
- Check *Swap Axes*
- Click *Save All*
- Load all the sinograms back in
- Open *Reconstruct* > *TomoPy Reconstruction*
- (parameters should be pre-filled)
- Select some slices in the image and click *Reconstruct Slice*
- (reconstruction quality should be good (at least as good as the quality when performing COR refinement) alone entire sample height)
- (optional) Click *Reconstruct Volume* and inspect the entire volume (maybe use Fiji for this as stack scrolling is much faster)