### PR TITLE
Add methods to view version number

### DIFF
--- a/mantidimaging/__init__.py
+++ b/mantidimaging/__init__.py
@@ -25,6 +25,8 @@
 
 from mantidimaging import core, main, ipython  # noqa: F401
 
+__version__ = '1.0.0'
+
 """
 The gui package is not imported here, because it will pull in all of PyQt
 packages, which we do not want when using only the CLI. This is both a speedup

--- a/mantidimaging/gui/ui/main_window.ui
+++ b/mantidimaging/gui/ui/main_window.ui
@@ -23,7 +23,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>20</height>
+     <height>25</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -48,6 +48,7 @@
      <string>Help</string>
     </property>
     <addaction name="actionOnlineDocumentation"/>
+    <addaction name="actionAbout"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuWorkflow"/>
@@ -109,6 +110,11 @@
   <action name="actionTomopyRecon">
    <property name="text">
     <string>TomoPy Reconstruction</string>
+   </property>
+  </action>
+  <action name="actionAbout">
+   <property name="text">
+    <string>About MantidImaging</string>
    </property>
   </action>
  </widget>

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -37,6 +37,7 @@ class MainWindowView(BaseMainWindowView):
 
         self.actionOnlineDocumentation.triggered.connect(
                 self.open_online_documentation)
+        self.actionAbout.triggered.connect(self.show_about)
 
         self.actionCorTilt.triggered.connect(self.show_cor_tilt_window)
         self.actionImageOperations.triggered.connect(self.show_filters_window)
@@ -50,6 +51,16 @@ class MainWindowView(BaseMainWindowView):
     def open_online_documentation(self):
         url = QtCore.QUrl('https://mantidproject.github.io/mantidimaging/')
         QtGui.QDesktopServices.openUrl(url)
+
+    def show_about(self):
+        from mantidimaging import __version__ as version_no
+        msg_box = QtWidgets.QMessageBox(self)
+        msg_box.setWindowTitle("About MantidImaging")#
+        msg_box.setTextFormat(QtCore.Qt.RichText)
+        msg_box.setText(
+                '<a href="https://github.com/mantidproject/mantidimaging">MantidImaging</a>'\
+                '<br>Version: <a href="https://github.com/mantidproject/mantidimaging/releases/tag/{0}">{0}</a>'.format(version_no))
+        msg_box.show()
 
     def show_load_dialogue(self):
         self.load_dialogue = MWLoadDialog(self)

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -33,11 +33,23 @@ def parse_args():
         help="Log verbosity level. "
              "Available options are: TRACE, DEBUG, INFO, WARN, CRITICAL")
 
+    parser.add_argument(
+        '--version',
+        action='store_true',
+        help='Print version number and exit.')
+
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
+
+    # Print version number and exit
+    if args.version:
+        from mantidimaging import __version__ as version_no
+        print(version_no)
+        return
+
     h.initialise_logging(logging.getLevelName(args.log_level))
 
     startup_checks()


### PR DESCRIPTION
Adds `--version` command line flag and *About MantidImaging* option in *Help* menu.

To test:
- Try both options and see that they work as expected
- See that links on *About MantidImaging* GUI dialog lead to appropriate places