### PR TITLE
Update travis build nightly to use Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,29 +6,25 @@ services:
   - docker
 
 env:
-  - MINICONDA_DIR=$HOME/miniconda ENVIRONMENT_DIR=$HOME/envs ENVIRONMENT_NAME=test-environment MANTIDIMAGING_DOCKER_RUN="docker run -e DISPLAY -v $HOME/.Xauthority:/home/developer/.Xauthority -v /tmp/.X11-unix:/tmp/.X11-unix:ro -v $TRAVIS_BUILD_DIR:/opt/mantidimaging -t dtasev/mantidimaging:travis-ci-2019.10"
+  - |
+    MINICONDA_DIR=$HOME/miniconda
+    ENVIRONMENT_DIR=$HOME/envs
+    ENVIRONMENT_NAME=test-environment
+    DOCKER_RUN="docker run -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:ro -v $TRAVIS_BUILD_DIR:/opt/mantidimaging"
+    DOCKER_IMAGE="-t dtasev/mantidimaging"
 
 before_install:
-  - docker pull dtasev/mantidimaging:travis-ci-2019.10
+  - docker pull dtasev/mantidimaging
 
 jobs:
   include:
     - stage: test
       script:
-        - $MANTIDIMAGING_DOCKER_RUN flake8
-        - $MANTIDIMAGING_DOCKER_RUN mypy --ignore-missing-imports mantidimaging
-        - $MANTIDIMAGING_DOCKER_RUN nosetests --xunit-file=/opt/result-report.xml
+        - $DOCKER_RUN $DOCKER_IMAGE flake8
+        - $DOCKER_RUN $DOCKER_IMAGE mypy --ignore-missing-imports mantidimaging
+        - $DOCKER_RUN $DOCKER_IMAGE nosetests --xunit-file=/opt/result-report.xml
 
     - stage: upload-nightly
       if: type = cron AND branch = master
       script:
-        - |
-          if [[ $UPLOAD_PACKAGE = "true" ]]; then
-            conda config --set anaconda_upload yes;
-          fi
-        - make build-conda-package-nightly
-        # stop caching from being ran for a package build
-        # this prevent caching big packages like anaconda and conda-forge
-        # that are only necessary for building the package
-        - exit 0
-
+        - $DOCKER_RUN -e UPLOAD_USER -e ANACONDA_API_TOKEN $DOCKER_IMAGE /bin/bash -c "conda config --set anaconda_upload yes && make build-conda-package-nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ jobs:
         - $DOCKER_RUN $DOCKER_IMAGE nosetests --xunit-file=/opt/result-report.xml
 
     - stage: upload-nightly
-      if: type = cron AND branch = master
+      if: type = cron
       script:
         - $DOCKER_RUN -e UPLOAD_USER -e ANACONDA_API_TOKEN $DOCKER_IMAGE /bin/bash -c "conda config --set anaconda_upload yes && make build-conda-package-nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,7 @@ services:
   - docker
 
 env:
-  - |
-    MINICONDA_DIR=$HOME/miniconda
-    ENVIRONMENT_DIR=$HOME/envs
-    ENVIRONMENT_NAME=test-environment
-    DOCKER_RUN="docker run -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:ro -v $TRAVIS_BUILD_DIR:/opt/mantidimaging"
-    DOCKER_IMAGE="-t dtasev/mantidimaging"
+  - MINICONDA_DIR=$HOME/miniconda ENVIRONMENT_DIR=$HOME/envs ENVIRONMENT_NAME=test-environment DOCKER_RUN="docker run -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:ro -v $TRAVIS_BUILD_DIR:/opt/mantidimaging" DOCKER_IMAGE="-t dtasev/mantidimaging"
 
 before_install:
   - docker pull dtasev/mantidimaging

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,6 @@ build-conda-package-nightly: .remind-current .remind-for-user .remind-for-anacon
 build-conda-package-release: .remind-current .remind-for-user .remind-for-anaconda-api install-build-requirements
 	MANTIDIMAGING_BUILD_TYPE='' conda-build ./conda $(AUTHENTICATION_PARAMS)
 
-build-docker-image: .remind-for-user
-	docker build --rm -t $$UPLOAD_USER/mantidimaging:travis-ci-2019.10 -f Dockerfile .
-
 .remind-current:
 	@echo "If automatic upload is wanted, then \`conda config --set anaconda_upload yes\` should be set."
 	@echo "Current: $$(conda config --get anaconda_upload)"
@@ -48,9 +45,3 @@ test-env:
 
 mypy:
 	python -m mypy --ignore-missing-imports mantidimaging
-
-docker-build:
-	sudo docker build --rm -t mantidimaging -f Dockerfile .
-
-docker-run:
-	sudo docker run -e DISPLAY -v $(HOME)/.Xauthority:/home/root/.Xauthority -v /tmp/.X11-unix:/tmp/.X11-unix:ro -t mantidimaging

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,12 @@
+# This Dockerfile creates a developer image. It requires that the following things are mounted:
+# - Mantid Imaging source at /opt/mantidimaging.
+# It also requires the DISPLAY environment variable and sharing the X11 socket via
+# -v /tmp/.X11-unix:/tmp/.X11-unix:ro
 FROM ubuntu:18.04
 
 WORKDIR /opt/
 
-RUN apt-get update && apt-get install -y wget git fontconfig \
+RUN apt-get update && apt-get install -y make wget git fontconfig \
       libglib2.0-0 \
       libxrandr2 \
       libxss1 \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,9 @@
+image_name = travis-ci-$$(git rev-parse --short HEAD)
+build-docker-image: .remind-for-user
+	# tags the image with the current commit short SHA, and without a label
+	docker build --rm -t $$UPLOAD_USER/mantidimaging:$(image_name) -t $$UPLOAD_USER/mantidimaging -f Dockerfile ..
+	docker push $$UPLOAD_USER/mantidimaging:$(image_name)
+	docker push $$UPLOAD_USER/mantidimaging
+
+.remind-for-user:
+	@if [ -z "$$UPLOAD_USER" ]; then echo "Environment variable UPLOAD_USER not set!"; exit 1; fi;

--- a/docker/README
+++ b/docker/README
@@ -1,0 +1,18 @@
+For creating a production docker image an account should be added to prevent using root for everything by default.
+
+This can be accomplished by adding the following lines in the Dockerfile.
+
+```
+# Set up a user `developer` with sudo rights
+RUN export uid=1000 gid=1000 && \
+    mkdir -p /home/developer && \
+    mkdir -p /etc/sudoers.d/ && \
+    echo "developer:x:${uid}:${gid}:Developer,,,:/home/developer:/bin/bash" >> /etc/passwd && \
+    echo "developer:x:${uid}:" >> /etc/group && \
+    echo "developer ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/developer && \
+    chmod 0440 /etc/sudoers.d/developer && \
+    chown ${uid}:${gid} -R /home/developer
+
+USER developer
+ENV HOME /home/developer
+```

--- a/docs/developer_guide/conda_packaging_and_docker_image.rst
+++ b/docs/developer_guide/conda_packaging_and_docker_image.rst
@@ -66,7 +66,7 @@ If you want to push a package to the original repository please contact the Mant
 Building the Docker image
 -------------------------
 
-The Docker image is currently used as a setup for the Travis test environment. The configuration is stored in the :code:`Dockerfile`, and a :code:`make` helper command is provided for building it:
+The Docker image is currently used as a setup for the Travis test environment. The configuration is stored in the :code:`docker/Dockerfile`, and a :code:`make` helper command is provided for building it:
 
    1. :code:`make build-docker-image`
 


### PR DESCRIPTION
- Move Docker files into docker/
- Install Docker in docker image
- Change Docker tag to use the commit SHA used for the Dockerfile. Travis will always use :latest (i.e. no tag at all)

TODO:
- Check builds, including the manually scheduled CRON build