### PR TITLE
Background correction and normalisation filter

### DIFF
--- a/mantidimaging/core/filters/background_correction_and_normalisation/__init__.py
+++ b/mantidimaging/core/filters/background_correction_and_normalisation/__init__.py
@@ -1,0 +1,4 @@
+NAME = 'Background Correction and Normalisation'
+
+from .background_correction_and_normalisation import execute, _cli_register  # noqa:F401
+from .background_correction_and_normalisation_gui import _gui_register  # noqa:F401  # noqa:F821

--- a/mantidimaging/core/filters/background_correction_and_normalisation/background_correction_and_normalisation.py
+++ b/mantidimaging/core/filters/background_correction_and_normalisation/background_correction_and_normalisation.py
@@ -1,0 +1,101 @@
+from logging import getLogger
+
+import numpy as np
+
+from mantidimaging import helper as h
+from mantidimaging.core.parallel import two_shared_mem as ptsm
+from mantidimaging.core.parallel import utility as pu
+from mantidimaging.core.utility.progress_reporting import Progress
+from mantidimaging.core.utility.value_scaling import apply_factors
+
+
+LOG = getLogger(__name__)
+
+
+def _cli_register(parser):
+    return parser
+
+
+def execute(data,
+            flat=None,
+            dark=None,
+            air_region=None,
+            cores=None,
+            chunksize=None,
+            progress=None):
+    """
+
+    :param data: Sample data which is to be processed. Expected in radiograms
+    :param flat: Flat (open beam) image to use in normalization
+    :param dark: Dark image to use in normalization
+    :param air_region: Open beam region used for calcualtion of normalisation factors.
+    :param cores: The number of cores that will be used to process the data.
+    :param chunksize: The number of chunks that each worker will receive.
+    :return: Filtered data (stack of images)
+    """
+    h.check_data_stack(data)
+
+    def check_corr_stack(name, stack):
+        if stack is None:
+            raise ValueError('{} image stack is None'.format(name))
+
+        if not isinstance(stack, np.ndarray):
+            raise ValueError('{} must be an ndarray'.format(name))
+
+        if stack.ndim != 3:
+            raise ValueError('{} must be 3 dimensional'.format(name))
+
+    check_corr_stack('flat', flat)
+    check_corr_stack('dark', dark)
+
+    _execute_seq(data.sample, flat, dark, air_region, progress)
+
+    h.check_data_stack(data)
+
+    return data
+
+
+def _execute_seq(sample,
+                 flat=None,
+                 dark=None,
+                 air_region=None,
+                 progress=None):
+    progress = Progress.ensure_instance(progress,
+                                        task_name='Background Correction and Normalisation')
+
+    with progress:
+        left, top, right, bottom = air_region
+
+        # Calculate sample normalisation factors
+        sample_factors = sample[:, top:bottom, left:right].sum(axis=(1, 2))
+        np.divide(sample_factors, sample_factors.max(), out=sample_factors)
+        np.divide(1.0, sample_factors, out=sample_factors)
+
+        # Calculate flat field normalisation factors
+        flat_factors = flat[:, top:bottom, left:right].sum(axis=(1, 2))
+        np.divide(flat_factors, flat_factors.max(), out=flat_factors)
+        np.divide(1.0, flat_factors, out=flat_factors)
+
+        # Normalise sample
+        apply_factors(sample, sample_factors)
+
+        # Normalise flat field
+        apply_factors(flat, flat_factors)
+
+        # Average flat field
+        average_flat_field = np.average(flat, axis=0)
+        LOG.info('Flat field sum: {}'.format(average_flat_field.sum()))
+
+        # Average dark field
+        average_dark_field = np.average(dark, axis=0)
+        LOG.info('Dark field sum: {}'.format(average_dark_field.sum()))
+
+        # Subtract dark field from sample
+        np.subtract(sample, average_dark_field, out=sample)
+
+        # Subtract dark field from flat field
+        np.subtract(average_flat_field, average_dark_field, out=average_flat_field)
+
+        # Divide sample by flat field
+        average_flat_field[average_flat_field == 0] = 1e-9
+        np.true_divide(sample, average_flat_field, out=sample)

--- a/mantidimaging/core/filters/background_correction_and_normalisation/background_correction_and_normalisation_gui.py
+++ b/mantidimaging/core/filters/background_correction_and_normalisation/background_correction_and_normalisation_gui.py
@@ -1,0 +1,57 @@
+import os
+from functools import partial
+
+from mantidimaging.core import io
+
+from . import execute
+
+
+def _gui_register(form, on_change):
+    from mantidimaging.gui.windows.stack_visualiser import Parameters
+    from mantidimaging.gui.utility import add_property_to_form
+
+    flatPath, _ = add_property_to_form(
+            'Flat', 'file',
+            form=form, on_change=on_change)
+
+    darkPath, _ = add_property_to_form(
+            'Dark', 'file',
+            form=form, on_change=on_change)
+
+    add_property_to_form(
+            'Select ROI on stack visualiser.', 'label',
+            form=form, on_change=on_change)
+
+    params = {
+        'air_region': Parameters.ROI
+    }
+
+    def custom_execute():
+        flat_path = str(flatPath.text())
+        dark_path = str(darkPath.text())
+        flat_extension = io.utility.get_file_extension(flat_path)
+        dark_extension = io.utility.get_file_extension(dark_path)
+
+        flat_dir = os.path.dirname(flat_path)
+        dark_dir = os.path.dirname(dark_path)
+
+        images_flat_only = io.loader.load(flat_dir, in_format=flat_extension)
+
+        # this will be put in the 'sample' attribute, because we load a single
+        # volume
+        flat = images_flat_only.sample.mean(axis=0)
+
+        images_dark_only = io.loader.load(dark_dir, in_format=dark_extension)
+
+        # this will be put in the 'sample' attribute, because we load a single
+        # volume
+        dark = images_dark_only.sample.mean(axis=0)
+
+        par = partial(execute, flat=flat, dark=dark)
+
+        return par
+
+    return (params,
+            None,
+            custom_execute,
+            None)

--- a/mantidimaging/core/utility/test/registrator_test.py
+++ b/mantidimaging/core/utility/test/registrator_test.py
@@ -25,6 +25,8 @@ class RegistratorTest(unittest.TestCase):
         self.assertEquals(modules, [
             'mantidimaging.core.filters.background_correction',
             'mantidimaging.core.filters.background_correction.test',
+            'mantidimaging.core.filters.background_correction_and_normalisation',
+            'mantidimaging.core.filters.background_correction_and_normalisation.test',
             'mantidimaging.core.filters.circular_mask',
             'mantidimaging.core.filters.circular_mask.test',
             'mantidimaging.core.filters.clip_values',
@@ -66,6 +68,7 @@ class RegistratorTest(unittest.TestCase):
 
         self.assertEquals(modules, [
             'mantidimaging.core.filters.background_correction',
+            'mantidimaging.core.filters.background_correction_and_normalisation',
             'mantidimaging.core.filters.circular_mask',
             'mantidimaging.core.filters.clip_values',
             'mantidimaging.core.filters.crop_coords',

--- a/mantidimaging/core/utility/test/value_scaling_test.py
+++ b/mantidimaging/core/utility/test/value_scaling_test.py
@@ -9,6 +9,7 @@ from mantidimaging.core.utility import value_scaling
 
 
 class ValueScalingTest(unittest.TestCase):
+
     def __init__(self, *args, **kwargs):
         super(ValueScalingTest, self).__init__(*args, **kwargs)
 
@@ -58,6 +59,33 @@ class ValueScalingTest(unittest.TestCase):
         our_factors = np.array([6., 6., 6., 6., 6., 6., 6., 6., 6., 6.])
         result = self.alg.apply_factor(images, our_factors, 1)
         npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
+        npt.assert_equal(images, result)
+
+    def test_apply_factors_array(self):
+        images, control = th.gen_img_shared_array_and_copy()
+        for z in range(images.shape[0]):
+            for y in range(images.shape[1]):
+                images[z, y] = y * 10
+                control[z, y] = y * 10 * z
+
+        our_factors = np.arange(0, images.shape[0])
+        result = self.alg.apply_factors(images, our_factors)
+        npt.assert_equal(result, control)
+        npt.assert_equal(images, control)
+        npt.assert_equal(images, result)
+
+    def test_apply_factors_array_2(self):
+        images = th.gen_img_shared_array()
+        images.fill(1)
+        our_factors = np.array([1.0, 1.1, 1.5, 1.2, 1.1, 1.05, 1.11, 1.12, 1.09, 1.0])
+        result = self.alg.apply_factors(images, our_factors)
+        npt.assert_equal(images, result)
+        for i in range(images.shape[0]):
+            npt.assert_almost_equal(
+                    images[i].sum(),
+                    images[i].size * our_factors[i],
+                    decimal=5)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/utility/value_scaling.py
+++ b/mantidimaging/core/utility/value_scaling.py
@@ -63,3 +63,19 @@ def apply_factor(data, scale_factors, cores=None, chunksize=None):
                                        "Applying scale factor")
 
     return data
+
+
+def apply_factors(data, scale_factors, cores=None, chunksize=None):
+    """
+
+    :param data: the data stack to which the scale factors will be applied.
+    :param scale_factors: The scale factors to be applied
+    """
+    scale_up_partial = ptsm.create_partial(
+        _scale_inplace, fwd_function=ptsm.inplace)
+
+    data, scale_factors = ptsm.execute(data, scale_factors,
+                                       scale_up_partial, cores, chunksize,
+                                       "Applying scale factors")
+
+    return data


### PR DESCRIPTION
Closes #264.

See commit messages for description of work.

## Testing

- Run this script (see `TODO`s first):
```python
import logging
import numpy as np
from mantidimaging.helper import initialise_logging
from mantidimaging.core.filters.background_correction_and_normalisation import execute as bg_corr_norm
from mantidimaging.core.data import Images
from mantidimaging.core.io.loader import load
from mantidimaging.core.io.saver import save

initialise_logging(logging.INFO)

# Load datasets
# This is on Olympic/Babylon5/Public/DanNixon, I recommend copying it locally first
# TODO: set this to wherever you have this dataset
sample = load('/media/datasets/tomography/psi_cylinder/sample/', indices=(0, 940, 10))
flat = load('/media/datasets/tomography/psi_cylinder/flat/')
dark = load('/media/datasets/tomography/psi_cylinder/dark/')

# Select open air region (this must not overlap the sample)
roi = (250, 1100, 500, 1300)

print('Sample shape:', sample.sample.shape)
print('Flat shape:', flat.sample.shape)
print('Dark shape:', dark.sample.shape)

# Save the sample for easier comparison later as the data shape will match the corrected dataset
# TODO: set this to some convenient local path
save(sample, '/media/scratch/mantidimaging_out/sample', overwrite_all=True)

# Run correction with normalisation
result = bg_corr_norm(sample, flat.sample, dark.sample, roi)

print('Result:', result)

# Save output
# TODO: set this to some convenient local path
save(result, '/media/scratch/mantidimaging_out/corr', overwrite_all=True)
```

- Open the sample and corrected datasets as image sequences in ImageJ (this is recommended as scrolling through an image stack is much faster than mantidimaging)
- Open *Image* > *Adjust* > *Brightness/Contrast...*
- For each image stack select the first image and click *Auto* in the *B&C* tool window (this will scale the displayed pixel intensity to that of the dataset, the corrected dataset has a different pixel range to the sample (ideally 0.0-1.0))
- Scroll through the sample, notice the varying background intensity (particularly on the third image)
- Scroll through the corrected dataset, notice the constant background intensity (across the image as well as the stack, the sample data is typically slightly brighter in the centre of the image)