### PR TITLE
Fix unreliable ExecutionTimer test

### DIFF
--- a/mantidimaging/core/utility/test/execution_timer_test.py
+++ b/mantidimaging/core/utility/test/execution_timer_test.py
@@ -17,9 +17,9 @@ class ExecutionTimerTest(unittest.TestCase):
             self.assertEquals(t.total_seconds, None)
             self.assertEquals(str(t), 'Elapsed time: unknown seconds')
 
-            time.sleep(0.01)
+            time.sleep(0.1)
 
-        self.assertAlmostEqual(t.total_seconds, 0.01, delta=0.001)
+        self.assertAlmostEqual(t.total_seconds, 0.1, delta=0.05)
 
     def test_custom_message(self):
         t = ExecutionTimer(msg='Task')


### PR DESCRIPTION
Attempt to fix a few sporadic failures of the ExecutionTimer unit test.

Increase the unit of time it artificially waits for and increase the tolerance of the total time comparison.

Noticed in particular on SL7.

To test:
- Run this test several times (ideally under high system load): `mantidimaging.core.utility.test.execution_timer_test.ExecutionTimerTest`
- See that it does not fail