### PR TITLE
Add Conda packagaing to CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,5 +57,13 @@ pipeline {
         }
       }
     }
+
+    stage('Package - Conda') {
+      steps {
+        timeout(30) {
+          sh 'buildscripts/conda/build.sh'
+        }
+      }
+    }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ pipeline {
       steps {
         timeout(15) {
           sh '${WORKSPACE}/buildscripts/install_anaconda.sh -b'
+          sh '${WORKSPACE}/anaconda/bin/conda install -y conda-build'
         }
       }
     }

--- a/buildscripts/conda/mantidimaging/meta.yaml
+++ b/buildscripts/conda/mantidimaging/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     - astropy
     - numpy
     - scipy
-    - matplotlib
+    - matplotlib 2.1.0
     - tomopy 1.1.2
     - pyqt
 


### PR DESCRIPTION
Closes #257.

Runs packaging of the project via Conda as a CI step, done to make sure the packaging is not broken. Later on the packaged package can be archived by Jenkins.

Also tidies up `Jenkinsfile` by updating `PATH` where appropriate.

To test:
- See that CI passes