### PR TITLE
Add a filter help button in the operations window

### DIFF
--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -193,7 +193,7 @@
               </property>
               <property name="sizeHint" stdset="0">
                <size>
-                <width>30</width>
+                <width>35</width>
                 <height>20</height>
                </size>
               </property>

--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>980</width>
+    <width>1100</width>
     <height>600</height>
    </rect>
   </property>
@@ -51,41 +51,7 @@
           <property name="fieldGrowthPolicy">
            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
           </property>
-          <item row="0" column="0">
-           <widget class="QLabel" name="filterLabel">
-            <property name="text">
-             <string>Filter:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="filterSelector">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="stackLabel">
-            <property name="text">
-             <string>Stack:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="StackSelectorWidgetView" name="stackSelector">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="2">
+          <item row="4" column="0" colspan="2">
            <widget class="QGroupBox" name="filterPropertiesContainer">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -106,7 +72,7 @@
             </layout>
            </widget>
           </item>
-          <item row="3" column="0" colspan="2">
+          <item row="5" column="0" colspan="2">
            <widget class="QGroupBox" name="previewPropertiesContainer">
             <property name="title">
              <string>Preview</string>
@@ -162,7 +128,7 @@
             </layout>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="6" column="0">
            <layout class="QHBoxLayout" name="horizontalLayout">
             <item>
              <widget class="QLabel" name="error_icon">
@@ -173,7 +139,7 @@
             </item>
            </layout>
           </item>
-          <item row="4" column="1">
+          <item row="6" column="1">
            <widget class="QTextEdit" name="error_text">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
@@ -191,6 +157,95 @@
              <bool>true</bool>
             </property>
            </widget>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <layout class="QHBoxLayout" name="stackHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="stackLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Stack:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="StackSelectorWidgetView" name="stackSelector">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="helpButtonEquivelantSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>30</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item row="1" column="0" colspan="2">
+           <layout class="QHBoxLayout" name="filterHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="filterLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Filter:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="filterSelector">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="filterHelpButton">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>30</width>
+                <height>30</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>?</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </item>

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -1,6 +1,7 @@
 from functools import partial
 from logging import getLogger
 from typing import Callable, TYPE_CHECKING, List, Any, Dict
+from inspect import getsourcefile
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.operations.base_filter import BaseFilter
@@ -103,3 +104,9 @@ class FiltersWindowModel(object):
         stack_params = get_parameters_from_stack(stack_presenter, self.params_needed_from_stack)
         apply_func = partial(self.apply_filter, stack_presenter.images, stack_params)
         start_async_task_view(stack_view, apply_func, post_filter)
+
+    def get_filter_module_name(self, filter_idx):
+        """
+        Returns the class name of the filter index passed to it
+        """
+        return self.filters[filter_idx].__module__

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -1,7 +1,6 @@
 from functools import partial
 from logging import getLogger
 from typing import Callable, TYPE_CHECKING, List, Any, Dict
-from inspect import getsourcefile
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.operations.base_filter import BaseFilter

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -3,7 +3,6 @@ from enum import Enum, auto
 from logging import getLogger
 from typing import Callable, Any, Optional
 from typing import TYPE_CHECKING
-
 import numpy as np
 from pyqtgraph import ImageItem
 
@@ -178,3 +177,6 @@ class FiltersWindowPresenter(BasePresenter):
         idx = self.model.preview_image_idx + offset
         idx = max(min(idx, self.max_preview_image_idx), 0)
         self.set_preview_image_index(idx)
+
+    def get_filter_module_name(self, filter_idx):
+        return self.model.get_filter_module_name(filter_idx)

--- a/mantidimaging/gui/windows/operations/test/model_test.py
+++ b/mantidimaging/gui/windows/operations/test/model_test.py
@@ -177,6 +177,13 @@ class FiltersWindowModelTest(unittest.TestCase):
 
         images.proj180deg.free_memory()
 
+    def test_get_filter_module_name(self):
+        self.model.filters = mock.MagicMock()
+
+        module_name = self.model.get_filter_module_name(0)
+
+        self.assertEqual("mock.mock", module_name)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -72,3 +72,10 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.view.clear_previews.assert_called_once()
         self.assertEqual(3, update_preview_image_mock.call_count)
         apply_filter_mock.assert_called_once()
+
+    def test_get_filter_module_name(self):
+        self.presenter.model.filters = mock.MagicMock()
+
+        module_name = self.presenter.get_filter_module_name(0)
+
+        self.assertEqual("mock.mock", module_name)

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -2,6 +2,8 @@ from typing import TYPE_CHECKING
 
 from PyQt5 import Qt
 from PyQt5.QtWidgets import QVBoxLayout, QCheckBox, QLabel, QApplication, QSplitter, QPushButton, QSizePolicy, QComboBox
+from PyQt5.QtGui import QDesktopServices
+from PyQt5.QtCore import QUrl
 from pyqtgraph import ImageItem
 
 from mantidimaging.gui.mvp_base import BaseMainWindowView
@@ -84,6 +86,9 @@ class FiltersWindowView(BaseMainWindowView):
         self.stackSelector.subscribe_to_main_window(main_window)
         self.stackSelector.select_eligible_stack()
 
+        # Handle help button pressed
+        self.filterHelpButton.pressed.connect(self.open_help_webpage)
+
     def cleanup(self):
         self.stackSelector.unsubscribe_from_main_window()
         self.presenter.disconnect_current_stack_roi()
@@ -161,3 +166,9 @@ class FiltersWindowView(BaseMainWindowView):
         self.error_icon.clear()
         self.error_text.clear()
         self.error_text.hide()
+
+    def open_help_webpage(self):
+        filter_module_path = self.presenter.get_filter_module_name(self.filterSelector.currentIndex())
+        url = QUrl("https://mantidproject.github.io/mantidimaging/api/" + filter_module_path + ".html")
+        if not QDesktopServices.openUrl(url):
+            self.show_error_dialog("Url could not be opened: " + url.toString())


### PR DESCRIPTION
To test:
Open operations window
Click the help button (the ? button next to filter choices) and a website should open
Check that each filter opens the correct website that correlates to the correct filter

Fixes #514 