### PR TITLE
Remove presenter reference on cleanup

### DIFF
--- a/mantidimaging/gui/windows/filters/view.py
+++ b/mantidimaging/gui/windows/filters/view.py
@@ -85,6 +85,7 @@ class FiltersWindowView(BaseMainWindowView):
     def cleanup(self):
         self.stackSelector.unsubscribe_from_main_window()
         self.main_window.filters = None
+        self.presenter = None
 
     def show(self):
         super(FiltersWindowView, self).show()


### PR DESCRIPTION
Closes #362 

As far as I can tell, something is keeping references to the filter window view + presenter after Qt is deallocating the signals. This change forces the python GC to catch up, although I couldn't find exactly what was holding the reference, so there may be a better solution.