### PR TITLE
Stack visualiser summed image option

### DIFF
--- a/mantidimaging/core/utility/registrator.py
+++ b/mantidimaging/core/utility/registrator.py
@@ -46,7 +46,7 @@ def get_package_children(package_name, packages=False, modules=False,
     # Ignore those that do not match the package/module selection criteria
     pkgs = filter(lambda p: p[2] and packages or not p[2] and modules, pkgs)
 
-    # Ignore moduels that we want to ignore
+    # Ignore modules that we want to ignore
     if ignore:
         pkgs = filter(lambda p: not any([m in p[1] for m in ignore]),
                       pkgs)

--- a/mantidimaging/external/pyqtgraph/imageview/ImageView.py
+++ b/mantidimaging/external/pyqtgraph/imageview/ImageView.py
@@ -547,16 +547,16 @@ class ImageView(QtGui.QWidget):
         return "t" in self.axes and self.axes["t"] is not None
 
     def roiClicked(self):
-        showRoiPlot = False
+        show_roi_plot = False
         if self.ui.roiBtn.isChecked():
-            showRoiPlot = True
             self.roi.show()
-            # self.ui.roiPlot.show()
-            self.ui.roiPlot.setMouseEnabled(True, True)
-            self.ui.splitter.setSizes([self.height() * 0.6, self.height() * 0.4])
-            self.roiCurve.show()
-            self.roiChanged()
-            self.ui.roiPlot.showAxis("left")
+            if self.image.ndim == 3:
+                show_roi_plot = True
+                self.ui.roiPlot.setMouseEnabled(True, True)
+                self.ui.splitter.setSizes([self.height() * 0.6, self.height() * 0.4])
+                self.roiCurve.show()
+                self.roiChanged()
+                self.ui.roiPlot.showAxis("left")
         else:
             self.roi.hide()
             self.ui.roiPlot.setMouseEnabled(False, False)
@@ -565,7 +565,7 @@ class ImageView(QtGui.QWidget):
             self.roiString = None
 
         if self.hasTimeAxis():
-            showRoiPlot = True
+            show_roi_plot = True
             mn = self.tVals.min()
             mx = self.tVals.max()
             self.ui.roiPlot.setXRange(mn, mx, padding=0.01)
@@ -578,7 +578,7 @@ class ImageView(QtGui.QWidget):
             self.timeLine.hide()
             # self.ui.roiPlot.hide()
 
-        self.ui.roiPlot.setVisible(showRoiPlot)
+        self.ui.roiPlot.setVisible(show_roi_plot)
 
     def roiChanged(self):
         if self.image is None:
@@ -590,12 +590,12 @@ class ImageView(QtGui.QWidget):
         left, right = roi_pos.x, roi_pos.x + roi_size.x
         top, bottom = roi_pos.y, roi_pos.y + roi_size.y
         self.roiString = f"({left}, {top}, {right}, {bottom})"
-        data = self.image[:, left:right, top:bottom]
-
-        if data is not None:
-            while data.ndim > 1:
-                data = data.mean(axis=1)
-            self.roiCurve.setData(y=data, x=self.tVals)
+        if self.image.ndim == 3:
+            data = self.image[:, left:right, top:bottom]
+            if data is not None:
+                while data.ndim > 1:
+                    data = data.mean(axis=1)
+                self.roiCurve.setData(y=data, x=self.tVals)
 
         if self.roi_changed_callback:
             self.roi_changed_callback(SensibleROI(left, top, right, bottom))
@@ -635,7 +635,7 @@ class ImageView(QtGui.QWidget):
             (eind, end) = self.timeIndex(self.normRgn.lines[1])
             # print start, end, sind, eind
             n = image[sind:eind + 1].mean(axis=0)
-            n.shape = (1, ) + n.shape
+            n.shape = (1,) + n.shape
             if div:
                 norm /= n
             else:
@@ -809,7 +809,12 @@ class ImageView(QtGui.QWidget):
         if event.exit:
             return
         pt = CloseEnoughPoint(event.pos())
-        msg = f"x={pt.x}, y={pt.y}, z={self.currentIndex}, value={self.image[self.currentIndex, pt.y, pt.x]}"
+        msg = f"x={pt.x}, y={pt.y}, "
+        if self.image.ndim == 3:
+            msg += f"z={self.currentIndex}, value={self.image[self.currentIndex, pt.y, pt.x]}"
+        else:
+            msg += f"value={self.image[pt.y, pt.x]}"
+
         if self.roiString is not None:
             msg += f" | roi = {self.roiString}"
         self.details.setText(msg)

--- a/mantidimaging/gui/windows/stack_visualiser/__init__.py
+++ b/mantidimaging/gui/windows/stack_visualiser/__init__.py
@@ -24,5 +24,6 @@ from mantidimaging.gui.windows.stack_visualiser.presenter import (  # noqa: F401
     StackVisualiserPresenter,
     SVNotification,
     SVParameters,
+    SVImageMode
 )  # noqa:F821
 from mantidimaging.gui.windows.stack_visualiser.view import StackVisualiserView  # noqa: F401

--- a/mantidimaging/gui/windows/stack_visualiser/model.py
+++ b/mantidimaging/gui/windows/stack_visualiser/model.py
@@ -1,0 +1,10 @@
+import numpy as np
+
+
+class SVModel:
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def create_averaged_image(images):
+        return np.mean(images, axis=0)

--- a/mantidimaging/gui/windows/stack_visualiser/model.py
+++ b/mantidimaging/gui/windows/stack_visualiser/model.py
@@ -6,5 +6,5 @@ class SVModel:
         pass
 
     @staticmethod
-    def create_averaged_image(images):
-        return np.mean(images, axis=0)
+    def sum_images(images):
+        return np.sum(images, axis=0)

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -20,7 +20,7 @@ class SVParameters(IntEnum):
 
 class SVImageMode(IntEnum):
     NORMAL = 0
-    AVERAGED = 1
+    SUMMED = 1
 
 
 class StackVisualiserPresenter(BasePresenter):
@@ -30,7 +30,7 @@ class StackVisualiserPresenter(BasePresenter):
         self.images = images
         self._current_image_index = 0
         self.image_mode: SVImageMode = SVImageMode.NORMAL
-        self.averaged_image = None
+        self.summed_image = None
 
     def notify(self, signal):
         try:
@@ -49,7 +49,7 @@ class StackVisualiserPresenter(BasePresenter):
         return self.images.sample[index]
 
     def refresh_image(self):
-        self.view.image = self.averaged_image if self.image_mode is SVImageMode.AVERAGED \
+        self.view.image = self.summed_image if self.image_mode is SVImageMode.SUMMED \
             else self.images.sample
 
     def get_parameter_value(self, parameter: SVParameters):
@@ -66,12 +66,12 @@ class StackVisualiserPresenter(BasePresenter):
 
     def toggle_image_mode(self):
         if self.image_mode is SVImageMode.NORMAL:
-            self.image_mode = SVImageMode.AVERAGED
+            self.image_mode = SVImageMode.SUMMED
         else:
             self.image_mode = SVImageMode.NORMAL
 
-        if self.image_mode is SVImageMode.AVERAGED and \
-                (self.averaged_image is None
-                 or self.averaged_image.shape != self.images.sample.shape[1:]):
-            self.averaged_image = self.model.create_averaged_image(self.images.sample)
+        if self.image_mode is SVImageMode.SUMMED and \
+                (self.summed_image is None
+                 or self.summed_image.shape != self.images.sample.shape[1:]):
+            self.summed_image = self.model.sum_images(self.images.sample)
         self.refresh_image()

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -35,7 +35,7 @@ class StackVisualiserPresenter(BasePresenter):
     def notify(self, signal):
         try:
             if signal == SVNotification.REFRESH_IMAGE:
-                self.set_displayed_image()
+                self.refresh_image()
             if signal == SVNotification.TOGGLE_IMAGE_MODE:
                 self.toggle_image_mode()
         except Exception as e:
@@ -48,12 +48,9 @@ class StackVisualiserPresenter(BasePresenter):
     def get_image(self, index):
         return self.images.sample[index]
 
-    def set_displayed_image(self):
-        if self.image_mode is SVImageMode.NORMAL:
-            to_display = self.images.sample
-        else:
-            to_display = self.averaged_image
-        self.view.image = to_display
+    def refresh_image(self):
+        self.view.image = self.averaged_image if self.image_mode is SVImageMode.AVERAGED \
+            else self.images.sample
 
     def get_parameter_value(self, parameter: SVParameters):
         """
@@ -75,4 +72,4 @@ class StackVisualiserPresenter(BasePresenter):
 
         if self.image_mode is SVImageMode.AVERAGED and self.averaged_image is None:
             self.averaged_image = self.model.create_averaged_image(self.images.sample)
-        self.set_displayed_image()
+        self.refresh_image()

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -3,10 +3,12 @@ from logging import getLogger
 
 from mantidimaging.core.data import Images
 from mantidimaging.gui.mvp_base import BasePresenter
+import numpy as np
 
 
 class SVNotification(IntEnum):
     REFRESH_IMAGE = 0
+    TOGGLE_IMAGE_MODE = 1
 
 
 class SVParameters(IntEnum):
@@ -16,16 +18,25 @@ class SVParameters(IntEnum):
     ROI = 0
 
 
+class SVImageMode(IntEnum):
+    NORMAL = 0
+    AVERAGED = 1
+
+
 class StackVisualiserPresenter(BasePresenter):
     def __init__(self, view, images: Images):
         super(StackVisualiserPresenter, self).__init__(view)
         self.images = images
         self._current_image_index = 0
+        self.image_mode: SVImageMode = SVImageMode.NORMAL
+        self.averaged_image = None
 
     def notify(self, signal):
         try:
             if signal == SVNotification.REFRESH_IMAGE:
                 self.view.show_current_image()
+            if signal == SVNotification.TOGGLE_IMAGE_MODE:
+                self.toggle_image_mode()
         except Exception as e:
             self.show_error(e)
             getLogger(__name__).exception("Notification handler failed")
@@ -33,8 +44,13 @@ class StackVisualiserPresenter(BasePresenter):
     def delete_data(self):
         self.images = None
 
-    def get_image(self, index):
-        return self.images.sample[index]
+    def get_image(self):
+        if self.image_mode is SVImageMode.NORMAL:
+            print("Getting normal image")
+            return self.images.sample
+        else:
+            print("Getting averaged image")
+            return self.averaged_image
 
     def get_parameter_value(self, parameter: SVParameters):
         """
@@ -47,3 +63,15 @@ class StackVisualiserPresenter(BasePresenter):
             raise ValueError(
                 "Invalid parameter name has been requested from the Stack "
                 "Visualiser, parameter: {0}".format(parameter))
+
+    def toggle_image_mode(self):
+        if self.image_mode is SVImageMode.NORMAL:
+            self.image_mode = SVImageMode.AVERAGED
+        else:
+            self.image_mode = SVImageMode.NORMAL
+
+        if self.image_mode is SVImageMode.AVERAGED and self.averaged_image is None:
+            self.averaged_image = np.divide(
+                np.sum(self.images.sample, axis=0),
+                self.images.sample.shape[0])
+        self.view.show_current_image()

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -35,7 +35,7 @@ class StackVisualiserPresenter(BasePresenter):
     def notify(self, signal):
         try:
             if signal == SVNotification.REFRESH_IMAGE:
-                self.view.show_current_image()
+                self.set_displayed_image()
             if signal == SVNotification.TOGGLE_IMAGE_MODE:
                 self.toggle_image_mode()
         except Exception as e:
@@ -45,13 +45,15 @@ class StackVisualiserPresenter(BasePresenter):
     def delete_data(self):
         self.images = None
 
-    def get_image(self):
+    def get_image(self, index):
+        return self.images.sample[index]
+
+    def set_displayed_image(self):
         if self.image_mode is SVImageMode.NORMAL:
-            print("Getting normal image")
-            return self.images.sample
+            to_display = self.images.sample
         else:
-            print("Getting averaged image")
-            return self.averaged_image
+            to_display = self.averaged_image
+        self.view.image = to_display
 
     def get_parameter_value(self, parameter: SVParameters):
         """

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -70,6 +70,8 @@ class StackVisualiserPresenter(BasePresenter):
         else:
             self.image_mode = SVImageMode.NORMAL
 
-        if self.image_mode is SVImageMode.AVERAGED and self.averaged_image is None:
+        if self.image_mode is SVImageMode.AVERAGED and \
+                (self.averaged_image is None
+                 or self.averaged_image.shape != self.images.sample.shape[1:]):
             self.averaged_image = self.model.create_averaged_image(self.images.sample)
         self.refresh_image()

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -3,7 +3,7 @@ from logging import getLogger
 
 from mantidimaging.core.data import Images
 from mantidimaging.gui.mvp_base import BasePresenter
-import numpy as np
+from .model import SVModel
 
 
 class SVNotification(IntEnum):
@@ -26,6 +26,7 @@ class SVImageMode(IntEnum):
 class StackVisualiserPresenter(BasePresenter):
     def __init__(self, view, images: Images):
         super(StackVisualiserPresenter, self).__init__(view)
+        self.model = SVModel()
         self.images = images
         self._current_image_index = 0
         self.image_mode: SVImageMode = SVImageMode.NORMAL
@@ -71,7 +72,5 @@ class StackVisualiserPresenter(BasePresenter):
             self.image_mode = SVImageMode.NORMAL
 
         if self.image_mode is SVImageMode.AVERAGED and self.averaged_image is None:
-            self.averaged_image = np.divide(
-                np.sum(self.images.sample, axis=0),
-                self.images.sample.shape[0])
-        self.view.show_current_image()
+            self.averaged_image = self.model.create_averaged_image(self.images.sample)
+        self.set_displayed_image()

--- a/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
@@ -34,7 +34,7 @@ class StackVisualiserPresenterTest(unittest.TestCase):
 
     def test_notify_refresh_image(self):
         self.presenter.notify(SVNotification.REFRESH_IMAGE)
-        self.view.show_current_image.assert_called_once_with()
+        self.view.image.assert_called_once_with()
 
 
 if __name__ == '__main__':

--- a/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
@@ -41,7 +41,7 @@ class StackVisualiserPresenterTest(unittest.TestCase):
                       "Image should have been set as sample images")
 
     def test_notify_refresh_image_averaged_image_mode(self):
-        self.presenter.image_mode = SVImageMode.AVERAGED
+        self.presenter.image_mode = SVImageMode.SUMMED
         self.presenter.notify(SVNotification.REFRESH_IMAGE)
         self.assertIs(self.view.image,
                       self.presenter.averaged_image,

--- a/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
@@ -4,7 +4,8 @@ import mock
 import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
-from mantidimaging.gui.windows.stack_visualiser import StackVisualiserPresenter, StackVisualiserView, SVNotification
+from mantidimaging.gui.windows.stack_visualiser import StackVisualiserPresenter, StackVisualiserView, SVNotification, \
+    SVImageMode
 
 
 class StackVisualiserPresenterTest(unittest.TestCase):
@@ -32,9 +33,19 @@ class StackVisualiserPresenterTest(unittest.TestCase):
         self.presenter.delete_data()
         self.assertIsNone(self.presenter.images, None)
 
-    def test_notify_refresh_image(self):
+    def test_notify_refresh_image_normal_image_mode(self):
+        self.presenter.image_mode = SVImageMode.NORMAL
         self.presenter.notify(SVNotification.REFRESH_IMAGE)
-        self.view.image.assert_called_once_with()
+        self.assertIs(self.view.image,
+                      self.presenter.images.sample,
+                      "Image should have been set as sample images")
+
+    def test_notify_refresh_image_averaged_image_mode(self):
+        self.presenter.image_mode = SVImageMode.AVERAGED
+        self.presenter.notify(SVNotification.REFRESH_IMAGE)
+        self.assertIs(self.view.image,
+                      self.presenter.averaged_image,
+                      "Image should have been set as averaged image")
 
 
 if __name__ == '__main__':

--- a/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
@@ -44,7 +44,7 @@ class StackVisualiserPresenterTest(unittest.TestCase):
         self.presenter.image_mode = SVImageMode.SUMMED
         self.presenter.notify(SVNotification.REFRESH_IMAGE)
         self.assertIs(self.view.image,
-                      self.presenter.averaged_image,
+                      self.presenter.summed_image,
                       "Image should have been set as averaged image")
 
 

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -36,12 +36,6 @@ class StackVisualiserViewTest(unittest.TestCase):
         self.dock.setWindowTitle(title)
         self.assertEqual(title, self.view.name)
 
-    def test_show_current_image(self):
-        self.view.image_view = mock.Mock()
-        self.view.show_current_image()
-
-        self.view.image_view.setImage.assert_called_once_with(self.test_data.sample)
-
     def test_closeEvent_deletes_images(self):
         self.dock.setFloating = mock.Mock()
         self.dock.deleteLater = mock.Mock()

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -8,6 +8,7 @@ from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.external.pyqtgraph.imageview.ImageView import ImageView
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.windows.stack_visualiser.presenter import StackVisualiserPresenter
+from .presenter import SVNotification
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401
@@ -71,7 +72,7 @@ class StackVisualiserView(BaseMainWindowView):
         return roi.left, roi.top, roi.right, roi.bottom
 
     def show_current_image(self):
-        self.image_view.setImage(self.presenter.images.sample)
+        self.image_view.setImage(self.presenter.get_image())
 
     def closeEvent(self, event):
         # this removes all references to the data, allowing it to be GC'ed
@@ -99,9 +100,12 @@ class StackVisualiserView(BaseMainWindowView):
 
     def build_context_menu(self) -> QMenu:
         menu = QMenu(self)
-        action = QAction("Change window name", menu)
-        action.triggered.connect(self.change_window_name_clicked)
-        menu.addAction(action)
+        change_name_action = QAction("Change window name", menu)
+        change_name_action.triggered.connect(self.change_window_name_clicked)
+        toggle_image_mode_action = QAction("Toggle show averaged image", menu)
+        toggle_image_mode_action.triggered.connect(
+            lambda: self.presenter.notify(SVNotification.TOGGLE_IMAGE_MODE))
+        menu.addActions([change_name_action, toggle_image_mode_action])
         return menu
 
     def change_window_name_clicked(self):

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -71,8 +71,13 @@ class StackVisualiserView(BaseMainWindowView):
         roi = SensibleROI.from_points(*self.image_view.get_roi())
         return roi.left, roi.top, roi.right, roi.bottom
 
-    def show_current_image(self):
-        self.image_view.setImage(self.presenter.get_image())
+    @property
+    def image(self):
+        return self.image_view.imageItem
+
+    @image.setter
+    def image(self, to_display):
+        self.image_view.setImage(to_display)
 
     def closeEvent(self, event):
         # this removes all references to the data, allowing it to be GC'ed


### PR DESCRIPTION
Closes #335 

Adds a 'Toggle show averaged image' option to the stack visualiser context menu. The averaged image is calculated lazily, and recalculated if the stack size changes (cropped). The ROI plot is hidden whilst viewing the averaged image, as it seems to only makes sense for a series of images.

One thought - if this is primarily for selecting a good ROI, would showing the max instead of the average be another option?