### PR TITLE
Add exit confirmation to GUI

### DIFF
--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -107,3 +107,7 @@ class MainWindowModel(object):
         :param stack_uuid: The unique ID of the stack that will be removed.
         """
         del self.active_stacks[stack_uuid]
+
+    @property
+    def have_active_stacks(self):
+        return len(self.active_stacks) > 0

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -116,3 +116,7 @@ class MainWindowPresenter(BasePresenter):
 
     def get_stack_visualiser(self, stack_uuid):
         return self.model.get_stack_visualiser(stack_uuid)
+
+    @property
+    def have_active_stacks(self):
+        return self.model.have_active_stacks


### PR DESCRIPTION
Adds a confirmation when exiting the GUI if there are active stacks loaded.

Fixes #262

To test, try exiting in the following conditions:
- Never loaded data, should exit immediately
- Load data and don't delete, should prompt for confirmation
- Load data and delete, should exit immediately