### PR TITLE
Run filters async with progress bar

### DIFF
--- a/mantidimaging/core/filters/gaussian/gaussian.py
+++ b/mantidimaging/core/filters/gaussian/gaussian.py
@@ -15,7 +15,7 @@ class GaussianFilter(BaseFilter):
     filter_name = "Gaussian"
 
     @staticmethod
-    def _filter_func(data, size=None, mode=None, order=None, cores=None, chunksize=None):
+    def _filter_func(data, size=None, mode=None, order=None, cores=None, chunksize=None, progress=None):
         """
         :param data: Input data as a 3D numpy.ndarray
         :param size: Size of the kernel
@@ -37,9 +37,9 @@ class GaussianFilter(BaseFilter):
 
         if size and size > 1:
             if pu.multiprocessing_available():
-                data = _execute_par(data, size, mode, order, cores, chunksize)
+                data = _execute_par(data, size, mode, order, cores, chunksize, progress)
             else:
-                data = _execute_seq(data, size, mode, order)
+                data = _execute_seq(data, size, mode, order, progress)
 
         h.check_data_stack(data)
         return data
@@ -153,7 +153,7 @@ def _execute_par(data, size, mode, order, cores=None, chunksize=None,
              "filter size/width: {1}.".format(data.dtype, size))
 
     progress.update()
-    data = psm.execute(data, f, cores, chunksize, "Gaussian")
+    data = psm.execute(data, f, cores, chunksize, "Gaussian", progress)
 
     progress.mark_complete()
     log.info("Finished  gaussian filter, with pixel data type: {0}, "

--- a/mantidimaging/core/filters/median_filter/median_filter.py
+++ b/mantidimaging/core/filters/median_filter/median_filter.py
@@ -128,6 +128,6 @@ def _execute_par(data, size, mode, cores=None, chunksize=None, progress=None):
                  "size/width: {1}.".format(data.dtype, size))
 
         progress.update()
-        data = psm.execute(data, f, cores, chunksize, "Median Filter")
+        data = psm.execute(data, f, cores, chunksize, "Median Filter", progress)
 
     return data

--- a/mantidimaging/core/filters/rebin/rebin.py
+++ b/mantidimaging/core/filters/rebin/rebin.py
@@ -167,7 +167,7 @@ def _execute_par(data, rebin_param, mode, cores=None, chunksize=None,
                                output_shape=resized_shape[1:])
 
         resized_data = pem.execute(
-            data, f, cores, chunksize, "Rebinning", output_data=resized_data)
+            data, f, cores, chunksize, "Rebinning", output_data=resized_data, progress=progress)
 
     return resized_data
 

--- a/mantidimaging/core/parallel/shared_mem.py
+++ b/mantidimaging/core/parallel/shared_mem.py
@@ -161,8 +161,7 @@ def execute(data=None,
                                         task_name=task_name)
 
     indices_list = pu.generate_indices(img_num)
-    for _ in enumerate(pool.imap(
-            partial_func, indices_list, chunksize=chunksize)):
+    for _ in pool.imap(partial_func, indices_list, chunksize=chunksize):
         progress.update()
 
     pool.close()

--- a/mantidimaging/gui/windows/filters/model.py
+++ b/mantidimaging/gui/windows/filters/model.py
@@ -7,6 +7,7 @@ import numpy as np
 from mantidimaging.core.data import Images
 from mantidimaging.core.filters.base_filter import BaseFilter
 from mantidimaging.core.filters.loader import load_filter_packages
+from mantidimaging.gui.dialogs.async_task import start_async_task_view
 from mantidimaging.gui.utility import get_parameters_from_stack
 from mantidimaging.gui.windows.stack_visualiser import SVNotification
 
@@ -66,17 +67,15 @@ class FiltersWindowModel(object):
         self.selected_filter = self.filters[filter_idx]
         self.filter_widget_kwargs = filter_widget_kwargs
 
-    def apply_filter(self, images: Images, stack_params: Dict[str, Any]):
+    def apply_filter(self, images: Images, stack_params: Dict[str, Any], progress=None):
         """
         Applies the selected filter to a given image stack.
         """
         log = getLogger(__name__)
 
-        # Generate the execute partial from filter registration
         do_before = self.selected_filter.do_before_wrapper()
         do_after = self.selected_filter.do_after_wrapper()
 
-        # Log execute function parameters
         log.info(f"Filter kwargs: {stack_params}")
 
         input_kwarg_widgets = self.filter_widget_kwargs.copy()
@@ -91,6 +90,7 @@ class FiltersWindowModel(object):
 
         # Run filter
         exec_func: partial = self.selected_filter.execute_wrapper(**input_kwarg_widgets)
+        exec_func.keywords["progress"] = progress
         ret_val = exec_func(images.sample, **stack_params)
 
         # Handle the return value from the algorithm dialog
@@ -121,8 +121,8 @@ class FiltersWindowModel(object):
 
         # Get auto parameters
         stack_params = get_parameters_from_stack(self.stack_presenter, self.params_needed_from_stack)
+        apply_func = partial(self.apply_filter, self.stack_presenter.images, stack_params)
 
-        self.apply_filter(self.stack_presenter.images, stack_params)
-
-        # Refresh the image in the stack visualiser
-        self.stack_presenter.notify(SVNotification.REFRESH_IMAGE)
+        start_async_task_view(self.stack_presenter.view,
+                              apply_func,
+                              lambda _: self.stack_presenter.notify(SVNotification.REFRESH_IMAGE))

--- a/mantidimaging/gui/windows/filters/test/model_test.py
+++ b/mantidimaging/gui/windows/filters/test/model_test.py
@@ -145,9 +145,10 @@ class FiltersWindowModelTest(unittest.TestCase):
         execute = mock.MagicMock(return_value=partial(self.execute_mock))
         execute.args = ["arg"]
         execute.keywords = {"kwarg": "kwarg"}
-        self.setup_mocks(execute)
+        originals = self.setup_mocks(execute)
 
         self.model.do_apply_filter()
+        self.reset_filter_model(*originals)
 
         op_history = self.model.stack_presenter.images.metadata['operation_history']
         self.assertEqual(len(op_history), 1, "One operation should have been recorded")

--- a/mantidimaging/gui/windows/filters/test/model_test.py
+++ b/mantidimaging/gui/windows/filters/test/model_test.py
@@ -77,21 +77,32 @@ class FiltersWindowModelTest(unittest.TestCase):
         f.do_before_wrapper = before
         f.do_after_wrapper = after
 
+    @staticmethod
+    def run_without_gui(task, on_complete):
+        task()
+        on_complete(None)
+
     def test_filters_populated(self):
         self.assertTrue(len(self.model.filter_names) > 0)
 
-    def test_do_apply_filter(self):
+    @mock.patch("mantidimaging.gui.windows.filters.model.start_async_task_view")
+    @mock.patch("mantidimaging.gui.windows.stack_visualiser.presenter.StackVisualiserPresenter.notify")
+    def test_do_apply_filter(self, mocked_notify, mocked_start_view):
+        mocked_start_view.side_effect = lambda _, task, on_complete: self.run_without_gui(task, on_complete)
         self.model.stack = self.sv_presenter.view
 
         execute = mock.MagicMock(return_value=partial(self.execute_mock))
         originals = self.setup_mocks(execute)
-
         self.model.do_apply_filter()
         self.reset_filter_model(*originals)
 
         execute.assert_called_once()
+        mocked_notify.assert_called_once()
 
-    def test_do_apply_filter_with_roi(self):
+    @mock.patch("mantidimaging.gui.windows.filters.model.start_async_task_view")
+    @mock.patch("mantidimaging.gui.windows.stack_visualiser.presenter.StackVisualiserPresenter.notify")
+    def test_do_apply_filter_with_roi(self, mocked_notify, mocked_start_view):
+        mocked_start_view.side_effect = lambda _, task, on_complete: self.run_without_gui(task, on_complete)
         self.model.stack = self.sv_presenter.view
 
         execute = mock.MagicMock(return_value=partial(self.execute_mock_with_roi))
@@ -103,8 +114,12 @@ class FiltersWindowModelTest(unittest.TestCase):
         self.reset_filter_model(*originals)
 
         execute.assert_called_once()
+        mocked_notify.assert_called_once()
 
-    def test_do_apply_filter_pre_post_processing(self):
+    @mock.patch("mantidimaging.gui.windows.filters.model.start_async_task_view")
+    @mock.patch("mantidimaging.gui.windows.stack_visualiser.presenter.StackVisualiserPresenter.notify")
+    def test_do_apply_filter_pre_post_processing(self, mocked_notify, mocked_start_view):
+        mocked_start_view.side_effect = lambda _, task, on_complete: self.run_without_gui(task, on_complete)
         self.model.stack = self.sv_presenter.view
 
         execute = mock.MagicMock(return_value=partial(self.execute_mock))
@@ -118,6 +133,27 @@ class FiltersWindowModelTest(unittest.TestCase):
         do_before.assert_called_once()
         execute.assert_called_once()
         do_after.assert_called_once()
+        mocked_notify.assert_called_once()
+
+    @mock.patch("mantidimaging.gui.windows.filters.model.start_async_task_view")
+    @mock.patch("mantidimaging.gui.windows.stack_visualiser.presenter.StackVisualiserPresenter.notify")
+    def test_operation_recorded_in_image_history(self, mocked_notify, mocked_start_view):
+        mocked_start_view.side_effect = lambda _, task, on_complete: self.run_without_gui(task, on_complete)
+        self.model.stack = self.sv_presenter.view
+        self.model.stack_presenter.images.metadata = {}
+
+        execute = mock.MagicMock(return_value=partial(self.execute_mock))
+        execute.args = ["arg"]
+        execute.keywords = {"kwarg": "kwarg"}
+        self.setup_mocks(execute)
+
+        self.model.do_apply_filter()
+
+        op_history = self.model.stack_presenter.images.metadata['operation_history']
+        self.assertEqual(len(op_history), 1, "One operation should have been recorded")
+        self.assertEqual(op_history[0]['args'], ['arg'])
+        self.assertEqual(op_history[0]['kwargs'], {"kwarg": "kwarg"})
+        mocked_notify.assert_called_once()
 
     def test_all_expected_filter_packages_loaded(self):
         expected_filter_names = ['Background Correction',
@@ -141,22 +177,6 @@ class FiltersWindowModelTest(unittest.TestCase):
             self.assert_(isinstance(filter_class(), BaseFilter))
         self.assertEqual(expected_filter_names,
                          self.model.filter_names, "Not all filters are named correctly")
-
-    def test_operation_recorded_in_image_history(self):
-        self.model.stack = self.sv_presenter.view
-        self.model.stack_presenter.images.metadata = {}
-
-        execute = mock.MagicMock(return_value=partial(self.execute_mock))
-        execute.args = ["arg"]
-        execute.keywords = {"kwarg": "kwarg"}
-        originals = self.setup_mocks(execute)
-
-        self.model.do_apply_filter()
-        op_history = self.model.stack_presenter.images.metadata['operation_history']
-        self.reset_filter_model(*originals)
-        self.assertEqual(len(op_history), 1, "One operation should have been recorded")
-        self.assertEqual(op_history[0]['args'], ['arg'])
-        self.assertEqual(op_history[0]['kwargs'], {"kwarg": "kwarg"})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #290 

This has highlighted that progress tracking doesn't seem to be very good for the filters, as they all either:
 - Call an external function for the majority of the processing.
 - Run in parallel if possible, which isn't handled very well.

Fixing either of these would likely be hard, so not sure it's really worth it unless specifically requested at some point.