### PR TITLE
Filter previews - difference image and histogram overplotting

### DIFF
--- a/mantidimaging/core/utility/histogram.py
+++ b/mantidimaging/core/utility/histogram.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-HISTOGRAM_BIN_SIZE = 2048
+DEFAULT_NUM_BINS = 2048
 
 
-def generate_histogram_from_image(image_data, bin_size=HISTOGRAM_BIN_SIZE):
-    histogram, bins = np.histogram(image_data.flatten(), bin_size)
+def generate_histogram_from_image(image_data, num_bins=DEFAULT_NUM_BINS):
+    histogram, bins = np.histogram(image_data.flatten(), num_bins)
     center = (bins[:-1] + bins[1:]) / 2
-    return (center, histogram, bins)
+    return center, histogram, bins

--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -168,12 +168,34 @@
            <enum>QLayout::SetDefaultConstraint</enum>
           </property>
           <item alignment="Qt::AlignRight|Qt::AlignTop">
+           <widget class="QCheckBox" name="showHistogramLegend">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Show Legend</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item alignment="Qt::AlignRight|Qt::AlignTop">
            <widget class="QCheckBox" name="combinedHistograms">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>22</height>
+             </size>
             </property>
             <property name="text">
              <string>Combine histograms</string>

--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -161,7 +161,34 @@
        </layout>
       </widget>
       <widget class="QWidget" name="layoutWidget_2">
-       <layout class="QVBoxLayout" name="previewsLayout"/>
+       <layout class="QVBoxLayout" name="previewsPaneLayout">
+        <item>
+         <layout class="QHBoxLayout" name="previewsPaneToolbar">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetDefaultConstraint</enum>
+          </property>
+          <item alignment="Qt::AlignRight|Qt::AlignTop">
+           <widget class="QCheckBox" name="combinedHistograms">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Combine histograms</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="previewsLayout"/>
+        </item>
+       </layout>
       </widget>
      </widget>
     </item>

--- a/mantidimaging/gui/windows/filters/filter_previews.py
+++ b/mantidimaging/gui/windows/filters/filter_previews.py
@@ -28,23 +28,23 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.addLabel("Image before")
         self.nextRow()
 
-        self.image_before, self.image_before_vb = self.add_image_in_vb()
+        self.image_before, self.image_before_vb = self.add_image_in_vb(name="before")
 
         self.nextRow()
         self.addLabel("Image after")
         self.nextRow()
 
-        self.image_after, self.image_after_bv = self.add_image_in_vb()
+        self.image_after, self.image_after_bv = self.add_image_in_vb(name="after")
 
         self.nextRow()
         self.addLabel("Image difference")
         self.nextRow()
 
-        self.image_difference, self.image_difference_vb = self.add_image_in_vb()
+        self.image_difference, self.image_difference_vb = self.add_image_in_vb(name="difference")
 
-    def add_image_in_vb(self):
+    def add_image_in_vb(self, name=None):
         im = ImageItem()
-        vb = self.addViewBox(invertY=True, lockAspect=True)
+        vb = self.addViewBox(invertY=True, lockAspect=True, name=name)
         vb.addItem(im)
         return im, vb
 

--- a/mantidimaging/gui/windows/filters/filter_previews.py
+++ b/mantidimaging/gui/windows/filters/filter_previews.py
@@ -1,7 +1,7 @@
 from typing import Tuple, Optional
 
 from numpy import ndarray
-from pyqtgraph import GraphicsLayoutWidget, ImageItem, PlotItem
+from pyqtgraph import GraphicsLayoutWidget, ImageItem, PlotItem, LegendItem
 
 histogram_axes_labels = {'left': 'Frequency', 'bottom': 'Value'}
 
@@ -18,10 +18,12 @@ class FilterPreviews(GraphicsLayoutWidget):
         super(FilterPreviews, self).__init__(parent, **kwargs)
         self.before_histogram_data = None
         self.after_histogram_data = None
-        self.combined_histograms = True
         self.histogram = None
         self.before_histogram = None
         self.after_histogram = None
+
+        self.combined_histograms = True
+        self.histogram_legend_visible = False
 
         self.addLabel("Image before")
         self.nextRow()
@@ -87,9 +89,9 @@ class FilterPreviews(GraphicsLayoutWidget):
             before_plot = self.histogram.plot(*self.before_histogram_data, pen=(0, 0, 200))
             if self.after_histogram_data is not None:
                 after_plot = self.histogram.plot(*self.after_histogram_data, pen=(0, 200, 0))
-                legend = self.histogram.addLegend()
-                legend.addItem(before_plot, "Before")
-                legend.addItem(after_plot, "After")
+                self.create_histogram_legend(before_plot, after_plot)
+                if not self.histogram_legend_visible:
+                    self.histogram.legend.hide()
         elif self.after_histogram_data is not None:
             self.histogram.plot(*self.after_histogram_data, pen=(0, 200, 0))
 
@@ -104,6 +106,11 @@ class FilterPreviews(GraphicsLayoutWidget):
         if self.after_histogram_data is not None:
             self.after_histogram.plot(*self.after_histogram_data, pen=(0, 200, 0))
 
+    def create_histogram_legend(self, before_plot, after_plot):
+        legend = self.histogram.addLegend()
+        legend.addItem(before_plot, "Before")
+        legend.addItem(after_plot, "After")
+
     def set_before_histogram(self, data: Tuple[ndarray]):
         self.before_histogram_data = data
         self.redraw_histograms()
@@ -111,3 +118,9 @@ class FilterPreviews(GraphicsLayoutWidget):
     def set_after_histogram(self, data: Tuple[ndarray]):
         self.after_histogram_data = data
         self.redraw_histograms()
+
+    @property
+    def histogram_legend(self) -> Optional[LegendItem]:
+        if self.histogram and self.histogram.legend:
+            return self.histogram.legend
+        return None

--- a/mantidimaging/gui/windows/filters/filter_previews.py
+++ b/mantidimaging/gui/windows/filters/filter_previews.py
@@ -11,20 +11,23 @@ class FilterPreviews(GraphicsLayoutWidget):
     image_after: ImageItem
     histogram_before: PlotItem
     histogram_after: PlotItem
+    histogram: PlotItem
 
     def __init__(self, parent=None, **kwargs):
         super(FilterPreviews, self).__init__(parent, **kwargs)
         self.before_histogram_data = None
         self.after_histogram_data = None
+        self.combined_histograms = False
 
         self.addLabel("Image before:")
-        self.addLabel("Pixel values before:")
         self.nextRow()
 
         self.image_before = ImageItem()
         self.image_before_vb = self.addViewBox(invertY=True)
         self.image_before_vb.addItem(self.image_before)
-        self.histogram = self.addPlot(labels=histogram_axes_labels)
+        self.histogram = None
+        self.before_histogram = None
+        self.after_histogram = None
 
         self.nextRow()
         self.addLabel("Image after:")
@@ -37,17 +40,52 @@ class FilterPreviews(GraphicsLayoutWidget):
     def clear_items(self):
         self.image_before.setImage()
         self.image_after.setImage()
-        self.histogram.clear()
+        self.delete_histograms()
 
-    # There seems to be a bug with pyqtgraph.PlotDataItem.setData not redrawing.
-    # This works around it by redrawing both plots completely, which is fast enough to be ok.
+    # There seems to be a bug with pyqtgraph.PlotDataItem.setData not forcing a redraw.
+    # We work around this by redrawing everything completely every time, which is unreasonably fast anyway.
     def redraw_histograms(self):
-        self.histogram.clear()
+        self.delete_histograms()
+        self.delete_histogram_labels()
+        if self.combined_histograms:
+            self.draw_combined_histogram()
+        else:
+            self.draw_separate_histograms()
+
+    def delete_histograms(self):
+        histogram_coords = [(1, 1), (3, 1)]
+        histograms = (self.getItem(*coord) for coord in histogram_coords)
+        for histogram in filter(lambda h: h is not None, histograms):
+            self.removeItem(histogram)
+        self.histogram = None
+        self.before_histogram = None
+        self.after_histogram = None
+
+    def delete_histogram_labels(self):
+        label_coords = [(0, 1), (2, 1)]
+        labels = (self.getItem(*coord) for coord in label_coords)
+        for label in filter(lambda h: h is not None, labels):
+            self.removeItem(label)
+
+    def draw_combined_histogram(self):
+        self.histogram = self.addPlot(row=1, col=1, labels=histogram_axes_labels)
+        self.addLabel("Pixel values", row=0, col=1)
         if self.before_histogram_data is not None:
             self.histogram.plot(*self.before_histogram_data, pen=(0, 0, 200))
 
         if self.after_histogram_data is not None:
             self.histogram.plot(*self.after_histogram_data, pen=(0, 200, 0))
+
+    def draw_separate_histograms(self):
+        self.before_histogram = self.addPlot(row=1, col=1, labels=histogram_axes_labels)
+        self.after_histogram = self.addPlot(row=3, col=1, labels=histogram_axes_labels)
+        self.addLabel("Pixel values before", row=0, col=1)
+        self.addLabel("Pixel values after", row=2, col=1)
+        if self.before_histogram_data is not None:
+            self.before_histogram.plot(*self.before_histogram_data, pen=(0, 0, 200))
+
+        if self.after_histogram_data is not None:
+            self.after_histogram.plot(*self.after_histogram_data, pen=(0, 200, 0))
 
     def set_before_histogram(self, data: Tuple[ndarray]):
         self.before_histogram_data = data

--- a/mantidimaging/gui/windows/filters/filter_previews.py
+++ b/mantidimaging/gui/windows/filters/filter_previews.py
@@ -10,15 +10,15 @@ after_pen = (0, 200, 0)
 
 Coord = namedtuple('Coord', ['row', 'col'])
 histogram_coords = {
-    "before": Coord(1, 1),
+    "before": Coord(3, 0),
     "after": Coord(3, 1),
-    "combined": Coord(1, 1)
+    "combined": Coord(3, 0)
 }
 
 label_coords = {
-    "before": Coord(0, 1),
+    "before": Coord(2, 0),
     "after": Coord(2, 1),
-    "combined": Coord(0, 1)
+    "combined": Coord(2, 1)
 }
 
 
@@ -42,20 +42,12 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.histogram_legend_visible = False
 
         self.addLabel("Image before")
-        self.nextRow()
-
-        self.image_before, self.image_before_vb = self.add_image_in_vb(name="before")
-
-        self.nextRow()
         self.addLabel("Image after")
-        self.nextRow()
-
-        self.image_after, self.image_after_bv = self.add_image_in_vb(name="after")
-
-        self.nextRow()
         self.addLabel("Image difference")
         self.nextRow()
 
+        self.image_before, self.image_before_vb = self.add_image_in_vb(name="before")
+        self.image_after, self.image_after_bv = self.add_image_in_vb(name="after")
         self.image_difference, self.image_difference_vb = self.add_image_in_vb(name="difference")
 
     def add_image_in_vb(self, name=None):
@@ -98,8 +90,8 @@ class FilterPreviews(GraphicsLayoutWidget):
 
     def draw_combined_histogram(self):
         self.histogram = self.addPlot(row=histogram_coords["combined"].row, col=histogram_coords["combined"].col,
-                                      labels=histogram_axes_labels, lockAspect=True)
-        self.addLabel("Pixel values", row=0, col=1)
+                                      labels=histogram_axes_labels, lockAspect=True, colspan=3)
+        self.addLabel("Pixel values", row=label_coords["combined"].row, col=label_coords["combined"].col)
 
         # Plot any histogram that has data, and add a legend if both exist
         if self.before_histogram_data is not None:

--- a/mantidimaging/gui/windows/filters/filter_previews.py
+++ b/mantidimaging/gui/windows/filters/filter_previews.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Tuple, Optional
 
 from pyqtgraph import GraphicsLayoutWidget, ImageItem, PlotItem
 from numpy import ndarray
@@ -9,15 +9,15 @@ histogram_axes_labels = {'left': 'Frequency', 'bottom': 'Value'}
 class FilterPreviews(GraphicsLayoutWidget):
     image_before: ImageItem
     image_after: ImageItem
-    histogram_before: PlotItem
-    histogram_after: PlotItem
-    histogram: PlotItem
+    histogram_before: Optional[PlotItem]
+    histogram_after: Optional[PlotItem]
+    histogram: Optional[PlotItem]
 
     def __init__(self, parent=None, **kwargs):
         super(FilterPreviews, self).__init__(parent, **kwargs)
         self.before_histogram_data = None
         self.after_histogram_data = None
-        self.combined_histograms = False
+        self.combined_histograms = True
 
         self.addLabel("Image before:")
         self.nextRow()

--- a/mantidimaging/gui/windows/filters/presenter.py
+++ b/mantidimaging/gui/windows/filters/presenter.py
@@ -1,12 +1,11 @@
 from enum import Enum
 from logging import getLogger
+from typing import Callable, Any
 
 import numpy as np
-from pyqtgraph import ImageItem, PlotItem
+from pyqtgraph import ImageItem
 
 from mantidimaging.core.data import Images
-from mantidimaging.core.utility.histogram import (
-    generate_histogram_from_image)
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.mvp_base import BasePresenter
@@ -138,7 +137,7 @@ class FiltersWindowPresenter(BasePresenter):
                 self._update_preview_image(
                     before_image_data,
                     self.view.preview_image_before,
-                    self.view.preview_histogram_before,
+                    self.view.previews.set_before_histogram,
                     progress)
 
                 # Generate sub-stack and run filter
@@ -158,16 +157,19 @@ class FiltersWindowPresenter(BasePresenter):
                     self._update_preview_image(
                         filtered_image_data,
                         self.view.preview_image_after,
-                        self.view.preview_histogram_after,
+                        self.view.previews.set_after_histogram,
                         progress)
 
             # Redraw
             progress.update(msg='Redraw canvas')
 
-    def _update_preview_image(self, image_data: np.ndarray, image: ImageItem, histogram: PlotItem, progress):
+    @staticmethod
+    def _update_preview_image(image_data: np.ndarray,
+                              image: ImageItem,
+                              redraw_histogram: Callable[[Any], None],
+                              progress):
         # Generate histogram data
         progress.update(msg='Generating histogram')
-        center, hist, _ = generate_histogram_from_image(image_data)
 
         # Update image
         progress.update(msg='Updating image')
@@ -175,8 +177,7 @@ class FiltersWindowPresenter(BasePresenter):
 
         # Update histogram
         progress.update(msg='Updating histogram')
-        histogram.clearPlots()
-        histogram.plot(hist)
+        redraw_histogram(image.getHistogram())
 
     def do_scroll_preview(self, offset):
         idx = self.model.preview_image_idx + offset

--- a/mantidimaging/gui/windows/filters/presenter.py
+++ b/mantidimaging/gui/windows/filters/presenter.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from logging import getLogger
-from typing import Callable, Any
+from typing import Callable, Any, Optional
 
 import numpy as np
 from pyqtgraph import ImageItem
@@ -126,7 +126,6 @@ class FiltersWindowPresenter(BasePresenter):
             # If there is no stack then clear the preview area
             if stack is None:
                 self.view.clear_previews()
-
             else:
                 # Add the remaining steps for calculating the preview
                 progress.add_estimated_steps(8)
@@ -159,6 +158,11 @@ class FiltersWindowPresenter(BasePresenter):
                         self.view.preview_image_after,
                         self.view.previews.set_after_histogram,
                         progress)
+                    self._update_preview_image(
+                        np.subtract(filtered_image_data, before_image_data),
+                        self.view.preview_image_difference,
+                        None,
+                        progress)
 
             # Redraw
             progress.update(msg='Redraw canvas')
@@ -166,7 +170,7 @@ class FiltersWindowPresenter(BasePresenter):
     @staticmethod
     def _update_preview_image(image_data: np.ndarray,
                               image: ImageItem,
-                              redraw_histogram: Callable[[Any], None],
+                              redraw_histogram: Optional[Callable[[Any], None]],
                               progress):
         # Generate histogram data
         progress.update(msg='Generating histogram')
@@ -175,9 +179,10 @@ class FiltersWindowPresenter(BasePresenter):
         progress.update(msg='Updating image')
         image.setImage(image_data)
 
-        # Update histogram
-        progress.update(msg='Updating histogram')
-        redraw_histogram(image.getHistogram())
+        if redraw_histogram:
+            # Update histogram
+            progress.update(msg='Updating histogram')
+            redraw_histogram(image.getHistogram())
 
     def do_scroll_preview(self, offset):
         idx = self.model.preview_image_idx + offset

--- a/mantidimaging/gui/windows/filters/view.py
+++ b/mantidimaging/gui/windows/filters/view.py
@@ -44,6 +44,8 @@ class FiltersWindowView(BaseMainWindowView):
         self.previewsLayout.addWidget(self.previews)
         self.clear_previews()
 
+        self.combinedHistograms.stateChanged.connect(self.histogram_mode_changed)
+
         # Handle preview index selection
         self.previewImageIndex.valueChanged[int].connect(
             self.presenter.set_preview_image_index)
@@ -88,6 +90,10 @@ class FiltersWindowView(BaseMainWindowView):
 
     def clear_previews(self):
         self.previews.clear_items()
+
+    def histogram_mode_changed(self):
+        self.previews.combined_histograms = self.combinedHistograms.isChecked()
+        self.previews.redraw_histograms()
 
     @property
     def preview_image_before(self) -> ImageItem:

--- a/mantidimaging/gui/windows/filters/view.py
+++ b/mantidimaging/gui/windows/filters/view.py
@@ -45,6 +45,7 @@ class FiltersWindowView(BaseMainWindowView):
         self.clear_previews()
 
         self.combinedHistograms.stateChanged.connect(self.histogram_mode_changed)
+        self.showHistogramLegend.stateChanged.connect(self.histogram_legend_vis_changed)
 
         # Handle preview index selection
         self.previewImageIndex.valueChanged[int].connect(
@@ -94,6 +95,15 @@ class FiltersWindowView(BaseMainWindowView):
     def histogram_mode_changed(self):
         self.previews.combined_histograms = self.combinedHistograms.isChecked()
         self.previews.redraw_histograms()
+
+    def histogram_legend_vis_changed(self):
+        self.previews.histogram_legend_visible = self.showHistogramLegend.isChecked()
+        legend = self.previews.histogram_legend
+        if legend:
+            if self.showHistogramLegend.isChecked():
+                legend.show()
+            else:
+                legend.hide()
 
     @property
     def preview_image_before(self) -> ImageItem:

--- a/mantidimaging/gui/windows/filters/view.py
+++ b/mantidimaging/gui/windows/filters/view.py
@@ -102,3 +102,7 @@ class FiltersWindowView(BaseMainWindowView):
     @property
     def preview_image_after(self) -> ImageItem:
         return self.previews.image_after
+
+    @property
+    def preview_image_difference(self) -> ImageItem:
+        return self.previews.image_difference

--- a/mantidimaging/gui/windows/filters/view.py
+++ b/mantidimaging/gui/windows/filters/view.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 from PyQt5 import Qt
 from PyQt5.QtWidgets import QVBoxLayout
-from pyqtgraph import ImageItem, PlotItem
+from pyqtgraph import ImageItem, PlotDataItem
 
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.utility import (
@@ -98,9 +98,9 @@ class FiltersWindowView(BaseMainWindowView):
         return self.previews.image_after
 
     @property
-    def preview_histogram_before(self) -> PlotItem:
-        return self.previews.histogram_before
+    def preview_histogram_before(self) -> PlotDataItem:
+        return self.previews.histogram_plot_before
 
     @property
-    def preview_histogram_after(self) -> PlotItem:
-        return self.previews.histogram_after
+    def preview_histogram_after(self) -> PlotDataItem:
+        return self.previews.histogram_plot_after

--- a/mantidimaging/gui/windows/filters/view.py
+++ b/mantidimaging/gui/windows/filters/view.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 from PyQt5 import Qt
 from PyQt5.QtWidgets import QVBoxLayout
-from pyqtgraph import ImageItem, PlotDataItem
+from pyqtgraph import ImageItem
 
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.utility import (
@@ -96,11 +96,3 @@ class FiltersWindowView(BaseMainWindowView):
     @property
     def preview_image_after(self) -> ImageItem:
         return self.previews.image_after
-
-    @property
-    def preview_histogram_before(self) -> PlotDataItem:
-        return self.previews.histogram_plot_before
-
-    @property
-    def preview_histogram_after(self) -> PlotDataItem:
-        return self.previews.histogram_plot_after


### PR DESCRIPTION
Ref #285
Closes #354 

Features added to filter previews:
 - Option to overplot histograms
 - Optional legend on overplotted histogram
 - Difference image
 - Ability to link images together for scrolling, zooming etc

Slight problem at the moment is that images in rows without plots expand slightly to fill the space, making them a little larger than the others, which makes the linked scrolling a bit glitchy. Some kind of empty spacer widget would probably work to fix - if I can find something I'll add to this PR, but for now leaving as is.

![filters](https://user-images.githubusercontent.com/42145431/68406099-1bf60500-0179-11ea-981a-e3b0be30842a.png)