### PR TITLE
Image type options for reconstruction

### DIFF
--- a/mantidimaging/gui/ui/tomopy_recon_window.ui
+++ b/mantidimaging/gui/ui/tomopy_recon_window.ui
@@ -27,21 +27,102 @@
         </property>
         <item>
          <layout class="QGridLayout" name="optionsLayout">
-          <item row="3" column="0">
-           <widget class="QLabel" name="maxProjAngleLebsl">
-            <property name="text">
-             <string>Maximum projection angle</string>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="0">
+          <item row="10" column="0">
            <widget class="QLabel" name="numIterLabel">
             <property name="text">
              <string>Number of iterations:</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
+          <item row="2" column="0">
+           <widget class="QLabel" name="stackSelectorLabel">
+            <property name="text">
+             <string>Stack:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="StackSelectorWidgetView" name="stackSelector"/>
+          </item>
+          <item row="10" column="1">
+           <widget class="QSpinBox" name="numIter">
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>99999</number>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QDoubleSpinBox" name="maxProjAngle">
+            <property name="maximum">
+             <double>9999.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>360.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="1">
+           <widget class="QComboBox" name="filterName">
+            <item>
+             <property name="text">
+              <string>none</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>shepp</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>cosine</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>hann</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>hamming</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>ramlak</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>parzen</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>butterworth</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="gradientLabel">
+            <property name="text">
+             <string>Rotation centre gradient:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="corLabel">
+            <property name="text">
+             <string>Rotation centre (at top of stack):</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
            <widget class="QDoubleSpinBox" name="gradient">
             <property name="decimals">
              <number>9</number>
@@ -57,51 +138,28 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="1">
-           <widget class="QSpinBox" name="previewSlice"/>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="corLabel">
+          <item row="9" column="0">
+           <widget class="QLabel" name="filterNameLabel">
             <property name="text">
-             <string>Rotation centre (at top of stack):</string>
+             <string>Reconstruction filter:</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
-           <widget class="QDoubleSpinBox" name="maxProjAngle">
-            <property name="maximum">
-             <double>9999.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>360.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="gradientLabel">
+          <item row="3" column="0">
+           <widget class="QLabel" name="label">
             <property name="text">
-             <string>Rotation centre gradient:</string>
+             <string>Stack image type:</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
-           <widget class="QDoubleSpinBox" name="cor">
-            <property name="maximum">
-             <double>9999.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>10.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0">
+          <item row="7" column="0">
            <widget class="QLabel" name="previewSliceLabel">
             <property name="text">
              <string>Preview slice:</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="1">
+          <item row="8" column="1">
            <widget class="QComboBox" name="algorithmName">
             <item>
              <property name="text">
@@ -175,83 +233,59 @@
             </item>
            </widget>
           </item>
-          <item row="7" column="0">
+          <item row="7" column="1">
+           <widget class="QSpinBox" name="previewSlice"/>
+          </item>
+          <item row="8" column="0">
            <widget class="QLabel" name="algorithmNameLabel">
             <property name="text">
              <string>Algorithm:</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="stackSelectorLabel">
+          <item row="4" column="0">
+           <widget class="QLabel" name="maxProjAngleLebsl">
             <property name="text">
-             <string>Stack:</string>
+             <string>Maximum projection angle</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="StackSelectorWidgetView" name="stackSelector"/>
-          </item>
-          <item row="8" column="0">
-           <widget class="QLabel" name="filterNameLabel">
-            <property name="text">
-             <string>Reconstruction filter:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="1">
-           <widget class="QComboBox" name="filterName">
-            <item>
-             <property name="text">
-              <string>none</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>shepp</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>cosine</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>hann</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>hamming</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>ramlak</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>parzen</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>butterworth</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="9" column="1">
-           <widget class="QSpinBox" name="numIter">
-            <property name="minimum">
-             <number>1</number>
-            </property>
+          <item row="5" column="1">
+           <widget class="QDoubleSpinBox" name="cor">
             <property name="maximum">
-             <number>99999</number>
+             <double>9999.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>10.000000000000000</double>
             </property>
            </widget>
+          </item>
+          <item row="3" column="1">
+           <layout class="QHBoxLayout" name="imageTypeButtonLayout">
+            <item>
+             <widget class="QRadioButton" name="sinogramTypeRadio">
+              <property name="text">
+               <string>Sinogram</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+              <attribute name="buttonGroup">
+               <string notr="true">imageTypeRadioGroup</string>
+              </attribute>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="projectionTypeRadio">
+              <property name="text">
+               <string>Projection</string>
+              </property>
+              <attribute name="buttonGroup">
+               <string notr="true">imageTypeRadioGroup</string>
+              </attribute>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </item>
@@ -308,4 +342,7 @@
  </customwidgets>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="imageTypeRadioGroup"/>
+ </buttongroups>
 </ui>

--- a/mantidimaging/gui/windows/stack_visualiser/model.py
+++ b/mantidimaging/gui/windows/stack_visualiser/model.py
@@ -8,3 +8,7 @@ class SVModel:
     @staticmethod
     def sum_images(images):
         return np.sum(images, axis=0)
+
+    @staticmethod
+    def swap_axes(images):
+        return np.swapaxes(images, 0, 1)

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -1,14 +1,19 @@
 from enum import IntEnum
 from logging import getLogger
+from typing import TYPE_CHECKING
 
 from mantidimaging.core.data import Images
 from mantidimaging.gui.mvp_base import BasePresenter
 from .model import SVModel
 
+if TYPE_CHECKING:
+    from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401
+
 
 class SVNotification(IntEnum):
     REFRESH_IMAGE = 0
     TOGGLE_IMAGE_MODE = 1
+    SWAP_AXES = 2
 
 
 class SVParameters(IntEnum):
@@ -38,6 +43,8 @@ class StackVisualiserPresenter(BasePresenter):
                 self.refresh_image()
             if signal == SVNotification.TOGGLE_IMAGE_MODE:
                 self.toggle_image_mode()
+            if signal == SVNotification.SWAP_AXES:
+                self.create_swapped_axis_stack()
         except Exception as e:
             self.show_error(e)
             getLogger(__name__).exception("Notification handler failed")
@@ -75,3 +82,8 @@ class StackVisualiserPresenter(BasePresenter):
                  or self.summed_image.shape != self.images.sample.shape[1:]):
             self.summed_image = self.model.sum_images(self.images.sample)
         self.refresh_image()
+
+    def create_swapped_axis_stack(self):
+        self.view.parent_create_stack(
+            Images(self.model.swap_axes(self.images.sample)),
+            f"{self.view.name}_inverted")

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -2,10 +2,11 @@ import unittest
 
 import mock
 from PyQt5 import QtCore
-from PyQt5.QtWidgets import QDockWidget, QMainWindow
+from PyQt5.QtWidgets import QDockWidget
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.utility.sensible_roi import SensibleROI
+from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.stack_visualiser import StackVisualiserView
 from mantidimaging.test_helpers import start_qapplication
 
@@ -21,7 +22,7 @@ class StackVisualiserViewTest(unittest.TestCase):
 
     def setUp(self):
         # mock the view so it has the same methods
-        self.window = QMainWindow()
+        self.window = MainWindowView()
         self.window.remove_stack = mock.Mock()
 
         self.dock = QDockWidget()

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -38,6 +38,7 @@ class StackVisualiserView(BaseMainWindowView):
         self.layout = QVBoxLayout(self)
         self.central_widget.setLayout(self.layout)
         self.setCentralWidget(self.central_widget)
+        self.parent_create_stack = self.parent().presenter.create_new_stack
 
         # capture the QDockWidget reference so that we can access the Qt widget
         # and change things like the title
@@ -116,7 +117,13 @@ class StackVisualiserView(BaseMainWindowView):
         show_metadata_action = QAction("Show image metadata", menu)
         show_metadata_action.triggered.connect(self.show_image_metadata)
 
-        menu.addActions([change_name_action, toggle_image_mode_action, show_metadata_action])
+        swap_axes_action = QAction("New stack with swapped axes", menu)
+        swap_axes_action.triggered.connect(lambda: self.presenter.notify(SVNotification.SWAP_AXES))
+
+        menu.addActions([change_name_action,
+                         toggle_image_mode_action,
+                         show_metadata_action,
+                         swap_axes_action])
         return menu
 
     def change_window_name_clicked(self):

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -117,7 +117,7 @@ class StackVisualiserView(BaseMainWindowView):
         show_metadata_action = QAction("Show image metadata", menu)
         show_metadata_action.triggered.connect(self.show_image_metadata)
 
-        swap_axes_action = QAction("New stack with swapped axes", menu)
+        swap_axes_action = QAction("Create sinograms from stack", menu)
         swap_axes_action.triggered.connect(lambda: self.presenter.notify(SVNotification.SWAP_AXES))
 
         menu.addActions([change_name_action,

--- a/mantidimaging/gui/windows/tomopy_recon/model.py
+++ b/mantidimaging/gui/windows/tomopy_recon/model.py
@@ -17,6 +17,7 @@ class TomopyReconWindowModel(object):
         self.preview_slice_idx = 0
         self.current_algorithm = "gridrec"
         self.current_filter = "none"
+        self.images_are_sinograms = True
 
         self.cors = None
         self.projection_angles = None
@@ -63,7 +64,8 @@ class TomopyReconWindowModel(object):
             filter_name=self.current_filter,
             proj_angles=self.projection_angles,
             num_iter=self.num_iter,
-            progress=progress)
+            progress=progress,
+            images_are_sinograms=self.images_are_sinograms)
 
     @staticmethod
     def load_allowed_recon_kwargs():

--- a/mantidimaging/gui/windows/tomopy_recon/presenter.py
+++ b/mantidimaging/gui/windows/tomopy_recon/presenter.py
@@ -100,6 +100,7 @@ class TomopyReconWindowPresenter(BasePresenter):
         self.model.current_filter = self.view.filter_name
         self.model.num_iter = self.view.num_iter
         self.model.generate_projection_angles(self.view.max_proj_angle)
+        self.model.images_are_sinograms = self.view.images_are_sinograms
 
     def do_reconstruct_slice(self):
         self.prepare_reconstruction()

--- a/mantidimaging/gui/windows/tomopy_recon/view.py
+++ b/mantidimaging/gui/windows/tomopy_recon/view.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from PyQt5.QtWidgets import QComboBox, QCheckBox, QSpinBox
+from PyQt5.QtWidgets import QComboBox, QSpinBox
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
 
@@ -18,7 +18,6 @@ class TomopyReconWindowView(BaseMainWindowView):
     algorithmName: QComboBox
     filterName: QComboBox
     numIter: QSpinBox
-    imagesAreSinograms: QCheckBox
 
     def __init__(self, main_window: 'MainWindowView', cmap='Greys_r'):
         super(TomopyReconWindowView, self).__init__(main_window, 'gui/ui/tomopy_recon_window.ui')
@@ -156,3 +155,7 @@ class TomopyReconWindowView(BaseMainWindowView):
     @property
     def num_iter(self):
         return self.numIter.value() if self.numIter.isVisible() else None
+
+    @property
+    def images_are_sinograms(self):
+        return self.sinogramTypeRadio.isChecked()


### PR DESCRIPTION
Closes #352 

Adds an option to the TomoPy window to pass through an `images_are_sinograms` flag to the reconstruction algorithm.

Also adds a context menu option to create a new stack using the current stacks sample with it's axes inverted, as an easier alternative to saving as sinograms then reloading.