### PR TITLE
441: cupy median filter

### DIFF
--- a/mantidimaging/core/filters/median_filter/median_filter.py
+++ b/mantidimaging/core/filters/median_filter/median_filter.py
@@ -83,7 +83,7 @@ def _execute_seq(data, size, mode, progress=None):
 
 def _execute_par(data, size, mode, cores=None, chunksize=None, progress=None):
     log = getLogger(__name__)
-    progress = Progress.ensure_instance(progress, task_name="Median filter")
+    progress = Progress.ensure_instance(progress, task_name='Median filter')
 
     # create the partial function to forward the parameters
     f = psm.create_partial(scipy_ndimage.median_filter, fwd_func=psm.return_fwd_func, size=size, mode=mode)

--- a/mantidimaging/core/filters/median_filter/median_filter.py
+++ b/mantidimaging/core/filters/median_filter/median_filter.py
@@ -20,7 +20,7 @@ class MedianFilter(BaseFilter):
     filter_name = "Median"
 
     @staticmethod
-    def filter_func(data, size=None, mode="reflect", cores=None, chunksize=None, progress=None):
+    def filter_func(data, size=None, mode="reflect", cores=None, chunksize=None, progress=None, force_cpu=True):
         """
         :param data: Input data as a 3D numpy.ndarray
         :param size: Size of the kernel
@@ -35,7 +35,7 @@ class MedianFilter(BaseFilter):
         h.check_data_stack(data)
 
         if size and size > 1:
-            if gpu.gpu_available() and data.ndim > 2:
+            if not force_cpu:
                 data = _execute_gpu(data, size, mode, progress)
             elif pu.multiprocessing_available():
                 data = _execute_par(data, size, mode, cores, chunksize, progress)

--- a/mantidimaging/core/filters/median_filter/median_filter.py
+++ b/mantidimaging/core/filters/median_filter/median_filter.py
@@ -51,7 +51,14 @@ class MedianFilter(BaseFilter):
 
         _, mode_field = add_property_to_form('Mode', 'choice', valid_values=modes(), form=form, on_change=on_change)
 
-        return {'size_field': size_field, 'mode_field': mode_field}
+        _, gpu_field = add_property_to_form('Use GPU',
+                                            'bool',
+                                            default_value=False,
+                                            tooltip='Run the median filter on the GPU',
+                                            form=form,
+                                            on_change=on_change)
+
+        return {'size_field': size_field, 'mode_field': mode_field, 'gpu_field': gpu_field}
 
     @staticmethod
     def execute_wrapper(size_field=None, mode_field=None):

--- a/mantidimaging/core/filters/median_filter/median_filter.py
+++ b/mantidimaging/core/filters/median_filter/median_filter.py
@@ -58,11 +58,14 @@ class MedianFilter(BaseFilter):
                                             form=form,
                                             on_change=on_change)
 
-        return {'size_field': size_field, 'mode_field': mode_field, 'gpu_field': gpu_field}
+        return {'size_field': size_field, 'mode_field': mode_field, 'use_gpu_field': gpu_field}
 
     @staticmethod
-    def execute_wrapper(size_field=None, mode_field=None):
-        return partial(MedianFilter.filter_func, size=size_field.value(), mode=mode_field.currentText())
+    def execute_wrapper(size_field=None, mode_field=None, use_gpu_field=None):
+        return partial(MedianFilter.filter_func,
+                       size=size_field.value(),
+                       mode=mode_field.currentText(),
+                       force_cpu=not use_gpu_field.isChecked())
 
 
 def modes():

--- a/mantidimaging/core/filters/median_filter/median_filter.py
+++ b/mantidimaging/core/filters/median_filter/median_filter.py
@@ -20,7 +20,7 @@ class MedianFilter(BaseFilter):
     filter_name = "Median"
 
     @staticmethod
-    def filter_func(data, size=None, mode="reflect", cuda=None, cores=None, chunksize=None, progress=None):
+    def filter_func(data, size=None, mode="reflect", cores=None, chunksize=None, progress=None):
         """
         :param data: Input data as a 3D numpy.ndarray
         :param size: Size of the kernel
@@ -46,12 +46,12 @@ class MedianFilter(BaseFilter):
         return data
 
     @staticmethod
-    def register_gui(form: "QFormLayout", on_change: Callable) -> Dict[str, Any]:
-        _, size_field = add_property_to_form("Kernel Size", "int", 3, (0, 1000), form=form, on_change=on_change)
+    def register_gui(form: 'QFormLayout', on_change: Callable) -> Dict[str, Any]:
+        _, size_field = add_property_to_form('Kernel Size', 'int', 3, (0, 1000), form=form, on_change=on_change)
 
-        _, mode_field = add_property_to_form("Mode", "choice", valid_values=modes(), form=form, on_change=on_change)
+        _, mode_field = add_property_to_form('Mode', 'choice', valid_values=modes(), form=form, on_change=on_change)
 
-        return {"size_field": size_field, "mode_field": mode_field}
+        return {'size_field': size_field, 'mode_field': mode_field}
 
     @staticmethod
     def execute_wrapper(size_field=None, mode_field=None):
@@ -63,12 +63,12 @@ class MedianFilter(BaseFilter):
 
 
 def modes():
-    return ["reflect", "constant", "nearest", "mirror", "wrap"]
+    return ['reflect', 'constant', 'nearest', 'mirror', 'wrap']
 
 
 def _execute_seq(data, size, mode, progress=None):
     log = getLogger(__name__)
-    progress = Progress.ensure_instance(progress, num_steps=data.shape[0], task_name="Median filter")
+    progress = Progress.ensure_instance(progress, num_steps=data.shape[0], task_name='Median filter')
 
     with progress:
         log.info("Median filter, with pixel data type: {0}, filter " "size/width: {1}.".format(data.dtype, size))

--- a/mantidimaging/core/filters/median_filter/median_filter.py
+++ b/mantidimaging/core/filters/median_filter/median_filter.py
@@ -55,11 +55,7 @@ class MedianFilter(BaseFilter):
 
     @staticmethod
     def execute_wrapper(size_field=None, mode_field=None):
-        return partial(
-            MedianFilter.filter_func,
-            size=size_field.value(),
-            mode=mode_field.currentText(),
-        )
+        return partial(MedianFilter.filter_func, size=size_field.value(), mode=mode_field.currentText())
 
 
 def modes():

--- a/mantidimaging/core/filters/median_filter/median_filter.py
+++ b/mantidimaging/core/filters/median_filter/median_filter.py
@@ -96,7 +96,7 @@ def _execute_par(data, size, mode, cores=None, chunksize=None, progress=None):
 
 def _execute_gpu(data, size, mode, progress=None):
     log = getLogger(__name__)
-    progress = Progress.ensure_instance(progress, num_steps=data.shape[0], task_name="Median filter")
+    progress = Progress.ensure_instance(progress, num_steps=data.shape[0], task_name="Median filter GPU")
     cuda = gpu.CudaExecuter(data.dtype)
 
     with progress:

--- a/mantidimaging/core/filters/median_filter/median_filter.py
+++ b/mantidimaging/core/filters/median_filter/median_filter.py
@@ -102,7 +102,6 @@ def _execute_gpu(data, size, mode, progress=None):
     with progress:
         log.info("GPU median filter, with pixel data type: {0}, filter " "size/width: {1}.".format(data.dtype, size))
 
-        progress.add_estimated_steps(data.shape[0])
         data = cuda.median_filter(data, size, mode, progress)
 
     return data

--- a/mantidimaging/core/filters/median_filter/test/median_filter_test.py
+++ b/mantidimaging/core/filters/median_filter/test/median_filter_test.py
@@ -8,6 +8,8 @@ from mantidimaging.core.filters.median_filter import MedianFilter
 from mantidimaging.core.utility.memory_usage import get_memory_usage_linux
 from mantidimaging.core.gpu import utility as gpu
 
+GPU_UTIL_LOC = "mantidimaging.core.gpu.utility.gpu_available"
+
 
 class MedianTest(unittest.TestCase):
     """
@@ -35,9 +37,8 @@ class MedianTest(unittest.TestCase):
         size = 3
         mode = "reflect"
 
-        th.switch_gpu_off()
-        result = MedianFilter.filter_func(images, size, mode)
-        th.switch_gpu_on()
+        with mock.patch(GPU_UTIL_LOC, return_value=False):
+            result = MedianFilter.filter_func(images, size, mode)
 
         th.assert_not_equals(result, control)
         th.assert_not_equals(images, control)
@@ -66,9 +67,8 @@ class MedianTest(unittest.TestCase):
         mode = "reflect"
 
         th.switch_mp_off()
-        th.switch_gpu_off()
-        result = MedianFilter.filter_func(images, size, mode)
-        th.switch_gpu_on()
+        with mock.patch(GPU_UTIL_LOC, return_value=False):
+            result = MedianFilter.filter_func(images, size, mode)
         th.switch_mp_on()
 
         th.assert_not_equals(result, control)

--- a/mantidimaging/core/filters/median_filter/test/median_filter_test.py
+++ b/mantidimaging/core/filters/median_filter/test/median_filter_test.py
@@ -35,7 +35,7 @@ class MedianTest(unittest.TestCase):
         images, control = th.gen_img_shared_array_and_copy()
 
         size = 3
-        mode = "reflect"
+        mode = 'reflect'
 
         with mock.patch(GPU_UTIL_LOC, return_value=False):
             result = MedianFilter.filter_func(images, size, mode)
@@ -51,7 +51,7 @@ class MedianTest(unittest.TestCase):
         images, control = th.gen_img_shared_array_and_copy()
 
         size = 3
-        mode = "reflect"
+        mode = 'reflect'
 
         result = MedianFilter.filter_func(images, size, mode)
 
@@ -64,7 +64,7 @@ class MedianTest(unittest.TestCase):
         images, control = th.gen_img_shared_array_and_copy()
 
         size = 3
-        mode = "reflect"
+        mode = 'reflect'
 
         th.switch_mp_off()
         with mock.patch(GPU_UTIL_LOC, return_value=False):
@@ -91,7 +91,7 @@ class MedianTest(unittest.TestCase):
         """
         images, control = th.gen_img_shared_array_and_copy()
         size = 3
-        mode = "reflect"
+        mode = 'reflect'
 
         cached_memory = get_memory_usage_linux(kb=True)[0]
 

--- a/mantidimaging/core/filters/median_filter/test/median_filter_test.py
+++ b/mantidimaging/core/filters/median_filter/test/median_filter_test.py
@@ -110,7 +110,9 @@ class MedianTest(unittest.TestCase):
         size_field.value = mock.Mock(return_value=0)
         mode_field = mock.Mock()
         mode_field.currentText = mock.Mock(return_value=0)
-        execute_func = MedianFilter.execute_wrapper(size_field, mode_field)
+        use_gpu_field = mock.Mock()
+        use_gpu_field.isChecked = mock.Mock(return_value=False)
+        execute_func = MedianFilter.execute_wrapper(size_field, mode_field, use_gpu_field)
 
         images, _ = th.gen_img_shared_array_and_copy()
         execute_func(images)

--- a/mantidimaging/core/filters/median_filter/test/median_filter_test.py
+++ b/mantidimaging/core/filters/median_filter/test/median_filter_test.py
@@ -37,8 +37,7 @@ class MedianTest(unittest.TestCase):
         size = 3
         mode = 'reflect'
 
-        with mock.patch(GPU_UTIL_LOC, return_value=False):
-            result = MedianFilter.filter_func(images, size, mode)
+        result = MedianFilter.filter_func(images, size, mode)
 
         th.assert_not_equals(result, control)
         th.assert_not_equals(images, control)
@@ -53,7 +52,7 @@ class MedianTest(unittest.TestCase):
         size = 3
         mode = 'reflect'
 
-        result = MedianFilter.filter_func(images, size, mode)
+        result = MedianFilter.filter_func(images, size, mode, force_cpu=False)
 
         th.assert_not_equals(result, control)
         th.assert_not_equals(images, control)
@@ -67,8 +66,7 @@ class MedianTest(unittest.TestCase):
         mode = 'reflect'
 
         th.switch_mp_off()
-        with mock.patch(GPU_UTIL_LOC, return_value=False):
-            result = MedianFilter.filter_func(images, size, mode)
+        result = MedianFilter.filter_func(images, size, mode)
         th.switch_mp_on()
 
         th.assert_not_equals(result, control)

--- a/mantidimaging/core/filters/median_filter/test/median_filter_test.py
+++ b/mantidimaging/core/filters/median_filter/test/median_filter_test.py
@@ -119,6 +119,7 @@ class MedianTest(unittest.TestCase):
 
         self.assertEqual(size_field.value.call_count, 1)
         self.assertEqual(mode_field.currentText.call_count, 1)
+        self.assertEqual(use_gpu_field.isChecked.call_count, 1)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/filters/median_filter/test/median_filter_test.py
+++ b/mantidimaging/core/filters/median_filter/test/median_filter_test.py
@@ -121,5 +121,5 @@ class MedianTest(unittest.TestCase):
         self.assertEqual(mode_field.currentText.call_count, 1)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/core/gpu/cuda_image_filters.cu
+++ b/mantidimaging/core/gpu/cuda_image_filters.cu
@@ -46,8 +46,10 @@ __device__ float find_neighbour_median(const float *padded_array,
     }
   }
 
-  return find_median_in_neighbour_array(neighbour_array,
-                                        filter_size * filter_size);
+  float median = find_median_in_neighbour_array(neighbour_array,
+                                                filter_size * filter_size);
+  free(neighbour_array);
+  return median;
 }
 __global__ void two_dimensional_median_filter(float *data_array,
                                               const float *padded_array,

--- a/mantidimaging/core/gpu/cuda_image_filters.cu
+++ b/mantidimaging/core/gpu/cuda_image_filters.cu
@@ -29,7 +29,8 @@ __device__ void print_neighbour_elements_in_two_dimensional_array(
   printf("\n");
 }
 /**
-  Insertion sorts a one dimensional array and returns its median.
+  Insertion sorts a 1D array and returns its median.
+  Helper function for the 2D median and 2D remove outlier filters.
 
   @param array     The float array.
   @param N         The size of the array.
@@ -62,7 +63,7 @@ __device__ float find_median_in_neighbour_array(float *neighbour_array,
   @param id_x                The x index of the current pixel.
   @param id_y                The y index of the current pixel.
   @param filter_size         The size of the filter.
-  @return                    The median of the pixel neighbourhood.
+  @return                    The median of the pixel's neighbourhood.
  */
 __device__ float find_neighbour_median(const float *padded_array,
                                        const int padded_img_width,
@@ -119,7 +120,7 @@ __global__ void two_dimensional_median_filter(float *data_array,
   @param Y                The width of the image.
   @param filter_size      The size of the filter.
   @param diff             The difference required to replace the original pixel
-  value with the median.
+                          value with the median.
  */
 __global__ void two_dimensional_remove_light_outliers(float *data_array,
                                                       const float *padded_array,
@@ -151,7 +152,7 @@ __global__ void two_dimensional_remove_light_outliers(float *data_array,
   @param Y                The width of the image.
   @param filter_size      The size of the filter.
   @param diff             The difference required to replace the original pixel
-  value with the median.
+                          value with the median.
  */
 __global__ void two_dimensional_remove_dark_outliers(float *data_array,
                                                      const float *padded_array,

--- a/mantidimaging/core/gpu/test/gpu_test.py
+++ b/mantidimaging/core/gpu/test/gpu_test.py
@@ -59,13 +59,29 @@ class GPUTest(unittest.TestCase):
     @unittest.skipIf(GPU_NOT_AVAIL, reason=GPU_SKIP_REASON)
     def test_gpu_result_matches_cpu_result_for_larger_images(self):
 
-        N = 1500
+        N = 1200
         size = 3
         mode = "reflect"
 
-        images = th.gen_img_shared_array(shape=(500, N, N))
+        images = th.gen_img_shared_array(shape=(20, N, N))
 
         gpu_result = MedianFilter.filter_func(images.copy(), size, mode, self.cuda)
+
+        th.switch_mp_off()
+        cpu_result = MedianFilter.filter_func(images.copy(), size, mode)
+        th.switch_mp_on()
+
+        npt.assert_almost_equal(gpu_result, cpu_result)
+
+    @unittest.skipIf(GPU_NOT_AVAIL, reason=GPU_SKIP_REASON)
+    def test_double_is_used_in_cuda_for_float_64_arrays(self):
+
+        size = 3
+        mode = "reflect"
+        images = th.gen_img_shared_array(dtype="float64")
+        cuda = gpu.CudaExecuter("float64")
+
+        gpu_result = MedianFilter.filter_func(images.copy(), size, mode, cuda)
 
         th.switch_mp_off()
         cpu_result = MedianFilter.filter_func(images.copy(), size, mode)

--- a/mantidimaging/core/gpu/test/gpu_test.py
+++ b/mantidimaging/core/gpu/test/gpu_test.py
@@ -22,6 +22,13 @@ class GPUTest(unittest.TestCase):
         if not GPU_NOT_AVAIL:
             self.cuda = gpu.CudaExecuter("float32")
 
+    @staticmethod
+    def run_serial(data, size, mode):
+        th.switch_mp_off()
+        cpu_result = MedianFilter.filter_func(data, size, mode)
+        th.switch_mp_on()
+        return cpu_result
+
     @unittest.skipIf(GPU_NOT_AVAIL, reason=GPU_SKIP_REASON)
     def test_numpy_pad_modes_match_scipy_median_modes(self):
 
@@ -32,10 +39,7 @@ class GPUTest(unittest.TestCase):
                 images = th.gen_img_shared_array()
 
                 gpu_result = MedianFilter.filter_func(images.copy(), size, mode, self.cuda)
-
-                th.switch_mp_off()
-                cpu_result = MedianFilter.filter_func(images.copy(), size, mode)
-                th.switch_mp_on()
+                cpu_result = self.run_serial(images.copy(), size, mode)
 
                 npt.assert_almost_equal(gpu_result[0], cpu_result[0])
 
@@ -49,10 +53,7 @@ class GPUTest(unittest.TestCase):
                 images = th.gen_img_shared_array()
 
                 gpu_result = MedianFilter.filter_func(images.copy(), size, mode, self.cuda)
-
-                th.switch_mp_off()
-                cpu_result = MedianFilter.filter_func(images.copy(), size, mode)
-                th.switch_mp_on()
+                cpu_result = self.run_serial(images.copy(), size, mode)
 
                 npt.assert_almost_equal(gpu_result, cpu_result)
 
@@ -66,10 +67,7 @@ class GPUTest(unittest.TestCase):
         images = th.gen_img_shared_array(shape=(20, N, N))
 
         gpu_result = MedianFilter.filter_func(images.copy(), size, mode, self.cuda)
-
-        th.switch_mp_off()
-        cpu_result = MedianFilter.filter_func(images.copy(), size, mode)
-        th.switch_mp_on()
+        cpu_result = self.run_serial(images.copy(), size, mode)
 
         npt.assert_almost_equal(gpu_result, cpu_result)
 
@@ -82,10 +80,7 @@ class GPUTest(unittest.TestCase):
         cuda = gpu.CudaExecuter("float64")
 
         gpu_result = MedianFilter.filter_func(images.copy(), size, mode, cuda)
-
-        th.switch_mp_off()
-        cpu_result = MedianFilter.filter_func(images.copy(), size, mode)
-        th.switch_mp_on()
+        cpu_result = self.run_serial(images.copy(), size, mode)
 
         npt.assert_almost_equal(gpu_result, cpu_result)
 
@@ -100,10 +95,7 @@ class GPUTest(unittest.TestCase):
         images = th.gen_img_shared_array(shape=(n_images, N, N))
 
         gpu_result = MedianFilter.filter_func(images.copy(), size, mode, self.cuda)
-
-        th.switch_mp_off()
-        cpu_result = MedianFilter.filter_func(images.copy(), size, mode)
-        th.switch_mp_on()
+        cpu_result = self.run_serial(images.copy(), size, mode)
 
         npt.assert_almost_equal(gpu_result, cpu_result)
 

--- a/mantidimaging/core/gpu/test/gpu_test.py
+++ b/mantidimaging/core/gpu/test/gpu_test.py
@@ -19,7 +19,8 @@ class GPUTest(unittest.TestCase):
     """
     def __init__(self, *args, **kwargs):
         super(GPUTest, self).__init__(*args, **kwargs)
-        self.cuda = gpu.CudaExecuter("float32")
+        if not GPU_NOT_AVAIL:
+            self.cuda = gpu.CudaExecuter("float32")
 
     @unittest.skipIf(GPU_NOT_AVAIL, reason=GPU_SKIP_REASON)
     def test_numpy_pad_modes_match_scipy_median_modes(self):
@@ -58,11 +59,11 @@ class GPUTest(unittest.TestCase):
     @unittest.skipIf(GPU_NOT_AVAIL, reason=GPU_SKIP_REASON)
     def test_gpu_result_matches_cpu_result_for_larger_images(self):
 
-        N = 120
+        N = 1500
         size = 3
         mode = "reflect"
 
-        images = th.gen_img_shared_array(shape=(5, N, N))
+        images = th.gen_img_shared_array(shape=(20, N, N))
 
         gpu_result = MedianFilter.filter_func(images.copy(), size, mode, self.cuda)
 

--- a/mantidimaging/core/gpu/test/gpu_test.py
+++ b/mantidimaging/core/gpu/test/gpu_test.py
@@ -123,17 +123,15 @@ class GPUTest(unittest.TestCase):
 
         import cupy as cp
 
-        N = 200
-        n_images = 2000
-        size = 3
-        mode = "reflect"
+        N = 20
+        n_images = 2
 
         images = th.gen_img_shared_array(shape=(n_images, N, N))
 
         with mock.patch("mantidimaging.core.gpu.utility._send_single_array_to_gpu",
                         side_effect=cp.cuda.memory.OutOfMemoryError(0, 0)):
             with mock.patch("mantidimaging.core.gpu.utility._free_memory_pool") as mock_free_gpu:
-                MedianFilter.filter_func(images.copy(), size, mode, self.cuda)
+                gpu._send_arrays_to_gpu_with_pinned_memory(images, [cp.cuda.Stream() for _ in range(n_images)])
 
         mock_free_gpu.assert_called()
 

--- a/mantidimaging/core/gpu/test/gpu_test.py
+++ b/mantidimaging/core/gpu/test/gpu_test.py
@@ -89,6 +89,24 @@ class GPUTest(unittest.TestCase):
 
         npt.assert_almost_equal(gpu_result, cpu_result)
 
+    @unittest.skipIf(GPU_NOT_AVAIL, reason=GPU_SKIP_REASON)
+    def test_image_slicing_works(self):
+
+        N = 30
+        n_images = 1000
+        size = 3
+        mode = "reflect"
+
+        images = th.gen_img_shared_array(shape=(n_images, N, N))
+
+        gpu_result = MedianFilter.filter_func(images.copy(), size, mode, self.cuda)
+
+        th.switch_mp_off()
+        cpu_result = MedianFilter.filter_func(images.copy(), size, mode)
+        th.switch_mp_on()
+
+        npt.assert_almost_equal(gpu_result, cpu_result)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/mantidimaging/core/gpu/test/gpu_test.py
+++ b/mantidimaging/core/gpu/test/gpu_test.py
@@ -63,7 +63,7 @@ class GPUTest(unittest.TestCase):
         size = 3
         mode = "reflect"
 
-        images = th.gen_img_shared_array(shape=(20, N, N))
+        images = th.gen_img_shared_array(shape=(500, N, N))
 
         gpu_result = MedianFilter.filter_func(images.copy(), size, mode, self.cuda)
 

--- a/mantidimaging/core/gpu/test/gpu_test.py
+++ b/mantidimaging/core/gpu/test/gpu_test.py
@@ -135,7 +135,6 @@ class GPUTest(unittest.TestCase):
 
         images = th.gen_img_shared_array(shape=(n_images, N, N))
 
-        # Mock the GPU running out of memory
         with mock.patch("mantidimaging.core.gpu.utility._send_single_array_to_gpu",
                         side_effect=cp.cuda.memory.OutOfMemoryError(0, 0)):
             gpu_result = MedianFilter.filter_func(images, size, mode, self.cuda)
@@ -154,7 +153,6 @@ class GPUTest(unittest.TestCase):
 
         images = th.gen_img_shared_array(shape=(n_images, N, N))
 
-        # Mock the GPU running out of memory
         with mock.patch("mantidimaging.core.gpu.utility._send_single_array_to_gpu",
                         side_effect=cp.cuda.memory.OutOfMemoryError(0, 0)):
             with mock.patch("mantidimaging.core.gpu.utility._free_memory_pool") as mock_free_gpu:

--- a/mantidimaging/core/gpu/test/gpu_test.py
+++ b/mantidimaging/core/gpu/test/gpu_test.py
@@ -93,7 +93,7 @@ class GPUTest(unittest.TestCase):
     def test_image_slicing_works(self):
 
         N = 30
-        n_images = 1000
+        n_images = gpu.MAX_GPU_SLICES * 3
         size = 3
         mode = "reflect"
 

--- a/mantidimaging/core/gpu/test/gpu_test.py
+++ b/mantidimaging/core/gpu/test/gpu_test.py
@@ -61,11 +61,11 @@ class GPUTest(unittest.TestCase):
     @unittest.skipIf(True, reason=GPU_SKIP_REASON)
     def test_gpu_result_matches_cpu_result_for_larger_images(self):
 
-        N = 1000
+        N = 200
         size = 3
         mode = "reflect"
 
-        images = np.random.uniform(low=0.0, high=100.0, size=(5, N, N))
+        images = np.random.uniform(low=0.0, high=100.0, size=(5, N, N)).astype("float32")
 
         gpu_result = MedianFilter.filter_func(images.copy(), size, mode)
 

--- a/mantidimaging/core/gpu/test/gpu_test.py
+++ b/mantidimaging/core/gpu/test/gpu_test.py
@@ -29,25 +29,18 @@ class GPUTest(unittest.TestCase):
         for mode in modes():
             with self.subTest(mode=mode):
 
-                np.random.seed(10)
+                images = th.gen_img_shared_array_and_copy()[0]
 
-                # images = th.gen_img_shared_array_and_copy()[0]
-                images = np.random.uniform(low=0.0, high=10.0, size=(2, 3, 3))
-                gpu_images = images.copy()
-                cpu_images = images.copy()
-
-                gpu_result = MedianFilter.filter_func(gpu_images, size, mode)
+                gpu_result = MedianFilter.filter_func(images.copy(), size, mode)
 
                 with mock.patch(GPU_UTILITY_LOC, return_value=False):
                     th.switch_mp_off()
-                    cpu_result = MedianFilter.filter_func(cpu_images, size, mode)
+                    cpu_result = MedianFilter.filter_func(images.copy(), size, mode)
                     th.switch_mp_on()
-                    print(cpu_result == images)
-                    print(images)
 
                 npt.assert_almost_equal(gpu_result[0], cpu_result[0])
 
-    @unittest.skipIf(True, reason=GPU_SKIP_REASON)
+    @unittest.skipIf(GPU_NOT_AVAIL, reason=GPU_SKIP_REASON)
     def test_gpu_result_matches_cpu_result_for_different_filter_sizes(self):
 
         mode = "reflect"
@@ -59,7 +52,9 @@ class GPUTest(unittest.TestCase):
                 gpu_result = MedianFilter.filter_func(images.copy(), size, mode)
 
                 with mock.patch(GPU_UTILITY_LOC, return_value=False):
+                    th.switch_mp_off()
                     cpu_result = MedianFilter.filter_func(images.copy(), size, mode)
+                    th.switch_mp_on()
 
                 npt.assert_almost_equal(gpu_result, cpu_result)
 
@@ -75,7 +70,9 @@ class GPUTest(unittest.TestCase):
         gpu_result = MedianFilter.filter_func(images.copy(), size, mode)
 
         with mock.patch(GPU_UTILITY_LOC, return_value=False):
+            th.switch_mp_off()
             cpu_result = MedianFilter.filter_func(images.copy(), size, mode)
+            th.switch_mp_on()
 
         npt.assert_almost_equal(gpu_result, cpu_result)
 

--- a/mantidimaging/core/gpu/test/import_test.py
+++ b/mantidimaging/core/gpu/test/import_test.py
@@ -2,6 +2,9 @@ import unittest
 
 from unittest import mock
 
+from mantidimaging.core.gpu import utility as gpu
+GPU_NOT_AVAIL = not gpu.gpu_available()
+
 
 class GPUImportTest(unittest.TestCase):
     @unittest.skip("I don't know how to mock a failed import.")
@@ -11,6 +14,7 @@ class GPUImportTest(unittest.TestCase):
             from mantidimaging.core.gpu import utility
             assert not utility.gpu_available()
 
+    @unittest.skipIf(GPU_NOT_AVAIL, reason="Can't run GPU tests without cupy installed.")
     def test_gpu_available_returns_false_when_cupy_isnt_installed_properly(self):
 
         import cupy

--- a/mantidimaging/core/gpu/test/import_test.py
+++ b/mantidimaging/core/gpu/test/import_test.py
@@ -9,6 +9,9 @@ GPU_NOT_AVAIL = not gpu.gpu_available()
 class GPUImportTest(unittest.TestCase):
     @unittest.skip("I don't know how to mock a failed import.")
     def test_gpu_available_returns_false_when_cupy_cant_be_loaded(self):
+        """
+        Test that the GPU utility reports that the GPU is not available if cupy isn't installed.
+        """
 
         with mock.patch("mantidimaging.core.gpu.utility.cp", side_effect=ModuleNotFoundError):
             from mantidimaging.core.gpu import utility
@@ -16,7 +19,9 @@ class GPUImportTest(unittest.TestCase):
 
     @unittest.skipIf(GPU_NOT_AVAIL, reason="Can't run GPU tests without cupy installed.")
     def test_gpu_available_returns_false_when_cupy_isnt_installed_properly(self):
-
+        """
+        Test that the GPU utility reports that the GPU is not available if cupy is installed but not set up properly.
+        """
         import cupy
         with mock.patch("cupy.add", side_effect=cupy.cuda.compiler.CompileException("", "", "", None)):
             from mantidimaging.core.gpu import utility

--- a/mantidimaging/core/gpu/test/import_test.py
+++ b/mantidimaging/core/gpu/test/import_test.py
@@ -10,9 +10,8 @@ class GPUImportTest(unittest.TestCase):
     @unittest.skip("I don't know how to mock a failed import.")
     def test_gpu_available_returns_false_when_cupy_cant_be_loaded(self):
         """
-        Test that the GPU utility reports that the GPU is not available if cupy isn't installed.
+        Test that the GPU utility reports the GPU is not available if cupy isn't installed.
         """
-
         with mock.patch("mantidimaging.core.gpu.utility.cp", side_effect=ModuleNotFoundError):
             from mantidimaging.core.gpu import utility
             assert not utility.gpu_available()
@@ -20,7 +19,7 @@ class GPUImportTest(unittest.TestCase):
     @unittest.skipIf(GPU_NOT_AVAIL, reason="Can't run GPU tests without cupy installed.")
     def test_gpu_available_returns_false_when_cupy_isnt_installed_properly(self):
         """
-        Test that the GPU utility reports that the GPU is not available if cupy is installed but not set up properly.
+        Test that the GPU utility reports the GPU is not available if cupy is installed but not set up properly.
         """
         import cupy
         with mock.patch("cupy.add", side_effect=cupy.cuda.compiler.CompileException("", "", "", None)):

--- a/mantidimaging/core/gpu/test/import_test.py
+++ b/mantidimaging/core/gpu/test/import_test.py
@@ -4,9 +4,10 @@ from unittest import mock
 
 
 class GPUImportTest(unittest.TestCase):
+    @unittest.Skip("I don't know how to mock a failed import.")
     def test_gpu_available_returns_false_when_cupy_cant_be_loaded(self):
 
-        with mock.patch.dict("sys.modules", cupy=None):
+        with mock.patch("mantidimaging.core.gpu.utility.cp", side_effect=ModuleNotFoundError):
             from mantidimaging.core.gpu import utility
             assert not utility.gpu_available()
 

--- a/mantidimaging/core/gpu/test/import_test.py
+++ b/mantidimaging/core/gpu/test/import_test.py
@@ -1,21 +1,18 @@
-import sys
 import unittest
 
 from unittest import mock
 
 
 class GPUImportTest(unittest.TestCase):
-    @unittest.skip("Cupy seems to load successfuly regardless")
     def test_gpu_available_returns_false_when_cupy_cant_be_loaded(self):
 
-        sys.modules["cupy"] = None
-        from mantidimaging.core.gpu import utility
-        assert not utility.gpu_available()
+        with mock.patch.dict("sys.modules", cupy=None):
+            from mantidimaging.core.gpu import utility
+            assert not utility.gpu_available()
 
     def test_gpu_available_returns_false_when_cupy_isnt_installed_properly(self):
 
         import cupy
-        with mock.patch("mantidimaging.core.gpu.utility.cp.core.core.ndarray.__mul__",
-                        side_effect=cupy.cuda.compiler.CompileException):
+        with mock.patch("cupy.add", side_effect=cupy.cuda.compiler.CompileException("", "", "", None)):
             from mantidimaging.core.gpu import utility
             assert not utility.gpu_available()

--- a/mantidimaging/core/gpu/test/import_test.py
+++ b/mantidimaging/core/gpu/test/import_test.py
@@ -1,0 +1,13 @@
+import sys
+import unittest
+from unittest import mock
+
+
+class GPUImportTest(unittest.TestCase):
+
+    def test_gpu_available_returns_false_when_cupy_cant_be_loaded(self):
+
+        sys.modules["cupy"] = None
+        from mantidimaging.core.gpu import utility as gpu
+        assert not gpu.gpu_available()
+

--- a/mantidimaging/core/gpu/test/import_test.py
+++ b/mantidimaging/core/gpu/test/import_test.py
@@ -1,6 +1,8 @@
 import sys
 import unittest
 
+from unittest import mock
+
 
 class GPUImportTest(unittest.TestCase):
     @unittest.skip("Cupy seems to load successfuly regardless")
@@ -9,3 +11,11 @@ class GPUImportTest(unittest.TestCase):
         sys.modules["cupy"] = None
         from mantidimaging.core.gpu import utility
         assert not utility.gpu_available()
+
+    def test_gpu_available_returns_false_when_cupy_isnt_installed_properly(self):
+
+        import cupy
+        with mock.patch("mantidimaging.core.gpu.utility.cp.core.core.ndarray.__mul__",
+                        side_effect=cupy.cuda.compiler.CompileException):
+            from mantidimaging.core.gpu import utility
+            assert not utility.gpu_available()

--- a/mantidimaging/core/gpu/test/import_test.py
+++ b/mantidimaging/core/gpu/test/import_test.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 
 class GPUImportTest(unittest.TestCase):
-    @unittest.Skip("I don't know how to mock a failed import.")
+    @unittest.skip("I don't know how to mock a failed import.")
     def test_gpu_available_returns_false_when_cupy_cant_be_loaded(self):
 
         with mock.patch("mantidimaging.core.gpu.utility.cp", side_effect=ModuleNotFoundError):

--- a/mantidimaging/core/gpu/test/import_test.py
+++ b/mantidimaging/core/gpu/test/import_test.py
@@ -1,13 +1,11 @@
 import sys
 import unittest
-from unittest import mock
 
 
 class GPUImportTest(unittest.TestCase):
-
+    @unittest.skip("Cupy seems to load successfuly regardless")
     def test_gpu_available_returns_false_when_cupy_cant_be_loaded(self):
 
         sys.modules["cupy"] = None
-        from mantidimaging.core.gpu import utility as gpu
-        assert not gpu.gpu_available()
-
+        from mantidimaging.core.gpu import utility
+        assert not utility.gpu_available()

--- a/mantidimaging/core/gpu/utility.py
+++ b/mantidimaging/core/gpu/utility.py
@@ -6,8 +6,16 @@ FREE_MEMORY_FACTOR = 0.8
 MAX_GPU_SLICES = 100
 KERNEL_FILENAME = "cuda_image_filters.cu"
 
+
+def _import_cupy():
+    import cupy
+    return cupy
+
+
+CUPY_INSTALLED = False
+
 try:
-    import cupy as cp
+    cp = _import_cupy()
 
     CUPY_INSTALLED = True
 
@@ -18,8 +26,8 @@ try:
 
     # TODO: Check that doubling an array works
 
-except ImportError:
-    CUPY_INSTALLED = False
+except ModuleNotFoundError:
+    pass
 
 EQUIVALENT_PAD_MODE = {
     "reflect": "symmetric",

--- a/mantidimaging/core/gpu/utility.py
+++ b/mantidimaging/core/gpu/utility.py
@@ -12,9 +12,16 @@ except ModuleNotFoundError:
     CUPY_NOT_IMPORTED = True
 
 MAX_CUPY_MEMORY_FRACTION = 0.8
-FREE_MEMORY_FACTOR = 0.8
 MAX_GPU_SLICES = 100
 KERNEL_FILENAME = "cuda_image_filters.cu"
+
+EQUIVALENT_PAD_MODE = {
+    "reflect": "symmetric",
+    "constant": "constant",
+    "nearest": "edge",
+    "mirror": "reflect",
+    "wrap": "wrap",
+}
 
 
 def _cupy_on_system():
@@ -40,15 +47,6 @@ def _cupy_installed_correctly():
 
     except cp.cuda.compiler.CompileException:
         return False
-
-
-EQUIVALENT_PAD_MODE = {
-    "reflect": "symmetric",
-    "constant": "constant",
-    "nearest": "edge",
-    "mirror": "reflect",
-    "wrap": "wrap",
-}
 
 
 def gpu_available():

--- a/mantidimaging/core/gpu/utility.py
+++ b/mantidimaging/core/gpu/utility.py
@@ -112,7 +112,6 @@ def _send_arrays_to_gpu_with_pinned_memory(cpu_arrays, streams):
         return gpu_arrays
 
     except cp.cuda.memory.OutOfMemoryError:
-        print("GPU is out of memory...")
         _free_memory_pool(gpu_arrays)
         return []
 
@@ -237,6 +236,11 @@ class CudaExecuter:
         # Send the data arrays and padded arrays to the GPU in slices
         gpu_data_slices = _send_arrays_to_gpu_with_pinned_memory(data[:slice_limit], streams)
         gpu_padded_data = _send_arrays_to_gpu_with_pinned_memory(cpu_padded_images[:slice_limit], streams)
+
+        # Return if the data transfer was not successful
+        if not gpu_data_slices or not gpu_padded_data:
+            print("Out of memory.")
+            return data
 
         for i in range(n_images):
 

--- a/mantidimaging/core/gpu/utility.py
+++ b/mantidimaging/core/gpu/utility.py
@@ -1,6 +1,8 @@
 import os
 import numpy as np
 
+from logging import getLogger
+
 MAX_CUPY_MEMORY_FRACTION = 0.8
 FREE_MEMORY_FACTOR = 0.8
 MAX_GPU_SLICES = 100
@@ -112,6 +114,7 @@ def _send_arrays_to_gpu_with_pinned_memory(cpu_arrays, streams):
         return gpu_arrays
 
     except cp.cuda.memory.OutOfMemoryError:
+        getLogger(__name__).error("Unable to send arrays to GPU. Median filter not performed.")
         _free_memory_pool(gpu_arrays)
         return []
 

--- a/mantidimaging/core/gpu/utility.py
+++ b/mantidimaging/core/gpu/utility.py
@@ -23,7 +23,8 @@ def _cupy_on_system():
 
 def _cupy_installed_correctly():
     try:
-        # Check that cupy was installed properly. If it is properly installed, then basic array multiplication will work without getting an exception.
+        # Check that cupy was installed properly. If it is properly installed, then basic array multiplication will
+        # work without getting an exception.
         a = cp.array([1])
         b = cp.array([1])
         cp.add(a, b)

--- a/mantidimaging/core/gpu/utility.py
+++ b/mantidimaging/core/gpu/utility.py
@@ -116,7 +116,7 @@ def _create_block_and_grid_args(data):
     """
     N = 10
     block_size = tuple(N for _ in range(data.ndim))
-    grid_size = tuple((shape // N) + 1 for shape in data.shape)
+    grid_size = tuple((shape // N) + 1 if shape % N != 0 else (shape // N) for shape in data.shape)
     return block_size, grid_size
 
 

--- a/mantidimaging/core/gpu/utility.py
+++ b/mantidimaging/core/gpu/utility.py
@@ -116,7 +116,7 @@ def _create_block_and_grid_args(data):
     """
     N = 10
     block_size = tuple(N for _ in range(data.ndim))
-    grid_size = tuple(shape // N if shape > N else 1 for shape in data.shape)
+    grid_size = tuple((shape // N) + 1 for shape in data.shape)
     return block_size, grid_size
 
 

--- a/mantidimaging/core/gpu/utility.py
+++ b/mantidimaging/core/gpu/utility.py
@@ -233,11 +233,10 @@ class CudaExecuter:
         for i in range(n_images):
 
             # Synchronise and use the current stream
-            streams[i % slice_limit].synchronize()
             streams[i % slice_limit].use()
 
             # Overwrite the contents of the GPU arrays
-            if i > slice_limit:
+            if i >= slice_limit:
                 _replace_gpu_array_contents(gpu_data_slices[i % slice_limit], data[i], streams[i % slice_limit])
                 _replace_gpu_array_contents(
                     gpu_padded_data[i % slice_limit],

--- a/mantidimaging/core/gpu/utility.py
+++ b/mantidimaging/core/gpu/utility.py
@@ -19,14 +19,19 @@ CUPY_INSTALLED = False
 try:
     cp = _import_cupy()
 
-    CUPY_INSTALLED = True
+    try:
+        # Check that cupy was installed properly. If it is properly installed, then basic array multiplication will work without getting an exception.
+        a = cp.array([1])
+        a * 2
+        CUPY_INSTALLED = True
+
+    except cp.cuda.compiler.CompileException:
+        pass
 
     # Initialise the memory pool
     mempool = cp.get_default_memory_pool()
     with cp.cuda.Device(0):
         mempool.set_limit(fraction=MAX_CUPY_MEMORY_FRACTION)
-
-    # TODO: Check that doubling an array works
 
 except ModuleNotFoundError:
     pass

--- a/mantidimaging/core/gpu/utility.py
+++ b/mantidimaging/core/gpu/utility.py
@@ -37,8 +37,8 @@ def gpu_available():
 
 def _load_cuda_kernel(dtype):
     """
-    Loads the CUDA kernel so that cupy can act as a mediator. Replaces instances of 'float' with 'double' if the dtype is
-    float64.
+    Loads the CUDA kernel so that cupy can act as a mediator. Replaces instances of 'float' with 'double' if the dtype
+    is float64.
     :param dtype: The data type of the array that is going to be processed.
     :return: The CUDA kernel in string format.
     """

--- a/mantidimaging/gui/utility/qt_helpers.py
+++ b/mantidimaging/gui/utility/qt_helpers.py
@@ -149,8 +149,6 @@ def add_property_to_form(
             right_widget.editingFinished.connect(lambda: on_change())
 
     elif dtype == 'bool':
-        # left_widget = None
-        # left_widget.text(label)
         right_widget = Qt.QCheckBox()
         if isinstance(default_value, bool):
             right_widget.setChecked(default_value)

--- a/mantidimaging/gui/utility/qt_helpers.py
+++ b/mantidimaging/gui/utility/qt_helpers.py
@@ -149,8 +149,9 @@ def add_property_to_form(
             right_widget.editingFinished.connect(lambda: on_change())
 
     elif dtype == 'bool':
-        left_widget = None
-        right_widget = Qt.QCheckBox(label)
+        # left_widget = None
+        # left_widget.text(label)
+        right_widget = Qt.QCheckBox()
         if isinstance(default_value, bool):
             right_widget.setChecked(default_value)
         elif isinstance(default_value, str):

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -125,16 +125,6 @@ def switch_mp_on():
     pu.multiprocessing_available = backup_mp_avail
 
 
-def switch_gpu_off():
-    global backup_gpu_avail
-    backup_gpu_avail = gpu.CUPY_INSTALLED = False
-    gpu.CUPY_INSTALLED = False
-
-
-def switch_gpu_on():
-    gpu.CUPY_INSTALLED = backup_gpu_avail
-
-
 def assert_files_exist(
     cls,
     base_name,

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -32,7 +32,6 @@ def gen_img_shared_array(shape=g_shape, dtype=np.float32):
 
 def generate_images_class_random_shared_array(shape=g_shape):
     from mantidimaging.core.data import Images
-
     d = pu.create_shared_array(shape)
     n = np.random.rand(shape[0], shape[1], shape[2])
     # move the data in the shared array
@@ -48,7 +47,7 @@ def gen_empty_shared_array(shape=g_shape):
     return d
 
 
-def gen_img_shared_array_with_val(val=1.0, shape=g_shape):
+def gen_img_shared_array_with_val(val=1., shape=g_shape):
     d = pu.create_shared_array(shape)
     n = np.full(shape, val)
     # move the data in the shared array
@@ -70,14 +69,12 @@ def assert_not_equals(numpy_ndarray1, numpy_ndarray2):
 
 def deepcopy(source):
     from copy import deepcopy
-
     return deepcopy(source)
 
 
 def shared_deepcopy(source):
     d = pu.create_shared_array(source.shape)
     from copy import deepcopy
-
     d[:] = deepcopy(source)[:]
     return d
 
@@ -85,13 +82,11 @@ def shared_deepcopy(source):
 def debug(switch=True):
     if switch:
         import pydevd
-
         pydevd.settrace("localhost", port=59003, stdoutToServer=True, stderrToServer=True)
 
 
 def vsdebug():
     import ptvsd
-
     ptvsd.enable_attach("my_secret", address=("0.0.0.0", 59003))
     print("Waiting for remote debugger at localhost:59003")
     # Enable the below line of code only if you want the application to wait
@@ -144,7 +139,6 @@ def assert_files_exist(
     :param single_file: Are we looking for a 'stack' of images
     """
     import unittest
-
     assert isinstance(cls, unittest.TestCase), "Work only if class is unittest.TestCase, it uses self.assertTrue!"
 
     if not single_file:

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -6,7 +6,6 @@ import numpy.testing as npt
 from six import StringIO
 
 from mantidimaging.core.parallel import utility as pu
-from mantidimaging.core.gpu import utility as gpu
 
 backup_mp_avail = None
 g_shape = (10, 8, 10)

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -82,12 +82,12 @@ def shared_deepcopy(source):
 def debug(switch=True):
     if switch:
         import pydevd
-        pydevd.settrace("localhost", port=59003, stdoutToServer=True, stderrToServer=True)
+        pydevd.settrace('localhost', port=59003, stdoutToServer=True, stderrToServer=True)
 
 
 def vsdebug():
     import ptvsd
-    ptvsd.enable_attach("my_secret", address=("0.0.0.0", 59003))
+    ptvsd.enable_attach("my_secret", address=('0.0.0.0', 59003))
     print("Waiting for remote debugger at localhost:59003")
     # Enable the below line of code only if you want the application to wait
     # untill the debugger has attached to it
@@ -119,14 +119,7 @@ def switch_mp_on():
     pu.multiprocessing_available = backup_mp_avail
 
 
-def assert_files_exist(
-    cls,
-    base_name,
-    file_extension,
-    file_extension_separator=".",
-    single_file=True,
-    num_images=1,
-):
+def assert_files_exist(cls, base_name, file_extension, file_extension_separator='.', single_file=True, num_images=1):
     """
     Asserts that a file exists.
 


### PR DESCRIPTION
- Adds an implementation of the median filter that runs on `cupy`
- The program checks that `cupy` is installed correctly. In some cases, installing `cupy` doesn't guarantee that it will actually work so I've attempted to manage that situation.
- The median filter defaults to running on the GPU if `cupy` is installed (this should be changed?) and the data has three dimensions
- 80% of available GPU memory is allocated to `cupy` upon initialisation
- The GPU stores a maximum of 100 images on it at any one time irrespective of size/precision, if a stack contains more than 100 images then these are "swapped" asynchronously to process the entire collection of images

I also made a change to the way the label for a checkbox is managed for filter options as I think this looks more consistent.