### PR TITLE
Reads monitor counts from current IMAT log file, adds monitor normalisation operation

### DIFF
--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -9,7 +9,7 @@ import numpy as np
 from mantidimaging.core.data.utility import mark_cropped
 from mantidimaging.core.operation_history import const
 from mantidimaging.core.parallel import utility as pu
-from mantidimaging.core.utility.data_containers import ProjectionAngles
+from mantidimaging.core.utility.data_containers import ProjectionAngles, Counts
 from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 
@@ -115,14 +115,14 @@ class Images:
 
         self.metadata[const.OPERATION_HISTORY].append({
             const.TIMESTAMP:
-            datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             const.OPERATION_NAME:
-            func_name,
+                func_name,
             const.OPERATION_ARGS: [a if accepted_type(a) else None for a in args],
             const.OPERATION_KEYWORD_ARGS: {k: prepare(v)
                                            for k, v in kwargs.items() if accepted_type(v)},
             const.OPERATION_DISPLAY_NAME:
-            display_name
+                display_name
         })
 
     def copy(self, flip_axes=False) -> 'Images':
@@ -272,6 +272,12 @@ class Images:
     def projection_angles(self):
         return self._log_file.projection_angles() if self._log_file is not None else \
             ProjectionAngles(np.linspace(0, math.tau, self.num_projections))
+
+    def counts(self) -> Optional[Counts]:
+        if self._log_file is not None:
+            return self._log_file.counts()
+        else:
+            return None
 
     @property
     def pixel_size(self):

--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -115,14 +115,14 @@ class Images:
 
         self.metadata[const.OPERATION_HISTORY].append({
             const.TIMESTAMP:
-                datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             const.OPERATION_NAME:
-                func_name,
+            func_name,
             const.OPERATION_ARGS: [a if accepted_type(a) else None for a in args],
             const.OPERATION_KEYWORD_ARGS: {k: prepare(v)
                                            for k, v in kwargs.items() if accepted_type(v)},
             const.OPERATION_DISPLAY_NAME:
-                display_name
+            display_name
         })
 
     def copy(self, flip_axes=False) -> 'Images':

--- a/mantidimaging/core/operations/monitor_normalisation/__init__.py
+++ b/mantidimaging/core/operations/monitor_normalisation/__init__.py
@@ -1,0 +1,3 @@
+from .monitor_normalisation import MonitorNormalisation  # noqa:F401
+
+FILTER_CLASS = MonitorNormalisation

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -19,11 +19,11 @@ class MonitorNormalisation(BaseFilter):
         if counts is None:
             return images
         else:
-            counts = counts.value
-        counts /= counts[0]
+            counts_val = counts.value
+            counts_val /= counts_val[0]
 
         div_partial = ptsm.create_partial(_divide_by_air_sum, fwd_function=ptsm.inplace)
-        images, air_sums = ptsm.execute(images.data, counts, div_partial, cores, chunksize, progress=progress)
+        images, _ = ptsm.execute(images.data, counts_val, div_partial, cores, chunksize, progress=progress)
         return images
 
     @staticmethod
@@ -31,7 +31,7 @@ class MonitorNormalisation(BaseFilter):
         return {}
 
     @staticmethod
-    def execute_wrapper() -> partial:
+    def execute_wrapper(*args) -> partial:
         return partial(MonitorNormalisation.filter_func)
 
     @staticmethod

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -1,0 +1,39 @@
+from functools import partial
+from typing import Callable, Dict, Any
+
+from PyQt5.QtWidgets import QFormLayout, QWidget
+
+from mantidimaging.core.data import Images
+from mantidimaging.core.operations.base_filter import BaseFilter
+from mantidimaging.core.operations.roi_normalisation.roi_normalisation import _divide_by_air_sum
+from mantidimaging.core.parallel import two_shared_mem as ptsm
+from mantidimaging.gui.mvp_base import BaseMainWindowView
+
+
+class MonitorNormalisation(BaseFilter):
+    filter_name = "Monitor Normalisation"
+
+    @staticmethod
+    def filter_func(images: Images, cores=None, chunksize=None, progress=None) -> Images:
+        counts = images.counts()
+        if counts is None:
+            return images
+        else:
+            counts = counts.value
+        counts /= counts[0]
+
+        div_partial = ptsm.create_partial(_divide_by_air_sum, fwd_function=ptsm.inplace)
+        images, air_sums = ptsm.execute(images.data, counts, div_partial, cores, chunksize, progress=progress)
+        return images
+
+    @staticmethod
+    def register_gui(form: 'QFormLayout', on_change: Callable, view: 'BaseMainWindowView') -> Dict[str, 'QWidget']:
+        return {}
+
+    @staticmethod
+    def execute_wrapper() -> partial:
+        return partial(MonitorNormalisation.filter_func)
+
+    @staticmethod
+    def validate_execute_kwargs(kwargs: Dict[str, Any]) -> bool:
+        return True

--- a/mantidimaging/core/operations/monitor_normalisation/test/monitor_normalisation_test.py
+++ b/mantidimaging/core/operations/monitor_normalisation/test/monitor_normalisation_test.py
@@ -1,0 +1,41 @@
+from functools import partial
+
+import mock
+import numpy as np
+import numpy.testing as npt
+
+from mantidimaging.core.utility.data_containers import Counts
+from mantidimaging.test_helpers.unit_test_helper import generate_images, assert_not_equals
+from ..monitor_normalisation import MonitorNormalisation
+
+
+def test_no_counts():
+    images = generate_images()
+    original = images.copy()
+    MonitorNormalisation.filter_func(images)
+    npt.assert_equal(original.data, images.data)
+
+
+def test_execute():
+    images = generate_images()
+    images._log_file = mock.Mock()
+    images._log_file.counts = mock.Mock(return_value=Counts(np.sin(np.linspace(0, 1, images.num_projections))))
+
+    original = images.copy()
+    MonitorNormalisation.filter_func(images)
+    images._log_file.counts.assert_called_once()
+    assert_not_equals(original.data, images.data)
+
+
+def test_register_gui():
+    assert MonitorNormalisation.register_gui(None, None, None) == {}
+
+
+def test_execute_wrapper():
+    wrapper = MonitorNormalisation.execute_wrapper()
+    assert wrapper is not None
+    assert isinstance(wrapper, partial)
+
+
+def test_validate_execute_kwargs():
+    assert MonitorNormalisation.validate_execute_kwargs({}) is True

--- a/mantidimaging/core/operations/monitor_normalisation/test/monitor_normalisation_test.py
+++ b/mantidimaging/core/operations/monitor_normalisation/test/monitor_normalisation_test.py
@@ -27,6 +27,22 @@ def test_execute():
     assert_not_equals(original.data, images.data)
 
 
+def test_execute2():
+    """
+    Test that the counts are correctly divided by the value at counts[0].
+
+    In this test that will make all the counts equal to 1, and the data will remain unchanged
+    """
+    images = generate_images()
+    images._log_file = mock.Mock()
+    images._log_file.counts = mock.Mock(return_value=Counts(np.full((10, ), 10)))
+
+    original = images.copy()
+    MonitorNormalisation.filter_func(images)
+    images._log_file.counts.assert_called_once()
+    npt.assert_equal(original.data, images.data)
+
+
 def test_register_gui():
     assert MonitorNormalisation.register_gui(None, None, None) == {}
 

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -77,6 +77,10 @@ class ProjectionAngles(SingleValue):
     __slots__ = 'value'
     value: numpy.ndarray
 
+@dataclass
+class Counts(SingleValue):
+    __slots__ = 'value'
+    value: numpy.ndarray
 
 @dataclass
 class Micron(SingleValue):

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -77,10 +77,12 @@ class ProjectionAngles(SingleValue):
     __slots__ = 'value'
     value: numpy.ndarray
 
+
 @dataclass
 class Counts(SingleValue):
     __slots__ = 'value'
     value: numpy.ndarray
+
 
 @dataclass
 class Micron(SingleValue):

--- a/mantidimaging/core/utility/imat_log_file_parser.py
+++ b/mantidimaging/core/utility/imat_log_file_parser.py
@@ -42,8 +42,9 @@ class IMATLogFile:
 
     def counts(self) -> Counts:
         counts = numpy.zeros(len(self._data[IMATLogColumn.COUNTS_BEFORE]))
-        for i, [before, after] in enumerate(
-                zip(self._data[IMATLogColumn.COUNTS_BEFORE], self._data[IMATLogColumn.COUNTS_AFTER])):
+        for i, [before,
+                after] in enumerate(zip(self._data[IMATLogColumn.COUNTS_BEFORE],
+                                        self._data[IMATLogColumn.COUNTS_AFTER])):
 
             # clips the string before the count number
             before = before[before.rfind(":") + 1:]

--- a/mantidimaging/core/utility/imat_log_file_parser.py
+++ b/mantidimaging/core/utility/imat_log_file_parser.py
@@ -3,7 +3,7 @@ from typing import List, Dict
 
 import numpy
 
-from mantidimaging.core.utility.data_containers import ProjectionAngles
+from mantidimaging.core.utility.data_containers import ProjectionAngles, Counts
 
 
 class IMATLogColumn(Enum):
@@ -34,7 +34,20 @@ class IMATLogFile:
     def projection_angles(self) -> ProjectionAngles:
         angles = numpy.zeros(len(self._data[IMATLogColumn.IMAGE_TYPE_IMAGE_COUNTER]))
         for i, angle_str in enumerate(self._data[IMATLogColumn.IMAGE_TYPE_IMAGE_COUNTER]):
-            assert "angle:" in angle_str
+            if "angle:" not in angle_str:
+                raise ValueError("Projection angles loaded from logfile do not have the correct formatting!")
             angles[i] = float(angle_str[angle_str.rfind(": ") + 1:])
 
         return ProjectionAngles(numpy.deg2rad(angles))
+
+    def counts(self) -> Counts:
+        counts = numpy.zeros(len(self._data[IMATLogColumn.COUNTS_BEFORE]))
+        for i, [before, after] in enumerate(
+                zip(self._data[IMATLogColumn.COUNTS_BEFORE], self._data[IMATLogColumn.COUNTS_AFTER])):
+
+            # clips the string before the count number
+            before = before[before.rfind(":") + 1:]
+            after = after[after.rfind(":") + 1:]
+            counts[i] = float(after) - float(before)
+
+        return Counts(counts)

--- a/mantidimaging/core/utility/test/imat_log_file_parser_test.py
+++ b/mantidimaging/core/utility/test/imat_log_file_parser_test.py
@@ -5,7 +5,8 @@ from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
 
 def test_parsing_log_file():
     test_input = [["ignored line"], ["ignored line"],
-                  ["timestamp", "projection index and angle: 0.100", "counts before", "counts_after"]]
+                  ["timestamp", "projection index and angle: 0.100", "counts before: 12345", "counts_after: 45678"]]
     logfile = IMATLogFile(test_input)
     assert len(logfile.projection_angles().value) == 1
     assert logfile.projection_angles().value[0] == np.deg2rad(0.1), f"Got: {logfile.projection_angles().value[0]}"
+    assert logfile.counts().value[0] == (45678 - 12345)


### PR DESCRIPTION
Parses the current IMAT log file and reads the monitor counts from them. Stores it in the `Images` class so they can be used for normalisation.

Adds monitor normalisation operation that uses the counts for normalisation