### PR TITLE
Pyqtgraph for filter previews

### DIFF
--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -31,16 +31,7 @@
         <property name="sizeConstraint">
          <enum>QLayout::SetDefaultConstraint</enum>
         </property>
-        <property name="leftMargin">
-         <number>9</number>
-        </property>
-        <property name="topMargin">
-         <number>9</number>
-        </property>
-        <property name="rightMargin">
-         <number>9</number>
-        </property>
-        <property name="bottomMargin">
+        <property name="margin">
          <number>9</number>
         </property>
         <item>
@@ -170,7 +161,7 @@
        </layout>
       </widget>
       <widget class="QWidget" name="layoutWidget_2">
-       <layout class="QVBoxLayout" name="mplLayout"/>
+       <layout class="QVBoxLayout" name="previewsLayout"/>
       </widget>
      </widget>
     </item>

--- a/mantidimaging/gui/windows/filters/filter_previews.py
+++ b/mantidimaging/gui/windows/filters/filter_previews.py
@@ -1,0 +1,38 @@
+from pyqtgraph import GraphicsLayoutWidget, ImageItem, PlotItem
+
+histogram_axes_labels = {'left': 'Frequency', 'bottom': 'Value'}
+
+
+class FilterPreviews(GraphicsLayoutWidget):
+    image_before: ImageItem
+    image_after: ImageItem
+    histogram_before: PlotItem
+    histogram_after: PlotItem
+
+    def __init__(self, parent=None, **kwargs):
+        super(FilterPreviews, self).__init__(parent, **kwargs)
+
+        self.addLabel("Image before:")
+        self.addLabel("Pixel values before:")
+        self.nextRow()
+
+        self.image_before = ImageItem()
+        self.image_before_vb = self.addViewBox(invertY=True)
+        self.image_before_vb.addItem(self.image_before)
+        self.histogram_before = self.addPlot(labels=histogram_axes_labels)
+
+        self.nextRow()
+        self.addLabel("Image after:")
+        self.addLabel("Pixel values after:")
+        self.nextRow()
+
+        self.image_after = ImageItem()
+        self.image_after_vb = self.addViewBox(invertY=True)
+        self.image_after_vb.addItem(self.image_after)
+        self.histogram_after = self.addPlot(labels=histogram_axes_labels)
+
+    def clear_items(self):
+        self.image_before.setImage()
+        self.image_after.setImage()
+        self.histogram_before.clear()
+        self.histogram_after.clear()

--- a/mantidimaging/gui/windows/filters/presenter.py
+++ b/mantidimaging/gui/windows/filters/presenter.py
@@ -126,7 +126,7 @@ class FiltersWindowPresenter(BasePresenter):
 
             # If there is no stack then clear the preview area
             if stack is None:
-                self.view.clear_preview_plots()
+                self.view.clear_previews()
 
             else:
                 # Add the remaining steps for calculating the preview

--- a/mantidimaging/gui/windows/filters/view.py
+++ b/mantidimaging/gui/windows/filters/view.py
@@ -38,20 +38,28 @@ class FiltersWindowView(BaseMainWindowView):
         # Handle apply filter
         self.applyButton.clicked.connect(lambda: self.presenter.notify(PresNotification.APPLY_FILTER))
 
+        histogram_axes_labels = {'left': 'Frequency', 'bottom': 'Value'}
         self.previews: GraphicsLayoutWidget = GraphicsLayoutWidget()
         self.previewsLayout.addWidget(self.previews)
+
+        self.previews.addLabel("Image before:")
+        self.previews.addLabel("Pixel values before:")
+        self.previews.nextRow()
 
         self.preview_image_before: ImageItem = ImageItem()
         self.preview_image_before_vb: ViewBox = self.previews.addViewBox(invertY=True)
         self.preview_image_before_vb.addItem(self.preview_image_before)
-        self.preview_histogram_before: PlotItem = self.previews.addPlot(title='Histogram Before')
+        self.preview_histogram_before: PlotItem = self.previews.addPlot(labels=histogram_axes_labels)
 
+        self.previews.nextRow()
+        self.previews.addLabel("Image after:")
+        self.previews.addLabel("Pixel values after:")
         self.previews.nextRow()
 
         self.preview_image_after: ImageItem = ImageItem()
         self.preview_image_after_vb = self.previews.addViewBox(invertY=True)
         self.preview_image_after_vb.addItem(self.preview_image_after)
-        self.preview_histogram_after: PlotItem = self.previews.addPlot(title='Histogram After')
+        self.preview_histogram_after: PlotItem = self.previews.addPlot(labels=histogram_axes_labels)
 
         self.clear_preview_plots()
 

--- a/mantidimaging/gui/windows/filters/view.py
+++ b/mantidimaging/gui/windows/filters/view.py
@@ -18,6 +18,13 @@ class FiltersWindowView(BaseMainWindowView):
     auto_update_triggered = Qt.pyqtSignal()
 
     previewsLayout: QVBoxLayout
+    previews: GraphicsLayoutWidget
+    preview_image_before: ImageItem
+    preview_image_before_vb: ViewBox
+    preview_histogram_before: PlotItem
+    preview_image_after: ImageItem
+    preview_image_after_vb: ViewBox
+    preview_histogram_after: PlotItem
 
     def __init__(self, main_window: 'MainWindowView'):
         super(FiltersWindowView, self).__init__(main_window, 'gui/ui/filters_window.ui')
@@ -39,27 +46,27 @@ class FiltersWindowView(BaseMainWindowView):
         self.applyButton.clicked.connect(lambda: self.presenter.notify(PresNotification.APPLY_FILTER))
 
         histogram_axes_labels = {'left': 'Frequency', 'bottom': 'Value'}
-        self.previews: GraphicsLayoutWidget = GraphicsLayoutWidget()
+        self.previews = GraphicsLayoutWidget()
         self.previewsLayout.addWidget(self.previews)
 
         self.previews.addLabel("Image before:")
         self.previews.addLabel("Pixel values before:")
         self.previews.nextRow()
 
-        self.preview_image_before: ImageItem = ImageItem()
-        self.preview_image_before_vb: ViewBox = self.previews.addViewBox(invertY=True)
+        self.preview_image_before = ImageItem()
+        self.preview_image_before_vb = self.previews.addViewBox(invertY=True)
         self.preview_image_before_vb.addItem(self.preview_image_before)
-        self.preview_histogram_before: PlotItem = self.previews.addPlot(labels=histogram_axes_labels)
+        self.preview_histogram_before = self.previews.addPlot(labels=histogram_axes_labels)
 
         self.previews.nextRow()
         self.previews.addLabel("Image after:")
         self.previews.addLabel("Pixel values after:")
         self.previews.nextRow()
 
-        self.preview_image_after: ImageItem = ImageItem()
+        self.preview_image_after = ImageItem()
         self.preview_image_after_vb = self.previews.addViewBox(invertY=True)
         self.preview_image_after_vb.addItem(self.preview_image_after)
-        self.preview_histogram_after: PlotItem = self.previews.addPlot(labels=histogram_axes_labels)
+        self.preview_histogram_after = self.previews.addPlot(labels=histogram_axes_labels)
 
         self.clear_preview_plots()
 

--- a/mantidimaging/gui/windows/savu_filters/presenter.py
+++ b/mantidimaging/gui/windows/savu_filters/presenter.py
@@ -154,7 +154,7 @@ class SavuFiltersWindowPresenter(BasePresenter):
 
             # If there is no stack then clear the preview area
             if stack is None:
-                self.view.clear_preview_plots()
+                self.view.clear_previews()
 
             else:
                 # Add the remaining steps for calculating the preview


### PR DESCRIPTION
Closes #330 

Currently using a class that is specific to the filter window, when looking at #331 and #332 will make something generic if it fits.

Haven't replaced the matplotlib toolbar, as that kind of functionality is accessible through right click menu in pyqtgraph instead.

Not if sure there's any equivalent for cmap.