### PR TITLE
Fix failing test

### DIFF
--- a/mantidimaging/core/filters/background_correction/test/background_correction_test.py
+++ b/mantidimaging/core/filters/background_correction/test/background_correction_test.py
@@ -135,8 +135,7 @@ class BackgroundCorrectionTest(unittest.TestCase):
         """
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
         """
-        execute_func = BackgroundCorrectionFilter.execute_wrapper(None, None)
-
+        execute_func = BackgroundCorrectionFilter.execute_wrapper(flat_path_widget=None, dark_path_widget=None)
         images, _ = th.gen_img_shared_array_and_copy()
         execute_func(images)
 

--- a/mantidimaging/gui/windows/filters/test/model_test.py
+++ b/mantidimaging/gui/windows/filters/test/model_test.py
@@ -56,10 +56,8 @@ class FiltersWindowModelTest(unittest.TestCase):
 
     def setup_mocks(self, execute_mock, do_before_mock=None, do_after_mock=None):
         f = self.model.selected_filter
-        orig_exec, orig_validate, orig_before, orig_after = f.execute_wrapper, \
-                                                            f.validate_execute_kwargs, \
-                                                            f.do_before_wrapper, \
-                                                            f.do_after_wrapper
+        orig_exec, orig_validate, orig_before, orig_after = \
+            f.execute_wrapper, f.validate_execute_kwargs, f.do_before_wrapper, f.do_after_wrapper
         self.model.setup_filter(0, {})
         f.execute_wrapper = lambda: execute_mock
         f.validate_execute_kwargs = lambda _: True

--- a/mantidimaging/gui/windows/filters/test/model_test.py
+++ b/mantidimaging/gui/windows/filters/test/model_test.py
@@ -55,15 +55,29 @@ class FiltersWindowModelTest(unittest.TestCase):
                          self.APPLY_BEFORE_AFTER_MAGIC_NUMBER)
 
     def setup_mocks(self, execute_mock, do_before_mock=None, do_after_mock=None):
+        f = self.model.selected_filter
+        orig_exec, orig_validate, orig_before, orig_after = f.execute_wrapper, \
+                                                            f.validate_execute_kwargs, \
+                                                            f.do_before_wrapper, \
+                                                            f.do_after_wrapper
         self.model.setup_filter(0, {})
-        self.model.selected_filter.execute_wrapper = lambda: execute_mock
-        self.model.selected_filter.validate_execute_kwargs = lambda _: True
+        f.execute_wrapper = lambda: execute_mock
+        f.validate_execute_kwargs = lambda _: True
 
         if do_before_mock:
-            self.model.selected_filter.do_before_wrapper = do_before_mock
+            f.do_before_wrapper = do_before_mock
 
         if do_after_mock:
-            self.model.selected_filter.do_after_wrapper = do_after_mock
+            f.do_after_wrapper = do_after_mock
+
+        return orig_exec, orig_validate, orig_before, orig_after
+
+    def reset_filter_model(self, exec, validate, before, after):
+        f = self.model.selected_filter
+        f.execute_wrapper = exec
+        f.validate_execute_kwargs = validate
+        f.do_before_wrapper = before
+        f.do_after_wrapper = after
 
     def test_filters_populated(self):
         self.assertTrue(len(self.model.filter_names) > 0)
@@ -72,9 +86,10 @@ class FiltersWindowModelTest(unittest.TestCase):
         self.model.stack = self.sv_presenter.view
 
         execute = mock.MagicMock(return_value=partial(self.execute_mock))
-        self.setup_mocks(execute)
+        originals = self.setup_mocks(execute)
 
         self.model.do_apply_filter()
+        self.reset_filter_model(*originals)
 
         execute.assert_called_once()
 
@@ -82,11 +97,12 @@ class FiltersWindowModelTest(unittest.TestCase):
         self.model.stack = self.sv_presenter.view
 
         execute = mock.MagicMock(return_value=partial(self.execute_mock_with_roi))
-        self.setup_mocks(execute)
+        originals = self.setup_mocks(execute)
         self.model.selected_filter.params = lambda: {'roi': SVParameters.ROI}
         self.model.do_apply_filter()
         # Reset state, as the same model is used for all tests
         self.model.selected_filter.params = lambda: {}
+        self.reset_filter_model(*originals)
 
         execute.assert_called_once()
 
@@ -96,9 +112,10 @@ class FiltersWindowModelTest(unittest.TestCase):
         execute = mock.MagicMock(return_value=partial(self.execute_mock))
         do_before = mock.MagicMock(return_value=partial(self.apply_before_mock))
         do_after = mock.MagicMock(return_value=partial(self.apply_after_mock))
-        self.setup_mocks(execute, do_before, do_after)
+        originals = self.setup_mocks(execute, do_before, do_after)
 
         self.model.do_apply_filter()
+        self.reset_filter_model(*originals)
 
         do_before.assert_called_once()
         execute.assert_called_once()
@@ -134,10 +151,11 @@ class FiltersWindowModelTest(unittest.TestCase):
         execute = mock.MagicMock(return_value=partial(self.execute_mock))
         execute.args = ["arg"]
         execute.keywords = {"kwarg": "kwarg"}
-        self.setup_mocks(execute)
+        originals = self.setup_mocks(execute)
 
         self.model.do_apply_filter()
         op_history = self.model.stack_presenter.images.metadata['operation_history']
+        self.reset_filter_model(*originals)
         self.assertEqual(len(op_history), 1, "One operation should have been recorded")
         self.assertEqual(op_history[0]['args'], ['arg'])
         self.assertEqual(op_history[0]['kwargs'], {"kwarg": "kwarg"})


### PR DESCRIPTION
There's probably a nicer way to fix this with `mock.patch` but it's a bit tricky due to the filter class inheritance going on. This PR saves and restores the original state of the wrapper functions after each test, so that when the actual functions are required by a later test they are available.