### PR TITLE
Op history dialog improvements

### DIFF
--- a/mantidimaging/core/operation_history/operations.py
+++ b/mantidimaging/core/operation_history/operations.py
@@ -27,8 +27,16 @@ class ImageOperation:
         return ImageOperation(
             filter_name=metadata_entry[const.OPERATION_NAME],
             filter_args=metadata_entry[const.OPERATION_ARGS],
-            filter_kwargs=metadata_entry[const.OPERATION_KEYWORD_ARGS], )
-        # Waiting for #388 display_name=op_history[const.OPERATION_DISPLAY_NAME],
+            filter_kwargs=metadata_entry[const.OPERATION_KEYWORD_ARGS],
+            display_name=metadata_entry.get(const.OPERATION_DISPLAY_NAME))
+
+    def serialize(self) -> Dict[str, Any]:
+        return {
+            const.OPERATION_NAME: self.filter_class_name,
+            const.OPERATION_ARGS: self.filter_args,
+            const.OPERATION_KEYWORD_ARGS: self.filter_kwargs,
+            const.OPERATION_DISPLAY_NAME: self.display_name,
+        }
 
     def __str__(self):
         return f"{self.display_name if self.display_name else self.filter_class_name}, " \

--- a/mantidimaging/gui/dialogs/op_history_copy/model.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/model.py
@@ -8,10 +8,9 @@ class OpHistoryCopyDialogModel:
     def __init__(self, images):
         self.images: Images = images
 
-    def apply_ops(self, ops: Iterable[ImageOperation], indices_to_apply: Iterable[bool]):
+    def apply_ops(self, ops: Iterable[ImageOperation]):
         # TODO: Preserve + append stack history - here and/or presenter?
-        selected_ops = (op for op, i in zip(ops, indices_to_apply) if i)
-        to_apply = ops_to_partials(selected_ops)
+        to_apply = ops_to_partials(ops)
         image = self.images.sample
         for op in to_apply:
             image = op(image)

--- a/mantidimaging/gui/dialogs/op_history_copy/presenter.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/presenter.py
@@ -1,11 +1,14 @@
 from enum import Enum
-from typing import List
+from typing import List, TYPE_CHECKING
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.operation_history import const
 from mantidimaging.core.operation_history.operations import ImageOperation, deserialize_metadata
 from mantidimaging.gui.mvp_base import BasePresenter
 from .model import OpHistoryCopyDialogModel
+
+if TYPE_CHECKING:
+    from mantidimaging.gui.windows.main import MainWindowView
 
 
 class Notification(Enum):
@@ -15,8 +18,10 @@ class Notification(Enum):
 
 class OpHistoryCopyDialogPresenter(BasePresenter):
     operations: List[ImageOperation]
+    main_window: 'MainWindowView'
 
     def __init__(self, view, images: Images, main_window):
+
         super(OpHistoryCopyDialogPresenter, self).__init__(view)
         self.model = OpHistoryCopyDialogModel(images)
         self.main_window = main_window
@@ -28,7 +33,10 @@ class OpHistoryCopyDialogPresenter(BasePresenter):
         elif signal == Notification.APPLY_OPS:
             self.apply_ops()
 
-    def set_stack_uuid(self, uuid):
+    def set_target_stack(self, uuid):
+        self.model.images = self.main_window.get_stack_visualiser(uuid).presenter.images
+
+    def set_source_stack(self, uuid):
         history_to_apply = self.main_window.get_stack_history(uuid)
         self.operations = deserialize_metadata(history_to_apply)
         self.display_op_history()

--- a/mantidimaging/gui/dialogs/op_history_copy/presenter.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/presenter.py
@@ -37,5 +37,6 @@ class OpHistoryCopyDialogPresenter(BasePresenter):
         pass
 
     def apply_ops(self):
-        result = self.model.apply_ops(self.operations, self.view.selected_op_indices)
+        selected_ops = (op for op, selected in zip(self.operations, self.view.selected_op_indices) if selected)
+        result = self.model.apply_ops(selected_ops)
         self.main_window.create_new_stack(Images(result), "A result")

--- a/mantidimaging/gui/dialogs/op_history_copy/view.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/view.py
@@ -14,8 +14,10 @@ class OpHistoryCopyDialogView(BaseDialogView):
     def __init__(self, parent, images, main_window):
         super(OpHistoryCopyDialogView, self).__init__(parent, "gui/ui/op_history_copy_dialog.ui")
         self.presenter = OpHistoryCopyDialogPresenter(self, images, main_window)
-        self.stackSelector.stack_selected_uuid.connect(self.presenter.set_stack_uuid)
-        self.stackSelector.subscribe_to_main_window(main_window)
+        self.stackTargetSelector.stack_selected_uuid.connect(self.presenter.set_target_stack)
+        self.stackSourceSelector.stack_selected_uuid.connect(self.presenter.set_source_stack)
+        self.stackSourceSelector.subscribe_to_main_window(main_window)
+        self.stackTargetSelector.subscribe_to_main_window(main_window)
         self.previews = FilterPreviews()
         self.previewsLayout.addWidget(self.previews)
         self.applyButton.clicked.connect(lambda: self.presenter.notify(Notification.APPLY_OPS))

--- a/mantidimaging/gui/dialogs/op_history_copy/view.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/view.py
@@ -1,6 +1,6 @@
 from typing import Iterable, Tuple
 
-from PyQt5.QtWidgets import QCheckBox, QHBoxLayout, QLabel, QGroupBox, QWidget
+from PyQt5.QtWidgets import QCheckBox, QLabel, QGroupBox, QWidget, QSizePolicy, QGridLayout
 
 from mantidimaging.core.operation_history.operations import ImageOperation
 from mantidimaging.gui.mvp_base import BaseDialogView
@@ -38,12 +38,24 @@ class OpHistoryCopyDialogView(BaseDialogView):
     def build_operation_row(operation: ImageOperation) -> Tuple[QWidget, QCheckBox]:
         # TODO: layout nicely
         parent = QWidget()
-        layout = QHBoxLayout(parent)
-        parent.setLayout(layout)
+        parent_layout = QGridLayout(parent)
+        parent.setLayout(parent_layout)
 
         check = QCheckBox(parent=parent, checked=True)
-        layout.addWidget(check)
-        layout.addWidget(QLabel(operation.friendly_name))
+        check.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        parent_layout.addWidget(check, 0, 0)
+
+        foo = QLabel(operation.display_name)
+        foo.setStyleSheet('font-weight: bold')
+        parent_layout.addWidget(foo, 0, 1)
+        row_num = 1
+        for arg in operation.filter_args:
+            parent_layout.addWidget(QLabel(arg), row_num, 1)
+            row_num += 1
+
+        for k, v in operation.filter_kwargs.items():
+            parent_layout.addWidget(QLabel(f"{k}: {v}"), row_num, 1)
+            row_num += 1
 
         return parent, check
 

--- a/mantidimaging/gui/dialogs/op_history_copy/view.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/view.py
@@ -20,11 +20,7 @@ class OpHistoryCopyDialogView(BaseDialogView):
         self.previewsLayout.addWidget(self.previews)
         self.applyButton.clicked.connect(lambda: self.presenter.notify(Notification.APPLY_OPS))
 
-        self.op_checks = []
-
     def display_op_history(self, operations: Iterable[ImageOperation]):
-        # Clear the operations container
-        self.op_checks = []
         layout = self.operationsContainer.layout()
         while layout.count():
             row = layout.takeAt(0)
@@ -34,10 +30,10 @@ class OpHistoryCopyDialogView(BaseDialogView):
         for op in operations:
             row, check = self.build_operation_row(op)
             check.stateChanged.connect(lambda: self.presenter.notify(Notification.SELECTED_OPS_CHANGED))
-            self.op_checks.append(check)
             layout.addWidget(row)
 
-    def build_operation_row(self, operation: ImageOperation) -> Tuple[QWidget, QCheckBox]:
+    @staticmethod
+    def build_operation_row(operation: ImageOperation) -> Tuple[QWidget, QCheckBox]:
         # TODO: layout nicely
         parent = QWidget()
         layout = QHBoxLayout(parent)

--- a/mantidimaging/gui/dialogs/op_history_copy/view.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/view.py
@@ -36,18 +36,17 @@ class OpHistoryCopyDialogView(BaseDialogView):
 
     @staticmethod
     def build_operation_row(operation: ImageOperation) -> Tuple[QWidget, QCheckBox]:
-        # TODO: layout nicely
         parent = QWidget()
         parent_layout = QGridLayout(parent)
         parent.setLayout(parent_layout)
 
         check = QCheckBox(parent=parent, checked=True)
-        check.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        check.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Preferred)
         parent_layout.addWidget(check, 0, 0)
 
-        foo = QLabel(operation.display_name)
-        foo.setStyleSheet('font-weight: bold')
-        parent_layout.addWidget(foo, 0, 1)
+        op_name_label = QLabel(operation.display_name)
+        op_name_label.setStyleSheet('font-weight: bold')
+        parent_layout.addWidget(op_name_label, 0, 1)
         row_num = 1
         for arg in operation.filter_args:
             parent_layout.addWidget(QLabel(arg), row_num, 1)

--- a/mantidimaging/gui/ui/op_history_copy_dialog.ui
+++ b/mantidimaging/gui/ui/op_history_copy_dialog.ui
@@ -10,230 +10,201 @@
     <height>589</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="windowTitle">
    <string>Copy stack history</string>
   </property>
-  <widget class="QWidget" name="widget" native="true">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>0</y>
-     <width>791</width>
-     <height>591</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <widget class="QSplitter" name="splitter">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>0</y>
-      <width>782</width>
-      <height>582</height>
-     </rect>
-    </property>
-    <property name="orientation">
-     <enum>Qt::Horizontal</enum>
-    </property>
-    <property name="opaqueResize">
-     <bool>true</bool>
-    </property>
-    <property name="childrenCollapsible">
-     <bool>true</bool>
-    </property>
-    <widget class="QWidget" name="layoutWidget_3">
-     <layout class="QVBoxLayout" name="filterLayout">
-      <property name="sizeConstraint">
-       <enum>QLayout::SetDefaultConstraint</enum>
-      </property>
-      <property name="margin">
-       <number>9</number>
-      </property>
-      <item>
-       <layout class="QFormLayout" name="optionsLayout">
-        <property name="fieldGrowthPolicy">
-         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-        </property>
-        <item row="0" column="0">
-         <widget class="QLabel" name="stackTargetLabel">
-          <property name="text">
-           <string>Apply to:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="StackSelectorWidgetView" name="stackTargetSelector"/>
-        </item>
-        <item row="2" column="0" colspan="2">
-         <widget class="QGroupBox" name="operationsContainer">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="title">
-           <string>Operations:</string>
-          </property>
-          <property name="checkable">
-           <bool>false</bool>
-          </property>
-          <layout class="QFormLayout" name="filterPropertiesLayout_2">
-           <property name="fieldGrowthPolicy">
-            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+  <layout class="QHBoxLayout" name="horizontalLayout_2">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QFormLayout" name="formLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="stackTargetLabel">
+           <property name="text">
+            <string>Apply to:</string>
            </property>
-          </layout>
-         </widget>
-        </item>
-        <item row="3" column="0" colspan="2">
-         <widget class="QGroupBox" name="previewPropertiesContainer">
-          <property name="title">
-           <string>Preview</string>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="StackSelectorWidgetView" name="stackTargetSelector"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="stackSourceLabel">
+           <property name="text">
+            <string>Operations from:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="StackSelectorWidgetView" name="stackSourceSelector"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="operationsContainer">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="title">
+          <string>Operations:</string>
+         </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+         <layout class="QFormLayout" name="filterPropertiesLayout_2">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetMinimumSize</enum>
           </property>
-          <layout class="QHBoxLayout" name="horizontalLayout_3">
-           <item>
-            <widget class="QCheckBox" name="previewAutoUpdate">
-             <property name="text">
-              <string>Auto Update</string>
-             </property>
-             <property name="checked">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="updatePreviewButton">
-             <property name="enabled">
-              <bool>true</bool>
-             </property>
-             <property name="text">
-              <string>Update Now</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QLabel" name="previewImageIndexLabel">
-             <property name="text">
-              <string>Image:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="previewImageIndex"/>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="stackSourceLabel">
-          <property name="text">
-           <string>Operations from:</string>
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
           </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="StackSelectorWidgetView" name="stackSourceSelector"/>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="buttonLayout">
-        <item>
-         <spacer name="buttonSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="applyButton">
-          <property name="text">
-           <string>Apply To Stack</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-    <widget class="QWidget" name="layoutWidget_4">
-     <layout class="QVBoxLayout" name="previewsPaneLayout">
-      <item>
-       <layout class="QHBoxLayout" name="previewsPaneToolbar">
-        <property name="sizeConstraint">
-         <enum>QLayout::SetDefaultConstraint</enum>
-        </property>
-        <item alignment="Qt::AlignRight|Qt::AlignTop">
-         <widget class="QCheckBox" name="showHistogramLegend">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Show Legend</string>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item alignment="Qt::AlignRight|Qt::AlignTop">
-         <widget class="QCheckBox" name="combinedHistograms">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Combine histograms</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QVBoxLayout" name="previewsLayout"/>
-      </item>
-     </layout>
-    </widget>
-   </widget>
-  </widget>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="previewPropertiesContainer">
+         <property name="title">
+          <string>Preview</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <item>
+           <widget class="QCheckBox" name="previewAutoUpdate">
+            <property name="text">
+             <string>Auto Update</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="updatePreviewButton">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string>Update Now</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QLabel" name="previewImageIndexLabel">
+            <property name="text">
+             <string>Image:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="previewImageIndex"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="buttonLayout">
+         <item>
+          <spacer name="buttonSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="applyButton">
+           <property name="text">
+            <string>Apply To Stack</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="previewsPaneLayout">
+       <item>
+        <layout class="QHBoxLayout" name="previewsPaneToolbar">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetDefaultConstraint</enum>
+         </property>
+         <item alignment="Qt::AlignRight|Qt::AlignTop">
+          <widget class="QCheckBox" name="showHistogramLegend">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Show Legend</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignRight|Qt::AlignTop">
+          <widget class="QCheckBox" name="combinedHistograms">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>22</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Combine histograms</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="previewsLayout"/>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/mantidimaging/gui/ui/op_history_copy_dialog.ui
+++ b/mantidimaging/gui/ui/op_history_copy_dialog.ui
@@ -60,16 +60,16 @@
          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
         </property>
         <item row="0" column="0">
-         <widget class="QLabel" name="stackLabel">
+         <widget class="QLabel" name="stackTargetLabel">
           <property name="text">
-           <string>Stack:</string>
+           <string>Apply to:</string>
           </property>
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="StackSelectorWidgetView" name="stackSelector"/>
+         <widget class="StackSelectorWidgetView" name="stackTargetSelector"/>
         </item>
-        <item row="1" column="0" colspan="2">
+        <item row="2" column="0" colspan="2">
          <widget class="QGroupBox" name="operationsContainer">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -90,7 +90,7 @@
           </layout>
          </widget>
         </item>
-        <item row="2" column="0" colspan="2">
+        <item row="3" column="0" colspan="2">
          <widget class="QGroupBox" name="previewPropertiesContainer">
           <property name="title">
            <string>Preview</string>
@@ -141,6 +141,16 @@
            </item>
           </layout>
          </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="stackSourceLabel">
+          <property name="text">
+           <string>Operations from:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="StackSelectorWidgetView" name="stackSourceSelector"/>
         </item>
        </layout>
       </item>


### PR DESCRIPTION
More of #318 

- Keep and extend op history when copying to new stack
- Show arguments when selecting which ops to apply
- Option to choose target stack to apply ops to
- Improve layouts, particularly resizing behaviour

![Screenshot from 2019-12-03 15-39-27](https://user-images.githubusercontent.com/42145431/70065487-20300980-15e3-11ea-9ea6-09f82e8c8040.png)
