### PR TITLE
Convert reconstructed slices to attenuation values

### DIFF
--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -9,7 +9,7 @@ import numpy as np
 from mantidimaging.core.data.utility import mark_cropped
 from mantidimaging.core.operation_history import const
 from mantidimaging.core.parallel import utility as pu
-from mantidimaging.core.utility.data_containers import ProjectionAngles
+from mantidimaging.core.utility.data_containers import ProjectionAngles, Micron
 from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 

--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -9,7 +9,7 @@ import numpy as np
 from mantidimaging.core.data.utility import mark_cropped
 from mantidimaging.core.operation_history import const
 from mantidimaging.core.parallel import utility as pu
-from mantidimaging.core.utility.data_containers import ProjectionAngles, Micron
+from mantidimaging.core.utility.data_containers import ProjectionAngles
 from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 
@@ -272,3 +272,11 @@ class Images:
     def projection_angles(self):
         return self._log_file.projection_angles() if self._log_file is not None else \
             ProjectionAngles(np.linspace(0, math.tau, self.num_projections))
+
+    @property
+    def pixel_size(self):
+        return self.metadata.get(const.PIXEL_SIZE, 0)
+
+    @pixel_size.setter
+    def pixel_size(self, value: int):
+        self.metadata[const.PIXEL_SIZE] = value

--- a/mantidimaging/core/filters/divide/divide.py
+++ b/mantidimaging/core/filters/divide/divide.py
@@ -33,7 +33,10 @@ class DivideFilter(BaseFilter):
         _, value_widget = add_property_to_form("Divide by", Type.FLOAT, form=form, on_change=on_change)
         assert value_widget is not None, "Requested widget was for FLOAT, got None instead"
         value_widget.setDecimals(7)
-        _, unit_widget = add_property_to_form("Unit", Type.CHOICE, valid_values=["micron", "cm"], form=form,
+        _, unit_widget = add_property_to_form("Unit",
+                                              Type.CHOICE,
+                                              valid_values=["micron", "cm"],
+                                              form=form,
                                               on_change=on_change)
 
         return {'value_widget': value_widget}

--- a/mantidimaging/core/filters/divide/divide.py
+++ b/mantidimaging/core/filters/divide/divide.py
@@ -17,14 +17,14 @@ class DivideFilter(BaseFilter):
     filter_name = "Divide"
 
     @staticmethod
-    def filter_func(data: Images, value: Union[int, float] = 0e7, unit="micron", progress=None) -> Images:
+    def filter_func(images: Images, value: Union[int, float] = 0e7, unit="micron", progress=None) -> Images:
         if unit == "micron":
             value *= 1e-4
 
-        h.check_data_stack(data)
+        h.check_data_stack(images)
         if value != 0e7 or value != -0e7:
-            data.data /= value
-        return data
+            images.data /= value
+        return images
 
     @staticmethod
     def register_gui(form: 'QFormLayout', on_change: Callable, view: 'BasePresenter') -> Dict[str, 'QWidget']:
@@ -33,10 +33,7 @@ class DivideFilter(BaseFilter):
         _, value_widget = add_property_to_form("Divide by", Type.FLOAT, form=form, on_change=on_change)
         assert value_widget is not None, "Requested widget was for FLOAT, got None instead"
         value_widget.setDecimals(7)
-        _, unit_widget = add_property_to_form("Unit",
-                                              Type.CHOICE,
-                                              valid_values=["micron", "cm"],
-                                              form=form,
+        _, unit_widget = add_property_to_form("Unit", Type.CHOICE, valid_values=["micron", "cm"], form=form,
                                               on_change=on_change)
 
         return {'value_widget': value_widget}

--- a/mantidimaging/core/operation_history/const.py
+++ b/mantidimaging/core/operation_history/const.py
@@ -4,6 +4,7 @@ TIMESTAMP = 'timestamp'
 OPERATION_KEYWORD_ARGS = 'kwargs'
 OPERATION_ARGS = 'args'
 OPERATION_DISPLAY_NAME = 'display_name'
+PIXEL_SIZE = 'pixel_size'
 
 OPERATION_NAME_COR_TILT_FINDING = 'cor_tilt_finding'
 COR_TILT_ROTATION_CENTRE = 'rotation_centre'

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -79,6 +79,12 @@ class ProjectionAngles(SingleValue):
 
 
 @dataclass
+class Micron(SingleValue):
+    __slots__ = 'value'
+    value: int
+
+
+@dataclass
 class ReconstructionParameters:
     algorithm: str
     filter_name: str
@@ -87,13 +93,11 @@ class ReconstructionParameters:
     tilt: Optional[Degrees] = None
 
     def to_dict(self) -> dict:
-        return {
-            'algorithm': self.algorithm,
-            'filter_name': self.filter_name,
-            'num_iter': self.num_iter,
-            'cor': str(self.cor),
-            'tilt': str(self.tilt)
-        }
+        return {'algorithm': self.algorithm,
+                'filter_name': self.filter_name,
+                'num_iter': self.num_iter,
+                'cor': str(self.cor),
+                'tilt': str(self.tilt)}
 
 
 Indices = namedtuple('Indices', ['start', 'end', 'step'])

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -93,11 +93,13 @@ class ReconstructionParameters:
     tilt: Optional[Degrees] = None
 
     def to_dict(self) -> dict:
-        return {'algorithm': self.algorithm,
-                'filter_name': self.filter_name,
-                'num_iter': self.num_iter,
-                'cor': str(self.cor),
-                'tilt': str(self.tilt)}
+        return {
+            'algorithm': self.algorithm,
+            'filter_name': self.filter_name,
+            'num_iter': self.num_iter,
+            'cor': str(self.cor),
+            'tilt': str(self.tilt)
+        }
 
 
 Indices = namedtuple('Indices', ['start', 'end', 'step'])

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -25,6 +25,7 @@ class MainWindowModel(object):
     def do_load_stack(self, parameters: LoadingParameters, progress):
         ds = Dataset(loader.load_p(parameters.sample, parameters.dtype, progress))
         ds.sample._is_sinograms = parameters.sinograms
+        ds.sample.pixel_size = parameters.pixel_size
 
         if parameters.sample.log_file:
             ds.sample.log_file = loader.load_log(parameters.sample.log_file)

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -115,6 +115,7 @@ class MainWindowModelTest(unittest.TestCase):
         lp.sample = sample_mock
         lp.dtype = "dtype_test"
         lp.sinograms = True
+        lp.pixel_size = 101
         progress_mock = mock.Mock()
 
         self.model.do_load_stack(lp, progress_mock)
@@ -130,6 +131,7 @@ class MainWindowModelTest(unittest.TestCase):
         lp.sample = sample_mock
         lp.dtype = "dtype_test"
         lp.sinograms = False
+        lp.pixel_size = 101
         progress_mock = mock.Mock()
 
         self.model.do_load_stack(lp, progress_mock)
@@ -145,6 +147,7 @@ class MainWindowModelTest(unittest.TestCase):
         lp.sample = sample_mock
         lp.dtype = "dtype_test"
         lp.sinograms = False
+        lp.pixel_size = 101
 
         flat_mock = mock.Mock()
         lp.flat = flat_mock
@@ -165,6 +168,7 @@ class MainWindowModelTest(unittest.TestCase):
         lp.sample = sample_mock
         lp.dtype = "dtype_test"
         lp.sinograms = False
+        lp.pixel_size = 101
 
         flat_mock = mock.Mock()
         lp.flat = flat_mock

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -105,6 +105,13 @@ class ReconstructWindowModel(object):
         # get the image height based on the current ROI
         recon = reconstructor.full(self.images, self.data_model.get_all_cors_from_regression(self.images.height),
                                    recon_params, progress)
+
+        if recon.pixel_size > 0:
+            recon = DivideFilter.filter_func(recon, value=recon.pixel_size, unit="micron", progress=progress)
+            recon.record_operation(DivideFilter.__name__,
+                                   DivideFilter.filter_name,
+                                   value=recon.pixel_size,
+                                   unit="micron")
         return recon
 
     @property

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import numpy as np
 
+from mantidimaging.core.filters.divide import DivideFilter
 from mantidimaging.core.operation_history import const
 from mantidimaging.core.reconstruct import get_reconstructor_for
 from mantidimaging.core.reconstruct.astra_recon import AstraRecon

--- a/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
+++ b/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
@@ -9,6 +9,7 @@ class MetadataDialog(Qt.QDialog):
     """
     Dialog used to show a pretty formatted version of the image metadata.
     """
+
     def __init__(self, parent: QWidget, images: Images):
         super(MetadataDialog, self).__init__(parent)
 
@@ -36,30 +37,41 @@ class MetadataDialog(Qt.QDialog):
         main_widget = QTreeWidget()
         main_widget.setHeaderLabel("Operation history")
         if len(metadata) != 0:
-            for i, op in enumerate(metadata[const.OPERATION_HISTORY]):
-                operation_item = QTreeWidgetItem(main_widget)
-                if const.OPERATION_DISPLAY_NAME in op and op[const.OPERATION_DISPLAY_NAME]:
-                    operation_item.setText(0, op[const.OPERATION_DISPLAY_NAME])
+            for key, value in metadata.items():
+                if key == const.OPERATION_HISTORY:
+                    MetadataDialog._build_operation_history(main_widget, metadata)
                 else:
-                    operation_item.setText(0, op[const.OPERATION_NAME])
+                    item = QTreeWidgetItem(main_widget)
+                    item.setText(0, value)
+                    main_widget.insertTopLevelItem(0, item)
 
-                main_widget.insertTopLevelItem(i, operation_item)
-
-                if op.get(const.TIMESTAMP, False):
-                    date_item = QTreeWidgetItem(operation_item)
-                    date_item.setText(0, f"Date: {op[const.TIMESTAMP]}")
-
-                if op.get(const.OPERATION_ARGS, False):
-                    args_item = QTreeWidgetItem(operation_item)
-                    args_item.setText(0, f"Positional arguments: {op[const.OPERATION_ARGS]}")
-
-                if op.get(const.OPERATION_KEYWORD_ARGS, False):
-                    kwargs_list_item = QTreeWidgetItem(operation_item)
-                    kwargs_list_item.setText(0, "Keyword arguments")
-                    # Note: Items must be added to the tree before they can expanded.
-                    # Nodes are added as they are created so these can be expanded by default
-                    kwargs_list_item.setExpanded(True)
-                    for kw, val in op[const.OPERATION_KEYWORD_ARGS].items():
-                        kwargs_item = QTreeWidgetItem(kwargs_list_item)
-                        kwargs_item.setText(0, f"{kw}: {val}")
         return main_widget
+
+    @staticmethod
+    def _build_operation_history(main_widget, metadata):
+        for i, op in enumerate(metadata[const.OPERATION_HISTORY]):
+            operation_item = QTreeWidgetItem(main_widget)
+            if const.OPERATION_DISPLAY_NAME in op and op[const.OPERATION_DISPLAY_NAME]:
+                operation_item.setText(0, op[const.OPERATION_DISPLAY_NAME])
+            else:
+                operation_item.setText(0, op[const.OPERATION_NAME])
+
+            main_widget.insertTopLevelItem(i, operation_item)
+
+            if op.get(const.TIMESTAMP, False):
+                date_item = QTreeWidgetItem(operation_item)
+                date_item.setText(0, f"Date: {op[const.TIMESTAMP]}")
+
+            if op.get(const.OPERATION_ARGS, False):
+                args_item = QTreeWidgetItem(operation_item)
+                args_item.setText(0, f"Positional arguments: {op[const.OPERATION_ARGS]}")
+
+            if op.get(const.OPERATION_KEYWORD_ARGS, False):
+                kwargs_list_item = QTreeWidgetItem(operation_item)
+                kwargs_list_item.setText(0, "Keyword arguments")
+                # Note: Items must be added to the tree before they can expanded.
+                # Nodes are added as they are created so these can be expanded by default
+                kwargs_list_item.setExpanded(True)
+                for kw, val in op[const.OPERATION_KEYWORD_ARGS].items():
+                    kwargs_item = QTreeWidgetItem(kwargs_list_item)
+                    kwargs_item.setText(0, f"{kw}: {val}")

--- a/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
+++ b/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
@@ -9,7 +9,6 @@ class MetadataDialog(Qt.QDialog):
     """
     Dialog used to show a pretty formatted version of the image metadata.
     """
-
     def __init__(self, parent: QWidget, images: Images):
         super(MetadataDialog, self).__init__(parent)
 

--- a/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
+++ b/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
@@ -42,7 +42,7 @@ class MetadataDialog(Qt.QDialog):
                     MetadataDialog._build_operation_history(main_widget, metadata)
                 else:
                     item = QTreeWidgetItem(main_widget)
-                    item.setText(0, value)
+                    item.setText(0, f"{key}: {str(value)}")
                     main_widget.insertTopLevelItem(0, item)
 
         return main_widget


### PR DESCRIPTION
The reconstruction now checks if a pixel size was provided during loading. If it was then it is divided by the pixel size right after reconstruction.

Also the `pixel_size` is now shown in the `Right Click on data -> Show History` dialog.

Fixes #478