### PR TITLE
Add missing coverage package

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,3 +20,4 @@ dependencies:
     - pylint==1.8.2
     - GitPython
     - sphinx
+    - coverage>=4.5.0


### PR DESCRIPTION
Fixes #253 

To test:
- Look at CI results and see that coverage was tested

(after this is merged the environments for [`mantidimaging-master`](http://builds.mantidproject.org/view/Imaging/job/mantidimaging-master/) will need to be either deleted or have `coverage` installed in them)