### PR TITLE
Fix failure when reconstructing image stack with no COR/TIlt has been performed

### DIFF
--- a/mantidimaging/core/reconstruct/test/utility_test.py
+++ b/mantidimaging/core/reconstruct/test/utility_test.py
@@ -154,6 +154,23 @@ TEST_PARAMS_4 = {
     ]
 }
 
+TEST_PARAMS_5 = {
+    'operation_history': [
+        {
+            'args': [],
+            'kwargs': {
+                'region_of_interest': [
+                    0,
+                    20,
+                    100,
+                    100
+                ]
+            },
+            'name': 'mantidimaging.core.filters.crop_coords.crop_coords.execute_single'
+        }
+    ]
+}
+
 
 class UtilityTest(TestCase):
 
@@ -244,6 +261,14 @@ class UtilityTest(TestCase):
 
     def test_get_cor_tilt_from_images_none(self):
         cor, tilt, m = utility.get_cor_tilt_from_images(None)
+        self.assertEquals(cor, 0)
+        self.assertEquals(tilt, 0.0)
+        self.assertEquals(m, 0.0)
+
+    def test_get_cor_tilt_from_images_no_cor_tilt_in_history(self):
+        imgs = Images()
+        imgs.properties = TEST_PARAMS_5
+        cor, tilt, m = utility.get_cor_tilt_from_images(imgs)
         self.assertEquals(cor, 0)
         self.assertEquals(tilt, 0.0)
         self.assertEquals(m, 0.0)

--- a/mantidimaging/core/reconstruct/utility.py
+++ b/mantidimaging/core/reconstruct/utility.py
@@ -57,10 +57,14 @@ def get_cor_tilt_from_images(images):
     Gets rotation centre at top of image and gradient with which to calculate
     rotation centre arrays for reconstruction.
     """
+    # If there is no stack history
     if not images or not images.has_history:
         return (0, 0.0, 0.0)
 
     last_find, last_find_idx = get_last_cor_tilt_find(images)
+    # If the stack history does not contain a COR/Tilt finding step
+    if not last_find:
+        return (0, 0.0, 0.0)
 
     cor = last_find[const.COR_TILT_ROTATION_CENTRE]
     tilt = last_find[const.COR_TILT_TILT_ANGLE_RAD]


### PR DESCRIPTION
See commit messages for description

Fixes #275

To test:
- TODO