### PR TITLE
Saving to different bit levels

### DIFF
--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -99,9 +99,7 @@ class Images:
     def save_metadata(self, f, rescale_params=None):
         self.metadata[const.SINOGRAMS] = self.is_sinograms
 
-        if rescale_params is None:
-            self.metadata[const.RESCALED] = ""
-        else:
+        if rescale_params is not None:
             self.metadata[const.RESCALED] = rescale_params
 
         json.dump(self.metadata, f, indent=4)

--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -96,8 +96,14 @@ class Images:
         self.metadata = json.load(f)
         self._is_sinograms = self.metadata.get(const.SINOGRAMS, False)
 
-    def save_metadata(self, f):
+    def save_metadata(self, f, rescale_params=None):
         self.metadata[const.SINOGRAMS] = self.is_sinograms
+
+        if rescale_params is None:
+            self.metadata[const.RESCALED] = ""
+        else:
+            self.metadata[const.RESCALED] = rescale_params
+
         json.dump(self.metadata, f, indent=4)
 
     def record_operation(self, func_name: str, display_name, *args, **kwargs):

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -140,8 +140,7 @@ class ImagesTest(unittest.TestCase):
         stream = io.StringIO()
         images.save_metadata(stream)
         self.assertEqual(stream.getvalue(), f'''{{
-    "{const.SINOGRAMS}": true,
-    "{const.RESCALED}": ""
+    "{const.SINOGRAMS}": true
 }}''')
 
     def test_helper_properties(self):

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -140,7 +140,8 @@ class ImagesTest(unittest.TestCase):
         stream = io.StringIO()
         images.save_metadata(stream)
         self.assertEqual(stream.getvalue(), f'''{{
-    "{const.SINOGRAMS}": true
+    "{const.SINOGRAMS}": true,
+    "{const.RESCALED}": ""
 }}''')
 
     def test_helper_properties(self):

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -99,7 +99,7 @@ def save(images: Images,
     elif pixel_depth == "int16":
         int16_size = 65536
         max_value = images.data.max()
-        slope = (max_value - 0) / int16_size
+        slope = max_value / int16_size
         rescale_params = {"offset": 0, "slope": slope}
 
         # Overwrite images with the copy that has been rescaled.

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from .utility import DEFAULT_IO_FILE_FORMAT
 from ..data.images import Images
-from ..filters.rescale import RescaleFilter
+from ..operations.rescale import RescaleFilter
 from ..utility.progress_reporting import Progress
 
 LOG = getLogger(__name__)
@@ -149,7 +149,7 @@ def save(images: Images,
 def do_rescale(images: Images, min_input, max_input, max_output):
     images_copy = images.copy()
     rescale = RescaleFilter()
-    rescale.filter_func(images_copy, min_input, max_input, max_output)
+    rescale.filter_func(images_copy, min_input, max_input, max_output, data_type=np.int16)
     return images_copy
 
 

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -145,8 +145,8 @@ def save(images: Images,
             for idx in range(num_images):
                 # Overwrite images with the copy that has been rescaled.
                 if pixel_depth == "int16":
-                    write_func(rescale_single_image(np.copy(images.data[idx]), min_value, max_value,
-                                                    INT16_SIZE - 1), names[idx], overwrite_all)
+                    write_func(rescale_single_image(np.copy(images.data[idx]), min_value, max_value, INT16_SIZE - 1),
+                               names[idx], overwrite_all)
                 else:
                     write_func(data[idx, :, :], names[idx], overwrite_all)
 

--- a/mantidimaging/core/operation_history/const.py
+++ b/mantidimaging/core/operation_history/const.py
@@ -20,3 +20,4 @@ OPERATION_NAME_TOMOPY_RECON = "tomopy_recon"
 
 OPERATION_NAME_AXES_SWAP = "axes_swap"
 SINOGRAMS = "sinograms"
+RESCALED = "rescaled"

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -19,15 +19,16 @@ class RescaleFilter(BaseFilter):
                     max_input: float = 10000.0,
                     max_output: float = 256.0,
                     progress=None,
-                    data_type=float32) -> Images:
+                    data_type=None) -> Images:
         images.data[images.data < min_input] = 0
         images.data[images.data > max_input] = 0
         images.data *= (max_output / images.data.max())
 
-        if data_type == int16 and not images.dtype == int16:
-            images.data = images.data.astype(int16)
-        elif data_type == float32 and not images.dtype == float32:
-            images.data = images.data.astype(float32)
+        if data_type is not None:
+            if data_type == int16 and not images.dtype == int16:
+                images.data = images.data.astype(int16)
+            elif data_type == float32 and not images.dtype == float32:
+                images.data = images.data.astype(float32)
 
         return images
 

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -1,5 +1,6 @@
 from functools import partial
 from typing import Dict, Any
+from numpy import issubdtype, int16, float32
 
 from PyQt5.QtWidgets import QDoubleSpinBox, QComboBox
 
@@ -17,10 +18,17 @@ class RescaleFilter(BaseFilter):
                     min_input: float = 0.0,
                     max_input: float = 10000.0,
                     max_output: float = 256.0,
-                    progress=None) -> Images:
+                    progress=None,
+                    data_type=float32) -> Images:
         images.data[images.data < min_input] = 0
         images.data[images.data > max_input] = 0
         images.data *= (max_output / images.data.max())
+
+        if data_type == int16 and not images.dtype == int16:
+            images.data = images.data.astype(int16)
+        elif data_type == float32 and not images.dtype == float32:
+            images.data = images.data.astype(float32)
+
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -1,6 +1,6 @@
 from functools import partial
 from typing import Dict, Any
-from numpy import int16, float32
+from numpy import int16, float32, ndarray
 
 from PyQt5.QtWidgets import QDoubleSpinBox, QComboBox
 
@@ -31,6 +31,19 @@ class RescaleFilter(BaseFilter):
                 images.data = images.data.astype(float32)
 
         return images
+
+    @staticmethod
+    def filter_single_image(image: ndarray, min_input: float, max_input: float, max_output: float, data_type=float32):
+        image[image < min_input] = 0
+        image[image > max_input] = 0
+        image *= (max_output / max_input)
+
+        if data_type == float32:
+            return image.astype(float32)
+        elif data_type == int16:
+            return image.astype(int16)
+        else:
+            raise ValueError("Only float32 and int16 data types are supported by single image rescale")
 
     @staticmethod
     def register_gui(form, on_change, view: FiltersWindowView) -> Dict[str, Any]:

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -1,6 +1,6 @@
 from functools import partial
 from typing import Dict, Any
-from numpy import issubdtype, int16, float32
+from numpy import int16, float32
 
 from PyQt5.QtWidgets import QDoubleSpinBox, QComboBox
 

--- a/mantidimaging/core/operations/rescale/rescale_test.py
+++ b/mantidimaging/core/operations/rescale/rescale_test.py
@@ -82,19 +82,15 @@ def test_scale_single_image():
     images.data[1] = 1.5
 
     # Scale to int16
-    scaled_image1 = RescaleFilter.filter_single_image(copy(images.data[0]), 0, images.data.max(),
-                                                      1, data_type=int16)
-    scaled_image2 = RescaleFilter.filter_single_image(copy(images.data[1]), 0, images.data.max(),
-                                                      1, data_type=int16)
+    scaled_image1 = RescaleFilter.filter_single_image(copy(images.data[0]), 0, images.data.max(), 1, data_type=int16)
+    scaled_image2 = RescaleFilter.filter_single_image(copy(images.data[1]), 0, images.data.max(), 1, data_type=int16)
 
     npt.assert_equal(0, scaled_image1)
     npt.assert_equal(1, scaled_image2)
 
     # Scale to float32
-    scaled_image3 = RescaleFilter.filter_single_image(copy(images.data[0]), 0, images.data.max(),
-                                                      2, data_type=float32)
-    scaled_image4 = RescaleFilter.filter_single_image(copy(images.data[1]), 0, images.data.max(),
-                                                      2, data_type=float32)
+    scaled_image3 = RescaleFilter.filter_single_image(copy(images.data[0]), 0, images.data.max(), 2, data_type=float32)
+    scaled_image4 = RescaleFilter.filter_single_image(copy(images.data[1]), 0, images.data.max(), 2, data_type=float32)
 
     npt.assert_equal(0.0, scaled_image3)
     npt.assert_equal(2.0, scaled_image4)

--- a/mantidimaging/core/operations/rescale/rescale_test.py
+++ b/mantidimaging/core/operations/rescale/rescale_test.py
@@ -1,5 +1,5 @@
 import pytest
-from numpy import testing as npt, int16, float32, finfo
+from numpy import testing as npt, int16, float32, finfo, copy
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.rescale import RescaleFilter
@@ -73,6 +73,36 @@ def test_type_changes_to_given_type(type, max_value):
                                        data_type=type)
 
     npt.assert_equal(images.dtype, type)
+
+
+def test_scale_single_image():
+    images = th.generate_images((2, 100, 100))
+
+    images.data[0] = -100.0
+    images.data[1] = 1.5
+
+    # Scale to int16
+    scaled_image1 = RescaleFilter.filter_single_image(copy(images.data[0]), 0, images.data.max(),
+                                                      1, data_type=int16)
+    scaled_image2 = RescaleFilter.filter_single_image(copy(images.data[1]), 0, images.data.max(),
+                                                      1, data_type=int16)
+
+    npt.assert_equal(0, scaled_image1)
+    npt.assert_equal(1, scaled_image2)
+
+    # Scale to float32
+    scaled_image3 = RescaleFilter.filter_single_image(copy(images.data[0]), 0, images.data.max(),
+                                                      2, data_type=float32)
+    scaled_image4 = RescaleFilter.filter_single_image(copy(images.data[1]), 0, images.data.max(),
+                                                      2, data_type=float32)
+
+    npt.assert_equal(0.0, scaled_image3)
+    npt.assert_equal(2.0, scaled_image4)
+
+    assert scaled_image1.dtype == int16
+    assert scaled_image2.dtype == int16
+    assert scaled_image3.dtype == float32
+    assert scaled_image4.dtype == float32
 
 
 if __name__ == "__main__":

--- a/mantidimaging/core/operations/rescale/rescale_test.py
+++ b/mantidimaging/core/operations/rescale/rescale_test.py
@@ -1,5 +1,5 @@
 import pytest
-from numpy import testing as npt
+from numpy import testing as npt, int16, float32, finfo
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.rescale import RescaleFilter
@@ -59,6 +59,23 @@ def test_execute_wrapper_with_preset(type: str, expected_max: float):
     assert partial.keywords['min_input'] == min_input_value
     assert partial.keywords['max_input'] == max_input_value
     assert partial.keywords['max_output'] == expected_max
+
+
+@pytest.mark.parametrize('type, max_value', [
+    (int16, 65535),
+    (float32, finfo(float32).max)
+])
+def test_type_changes_to_given_type(type, max_value):
+    images = th.generate_images((10, 100, 100))
+
+    expected_min_input = 0
+    images = RescaleFilter.filter_func(images,
+                                       min_input=expected_min_input,
+                                       max_input=images.data.max(),
+                                       max_output=max_value,
+                                       data_type=type)
+
+    npt.assert_equal(images.dtype, type)
 
 
 if __name__ == "__main__":

--- a/mantidimaging/core/operations/rescale/rescale_test.py
+++ b/mantidimaging/core/operations/rescale/rescale_test.py
@@ -61,10 +61,7 @@ def test_execute_wrapper_with_preset(type: str, expected_max: float):
     assert partial.keywords['max_output'] == expected_max
 
 
-@pytest.mark.parametrize('type, max_value', [
-    (int16, 65535),
-    (float32, finfo(float32).max)
-])
+@pytest.mark.parametrize('type, max_value', [(int16, 65535), (float32, finfo(float32).max)])
 def test_type_changes_to_given_type(type, max_value):
     images = th.generate_images((10, 100, 100))
 

--- a/mantidimaging/gui/ui/save_dialog.ui
+++ b/mantidimaging/gui/ui/save_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>405</width>
-    <height>214</height>
+    <width>406</width>
+    <height>216</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -37,18 +37,16 @@
       </widget>
      </item>
      <item row="3" column="1" colspan="2">
-      <widget class="QComboBox" name="comboBox">
+      <widget class="QComboBox" name="pixelDepth">
        <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="editable">
         <bool>false</bool>
        </property>
        <property name="currentIndex">
-        <number>1</number>
+        <number>0</number>
        </property>
-       <item>
-        <property name="text">
-         <string>int8</string>
-        </property>
-       </item>
        <item>
         <property name="text">
          <string>int16</string>
@@ -56,32 +54,7 @@
        </item>
        <item>
         <property name="text">
-         <string>int32</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>int64</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>float8</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>float16</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
          <string>float32</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>float64</string>
         </property>
        </item>
       </widget>
@@ -106,7 +79,7 @@
      <item row="3" column="0">
       <widget class="QLabel" name="label_4">
        <property name="enabled">
-        <bool>false</bool>
+        <bool>true</bool>
        </property>
        <property name="text">
         <string>Pixel bit depth</string>

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -41,14 +41,15 @@ class MainWindowModel(object):
 
         return ds
 
-    def do_saving(self, stack_uuid, output_dir, name_prefix, image_format, overwrite, progress):
+    def do_saving(self, stack_uuid, output_dir, name_prefix, image_format, overwrite, pixel_depth, progress):
         svp = self.get_stack_visualiser(stack_uuid).presenter
         filenames = saver.save(svp.images,
                                output_dir=output_dir,
                                name_prefix=name_prefix,
                                overwrite_all=overwrite,
                                out_format=image_format,
-                               progress=progress)
+                               progress=progress,
+                               pixel_depth=pixel_depth)
         svp.images.filenames = filenames
         return True
 

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -48,8 +48,8 @@ class MainWindowModel(object):
                                name_prefix=name_prefix,
                                overwrite_all=overwrite,
                                out_format=image_format,
-                               progress=progress,
-                               pixel_depth=pixel_depth)
+                               pixel_depth=pixel_depth,
+                               progress=progress)
         svp.images.filenames = filenames
         return True
 

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -120,7 +120,8 @@ class MainWindowPresenter(BasePresenter):
             'output_dir': self.view.save_dialogue.save_path(),
             'name_prefix': self.view.save_dialogue.name_prefix(),
             'image_format': self.view.save_dialogue.image_format(),
-            'overwrite': self.view.save_dialogue.overwrite()
+            'overwrite': self.view.save_dialogue.overwrite(),
+            'pixel_depth': self.view.save_dialogue.pixel_depth()
         }
         start_async_task_view(self.view, self.model.do_saving, self._on_save_done, kwargs)
 

--- a/mantidimaging/gui/windows/main/save_dialog.py
+++ b/mantidimaging/gui/windows/main/save_dialog.py
@@ -51,3 +51,6 @@ class MWSaveDialog(Qt.QDialog):
 
     def image_format(self):
         return str(self.formats.currentText())
+
+    def pixel_depth(self):
+        return str(self.pixelDepth.currentText())


### PR DESCRIPTION
Work:
Enabled the drop down in the save menu that allows you to choose the type that will be saved to file, which influences file size, choices between float32 and int16.

Test:
Open Mantidimaging
Load some data
Open File->Save
Choose int16 and repeat with float32
Save the files in both types and ensure they look similar enough (It shouldn't be noticeable beside int16 has half the file size)
