### PR TITLE
Fixed invalid kwarg for stack rename call

### DIFF
--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -55,8 +55,8 @@ class MainWindowPresenter(BasePresenter):
         self.model.do_remove_stack(uuid)
         self.view.active_stacks_changed.emit()
 
-    def _do_rename(self, old_name: str, new_name: str):
-        dock = self.model.get_stack_by_name(old_name)
+    def _do_rename(self, current_name: str, new_name: str):
+        dock = self.model.get_stack_by_name(current_name)
         if dock:
             dock.setWindowTitle(new_name)
             self.view.active_stacks_changed.emit()


### PR DESCRIPTION
To test:
- Load a stack
- Right click > change window name
- Enter something and OK
- Should rename successfully

Fixes #532