### PR TITLE
Improved history display

### DIFF
--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -70,7 +70,7 @@ class Images:
     def save_metadata(self, f):
         json.dump(self.metadata, f)
 
-    def record_operation(self, func_name: str, *args, **kwargs):
+    def record_operation(self, func_name: str, display_name=None, *args, **kwargs):
         if const.OPERATION_HISTORY not in self.metadata:
             self.metadata[const.OPERATION_HISTORY] = []
 
@@ -82,7 +82,8 @@ class Images:
             const.OPERATION_ARGS:
                 [a if accepted_type(a) else None for a in args],
             const.OPERATION_KEYWORD_ARGS:
-                {k: v for k, v in kwargs.items() if accepted_type(v)}
+                {k: v for k, v in kwargs.items() if accepted_type(v)},
+            const.OPERATION_DISPLAY_NAME: display_name
         })
 
     @staticmethod

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -44,6 +44,7 @@ class ImagesTest(unittest.TestCase):
 
         imgs.record_operation(
             'test_func',
+            'A pretty name',
             56, 9002, np.ndarray((800, 1024, 1024)), 'yes', False,
             this=765, that=495.0, roi=(1, 2, 3, 4))
 
@@ -53,12 +54,13 @@ class ImagesTest(unittest.TestCase):
             'operation_history': [
                 {
                     'name': 'test_func',
+                    'display_name': 'A pretty name',
                     'args': [56, 9002, None, 'yes', False],
                     'kwargs': {
                         'this': 765,
                         'that': 495.0,
                         'roi': (1, 2, 3, 4)
-                    }
+                    },
                 }
             ]
         })

--- a/mantidimaging/core/operation_history/const.py
+++ b/mantidimaging/core/operation_history/const.py
@@ -2,6 +2,7 @@ OPERATION_HISTORY = 'operation_history'
 OPERATION_NAME = 'name'
 OPERATION_KEYWORD_ARGS = 'kwargs'
 OPERATION_ARGS = 'args'
+OPERATION_DISPLAY_NAME = 'display_name'
 
 OPERATION_NAME_COR_TILT_FINDING = 'cor_tilt_finding'
 COR_TILT_ROTATION_CENTRE = 'rotation_centre'

--- a/mantidimaging/gui/windows/filters/model.py
+++ b/mantidimaging/gui/windows/filters/model.py
@@ -109,7 +109,8 @@ class FiltersWindowModel(object):
 
         # store the executed filter in history if it all executed successfully
         exec_func.keywords.update(stack_params)
-        images.record_operation(f"{self.selected_filter.__name__}",      # type: ignore
+        images.record_operation(self.selected_filter.__module__,
+                                self.selected_filter.filter_name,
                                 *exec_func.args, **exec_func.keywords)
 
     def do_apply_filter(self):

--- a/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
+++ b/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
@@ -1,7 +1,7 @@
 from PyQt5 import Qt
-from PyQt5.QtWidgets import QWidget
+from PyQt5.QtWidgets import QWidget, QTreeWidget, QTreeWidgetItem
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import Images, const
 
 
 class MetadataDialog(Qt.QDialog):
@@ -9,21 +9,48 @@ class MetadataDialog(Qt.QDialog):
     Dialog used to show a pretty formatted version of the image metadata.
     """
 
-    def __init__(self, parent: QWidget, image: Images):
+    def __init__(self, parent: QWidget, images: Images):
         super(MetadataDialog, self).__init__(parent)
 
         self.setWindowTitle('Image Metadata')
         self.setSizeGripEnabled(True)
         self.resize(600, 300)
 
-        metadataText = Qt.QTextEdit()
-        metadataText.setReadOnly(True)
-        metadataText.setText(image.metadata_pretty)
+        main_widget = MetadataDialog.build_metadata_tree(images.metadata)
 
         buttons = Qt.QDialogButtonBox(Qt.QDialogButtonBox.Ok)
         buttons.accepted.connect(self.accept)
 
         layout = Qt.QVBoxLayout()
-        layout.addWidget(metadataText)
+        layout.addWidget(main_widget)
         layout.addWidget(buttons)
         self.setLayout(layout)
+
+    @staticmethod
+    def build_metadata_tree(metadata):
+        """
+        Builds a QTreeWidget from the 'operation_history' metadata of an image.
+
+        The top level items are operations, and each has any args and/or kwargs as child nodes.
+        """
+        main_widget = QTreeWidget()
+        main_widget.setHeaderLabel("Operation history")
+        for i, op in enumerate(metadata[const.OPERATION_HISTORY]):
+            operation_item = QTreeWidgetItem(main_widget)
+            operation_item.setText(0, op[const.OPERATION_NAME])
+            main_widget.insertTopLevelItem(i, operation_item)
+
+            if op[const.OPERATION_ARGS]:
+                args_item = QTreeWidgetItem(operation_item)
+                args_item.setText(0, f"Positional arguments: {', '.join(op[const.OPERATION_ARGS])}")
+
+            if op[const.OPERATION_KEYWORD_ARGS]:
+                kwargs_list_item = QTreeWidgetItem(operation_item)
+                kwargs_list_item.setText(0, "Keyword arguments")
+                # Note: Items must be added to the tree before they can expanded.
+                # Nodes are added as they are created so these can be expanded by default
+                kwargs_list_item.setExpanded(True)
+                for kw, val in op[const.OPERATION_KEYWORD_ARGS].items():
+                    kwargs_item = QTreeWidgetItem(kwargs_list_item)
+                    kwargs_item.setText(0, f"{kw}: {val}")
+        return main_widget

--- a/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
+++ b/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
@@ -1,7 +1,8 @@
 from PyQt5 import Qt
 from PyQt5.QtWidgets import QWidget, QTreeWidget, QTreeWidgetItem
 
-from mantidimaging.core.data import Images, const
+from mantidimaging.core.data import Images
+from mantidimaging.core.operation_history import const
 
 
 class MetadataDialog(Qt.QDialog):
@@ -37,7 +38,11 @@ class MetadataDialog(Qt.QDialog):
         main_widget.setHeaderLabel("Operation history")
         for i, op in enumerate(metadata[const.OPERATION_HISTORY]):
             operation_item = QTreeWidgetItem(main_widget)
-            operation_item.setText(0, op[const.OPERATION_NAME])
+            if const.OPERATION_DISPLAY_NAME in op and op[const.OPERATION_DISPLAY_NAME]:
+                operation_item.setText(0, op[const.OPERATION_DISPLAY_NAME])
+            else:
+                operation_item.setText(0, op[const.OPERATION_NAME])
+
             main_widget.insertTopLevelItem(i, operation_item)
 
             if op[const.OPERATION_ARGS]:


### PR DESCRIPTION
Closes #320 

![metadata](https://user-images.githubusercontent.com/42145431/69075299-05796480-0a29-11ea-9891-5b8436dedc36.png)

Last two filters applied after second commit, I think including an optional display name is a nice to have.