### PR TITLE
Staged loading for stacks

### DIFF
--- a/mantidimaging/core/io/loader/img_loader.py
+++ b/mantidimaging/core/io/loader/img_loader.py
@@ -7,8 +7,7 @@ import numpy as np
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.io.utility import get_file_names
-from mantidimaging.core.parallel import two_shared_mem as ptsm
-from mantidimaging.core.parallel import utility as pu
+from mantidimaging.core.parallel import two_shared_mem as ptsm, utility as pu
 from mantidimaging.core.utility.progress_reporting import Progress
 from . import stack_loader
 

--- a/mantidimaging/gui/ui/load_dialog.ui
+++ b/mantidimaging/gui/ui/load_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>300</width>
-    <height>362</height>
+    <height>397</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -40,16 +40,7 @@
      <item>
       <widget class="QWidget" name="flat_widget" native="true">
        <layout class="QHBoxLayout" name="flatLayout">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
+        <property name="margin">
          <number>0</number>
         </property>
         <item>
@@ -68,16 +59,7 @@
      <item>
       <widget class="QWidget" name="dark_widget" native="true">
        <layout class="QHBoxLayout" name="darkLayout">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
+        <property name="margin">
          <number>0</number>
         </property>
         <item>
@@ -187,6 +169,28 @@
         </widget>
        </item>
       </layout>
+     </item>
+     <item alignment="Qt::AlignRight">
+      <widget class="QCheckBox" name="staged_load">
+       <property name="cursor">
+        <cursorShape>ArrowCursor</cursorShape>
+       </property>
+       <property name="toolTip">
+        <string>Simultaneously load a preview and the full stack. Useful for quickly working with large stacks.</string>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::LeftToRight</enum>
+       </property>
+       <property name="autoFillBackground">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Staged load</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/mantidimaging/gui/windows/main/load_dialog.py
+++ b/mantidimaging/gui/windows/main/load_dialog.py
@@ -3,7 +3,7 @@ from logging import getLogger
 from typing import Dict, Optional, Tuple
 
 from PyQt5 import Qt
-from PyQt5.QtWidgets import QLineEdit, QPushButton, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QLineEdit, QPushButton, QVBoxLayout, QWidget, QCheckBox
 
 from mantidimaging.core.io.loader import read_in_shape
 from mantidimaging.core.io.utility import get_file_extension, get_prefix
@@ -25,6 +25,7 @@ class MWLoadDialog(Qt.QDialog):
     dark_flat_button: QPushButton
     dark_widget: QWidget
     flat_widget: QWidget
+    staged_load: QCheckBox
 
     def __init__(self, parent):
         super(MWLoadDialog, self).__init__(parent)
@@ -186,4 +187,5 @@ class MWLoadDialog(Qt.QDialog):
                 'image_format': self.image_format,
                 'parallel_load': self.parallel_load(),
                 'indices': self.indices(),
-                'custom_name': self.window_title()}
+                'custom_name': self.window_title(),
+                'staged_load': self.staged_load.isChecked()}

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -42,12 +42,11 @@ class MainWindowPresenter(BasePresenter):
             dock.setWindowTitle(new_name)
             self.view.active_stacks_changed.emit()
 
-    def load_stack(self, kwargs=None):
-        log = getLogger(__name__)
+    def load_stack(self):
+        kwargs = self.view.load_dialogue.get_kwargs()
 
-        if not kwargs['sample_path']:
-            log.debug("No sample path provided, cannot load anything")
-            return
+        if 'sample_path' not in kwargs or not kwargs['sample_path']:
+            raise ValueError("No sample path provided, cannot load anything")
 
         self.start_async_task(kwargs, self.model.do_load_stack, self._on_stack_load_done)
 

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -93,7 +93,7 @@ class MainWindowView(BaseMainWindowView):
         self.presenter.notify(PresNotification.SAVE)
 
     def execute_load(self):
-        self.presenter.load_stack(self.load_dialogue.get_kwargs())
+        self.presenter.notify(PresNotification.LOAD)
 
     def show_save_dialogue(self):
         self.save_dialogue = MWSaveDialog(self, self.stack_list())


### PR DESCRIPTION
Closes #329

Adds a 'staged load' option on loading which loads a preview and the full stack asynchronously. This PR opens each as a separate stack, rather than replacing the images in the existing one, as I thought that was a lot more likely to be buggy and wasn't sure there was much of a benefit.