### PR TITLE
Improve outlier filter parameters

### DIFF
--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -82,26 +82,37 @@ class OutliersFilter(BaseFilter):
         _, size_field = add_property_to_form('Size', Type.INT, 3, (0, 1000), form=form, on_change=on_change)
 
         _, mode_field = add_property_to_form('Mode', Type.CHOICE, valid_values=modes(), form=form, on_change=on_change)
-        _, axis_field = add_property_to_form('Axis', Type.INT, 0, (0, 2), form=form, on_change=on_change)
+        _, apply_to_field = add_property_to_form('Apply to', Type.CHOICE,
+                                                 valid_values=("Projections", "Sinograms"), form=form,
+                                                 on_change=on_change)
 
-        _, dim_field = add_property_to_form('Dims', Type.CHOICE, valid_values=dims(), form=form, on_change=on_change)
+        _, median_filter_field = add_property_to_form('Median filter dimensions', Type.CHOICE, valid_values=dims(),
+                                                      form=form, on_change=on_change)
 
         return {
             'diff_field': diff_field,
             'size_field': size_field,
             'mode_field': mode_field,
-            'axis_field': axis_field,
-            'dim_field': dim_field
+            'apply_to_field': apply_to_field,
+            'median_filter_field': median_filter_field
         }
 
     @staticmethod
-    def execute_wrapper(diff_field=None, size_field=None, mode_field=None, axis_field=None, dim_field=None):
+    def execute_wrapper(diff_field=None, size_field=None, mode_field=None, apply_to_field=None,
+                        median_filter_field=None):
+        if apply_to_field.currentText() == "Projections":
+            axis = 0
+        elif apply_to_field.currentText() == "Sinograms":
+            axis = 1
+        else:
+            raise AttributeError("apply_to_field not given a valid input.")
+
         return partial(OutliersFilter.filter_func,
                        diff=diff_field.value(),
                        radius=size_field.value(),
                        mode=mode_field.currentText(),
-                       axis=axis_field.value(),
-                       type=dim_field.currentText())
+                       axis=axis,
+                       type=median_filter_field.currentText())
 
 
 def modes():

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -82,12 +82,17 @@ class OutliersFilter(BaseFilter):
         _, size_field = add_property_to_form('Size', Type.INT, 3, (0, 1000), form=form, on_change=on_change)
 
         _, mode_field = add_property_to_form('Mode', Type.CHOICE, valid_values=modes(), form=form, on_change=on_change)
-        _, apply_to_field = add_property_to_form('Apply to', Type.CHOICE,
-                                                 valid_values=("Projections", "Sinograms"), form=form,
+        _, apply_to_field = add_property_to_form('Apply to',
+                                                 Type.CHOICE,
+                                                 valid_values=("Projections", "Sinograms"),
+                                                 form=form,
                                                  on_change=on_change)
 
-        _, median_filter_field = add_property_to_form('Median filter dimensions', Type.CHOICE, valid_values=dims(),
-                                                      form=form, on_change=on_change)
+        _, median_filter_field = add_property_to_form('Median filter dimensions',
+                                                      Type.CHOICE,
+                                                      valid_values=dims(),
+                                                      form=form,
+                                                      on_change=on_change)
 
         return {
             'diff_field': diff_field,
@@ -98,7 +103,10 @@ class OutliersFilter(BaseFilter):
         }
 
     @staticmethod
-    def execute_wrapper(diff_field=None, size_field=None, mode_field=None, apply_to_field=None,
+    def execute_wrapper(diff_field=None,
+                        size_field=None,
+                        mode_field=None,
+                        apply_to_field=None,
                         median_filter_field=None):
         if apply_to_field.currentText() == "Projections":
             axis = 0

--- a/mantidimaging/core/operations/outliers/test/outliers_test.py
+++ b/mantidimaging/core/operations/outliers/test/outliers_test.py
@@ -38,11 +38,12 @@ class OutliersTest(unittest.TestCase):
         size_field.value = mock.Mock(return_value=0)
         mode_field = mock.Mock()
         mode_field.currentText = mock.Mock(return_value=OUTLIERS_BRIGHT)
-        axis_field = mock.Mock()
-        axis_field.value = mock.Mock(return_value=0)
-        dim_field = mock.Mock()
-        dim_field.currentText = mock.Mock(return_value=DIM_2D)
-        execute_func = OutliersFilter.execute_wrapper(diff_field, size_field, mode_field, axis_field, dim_field)
+        apply_to_field = mock.Mock()
+        apply_to_field.currentText = mock.Mock(return_value="Projections")
+        median_filter_field = mock.Mock()
+        median_filter_field.currentText = mock.Mock(return_value=DIM_2D)
+        execute_func = OutliersFilter.execute_wrapper(diff_field, size_field, mode_field, apply_to_field,
+                                                      median_filter_field)
 
         images = th.generate_images()
         execute_func(images)
@@ -50,8 +51,8 @@ class OutliersTest(unittest.TestCase):
         self.assertEqual(diff_field.value.call_count, 1)
         self.assertEqual(size_field.value.call_count, 1)
         self.assertEqual(mode_field.currentText.call_count, 1)
-        self.assertEqual(axis_field.value.call_count, 1)
-        self.assertEqual(dim_field.currentText.call_count, 1)
+        self.assertEqual(apply_to_field.currentText.call_count, 1)
+        self.assertEqual(median_filter_field.currentText.call_count, 1)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/operations/outliers_isis/outliers_isis.py
+++ b/mantidimaging/core/operations/outliers_isis/outliers_isis.py
@@ -56,8 +56,10 @@ class OutliersISISFilter(BaseFilter):
 
         _, size_field = add_property_to_form('Size', Type.INT, 3, (0, 1000), form=form, on_change=on_change)
 
-        _, apply_to_field = add_property_to_form('Apply to', Type.CHOICE,
-                                                 valid_values=("Projections", "Sinograms"), form=form,
+        _, apply_to_field = add_property_to_form('Apply to',
+                                                 Type.CHOICE,
+                                                 valid_values=("Projections", "Sinograms"),
+                                                 form=form,
                                                  on_change=on_change)
 
         return {'diff_field': diff_field, 'size_field': size_field, 'apply_to_field': apply_to_field}
@@ -71,7 +73,4 @@ class OutliersISISFilter(BaseFilter):
         else:
             raise AttributeError("apply_to_field not given a valid input.")
 
-        return partial(OutliersISISFilter.filter_func,
-                       diff=diff_field.value(),
-                       radius=size_field.value(),
-                       axis=axis)
+        return partial(OutliersISISFilter.filter_func, diff=diff_field.value(), radius=size_field.value(), axis=axis)

--- a/mantidimaging/core/operations/outliers_isis/outliers_isis.py
+++ b/mantidimaging/core/operations/outliers_isis/outliers_isis.py
@@ -56,13 +56,22 @@ class OutliersISISFilter(BaseFilter):
 
         _, size_field = add_property_to_form('Size', Type.INT, 3, (0, 1000), form=form, on_change=on_change)
 
-        _, axis_field = add_property_to_form('Axis', Type.INT, 0, (0, 1), form=form, on_change=on_change)
+        _, apply_to_field = add_property_to_form('Apply to', Type.CHOICE,
+                                                 valid_values=("Projections", "Sinograms"), form=form,
+                                                 on_change=on_change)
 
-        return {'diff_field': diff_field, 'size_field': size_field, 'axis_field': axis_field}
+        return {'diff_field': diff_field, 'size_field': size_field, 'apply_to_field': apply_to_field}
 
     @staticmethod
-    def execute_wrapper(diff_field=None, size_field=None, axis_field=None):
+    def execute_wrapper(diff_field=None, size_field=None, apply_to_field=None):
+        if apply_to_field.currentText() == "Projections":
+            axis = 0
+        elif apply_to_field.currentText() == "Sinograms":
+            axis = 1
+        else:
+            raise AttributeError("apply_to_field not given a valid input.")
+
         return partial(OutliersISISFilter.filter_func,
                        diff=diff_field.value(),
                        radius=size_field.value(),
-                       axis=axis_field.value())
+                       axis=axis)

--- a/mantidimaging/core/operations/outliers_isis/test/outliers_isis_test.py
+++ b/mantidimaging/core/operations/outliers_isis/test/outliers_isis_test.py
@@ -35,16 +35,62 @@ class OutliersISISTest(unittest.TestCase):
         diff_field.value = mock.Mock(return_value=0)
         size_field = mock.Mock()
         size_field.value = mock.Mock(return_value=0)
-        axis_field = mock.Mock()
-        axis_field.value = mock.Mock(return_value=0)
-        execute_func = OutliersISISFilter.execute_wrapper(diff_field, size_field, axis_field)
+        apply_to_field = mock.Mock()
+        apply_to_field.currentText = mock.Mock(return_value="Projections")
+        execute_func = OutliersISISFilter.execute_wrapper(diff_field, size_field, apply_to_field)
 
         images = th.generate_images()
         execute_func(images)
 
         self.assertEqual(diff_field.value.call_count, 1)
         self.assertEqual(size_field.value.call_count, 1)
-        self.assertEqual(axis_field.value.call_count, 1)
+        self.assertEqual(apply_to_field.currentText.call_count, 1)
+
+    def test_apply_to_field_accepts_projections(self):
+        diff_field = mock.Mock()
+        diff_field.value = mock.Mock(return_value=0)
+        size_field = mock.Mock()
+        size_field.value = mock.Mock(return_value=0)
+        apply_to_field = mock.Mock()
+        apply_to_field.currentText = mock.Mock(return_value="Projections")
+        execute_func = OutliersISISFilter.execute_wrapper(diff_field, size_field, apply_to_field)
+
+        images = th.generate_images()
+        execute_func(images)
+
+        self.assertEqual(diff_field.value.call_count, 1)
+        self.assertEqual(size_field.value.call_count, 1)
+        self.assertEqual(apply_to_field.currentText.call_count, 1)
+
+    def test_apply_to_field_accepts_sinograms(self):
+        diff_field = mock.Mock()
+        diff_field.value = mock.Mock(return_value=0)
+        size_field = mock.Mock()
+        size_field.value = mock.Mock(return_value=0)
+        apply_to_field = mock.Mock()
+        apply_to_field.currentText = mock.Mock(return_value="Sinograms")
+        execute_func = OutliersISISFilter.execute_wrapper(diff_field, size_field, apply_to_field)
+
+        images = th.generate_images()
+        execute_func(images)
+
+        self.assertEqual(diff_field.value.call_count, 1)
+        self.assertEqual(size_field.value.call_count, 1)
+        self.assertEqual(apply_to_field.currentText.call_count, 2)
+
+    def test_apply_to_field_throws_attribute_error(self):
+        apply_to_field = mock.Mock()
+        apply_to_field.currentText = mock.Mock(return_value="AbsoluteRandomRubbish")
+
+        error_called = False
+        try:
+            OutliersISISFilter.execute_wrapper(None, None, apply_to_field)
+        except AttributeError as error:
+            error_called = True
+            self.assertEqual(str(error), "apply_to_field not given a valid input.")
+
+        self.assertEqual(apply_to_field.currentText.call_count, 2)
+        self.assertTrue(error_called)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
BLOCKED BY #512 

Change Axis choices from integer to a dropdown with choices "projections" (same as axis=0) and "sinograms" (same as axis=1)
Rename label of Axis to Apply to, so that the end looks something like Apply to: projections or Apply to: sinograms
Rename Dims to "Median filter dimensions", keep the values 1D and 2D (2D default)

Fixes #497 