### PR TITLE
Histogram no longer changes zoom when changing operation parameters

### DIFF
--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -107,13 +107,13 @@ class FilterPreviews(GraphicsLayoutWidget):
                 before_plot = self.histogram.plot(*before_data, pen=before_pen, clear=True)
                 self.legend.addItem(before_plot, "Before")
             else:
-                before_plot = self.before_histogram.plot(*before_data, pen=before_pen, clear=True)
+                self.before_histogram.plot(*before_data, pen=before_pen, clear=True)
         if _data_valid_for_histogram(after_data):
             if self.combined_histograms:
                 after_plot = self.histogram.plot(*after_data, pen=after_pen)
                 self.legend.addItem(after_plot, "After")
             else:
-                after_plot = self.after_histogram.plot(*after_data, pen=after_pen)
+                self.after_histogram.plot(*after_data, pen=after_pen)
 
     def init_separate_histograms(self):
         hc = histogram_coords

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -98,14 +98,22 @@ class FilterPreviews(GraphicsLayoutWidget):
 
         self.legend = self.histogram.addLegend()
 
-    def set_histogram_data(self, before_data, after_data):
+    def update_histogram_data(self):
         # Plot any histogram that has data, and add a legend if both exist
+        before_data = self.image_before.getHistogram()
+        after_data = self.image_after.getHistogram()
         if _data_valid_for_histogram(before_data):
-            before_plot = self.histogram.plot(*before_data, pen=before_pen, clear=True)
-            self.legend.addItem(before_plot, "Before")
+            if self.combined_histograms:
+                before_plot = self.histogram.plot(*before_data, pen=before_pen, clear=True)
+                self.legend.addItem(before_plot, "Before")
+            else:
+                before_plot = self.before_histogram.plot(*before_data, pen=before_pen, clear=True)
         if _data_valid_for_histogram(after_data):
-            after_plot = self.histogram.plot(*after_data, pen=after_pen)
-            self.legend.addItem(after_plot, "After")
+            if self.combined_histograms:
+                after_plot = self.histogram.plot(*after_data, pen=after_pen)
+                self.legend.addItem(after_plot, "After")
+            else:
+                after_plot = self.after_histogram.plot(*after_data, pen=after_pen)
 
     def init_separate_histograms(self):
         hc = histogram_coords
@@ -124,6 +132,21 @@ class FilterPreviews(GraphicsLayoutWidget):
             self.before_histogram.plot(*self.before_histogram_data, pen=before_pen)
         if _data_valid_for_histogram(self.after_histogram_data):
             self.after_histogram.plot(*self.after_histogram_data, pen=after_pen)
+
+    def delete_histograms(self):
+        coords = set(c for c in histogram_coords.values())
+        histograms = (self.getItem(*coord) for coord in coords)
+        for histogram in filter(lambda h: h is not None, histograms):
+            self.removeItem(histogram)
+        self.histogram = None
+        self.before_histogram = None
+        self.after_histogram = None
+
+    def delete_histogram_labels(self):
+        coords = set(c for c in label_coords.values())
+        labels = (self.getItem(*coord) for coord in coords)
+        for label in filter(lambda h: h is not None, labels):
+            self.removeItem(label)
 
     @property
     def histogram_legend(self) -> Optional[LegendItem]:

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -136,7 +136,7 @@ class FiltersWindowPresenter(BasePresenter):
             subset: Images = stack_presenter.get_image(self.model.preview_image_idx)
             before_image = np.copy(subset.data[0])
             # Update image before
-            before_histogram = self._update_preview_image(before_image, self.view.preview_image_before)
+            self._update_preview_image(before_image, self.view.preview_image_before)
 
             # Generate sub-stack and run filter
             exec_kwargs = get_parameters_from_stack(stack_presenter, self.model.params_needed_from_stack)
@@ -150,9 +150,9 @@ class FiltersWindowPresenter(BasePresenter):
 
             filtered_image_data = subset.data[0]
 
-            after_histogram = self._update_preview_image(filtered_image_data, self.view.preview_image_after)
+            self._update_preview_image(filtered_image_data, self.view.preview_image_after)
 
-            self.view.previews.set_histogram_data(before_histogram, after_histogram)
+            self.view.previews.update_histogram_data()
 
             if filtered_image_data.shape == before_image.shape:
                 diff = np.subtract(filtered_image_data, before_image)
@@ -168,8 +168,6 @@ class FiltersWindowPresenter(BasePresenter):
     def _update_preview_image(image_data: Optional[np.ndarray], image: ImageItem):
         image.clear()
         image.setImage(image_data)
-
-        return image.getHistogram()
 
     def do_scroll_preview(self, offset):
         idx = self.model.preview_image_idx + offset

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -122,8 +122,19 @@ class FiltersWindowView(BaseMainWindowView):
         self.previews.clear_items()
 
     def histogram_mode_changed(self):
-        self.previews.combined_histograms = self.combinedHistograms.isChecked()
-        self.previews.redraw_histograms()
+        combined_histograms = self.combinedHistograms.isChecked()
+        self.previews.combined_histograms = combined_histograms
+
+        # Clear old histogram bits
+        self.previews.delete_histograms()
+        self.previews.delete_histogram_labels()
+
+        # Init the correct histograms
+        if combined_histograms:
+            self.previews.init_histogram()
+        else:
+            self.previews.init_separate_histograms()
+        self.previews.update_histogram_data()
 
     def histogram_legend_is_changed(self):
         self.previews.histogram_legend_visible = self.showHistogramLegend.isChecked()


### PR DESCRIPTION
How to Test:
- Open imaging
- Load Data
- Open operations window
- Switch operation to `remove outliers tomopy`
- Zoom in on a peak on the combined histogram
- Change a `remove outliers tomopy` parameter
- Histogram should still be zoomed in looking at that peak
- Switch to split histograms
- switch back
- Everything should look fine!