### PR TITLE
Adding a new centre of rotation row in the COR/Tilt GUI no longer shown an error

### DIFF
--- a/mantidimaging/gui/windows/cor_tilt/model.py
+++ b/mantidimaging/gui/windows/cor_tilt/model.py
@@ -1,22 +1,24 @@
 from logging import getLogger
 
 import numpy as np
+from typing import Optional
 
-from mantidimaging.core.cor_tilt import (
-    run_auto_finding_on_images, update_image_operations)
+from mantidimaging.core.cor_tilt import (run_auto_finding_on_images, update_image_operations)
 from mantidimaging.core.reconstruct import tomopy_reconstruct_preview
-from mantidimaging.core.utility.projection_angles import (
-    generate as generate_projection_angles)
+from mantidimaging.core.utility.projection_angles import (generate as generate_projection_angles)
+
+from mantidimaging.gui.windows.cor_tilt.point_table_model import CorTiltPointQtModel
+from mantidimaging.core.data import Images
 
 LOG = getLogger(__name__)
 
 
 class CORTiltWindowModel(object):
-
-    def __init__(self, model):
-        self.stack = None
+    def __init__(self, model: CorTiltPointQtModel):
+        self.stack: Optional[Images] = None
         self.preview_projection_idx = 0
         self.preview_slice_idx = 0
+        self.selected_row = 0
         self.roi = None
         self.projection_indices = None
         self.model = model
@@ -36,13 +38,11 @@ class CORTiltWindowModel(object):
 
     @property
     def num_projections(self):
-        s = self.sample
-        return s.shape[0] if s is not None else 0
+        return self.sample.shape[0] if self.sample is not None else 0
 
     @property
     def num_slices(self):
-        s = self.sample
-        return s.shape[1] if s is not None else 0
+        return self.sample.shape[1] if self.sample is not None else 0
 
     @property
     def cor_for_current_preview_slice(self):
@@ -58,8 +58,7 @@ class CORTiltWindowModel(object):
         if stack is not None:
             image_shape = self.sample[0].shape
             self.roi = (0, 0, image_shape[1] - 1, image_shape[0] - 1)
-            self.proj_angles = generate_projection_angles(
-                360, self.sample.shape[0])
+            self.proj_angles = generate_projection_angles(360, self.sample.shape[0])
 
     def update_roi_from_stack(self):
         self.model.clear_results()
@@ -120,8 +119,7 @@ class CORTiltWindowModel(object):
             raise ValueError('No sample to use for preview reconstruction')
 
         # Perform single slice reconstruction
-        return tomopy_reconstruct_preview(
-            self.sample, slice_idx, cor, self.proj_angles)
+        return tomopy_reconstruct_preview(self.sample, slice_idx, cor, self.proj_angles)
 
     @property
     def preview_tilt_line_data(self):

--- a/mantidimaging/gui/windows/cor_tilt/point_table_model.py
+++ b/mantidimaging/gui/windows/cor_tilt/point_table_model.py
@@ -1,18 +1,15 @@
 from PyQt5.QtCore import Qt, QAbstractTableModel, QModelIndex
 
-from mantidimaging.core.cor_tilt import (
-        CorTiltDataModel, Field, FIELD_NAMES)
+from mantidimaging.core.cor_tilt import (CorTiltDataModel, Field, FIELD_NAMES)
 
 
 class CorTiltPointQtModel(QAbstractTableModel, CorTiltDataModel):
     """
     Qt data model for COR/Tilt finding.
     """
-
     def populate_slice_indices(self, begin, end, count, cor=0.0):
         self.beginResetModel()
-        super(CorTiltPointQtModel, self).populate_slice_indices(
-                begin, end, count, cor)
+        super(CorTiltPointQtModel, self).populate_slice_indices(begin, end, count, cor)
         self.endResetModel()
 
     def sort_points(self):
@@ -81,10 +78,7 @@ class CorTiltPointQtModel(QAbstractTableModel, CorTiltDataModel):
         return True
 
     def insertRows(self, row, count, parent=None):
-        self.beginInsertRows(
-                parent if parent is not None else QModelIndex(),
-                row,
-                row + count - 1)
+        self.beginInsertRows(parent if parent is not None else QModelIndex(), row, row + count - 1)
 
         for _ in range(count):
             self.add_point(row)
@@ -95,10 +89,7 @@ class CorTiltPointQtModel(QAbstractTableModel, CorTiltDataModel):
         if self.empty:
             return
 
-        self.beginRemoveRows(
-                parent if parent is not None else QModelIndex(),
-                row,
-                row + count - 1)
+        self.beginRemoveRows(parent if parent is not None else QModelIndex(), row, row + count - 1)
 
         for _ in range(count):
             self.remove_point(row)
@@ -109,23 +100,19 @@ class CorTiltPointQtModel(QAbstractTableModel, CorTiltDataModel):
         if self.empty:
             return
 
-        self.beginRemoveRows(
-                parent if parent else QModelIndex(),
-                0,
-                self.num_points - 1)
+        self.beginRemoveRows(parent if parent else QModelIndex(), 0, self.num_points - 1)
 
         self.clear_points()
 
         self.endRemoveRows()
 
-    def appendNewRow(self, slice_idx, cor=0):
+    def appendNewRow(self, row, slice_idx, cor=0):
         self.insertRows(self.num_points, 1)
 
-        self.setData(
-                self.index(self.num_points - 1, Field.SLICE_INDEX.value),
-                slice_idx)
+        self.setData(self.index(self.num_points - 1, Field.SLICE_INDEX.value), slice_idx)
 
-        self.set_cor_at_slice(slice_idx, cor)
+        # the data is added on the row _after_ the selected one
+        self.set_point(row + 1, cor=cor)
 
     def headerData(self, section, orientation, role):
         if orientation != Qt.Horizontal:

--- a/mantidimaging/gui/windows/cor_tilt/test/presenter_test.py
+++ b/mantidimaging/gui/windows/cor_tilt/test/presenter_test.py
@@ -1,19 +1,15 @@
 import unittest
 
-import numpy as np
-
-from mantidimaging.core.data import Images
-
-from mantidimaging.gui.windows.cor_tilt import (
-    CORTiltWindowView, CORTiltWindowPresenter)
-from mantidimaging.gui.windows.stack_visualiser import (
-    StackVisualiserView, StackVisualiserPresenter)
-
 import mock
+import numpy as np
+from mantidimaging.core.data import Images
+from mantidimaging.core.data import const as data_const
+from mantidimaging.gui.windows.cor_tilt import CORTiltWindowPresenter, CORTiltWindowView
+from mantidimaging.gui.windows.cor_tilt.presenter import Notification as PresNotification
+from mantidimaging.gui.windows.stack_visualiser import StackVisualiserPresenter, StackVisualiserView
 
 
 class CORTiltWindowPresenterTest(unittest.TestCase):
-
     def setUp(self):
         # Mock view
         self.view = mock.create_autospec(CORTiltWindowView)
@@ -41,3 +37,20 @@ class CORTiltWindowPresenterTest(unittest.TestCase):
 
         self.presenter.set_preview_projection_idx(5)
         self.assertEquals(self.presenter.model.preview_projection_idx, 5)
+
+    def test_do_add_manual_cor_table_row_no_last_result(self):
+        self.presenter.model.selected_row = 0
+        self.presenter.model.preview_slice_idx = 15
+        self.presenter.notify(PresNotification.ADD_NEW_COR_TABLE_ROW)
+        self.view.add_cor_table_row.assert_called_once_with(self.presenter.model.selected_row,
+                                                            self.presenter.model.preview_slice_idx, 0)
+
+    def test_do_add_manual_cor_table_row_with_last_result_cor(self):
+        self.presenter.model.selected_row = 0
+        self.presenter.model.preview_slice_idx = 15
+        self.presenter.model.last_result = {data_const.COR_TILT_ROTATION_CENTRE: 4141}
+
+        self.presenter.notify(PresNotification.ADD_NEW_COR_TABLE_ROW)
+        self.view.add_cor_table_row.assert_called_once_with(
+            self.presenter.model.selected_row, self.presenter.model.preview_slice_idx,
+            self.presenter.model.last_result[data_const.COR_TILT_ROTATION_CENTRE])

--- a/mantidimaging/gui/windows/cor_tilt/view.py
+++ b/mantidimaging/gui/windows/cor_tilt/view.py
@@ -7,9 +7,9 @@ from matplotlib.figure import Figure
 from mantidimaging.core.cor_tilt import Field
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.widgets import NavigationToolbarSimple
-from .point_table_model import CorTiltPointQtModel
-from .presenter import CORTiltWindowPresenter
-from .presenter import Notification as PresNotification
+from mantidimaging.gui.windows.cor_tilt.point_table_model import CorTiltPointQtModel
+from mantidimaging.gui.windows.cor_tilt.presenter import CORTiltWindowPresenter
+from mantidimaging.gui.windows.cor_tilt.presenter import Notification as PresNotification
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401
@@ -123,6 +123,7 @@ class CORTiltWindowView(BaseMainWindowView):
             if item.isValid():
                 slice_idx = item.model().point(item.row())[
                     Field.SLICE_INDEX.value]
+                self.presenter.set_row(item.row())
                 self.presenter.set_preview_slice_idx(slice_idx)
                 self.presenter.notify(
                     PresNotification.PREVIEW_RECONSTRUCTION_SET_COR)
@@ -334,11 +335,11 @@ class CORTiltWindowView(BaseMainWindowView):
         enough_to_fit = self.tableView.model().num_points >= 2
         self.manualFitButton.setEnabled(enough_to_fit)
 
-    def add_cor_table_row(self, idx, cor):
+    def add_cor_table_row(self, row, slice_index, cor):
         """
         Adds a row to the manual COR table with a specified slice index.
         """
-        self.tableView.model().appendNewRow(idx, cor)
+        self.tableView.model().appendNewRow(row, slice_index, cor)
 
     @property
     def slice_count(self):

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -54,12 +54,14 @@ class MainWindowView(BaseMainWindowView):
         self.actionOnlineDocumentation.triggered.connect(self.open_online_documentation)
         self.actionAbout.triggered.connect(self.show_about)
 
-        self.actionCorTilt.triggered.connect(self.show_cor_tilt_window)
         self.actionFilters.triggered.connect(self.show_filters_window)
         self.actionFilters.setShortcut("Ctrl+F")
         self.actionSavuFilters.triggered.connect(self.show_savu_filters_window)
         self.actionSavuFilters.setShortcut("Ctrl+Shift+F")
+        self.actionCorTilt.triggered.connect(self.show_cor_tilt_window)
+        self.actionCorTilt.setShortcut("Ctrl+R")
         self.actionTomopyRecon.triggered.connect(self.show_tomopy_recon_window)
+        self.actionTomopyRecon.setShortcut("Ctrl+Shfit+R")
 
         self.active_stacks_changed.connect(self.update_shortcuts)
 
@@ -80,9 +82,7 @@ class MainWindowView(BaseMainWindowView):
         msg_box.setText(
             '<a href="https://github.com/mantidproject/mantidimaging">MantidImaging</a>'
             '<br>Version: <a href="https://github.com/mantidproject/mantidimaging/releases/tag/{0}">{0}</a>'.format(
-                version_no
-            )
-        )
+                version_no))
         msg_box.show()
 
     def show_load_dialogue(self):
@@ -159,9 +159,8 @@ class MainWindowView(BaseMainWindowView):
         dock_widget.setWidget(StackVisualiserView(self, dock_widget, stack))
 
         # proof of concept above
-        assert isinstance(
-            dock_widget.widget(), StackVisualiserView
-        ), "Widget inside dock_widget is not an StackVisualiserView!"
+        assert isinstance(dock_widget.widget(),
+                          StackVisualiserView), "Widget inside dock_widget is not an StackVisualiserView!"
 
         dock_widget.setFloating(floating)
 
@@ -180,9 +179,10 @@ class MainWindowView(BaseMainWindowView):
         if self.presenter.have_active_stacks:
             # Show confirmation box asking if the user really wants to quit if
             # they have data loaded
-            msg_box = QtWidgets.QMessageBox.question(
-                self, "Quit", "Are you sure you want to quit?", defaultButton=QtWidgets.QMessageBox.No
-            )
+            msg_box = QtWidgets.QMessageBox.question(self,
+                                                     "Quit",
+                                                     "Are you sure you want to quit?",
+                                                     defaultButton=QtWidgets.QMessageBox.No)
             should_close = msg_box == QtWidgets.QMessageBox.Yes
 
         if should_close:


### PR DESCRIPTION
This PR fixes the error that was shown when the user clicked Add in the COR/tilt GUI. This function is available after the automatic COR calculation is performed.

To test:

- Load a stack
- Open cor/tilt GUI and run an automatic calculation
- On the results tab select a row and click add
- The new row should have the same slice index and COR
- Remove/clear all should still work

No related issue