### PR TITLE
Savu filters

### DIFF
--- a/deps/dev-requirements.pip
+++ b/deps/dev-requirements.pip
@@ -1,7 +1,7 @@
 nose == 1.3.7
 nose-randomly == 1.2.6
 testfixtures == 6.10.0
-flake8 == 3.7.8
+flake8
 pylint == 2.4.3
 coverage == 4.5
 hazelnut == 0.4.1

--- a/docs/developer_guide/index.rst
+++ b/docs/developer_guide/index.rst
@@ -14,3 +14,4 @@ Developer Guide
    python_3x_performance_issues
    parallelism
    execution_splitter
+   savu_hebi

--- a/docs/developer_guide/release.rst
+++ b/docs/developer_guide/release.rst
@@ -9,9 +9,9 @@ The version number is expected to be in SemVer format and will be referred to as
 ``M.m.p``, adjust this as appropriate.
 
 - Update version numbers in:
-  - ``setup.py``
-  - ``mantidimaging/__init__.py``
-  - ``docs/conf.py``
+   - ``setup.py``
+   - ``mantidimaging/__init__.py``
+   - ``docs/conf.py``
 - Create Git tag from ``master``: ``git tag M.m.p --sign``
 - Push the tag to the repository: ``git push M.m.p``
 - (optional) Add release notes in GitHub

--- a/docs/developer_guide/savu_hebi.rst
+++ b/docs/developer_guide/savu_hebi.rst
@@ -36,9 +36,11 @@ How everything is connected:
 
 To apply a 'savu filter' to an image stack:
  - |process_list_built|
- - Submits a job to hebi with the pl and path to the input data.
- - Hebi validates everything and starts savu as a subprocess.
- - Once savu completes, hebi sends a message to imaging's ws client.
+ - Submits a job to hebi with the process list, and a path to the input data.
+ - Hebi validates everything. If there is a problem, responds with 400.
+ - Otherwise, hebi starts a savu subprocess to run the process list on the input and responds to imaging with a 200.
+ - Imaging joins a 'room' in hebi via websocket. Each room corresponds to a job.
+ - When savu completes a job, hebi sends a message to all clients in the matching room.
  - Imaging then loads an image stack from the folder savu wrote it's output to.
 
 .. |container_setup| replace:: A hebi container, which extends a savu container, runs locally. It is either started as a separate process, or automatically_ when the GUI starts up, as a subprocess.

--- a/docs/developer_guide/savu_hebi.rst
+++ b/docs/developer_guide/savu_hebi.rst
@@ -1,0 +1,48 @@
+Savu and hebi integration overview
+==================================
+
+Savu_ is a package developed at Diamond for processing tomographic data which is
+integrated into mantidimaging via Hebi_, a RESTful API. The aim of the integration
+is to be able to process data with savu's processing plugins via the gui, with a
+similar UX to using the tomopy filters built in to the 'filters' window. Savu is
+designed to run in a variety of environments, which makes the integration somewhat
+complicated.
+
+Savu workflow
+-------------
+
+Savu works by applying the plugins specified in a process list to the data in a folder.
+
+A process list:
+ - Is a nexus (.nxs) file
+ - Starts with a loader plugin
+ - Has one or more processing plugins
+ - Optionally ends with a saver plugin
+ - Internally to savu, can be built with `savu_config`
+
+Hebi
+----
+
+Hebi_ is a REST api on top of savu which creates and monitors 'jobs' running in savu.
+It is WIP, and the API can be expected to evolve over time.
+
+Imaging to hebi to savu and back
+--------------------------------
+
+How everything is connected:
+ - |container_setup|
+ - An http client is connected to hebi to submit jobs, ask for plugin details etc.
+ - A websocket client waits for messages from hebi, signalling when jobs complete.
+
+To apply a 'savu filter' to an image stack:
+ - |process_list_built|
+ - Submits a job to hebi with the pl and path to the input data.
+ - Hebi validates everything and starts savu as a subprocess.
+ - Once savu completes, hebi sends a message to imaging's ws client.
+ - Imaging then loads an image stack from the folder savu wrote it's output to.
+
+.. |container_setup| replace:: A hebi container, which extends a savu container, runs locally. It is either started as a separate process, or automatically_ when the GUI starts up, as a subprocess.
+.. |process_list_built| replace:: Imaging creates and saves a process list. It is composed of a (fixed) loader, a single processor with parameters taken from the GUI, and a (fixed) saver.
+.. _Hebi: https://github.com/DiamondLightSource/hebi
+.. _Savu: https://github.com/DiamondLightSource/savu
+.. _automatically: https://github.com/mantidproject/mantidimaging/pull/355

--- a/docs/user_guide/installation.rst
+++ b/docs/user_guide/installation.rst
@@ -18,7 +18,7 @@ have one on your machine.
   - :code:`conda config --prepend channels anaconda`
   - :code:`conda config --prepend channels defaults`
 
-3. Create a virtual environment with Mantid Imaging installed: :code:`conda create -n mantidimaging -c dtasev mantidimaging`
+3. Create a virtual environment with Mantid Imaging installed: :code:`conda create -n mantidimaging -c dtasev mantidimaging python=3.7`
 4. Activate the newly created environment: :code:`conda activate mantidimaging`
 5. Install additional :code:`pip` dependencies with :code:`pip install deps/pip-requirements.txt` from the source folder.
 

--- a/mantidimaging/core/utility/registrator.py
+++ b/mantidimaging/core/utility/registrator.py
@@ -50,7 +50,7 @@ def get_package_children(package_name, packages=False, modules=False, ignore=Non
     return pkgs
 
 
-def import_items(names: List[str], required_attributes: Optional[List[str]] = None) -> Iterator[object]:
+def import_items(names: List[str], required_attributes: Optional[List[str]] = None):
     """
     Imports a list of packages/modules and filters out those that do not have a
     specified required list of attributes.
@@ -61,13 +61,12 @@ def import_items(names: List[str], required_attributes: Optional[List[str]] = No
 
     :return: List of imported packages/modules
     """
-    imported: Iterator[Module] = (importlib.import_module(n) for n in names)
+    imported = (importlib.import_module(n) for n in names)
 
     # Filter out those that do not contain all the required attributes
     if required_attributes:
-        imported = filter(
-            lambda i: all([hasattr(i, a) for a in required_attributes]),    # type: ignore
-            imported)
+        imported = filter(  # type: ignore
+            lambda i: all([hasattr(i, a) for a in required_attributes]), imported)  # type: ignore
 
     return imported
 

--- a/mantidimaging/core/utility/registrator.py
+++ b/mantidimaging/core/utility/registrator.py
@@ -4,8 +4,6 @@ import pkgutil
 import sys
 from typing import List, Iterator, Optional
 
-from typed_ast._ast3 import Module
-
 
 def find_package_path(package_str):
     """
@@ -52,7 +50,7 @@ def get_package_children(package_name, packages=False, modules=False, ignore=Non
     return pkgs
 
 
-def import_items(names: List[str], required_attributes: Optional[List[str]] = None) -> Iterator[Module]:
+def import_items(names: List[str], required_attributes: Optional[List[str]] = None) -> Iterator[object]:
     """
     Imports a list of packages/modules and filters out those that do not have a
     specified required list of attributes.

--- a/mantidimaging/core/utility/savu_interop/plugin_list.py
+++ b/mantidimaging/core/utility/savu_interop/plugin_list.py
@@ -99,22 +99,32 @@ class SAVUPluginList:
 
         self.plugins: List[SAVUPluginListEntry] = []
 
-        self.append_plugins: List[SAVUPluginListEntry] = [
-            SAVUPluginListEntry(active=True,
-                                data=np.string_(
-                                    '{"in_datasets": [], "out_datasets": [], "prefix": null, "pattern": "VOLUME_XZ"}'),
-                                desc=np.string_(
-                                    '{"in_datasets": "The name of the dataset to save.", "out_datasets": "Hidden, '
-                                    'dummy out_datasets entry.", "prefix": "Override the default output tiff file '
-                                    'prefix.", "pattern": "How to slice the data."}'),
-                                hide=np.string_('["out_datasets"]'),
-                                id=np.string_('savu.plugins.savers.tiff_saver'),
-                                name=np.string_('TiffSaver'),
-                                user=np.string_('[]'))
-        ]
+        self.append_plugins: List[SAVUPluginListEntry] = []
 
     def add_plugin(self, plugin: SAVUPluginListEntry):
         self.plugins.append(plugin)
+
+    def finalize(self):
+        """
+        Append a saver plugin to the list. This should be called as a final method before saving the SPL.
+
+        This is not included in the constructor as the pattern of the data tob e saved is dependent on intermediate
+        plugins, which are added later, and entries are immutable.
+        """
+        pattern = "VOLUME_XZ" if b"recon" in self.plugins[-1].id else "PROJECTION"
+        self.append_plugins.append(
+            SAVUPluginListEntry(
+                active=True,
+                data=np.string_(
+                    '{"in_datasets": [], "out_datasets": [], "prefix": null, "pattern": "' + pattern + '"}'),
+                desc=np.string_(
+                    '{"in_datasets": "The name of the dataset to save.", "out_datasets": "Hidden, '
+                    'dummy out_datasets entry.", "prefix": "Override the default output tiff file '
+                    'prefix.", "pattern": "How to slice the data."}'),
+                hide=np.string_('["out_datasets"]'),
+                id=np.string_('savu.plugins.savers.tiff_saver'),
+                name=np.string_('TiffSaver'),
+                user=np.string_('[]')))
 
     def __len__(self):
         return len(self.prepend_plugins) + len(self.plugins) + len(self.append_plugins)

--- a/mantidimaging/core/utility/savu_interop/plugin_list.py
+++ b/mantidimaging/core/utility/savu_interop/plugin_list.py
@@ -45,8 +45,7 @@ class SAVUPlugin(object):
         """
         for param in self.parameters:
             if not param.is_hidden and \
-                    not param.name == "in_datasets" and \
-                    not param.name == "out_datasets":
+                    param.name not in ["in_datasets", "out_datasets", "preview"]:
                 yield param
 
 
@@ -75,14 +74,14 @@ class SAVUPluginList:
     # Savu has these spaces in there, they can't be removed or it won't properly load
     PLUGIN_INDEX_FMT = "   {} "
 
-    def __init__(self, data_prefix, num_images, preview=""):
+    def __init__(self, data_prefix, num_images, preview=None):
+        # preview is in format: [<indices start:end:step>, <rows start:end:step>, <columns start:end:step>]
         self.prepend_plugins: List[SAVUPluginListEntry] = [
-            # preview is in format: [<indices start:end:step>, <rows start:end:step>, <columns start:end:step>]
             SAVUPluginListEntry(active=True,
                                 data=np.string_(
                                     f'{{"data_prefix": "{data_prefix}", "flat_prefix": null, "dark_prefix": null, '
                                     f'"angles": "np.linspace(0, 360, {num_images})", '
-                                    f'"frame_dim": 0, "preview": "{preview}",'
+                                    f'"frame_dim": 0, "preview": ["{preview[0]}:{preview[1]}:{preview[2]}", ":", ":"],'
                                     f'"dataset_name": "tomo"}}'),
                                 desc=np.string_(
                                     '{"data_prefix": "A file prefix for the data file.", "flat_prefix": "A file prefix '

--- a/mantidimaging/external/pyqtgraph/imageview/ImageView.py
+++ b/mantidimaging/external/pyqtgraph/imageview/ImageView.py
@@ -609,7 +609,7 @@ class ImageView(QtGui.QWidget):
             ax = np.argmax(data.shape)
             sl = [slice(None)] * data.ndim
             sl[ax] = slice(None, None, 2)
-            data = data[sl]
+            data = data[tuple(sl)]
         return nanmin(data), nanmax(data)
 
     def normalize(self, image):

--- a/mantidimaging/gui/ui/savu_filters_window.ui
+++ b/mantidimaging/gui/ui/savu_filters_window.ui
@@ -6,229 +6,304 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
-    <height>600</height>
+    <width>707</width>
+    <height>651</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>SAVU Filters</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QVBoxLayout" name="verticalLayout">
+   <layout class="QHBoxLayout" name="horizontalLayout_3">
     <item>
-     <layout class="QHBoxLayout" name="stackParametersLayout" stretch="1,0">
+     <layout class="QVBoxLayout" name="filterParametersLayout">
       <item>
-       <layout class="QFormLayout" name="stackSelectorLayout">
-        <property name="sizeConstraint">
-         <enum>QLayout::SetMaximumSize</enum>
-        </property>
-        <property name="fieldGrowthPolicy">
-         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-        </property>
-        <property name="formAlignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-        <item row="0" column="0">
-         <widget class="QLabel" name="filterLabel">
-          <property name="text">
-           <string>Filter:</string>
+       <layout class="QHBoxLayout" name="stackParametersLayout" stretch="1,0">
+        <item>
+         <layout class="QFormLayout" name="stackSelectorLayout">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetMaximumSize</enum>
           </property>
-          <property name="buddy">
-           <cstring>filterSelector</cstring>
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
           </property>
-         </widget>
+          <property name="formAlignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="filterLabel">
+            <property name="text">
+             <string>Filter:</string>
+            </property>
+            <property name="buddy">
+             <cstring>filterSelector</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="filterSelector"/>
+          </item>
+          <item row="1" column="1">
+           <widget class="StackSelectorWidgetView" name="stackSelector"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="stackLabel">
+            <property name="text">
+             <string>Stack:</string>
+            </property>
+            <property name="buddy">
+             <cstring>stackSelector</cstring>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
-        <item row="0" column="1">
-         <widget class="QComboBox" name="filterSelector"/>
-        </item>
-        <item row="1" column="1">
-         <widget class="StackSelectorWidgetView" name="stackSelector"/>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="stackLabel">
-          <property name="text">
-           <string>Stack:</string>
+        <item>
+         <widget class="QGroupBox" name="indicesGroup">
+          <property name="maximumSize">
+           <size>
+            <width>387</width>
+            <height>16777215</height>
+           </size>
           </property>
-          <property name="buddy">
-           <cstring>stackSelector</cstring>
+          <property name="title">
+           <string>Indices</string>
           </property>
+          <property name="alignment">
+           <set>Qt::AlignHCenter|Qt::AlignTop</set>
+          </property>
+          <property name="flat">
+           <bool>false</bool>
+          </property>
+          <layout class="QFormLayout" name="formLayout">
+           <property name="sizeConstraint">
+            <enum>QLayout::SetMaximumSize</enum>
+           </property>
+           <item row="0" column="0">
+            <widget class="QLabel" name="startLabel">
+             <property name="text">
+              <string>Start</string>
+             </property>
+             <property name="buddy">
+              <cstring>startInput</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="startInput">
+             <property name="maximum">
+              <number>9999</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="endLabel">
+             <property name="text">
+              <string>End</string>
+             </property>
+             <property name="buddy">
+              <cstring>endInput</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QSpinBox" name="endInput">
+             <property name="maximum">
+              <number>9999</number>
+             </property>
+             <property name="value">
+              <number>9999</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="stepLabel">
+             <property name="text">
+              <string>Step</string>
+             </property>
+             <property name="buddy">
+              <cstring>stepInput</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="stepInput">
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>9999</number>
+             </property>
+             <property name="value">
+              <number>1</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </widget>
         </item>
        </layout>
       </item>
       <item>
-       <widget class="QGroupBox" name="indicesGroup">
-        <property name="maximumSize">
+       <widget class="QGroupBox" name="filterPropertiesContainer">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="title">
+         <string>Filter Properties</string>
+        </property>
+        <property name="checkable">
+         <bool>false</bool>
+        </property>
+        <layout class="QFormLayout" name="filterPropertiesLayout">
+         <property name="fieldGrowthPolicy">
+          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+         </property>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="filterDescriptionBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
          <size>
-          <width>387</width>
-          <height>16777215</height>
+          <width>0</width>
+          <height>60</height>
          </size>
         </property>
         <property name="title">
-         <string>Indices</string>
+         <string>Description</string>
         </property>
-        <property name="alignment">
-         <set>Qt::AlignHCenter|Qt::AlignTop</set>
-        </property>
-        <property name="flat">
-         <bool>false</bool>
-        </property>
-        <layout class="QFormLayout" name="formLayout">
-         <property name="sizeConstraint">
-          <enum>QLayout::SetMaximumSize</enum>
-         </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="startLabel">
-           <property name="text">
-            <string>Start</string>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <widget class="QTextEdit" name="info">
+           <property name="autoFillBackground">
+            <bool>false</bool>
            </property>
-           <property name="buddy">
-            <cstring>startInput</cstring>
+           <property name="readOnly">
+            <bool>true</bool>
            </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QSpinBox" name="startInput">
-           <property name="maximum">
-            <number>9999</number>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="endLabel">
-           <property name="text">
-            <string>End</string>
-           </property>
-           <property name="buddy">
-            <cstring>endInput</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QSpinBox" name="endInput">
-           <property name="maximum">
-            <number>9999</number>
-           </property>
-           <property name="value">
-            <number>9999</number>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="stepLabel">
-           <property name="text">
-            <string>Step</string>
-           </property>
-           <property name="buddy">
-            <cstring>stepInput</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QSpinBox" name="stepInput">
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>9999</number>
-           </property>
-           <property name="value">
-            <number>1</number>
+           <property name="textInteractionFlags">
+            <set>Qt::NoTextInteraction</set>
            </property>
           </widget>
          </item>
         </layout>
        </widget>
       </item>
+      <item>
+       <layout class="QHBoxLayout" name="pluginButtonLayout">
+        <property name="sizeConstraint">
+         <enum>QLayout::SetFixedSize</enum>
+        </property>
+        <item>
+         <spacer name="buttonSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="addPluginToListButton">
+          <property name="text">
+           <string>Add To Process List</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="applyButton">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>27</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Apply Filter To Stack</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
     </item>
     <item>
-     <widget class="QGroupBox" name="filterPropertiesContainer">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
+     <widget class="Line" name="line">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
       </property>
-      <property name="title">
-       <string>Filter Properties</string>
-      </property>
-      <property name="checkable">
-       <bool>false</bool>
-      </property>
-      <layout class="QFormLayout" name="filterPropertiesLayout">
-       <property name="fieldGrowthPolicy">
-        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-       </property>
-      </layout>
      </widget>
     </item>
     <item>
-     <widget class="QGroupBox" name="filterDescriptionBox">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>0</width>
-        <height>60</height>
-       </size>
-      </property>
-      <property name="title">
-       <string>Description</string>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
-       <item>
-        <widget class="QTextEdit" name="info">
-         <property name="autoFillBackground">
-          <bool>false</bool>
-         </property>
-         <property name="readOnly">
-          <bool>true</bool>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::NoTextInteraction</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="buttonLayout">
-         <property name="sizeConstraint">
-          <enum>QLayout::SetFixedSize</enum>
-         </property>
-         <item>
-          <spacer name="buttonSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QPushButton" name="applyButton">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>27</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Apply To Stack</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
+     <layout class="QVBoxLayout" name="processListLayout">
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="processListButtonLayout">
+        <property name="sizeConstraint">
+         <enum>QLayout::SetFixedSize</enum>
+        </property>
+        <item>
+         <spacer name="buttonSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="saveListButton">
+          <property name="text">
+           <string>Save Process List</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="applyListButton">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>27</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Apply List To Stack</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
     </item>
    </layout>
   </widget>

--- a/mantidimaging/gui/ui/savu_filters_window.ui
+++ b/mantidimaging/gui/ui/savu_filters_window.ui
@@ -16,184 +16,218 @@
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
-     <widget class="QSplitter" name="splitter">
-      <property name="orientation">
-       <enum>Qt::Horizontal</enum>
-      </property>
-      <property name="opaqueResize">
-       <bool>true</bool>
-      </property>
-      <property name="childrenCollapsible">
-       <bool>true</bool>
-      </property>
-      <widget class="QWidget" name="layoutWidget">
-       <layout class="QVBoxLayout" name="filterLayout">
+     <layout class="QHBoxLayout" name="stackParametersLayout" stretch="1,0">
+      <item>
+       <layout class="QFormLayout" name="stackSelectorLayout">
         <property name="sizeConstraint">
-         <enum>QLayout::SetDefaultConstraint</enum>
+         <enum>QLayout::SetMaximumSize</enum>
         </property>
-        <property name="margin">
-         <number>9</number>
+        <property name="fieldGrowthPolicy">
+         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
         </property>
-        <item>
-         <layout class="QFormLayout" name="optionsLayout">
-          <property name="fieldGrowthPolicy">
-           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+        <property name="formAlignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <item row="0" column="0">
+         <widget class="QLabel" name="filterLabel">
+          <property name="text">
+           <string>Filter:</string>
           </property>
-          <item row="0" column="0">
-           <widget class="QLabel" name="filterLabel">
-            <property name="text">
-             <string>Filter:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="filterSelector"/>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="stackLabel">
-            <property name="text">
-             <string>Stack:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="StackSelectorWidgetView" name="stackSelector"/>
-          </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QGroupBox" name="filterPropertiesContainer">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="title">
-             <string>Filter Properties</string>
-            </property>
-            <property name="checkable">
-             <bool>false</bool>
-            </property>
-            <layout class="QFormLayout" name="filterPropertiesLayout">
-             <property name="fieldGrowthPolicy">
-              <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-             </property>
-            </layout>
-           </widget>
-          </item>
-          <item row="3" column="0" colspan="2">
-           <widget class="QGroupBox" name="previewPropertiesContainer">
-            <property name="title">
-             <string>Preview</string>
-            </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_2">
-             <item>
-              <widget class="QCheckBox" name="previewAutoUpdate">
-               <property name="text">
-                <string>Auto Update</string>
-               </property>
-               <property name="checked">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="updatePreviewButton">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="text">
-                <string>Update Now</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QLabel" name="previewImageIndexLabel">
-               <property name="text">
-                <string>Image:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QSpinBox" name="previewImageIndex"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="4" column="0" colspan="2">
-           <widget class="QGroupBox" name="filterDescriptionBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>60</height>
-             </size>
-            </property>
-            <property name="title">
-             <string>Description</string>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_3">
-             <item>
-              <widget class="QTextEdit" name="info">
-               <property name="autoFillBackground">
-                <bool>false</bool>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-               <property name="textInteractionFlags">
-                <set>Qt::NoTextInteraction</set>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
+          <property name="buddy">
+           <cstring>filterSelector</cstring>
+          </property>
+         </widget>
         </item>
-        <item>
-         <layout class="QHBoxLayout" name="buttonLayout">
-          <item>
-           <spacer name="buttonSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QPushButton" name="applyButton">
-            <property name="text">
-             <string>Apply To Stack</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="filterSelector"/>
+        </item>
+        <item row="1" column="1">
+         <widget class="StackSelectorWidgetView" name="stackSelector"/>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="stackLabel">
+          <property name="text">
+           <string>Stack:</string>
+          </property>
+          <property name="buddy">
+           <cstring>stackSelector</cstring>
+          </property>
+         </widget>
         </item>
        </layout>
-      </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="indicesGroup">
+        <property name="maximumSize">
+         <size>
+          <width>387</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="title">
+         <string>Indices</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignHCenter|Qt::AlignTop</set>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
+        </property>
+        <layout class="QFormLayout" name="formLayout">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetMaximumSize</enum>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="startLabel">
+           <property name="text">
+            <string>Start</string>
+           </property>
+           <property name="buddy">
+            <cstring>startInput</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QSpinBox" name="startInput">
+           <property name="maximum">
+            <number>9999</number>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="endLabel">
+           <property name="text">
+            <string>End</string>
+           </property>
+           <property name="buddy">
+            <cstring>endInput</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="endInput">
+           <property name="maximum">
+            <number>9999</number>
+           </property>
+           <property name="value">
+            <number>9999</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="stepLabel">
+           <property name="text">
+            <string>Step</string>
+           </property>
+           <property name="buddy">
+            <cstring>stepInput</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QSpinBox" name="stepInput">
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>9999</number>
+           </property>
+           <property name="value">
+            <number>1</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <widget class="QGroupBox" name="filterPropertiesContainer">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="title">
+       <string>Filter Properties</string>
+      </property>
+      <property name="checkable">
+       <bool>false</bool>
+      </property>
+      <layout class="QFormLayout" name="filterPropertiesLayout">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+       </property>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <widget class="QGroupBox" name="filterDescriptionBox">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>60</height>
+       </size>
+      </property>
+      <property name="title">
+       <string>Description</string>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QTextEdit" name="info">
+         <property name="autoFillBackground">
+          <bool>false</bool>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::NoTextInteraction</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="buttonLayout">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetFixedSize</enum>
+         </property>
+         <item>
+          <spacer name="buttonSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="applyButton">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>27</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Apply To Stack</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
      </widget>
     </item>
    </layout>

--- a/mantidimaging/gui/ui/savu_filters_window.ui
+++ b/mantidimaging/gui/ui/savu_filters_window.ui
@@ -218,7 +218,7 @@
          </spacer>
         </item>
         <item>
-         <widget class="QPushButton" name="addPluginToListButton">
+         <widget class="QPushButton" name="confirmPluginButton">
           <property name="text">
            <string>Add To Process List</string>
           </property>

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -71,7 +71,7 @@ class MainWindowView(BaseMainWindowView):
         self.actionCorTilt.triggered.connect(self.show_cor_tilt_window)
         self.actionCorTilt.setShortcut("Ctrl+R")
         self.actionTomopyRecon.triggered.connect(self.show_tomopy_recon_window)
-        self.actionTomopyRecon.setShortcut("Ctrl+Shfit+R")
+        self.actionTomopyRecon.setShortcut("Ctrl+Shift+R")
 
         self.active_stacks_changed.connect(self.update_shortcuts)
 

--- a/mantidimaging/gui/windows/savu_filters/model.py
+++ b/mantidimaging/gui/windows/savu_filters/model.py
@@ -146,7 +146,7 @@ class SavuFiltersWindowModel(object):
         self.PROCESS_LIST_DIR.mkdir(parents=True, exist_ok=True)
 
         if name is None:
-            name = f"pl_{self.stack.name}_{len(spl)}.nxs" if self.stack else "pl_unnamed"
+            name = f"pl_{self.stack.name}_{len(spl)}.nxs" if self.stack else "pl_unnamed.nxs"
         elif not name.endswith(".nxs"):
             name = name + ".nxs"
 

--- a/mantidimaging/gui/windows/savu_filters/model.py
+++ b/mantidimaging/gui/windows/savu_filters/model.py
@@ -138,10 +138,10 @@ class SavuFiltersWindowModel(object):
             raise ValueError("Invalid indices, start must be less than end")
 
         dataset = self._get_dataset_path()
-        pl_path = self.save_process_list(plugin_entries)
+        pl_path = self.save_process_list(plugin_entries, indices)
         self.do_apply_process_list(pl_path, dataset)
 
-    def save_process_list(self, plugin_entries: List[SAVUPluginListEntry], indices):
+    def save_process_list(self, plugin_entries: List[SAVUPluginListEntry], indices, name: Optional[str] = None):
         prefix = self._get_file_prefix()
 
         # save out nxs file
@@ -154,7 +154,12 @@ class SavuFiltersWindowModel(object):
         # if they already exist, nothing is done
         self.PROCESS_LIST_DIR.mkdir(parents=True, exist_ok=True)
 
-        file = self.PROCESS_LIST_DIR / f"pl_{self.stack.name}_{len(spl)}.nxs"
+        if name is None:
+            name = f"pl_{self.stack.name}_{len(spl)}.nxs" if self.stack else "pl_unnamed"
+        elif not name.endswith(".nxs"):
+            name = name + ".nxs"
+
+        file = self.PROCESS_LIST_DIR / name
         savu_config_writer.save(spl, file, overwrite=True)
         return file
 
@@ -222,7 +227,7 @@ class SavuFiltersWindowModel(object):
         # self.stack_presenter.notify(SVNotification.REFRESH_IMAGE)
 
     @staticmethod
-    def create_plugin_entry_from(current_filter: CurrentFilterData):
+    def create_plugin_entry_from(current_filter: CurrentFilterData) -> SAVUPluginListEntry:
         plugin = current_filter[0]
         data = {}
         description = {}
@@ -249,4 +254,3 @@ class SavuFiltersWindowModel(object):
                                    id=np.string_(plugin.id),
                                    name=np.string_(plugin.name),
                                    user=np.string_("[]"))
-

--- a/mantidimaging/gui/windows/savu_filters/model.py
+++ b/mantidimaging/gui/windows/savu_filters/model.py
@@ -180,6 +180,7 @@ class SavuFiltersWindowModel(object):
         spl = SAVUPluginList(prefix, self.stack_presenter.images.count())
         plugin = self._create_plugin_entry_from(current_filter)
         spl.add_plugin(plugin)
+        spl.finalize()
 
         # makes sure the directories exists, they are created recursively
         # if they already exist, nothing is done

--- a/mantidimaging/gui/windows/savu_filters/model.py
+++ b/mantidimaging/gui/windows/savu_filters/model.py
@@ -131,6 +131,9 @@ class SavuFiltersWindowModel(object):
         self.apply_process_list([plugin], indices)
 
     def apply_process_list(self, plugin_entries: List[SAVUPluginListEntry], indices):
+        if not plugin_entries:
+            raise ValueError("No plugins selected")
+
         if not self.stack:
             raise ValueError("No stack selected")
 

--- a/mantidimaging/gui/windows/savu_filters/model.py
+++ b/mantidimaging/gui/windows/savu_filters/model.py
@@ -24,10 +24,6 @@ if TYPE_CHECKING:
 CurrentFilterData = Union[Tuple, Tuple[SAVUPlugin, List[QWidget]]]
 
 
-def ensure_tuple(val):
-    return val if isinstance(val, tuple) else (val,)
-
-
 class SavuFiltersWindowModel(object):
     PROCESS_LIST_DIR = Path("~/mantidimaging/process_lists").expanduser()
 
@@ -38,9 +34,6 @@ class SavuFiltersWindowModel(object):
         self.presenter: 'SavuFiltersWindowPresenter' = presenter
 
         self.parameters_from_stack = {}
-        self.do_before_wrapper = lambda: lambda: None
-        self.execute_wrapper = lambda: lambda _: None
-        self.do_after_wrapper = lambda: lambda *_: None
 
         # Update the local filter registry
         self.filters: List[SAVUPlugin] = []
@@ -103,11 +96,6 @@ class SavuFiltersWindowModel(object):
     @property
     def stack_presenter(self):
         return self.stack.presenter if self.stack else None
-
-    @property
-    def num_images_in_stack(self):
-        num_images = self.stack_presenter.images.sample.shape[0] if self.stack_presenter is not None else 0
-        return num_images
 
     @property
     def image_shape(self):

--- a/mantidimaging/gui/windows/savu_filters/presenter.py
+++ b/mantidimaging/gui/windows/savu_filters/presenter.py
@@ -54,11 +54,12 @@ class SavuFiltersWindowPresenter(BasePresenter):
         if self.model.stack:
             self.model.stack.roi_updated.disconnect(self.handle_roi_selection)
 
+        self.model.stack = stack
+
         # Connect ROI update signal to newly selected stack
         if stack:
             stack.roi_updated.connect(self.handle_roi_selection)
-
-        self.model.stack = stack
+            self.view.reset_indices_inputs(self.model.image_shape)
 
     def handle_roi_selection(self, roi):
         if roi:
@@ -101,7 +102,8 @@ class SavuFiltersWindowPresenter(BasePresenter):
 
     def do_apply_filter(self):
         self.view.clear_output_text()
-        self.model.do_apply_filter(self.current_filter)
+        indices = [self.view.startInput.value(), self.view.endInput.value(), self.view.stepInput.value()]
+        self.model.do_apply_filter(self.current_filter, indices)
 
     def do_job_submission_success(self, response_content: JobRunResponseContent):
         self.remote_presenter.do_job_submission_success(response_content)

--- a/mantidimaging/gui/windows/savu_filters/presenter.py
+++ b/mantidimaging/gui/windows/savu_filters/presenter.py
@@ -29,7 +29,7 @@ class Notification(Enum):
 
 
 class Mode(Enum):
-    """To determine if a new plugin is being configured, or one in the process list is being edited
+    """To determine if a new plugin is being configured, or one in the process list is being edited.
 
     The presenter is initially in ADDING mode. When the parameters of a plugin are loaded from the process list,
     it switches to EDITING mode. If a new filter is selected from the dropdown, or the

--- a/mantidimaging/gui/windows/savu_filters/presenter.py
+++ b/mantidimaging/gui/windows/savu_filters/presenter.py
@@ -39,8 +39,8 @@ class Mode(Enum):
 
 
 class SavuFiltersWindowPresenter(BasePresenter):
-    def __init__(self, view: 'SavuFiltersWindowView',
-                 main_window: 'MainWindowView',
+
+    def __init__(self, view: 'SavuFiltersWindowView', main_window: 'MainWindowView',
                  remote_presenter: SavuFiltersRemotePresenter):
         super(SavuFiltersWindowPresenter, self).__init__(view)
 
@@ -144,7 +144,10 @@ class SavuFiltersWindowPresenter(BasePresenter):
         self.remote_presenter.do_job_submission_success(response_content)
 
     def do_job_submission_failure(self, error_response: Response):
-        raise NotImplementedError(f"(Unhandled) error response from hebi:\n{error_response.reason}")
+        er = json.loads(error_response.text)
+        msg = f"Error response from hebi:\n{error_response.status_code}: {error_response.reason}\n{er['message']}"
+        self.view.append_output_text(msg)
+        raise NotImplementedError(msg)
 
     def confirm_plugin(self):
         entry = SavuFiltersWindowModel.create_plugin_entry_from(self.current_filter)

--- a/mantidimaging/gui/windows/savu_filters/process_list/__init__.py
+++ b/mantidimaging/gui/windows/savu_filters/process_list/__init__.py
@@ -1,0 +1,3 @@
+from .view import ProcessListView  # noqa: F401
+from .presenter import ProcessListPresenter  # noqa: F401
+from .model import ProcessListModel  # noqa: F401

--- a/mantidimaging/gui/windows/savu_filters/process_list/model.py
+++ b/mantidimaging/gui/windows/savu_filters/process_list/model.py
@@ -1,0 +1,3 @@
+class ProcessListModel:
+    def __init__(self):
+        self.plugins = []

--- a/mantidimaging/gui/windows/savu_filters/process_list/presenter.py
+++ b/mantidimaging/gui/windows/savu_filters/process_list/presenter.py
@@ -1,6 +1,8 @@
 from enum import Enum, auto
 from typing import TYPE_CHECKING
 
+from mantidimaging.core.utility.savu_interop.plugin_list import SAVUPluginListEntry
+
 from .model import ProcessListModel
 
 if TYPE_CHECKING:
@@ -17,7 +19,7 @@ class ProcessListPresenter:
         self.view = view
         self.model = ProcessListModel()
 
-    def notify(self, signal):
+    def notify(self, signal: Notification):
         if signal == Notification.CHANGE_ORDER:
             self.change_order(self.view.order_change_request)
             self.view.order_change_request = None
@@ -38,3 +40,9 @@ class ProcessListPresenter:
     def remove_plugin(self, index):
         self.view.remove_plugin(index)
         self.model.plugins.pop(index)
+
+    def edit_plugin(self, index):
+        pass
+
+    def overwrite_plugin(self, index: int, entry: SAVUPluginListEntry):
+        self.model.plugins[index] = entry

--- a/mantidimaging/gui/windows/savu_filters/process_list/presenter.py
+++ b/mantidimaging/gui/windows/savu_filters/process_list/presenter.py
@@ -1,0 +1,40 @@
+from enum import Enum, auto
+from typing import TYPE_CHECKING
+
+from .model import ProcessListModel
+
+if TYPE_CHECKING:
+    from .view import ProcessListView
+
+
+class Notification(Enum):
+    CHANGE_ORDER = auto()
+    REMOVE_PLUGIN = auto()
+
+
+class ProcessListPresenter:
+    def __init__(self, view: 'ProcessListView'):
+        self.view = view
+        self.model = ProcessListModel()
+
+    def notify(self, signal):
+        if signal == Notification.CHANGE_ORDER:
+            self.change_order(self.view.order_change_request)
+            self.view.order_change_request = None
+        elif signal == Notification.REMOVE_PLUGIN:
+            self.remove_plugin(self.view.to_remove)
+            self.view.to_remove = None
+
+    def add_plugin(self, plugin):
+        self.view.display_plugin(plugin.name.decode("utf-8"))
+        self.model.plugins.append(plugin)
+
+    def change_order(self, indices_to_change):
+        start_index, new_index = indices_to_change
+        self.view.swap(start_index, new_index)
+        self.model.plugins[start_index], self.model.plugins[new_index] = \
+            self.model.plugins[new_index], self.model.plugins[start_index]
+
+    def remove_plugin(self, index):
+        self.view.remove_plugin(index)
+        self.model.plugins.pop(index)

--- a/mantidimaging/gui/windows/savu_filters/process_list/presenter.py
+++ b/mantidimaging/gui/windows/savu_filters/process_list/presenter.py
@@ -1,5 +1,5 @@
 from enum import Enum, auto
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
 
 from mantidimaging.core.utility.savu_interop.plugin_list import SAVUPluginListEntry
 
@@ -17,32 +17,34 @@ class Notification(Enum):
 class ProcessListPresenter:
     def __init__(self, view: 'ProcessListView'):
         self.view = view
-        self.model = ProcessListModel()
+        self.model: ProcessListModel = ProcessListModel()
 
     def notify(self, signal: Notification):
         if signal == Notification.CHANGE_ORDER:
+            if self.view.order_change_request is None:
+                raise RuntimeError("Process list view 'order_change_request' was unexpectedly unset")
             self.change_order(self.view.order_change_request)
             self.view.order_change_request = None
+
         elif signal == Notification.REMOVE_PLUGIN:
+            if self.view.to_remove is None:
+                raise RuntimeError("Process list view 'to_remove' was unexpectedly unset")
             self.remove_plugin(self.view.to_remove)
             self.view.to_remove = None
 
-    def add_plugin(self, plugin):
+    def add_plugin(self, plugin: SAVUPluginListEntry):
         self.view.display_plugin(plugin.name.decode("utf-8"))
         self.model.plugins.append(plugin)
 
-    def change_order(self, indices_to_change):
+    def change_order(self, indices_to_change: Tuple[int, int]):
         start_index, new_index = indices_to_change
         self.view.swap(start_index, new_index)
         self.model.plugins[start_index], self.model.plugins[new_index] = \
             self.model.plugins[new_index], self.model.plugins[start_index]
 
-    def remove_plugin(self, index):
+    def remove_plugin(self, index: int):
         self.view.remove_plugin(index)
         self.model.plugins.pop(index)
-
-    def edit_plugin(self, index):
-        pass
 
     def overwrite_plugin(self, index: int, entry: SAVUPluginListEntry):
         self.model.plugins[index] = entry

--- a/mantidimaging/gui/windows/savu_filters/process_list/test/presenter_test.py
+++ b/mantidimaging/gui/windows/savu_filters/process_list/test/presenter_test.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest import mock
+
+import numpy as np
+
+from mantidimaging.core.utility.savu_interop.plugin_list import SAVUPluginListEntry
+from mantidimaging.gui.windows.savu_filters.process_list import ProcessListView, ProcessListPresenter
+
+
+PLUGIN_NAME = "TestPlugin"
+
+
+class ProcessListPresenterTest(unittest.TestCase):
+    def setUp(self):
+        view = mock.create_autospec(ProcessListView)
+        self.presenter = ProcessListPresenter(view)
+
+    @staticmethod
+    def _test_plugin():
+        return SAVUPluginListEntry(True, *[np.string_() for _ in range(4)],
+                                   name=np.string_(PLUGIN_NAME), user=np.string_())
+
+    def test_add_plugin(self):
+        plugin = self._test_plugin()
+        self.presenter.add_plugin(plugin)
+        self.assertEqual(len(self.presenter.model.plugins), 1, "Model should have a plugin")
+        self.assertEqual(self.presenter.model.plugins[0], plugin, "Plugin in model should be the one added")
+        self.presenter.view.display_plugin.assert_called_once_with(PLUGIN_NAME)

--- a/mantidimaging/gui/windows/savu_filters/process_list/test/view_test.py
+++ b/mantidimaging/gui/windows/savu_filters/process_list/test/view_test.py
@@ -1,0 +1,67 @@
+import sys
+import unittest
+
+from PyQt5 import Qt
+
+from mantidimaging.gui.windows.savu_filters.process_list import ProcessListView
+
+app = Qt.QApplication(sys.argv)
+PLUGIN_NAME_1 = "TestPlugin"
+PLUGIN_NAME_2 = "TestPlugin2"
+
+
+class ProcessListViewTest(unittest.TestCase):
+    def setUp(self):
+        self.view = ProcessListView(None)
+
+    def _get_plugin_widget(self, n):
+        return self.view.processing_plugins_layout.itemAt(n).widget()
+
+    def test_plugins_labelled_correctly(self):
+        self.view.display_plugin(PLUGIN_NAME_1)
+        self.view.display_plugin(PLUGIN_NAME_2)
+
+        def get_button_text(plugin_widget):
+            return plugin_widget.layout().itemAt(1).widget().text()
+
+        self.assertEqual(self._get_plugin_widget(0).pos_label.text(), "1")
+        self.assertEqual(self._get_plugin_widget(1).pos_label.text(), "2")
+        self.assertEqual(get_button_text(self._get_plugin_widget(0)), PLUGIN_NAME_1)
+        self.assertEqual(get_button_text(self._get_plugin_widget(1)), PLUGIN_NAME_2)
+
+    def test_movement_button_states(self):
+        self.view.display_plugin(PLUGIN_NAME_1)
+        self.assertEqual(self._get_plugin_widget(0).up_button.isEnabled(), False)
+        self.assertEqual(self._get_plugin_widget(0).down_button.isEnabled(), False)
+
+        self.view.display_plugin(PLUGIN_NAME_1)
+        self.assertEqual(self._get_plugin_widget(0).up_button.isEnabled(), False)
+        self.assertEqual(self._get_plugin_widget(0).down_button.isEnabled(), True)
+        self.assertEqual(self._get_plugin_widget(1).up_button.isEnabled(), True)
+        self.assertEqual(self._get_plugin_widget(1).down_button.isEnabled(), False)
+
+        self.view.display_plugin(PLUGIN_NAME_1)
+        self.assertEqual(self._get_plugin_widget(0).up_button.isEnabled(), False)
+        self.assertEqual(self._get_plugin_widget(0).down_button.isEnabled(), True)
+        self.assertEqual(self._get_plugin_widget(1).up_button.isEnabled(), True)
+        self.assertEqual(self._get_plugin_widget(1).down_button.isEnabled(), True)
+        self.assertEqual(self._get_plugin_widget(2).up_button.isEnabled(), True)
+        self.assertEqual(self._get_plugin_widget(2).down_button.isEnabled(), False)
+
+    def test_remove_plugin_only_plugin(self):
+        self.view.display_plugin(PLUGIN_NAME_1)
+        self.view.remove_plugin(0)
+        self.assertEqual(len(self.view.plugin_widgets), 0)
+        with self.assertRaises(AttributeError):
+            self._get_plugin_widget(0)
+
+    def test_remove_plugin_movement_arrows_correct(self):
+        self.view.display_plugin(PLUGIN_NAME_1)
+        self.view.display_plugin(PLUGIN_NAME_1)
+        self.view.display_plugin(PLUGIN_NAME_1)
+        self.view.remove_plugin(0)
+        self.assertEqual(len(self.view.plugin_widgets), 2)
+        self.assertEqual(self._get_plugin_widget(0).up_button.isEnabled(), False)
+        self.assertEqual(self._get_plugin_widget(0).down_button.isEnabled(), True)
+        self.assertEqual(self._get_plugin_widget(1).up_button.isEnabled(), True)
+        self.assertEqual(self._get_plugin_widget(1).down_button.isEnabled(), False)

--- a/mantidimaging/gui/windows/savu_filters/process_list/view.py
+++ b/mantidimaging/gui/windows/savu_filters/process_list/view.py
@@ -1,0 +1,101 @@
+from PyQt5 import Qt
+
+from .presenter import ProcessListPresenter, Notification
+
+
+class ProcessListView(Qt.QGroupBox):
+    def __init__(self, parent):
+        super(Qt.QGroupBox, self).__init__("Process List", parent)
+        self.setLayout(Qt.QVBoxLayout(self))
+        self.processing_plugins_layout = Qt.QVBoxLayout()
+
+        self.layout().addWidget(
+            PluginDisplayWidget(parent=self, plugin_name="ImageLoader", fixed=True))
+        self.layout().addLayout(self.processing_plugins_layout)
+        self.layout().addWidget(
+            PluginDisplayWidget(parent=self, plugin_name="TiffSaver", fixed=True))
+
+        self.presenter = ProcessListPresenter(self)
+        self.order_change_request = None
+        self.to_remove = None
+
+        self.plugin_widgets = []
+
+    def add_plugin(self, plugin):
+        self.presenter.add_plugin(plugin)
+
+    def display_plugin(self, plugin_name, fixed=False):
+        widget = PluginDisplayWidget(parent=self, plugin_name=plugin_name, fixed=fixed)
+        self.processing_plugins_layout.addWidget(widget)
+        self.plugin_widgets.append(widget)
+
+        self._correct_movement_button_states()
+
+    def _correct_movement_button_states(self):
+        for i, widget in enumerate(self.plugin_widgets):
+            widget.up_button.setEnabled(True)
+            widget.down_button.setEnabled(True)
+
+            if i == 0:
+                widget.up_button.setEnabled(False)
+            if i == len(self.plugin_widgets) - 1:
+                widget.down_button.setEnabled(False)
+
+    def change_order(self, old_index, new_index):
+        self.order_change_request = (old_index, new_index)
+        self.presenter.notify(Notification.CHANGE_ORDER)
+
+    def signal_remove_plugin(self, index):
+        self.to_remove = index
+        self.presenter.notify(Notification.REMOVE_PLUGIN)
+
+    def remove_plugin(self, index):
+        to_remove = self.plugin_widgets.pop(index)
+        self.processing_plugins_layout.removeWidget(to_remove)
+        to_remove.deleteLater()
+        self._correct_movement_button_states()
+
+    def swap(self, index_1, index_2):
+        to_move = self.plugin_widgets[index_1]
+
+        self.processing_plugins_layout.removeWidget(to_move)
+        self.processing_plugins_layout.insertWidget(index_2, to_move)
+
+        self.plugin_widgets[index_1], self.plugin_widgets[index_2] = \
+            self.plugin_widgets[index_2], self.plugin_widgets[index_1]
+
+        self._correct_movement_button_states()
+
+    @property
+    def plugin_entries(self):
+        return self.presenter.model.plugins
+
+
+class PluginDisplayWidget(Qt.QWidget):
+    def __init__(self, parent, plugin_name, fixed=False):
+        super(Qt.QWidget, self).__init__(parent)
+        self.setLayout(Qt.QHBoxLayout(self))
+
+        plugin_button = Qt.QPushButton(plugin_name, self)
+        build_icon = self.style().standardIcon
+        self.up_button = Qt.QPushButton(build_icon(self.style().SP_ArrowUp), "", self)
+        self.down_button = Qt.QPushButton(build_icon(self.style().SP_ArrowDown), "", self)
+        remove_button = Qt.QPushButton(build_icon(self.style().SP_DialogCancelButton), "", self)
+        buttons = [plugin_button, self.up_button, self.down_button, remove_button]
+
+        self.up_button.clicked.connect(lambda: self.parent().change_order(self.index, self.index - 1))
+        self.down_button.clicked.connect(lambda: self.parent().change_order(self.index, self.index + 1))
+        remove_button.clicked.connect(lambda: self.parent().signal_remove_plugin(self.index))
+
+        for btn in buttons:
+            btn.setSizePolicy(Qt.QSizePolicy.Fixed, Qt.QSizePolicy.Maximum)
+            self.layout().addWidget(btn)
+        plugin_button.setSizePolicy(Qt.QSizePolicy.Expanding, Qt.QSizePolicy.Maximum)
+
+        if fixed:
+            for btn in buttons:
+                btn.setEnabled(False)
+
+    @property
+    def index(self):
+        return self.parent().plugin_widgets.index(self)

--- a/mantidimaging/gui/windows/savu_filters/process_list/view.py
+++ b/mantidimaging/gui/windows/savu_filters/process_list/view.py
@@ -1,47 +1,46 @@
+from typing import Optional, List
+
 from PyQt5 import Qt
+from mantidimaging.core.utility.savu_interop.plugin_list import SAVUPluginListEntry
 
 from .presenter import ProcessListPresenter, Notification
 
 
 class ProcessListView(Qt.QGroupBox):
+    plugin_change_request = Qt.pyqtSignal()
+
     def __init__(self, parent):
         super(Qt.QGroupBox, self).__init__("Process List", parent)
         self.setLayout(Qt.QVBoxLayout(self))
         self.processing_plugins_layout = Qt.QVBoxLayout()
 
         self.layout().addWidget(
-            PluginDisplayWidget(parent=self, plugin_name="ImageLoader", fixed=True))
+            PluginDisplayWidget(parent=self, pos="First", plugin_name="ImageLoader", fixed=True))
         self.layout().addLayout(self.processing_plugins_layout)
         self.layout().addWidget(
-            PluginDisplayWidget(parent=self, plugin_name="TiffSaver", fixed=True))
+            PluginDisplayWidget(parent=self, pos="Last", plugin_name="TiffSaver", fixed=True))
 
-        self.presenter = ProcessListPresenter(self)
-        self.order_change_request = None
-        self.to_remove = None
+        self.presenter: ProcessListPresenter = ProcessListPresenter(self)
+        self.order_change_request: Optional[int] = None
+        self.to_remove: Optional[int] = None
+        self.to_edit: Optional[int] = None
 
-        self.plugin_widgets = []
+        self.plugin_widgets: List[PluginDisplayWidget] = []
 
     def add_plugin(self, plugin):
         self.presenter.add_plugin(plugin)
 
     def display_plugin(self, plugin_name, fixed=False):
-        widget = PluginDisplayWidget(parent=self, plugin_name=plugin_name, fixed=fixed)
+        widget = PluginDisplayWidget(parent=self,
+                                     pos=len(self.plugin_entries) + 1,
+                                     plugin_name=plugin_name,
+                                     fixed=fixed)
         self.processing_plugins_layout.addWidget(widget)
         self.plugin_widgets.append(widget)
 
-        self._correct_movement_button_states()
+        self._correct_display_widget_states()
 
-    def _correct_movement_button_states(self):
-        for i, widget in enumerate(self.plugin_widgets):
-            widget.up_button.setEnabled(True)
-            widget.down_button.setEnabled(True)
-
-            if i == 0:
-                widget.up_button.setEnabled(False)
-            if i == len(self.plugin_widgets) - 1:
-                widget.down_button.setEnabled(False)
-
-    def change_order(self, old_index, new_index):
+    def signal_order_change(self, old_index, new_index):
         self.order_change_request = (old_index, new_index)
         self.presenter.notify(Notification.CHANGE_ORDER)
 
@@ -49,11 +48,9 @@ class ProcessListView(Qt.QGroupBox):
         self.to_remove = index
         self.presenter.notify(Notification.REMOVE_PLUGIN)
 
-    def remove_plugin(self, index):
-        to_remove = self.plugin_widgets.pop(index)
-        self.processing_plugins_layout.removeWidget(to_remove)
-        to_remove.deleteLater()
-        self._correct_movement_button_states()
+    def signal_edit_plugin(self, index):
+        self.to_edit = index
+        self.plugin_change_request.emit()
 
     def swap(self, index_1, index_2):
         to_move = self.plugin_widgets[index_1]
@@ -64,17 +61,47 @@ class ProcessListView(Qt.QGroupBox):
         self.plugin_widgets[index_1], self.plugin_widgets[index_2] = \
             self.plugin_widgets[index_2], self.plugin_widgets[index_1]
 
-        self._correct_movement_button_states()
+        self._correct_display_widget_states()
+
+    def remove_plugin(self, index):
+        to_remove = self.plugin_widgets.pop(index)
+        self.processing_plugins_layout.removeWidget(to_remove)
+        to_remove.deleteLater()
+        self._correct_display_widget_states()
+
+    def _correct_display_widget_states(self):
+        """Sets the number labels and enabled states of the up/down buttons for all processing plugin display widgets"""
+        if not self.plugin_widgets:
+            return
+
+        for i, widget in enumerate(self.plugin_widgets):
+            widget.pos_label.setText(str(i + 1))
+            widget.up_button.setEnabled(True)
+            widget.down_button.setEnabled(True)
+        self.plugin_widgets[0].up_button.setEnabled(False)
+        self.plugin_widgets[-1].down_button.setEnabled(False)
 
     @property
     def plugin_entries(self):
         return self.presenter.model.plugins
 
+    @property
+    def plugin_to_edit(self):
+        return self.plugin_entries[self.to_edit]
+
+    def save_edited_plugin(self, entry: SAVUPluginListEntry):
+        if self.to_edit is None:
+            raise RuntimeError("RIP (Write something here)")
+        self.presenter.overwrite_plugin(self.to_edit, entry)
+
 
 class PluginDisplayWidget(Qt.QWidget):
-    def __init__(self, parent, plugin_name, fixed=False):
+    def __init__(self, parent, pos, plugin_name, fixed=False):
         super(Qt.QWidget, self).__init__(parent)
         self.setLayout(Qt.QHBoxLayout(self))
+        self.pos_label = Qt.QLabel(str(pos))
+        self.pos_label.setSizePolicy(Qt.QSizePolicy.Fixed, Qt.QSizePolicy.Maximum)
+        self.layout().addWidget(self.pos_label)
 
         plugin_button = Qt.QPushButton(plugin_name, self)
         build_icon = self.style().standardIcon
@@ -83,8 +110,9 @@ class PluginDisplayWidget(Qt.QWidget):
         remove_button = Qt.QPushButton(build_icon(self.style().SP_DialogCancelButton), "", self)
         buttons = [plugin_button, self.up_button, self.down_button, remove_button]
 
-        self.up_button.clicked.connect(lambda: self.parent().change_order(self.index, self.index - 1))
-        self.down_button.clicked.connect(lambda: self.parent().change_order(self.index, self.index + 1))
+        plugin_button.clicked.connect(lambda: self.parent().signal_edit_plugin(self.index))
+        self.up_button.clicked.connect(lambda: self.parent().signal_order_change(self.index, self.index - 1))
+        self.down_button.clicked.connect(lambda: self.parent().signal_order_change(self.index, self.index + 1))
         remove_button.clicked.connect(lambda: self.parent().signal_remove_plugin(self.index))
 
         for btn in buttons:

--- a/mantidimaging/gui/windows/savu_filters/view.py
+++ b/mantidimaging/gui/windows/savu_filters/view.py
@@ -2,7 +2,7 @@ import os
 from typing import TYPE_CHECKING
 
 from PyQt5 import Qt
-from PyQt5.QtWidgets import QLabel, QMainWindow, QTextEdit
+from PyQt5.QtWidgets import QLabel, QMainWindow, QTextEdit, QSpinBox
 
 from mantidimaging.core.configs.savu_backend_docker import RemoteConfig, RemoteConstants
 from mantidimaging.gui.mvp_base import BaseMainWindowView
@@ -20,6 +20,8 @@ class SavuFiltersWindowView(BaseMainWindowView):
     savu_finished = Qt.pyqtSignal(str)
     info: QLabel
     description: QLabel
+    startInput: QSpinBox
+    endInput: QSpinBox
 
     def __init__(self, main_window: 'MainWindowView'):
         """
@@ -97,3 +99,10 @@ class SavuFiltersWindowView(BaseMainWindowView):
             'in_prefix': '',
         }
         self.main_window.presenter.load_stack(**kwargs)
+
+    def reset_indices_inputs(self, image_indices):
+        self.startInput.setMaximum(image_indices[0])
+        self.endInput.setMaximum(image_indices[0])
+        self.stepInput.setMaximum(image_indices[0])
+        self.startInput.setValue(0)
+        self.endInput.setValue(image_indices[0])

--- a/mantidimaging/gui/windows/savu_filters/view.py
+++ b/mantidimaging/gui/windows/savu_filters/view.py
@@ -39,8 +39,8 @@ class SavuFiltersWindowView(BaseMainWindowView):
         self.floating_output = QTextEdit(self.floating_output_window)
         self.floating_output_window.setCentralWidget(self.floating_output)
         self.floating_output_window.show()
-        self.new_output.connect(self.append_output_text)
 
+        self.new_output.connect(self.append_output_text)
         self.savu_finished.connect(self.load_savu_stack)
 
         # Populate list of filters and handle filter selection
@@ -48,11 +48,10 @@ class SavuFiltersWindowView(BaseMainWindowView):
         self.filterSelector.currentIndexChanged[int].connect(self.handle_filter_selection)
         self.handle_filter_selection()
 
-        # Handle stack selection
         self.stackSelector.stack_selected_uuid.connect(self.presenter.set_stack_uuid)
-
-        # Handle apply filter
         self.applyButton.clicked.connect(lambda: self.presenter.notify(PresNotification.APPLY_FILTER))
+        self.applyListButton.clicked.connect(lambda: self.presenter.notify(PresNotification.APPLY_LIST))
+        self.addPluginToListButton.clicked.connect(lambda: self.presenter.notify(PresNotification.ADD_PLUGIN))
 
         self.stackSelector.subscribe_to_main_window(main_window)
 

--- a/mantidimaging/gui/windows/savu_filters/view.py
+++ b/mantidimaging/gui/windows/savu_filters/view.py
@@ -6,7 +6,6 @@ from PyQt5.QtWidgets import QLabel, QMainWindow, QTextEdit, QSpinBox
 
 from mantidimaging.core.configs.savu_backend_docker import RemoteConfig, RemoteConstants
 from mantidimaging.gui.mvp_base import BaseMainWindowView
-from mantidimaging.gui.utility import delete_all_widgets_from_layout
 from mantidimaging.gui.windows.savu_filters.presenter import Notification as PresNotification
 from mantidimaging.gui.windows.savu_filters.presenter import SavuFiltersWindowPresenter
 from mantidimaging.gui.windows.savu_filters.remote_presenter import SavuFiltersRemotePresenter
@@ -51,7 +50,7 @@ class SavuFiltersWindowView(BaseMainWindowView):
         self.stackSelector.stack_selected_uuid.connect(self.presenter.set_stack_uuid)
         self.applyButton.clicked.connect(lambda: self.presenter.notify(PresNotification.APPLY_FILTER))
         self.applyListButton.clicked.connect(lambda: self.presenter.notify(PresNotification.APPLY_LIST))
-        self.addPluginToListButton.clicked.connect(lambda: self.presenter.notify(PresNotification.ADD_PLUGIN))
+        self.confirmPluginButton.clicked.connect(lambda: self.presenter.notify(PresNotification.CONFIRM_PLUGIN))
 
         self.stackSelector.subscribe_to_main_window(main_window)
 
@@ -63,13 +62,6 @@ class SavuFiltersWindowView(BaseMainWindowView):
         super(SavuFiltersWindowView, self).show()
 
     def handle_filter_selection(self):
-        """
-        Handle selection of a filter from the drop down list.
-        """
-        # Remove all existing items from the properties layout
-        delete_all_widgets_from_layout(self.filterPropertiesLayout)
-
-        # Do registration of new filter
         self.presenter.notify(PresNotification.REGISTER_ACTIVE_FILTER)
 
     def set_description(self, info, desc):


### PR DESCRIPTION
Follow up to #355 

Enables use of non-reconstruction savu plugins + plugins with list/tuple parameters, and adds functionality to create and run process lists through the gui, in addition to individual filters.

Loading + saving process lists is not included in this PR.

GUI:

![Screenshot from 2020-01-29 09-40-54](https://user-images.githubusercontent.com/42145431/73345158-789a2500-427b-11ea-960f-7ed1ad0c82c6.png)

The process list pane is encapsulated as a widget with it's own model/view/presenter. The save button does nothing yet.