### PR TITLE
Changes timer to perf_counter

### DIFF
--- a/mantidimaging/core/utility/progress_reporting/progress.py
+++ b/mantidimaging/core/utility/progress_reporting/progress.py
@@ -195,7 +195,7 @@ class Progress(object):
 
             msg = f"{f'{msg}' if len(msg) > 0 else ''} | {self.current_step}/{self.end_step} | " \
                   f"Time: {fmt(self.execution_time())}, ETA: {fmt(eta)}"
-            step_details = ProgressHistory(time.process_time(), self.current_step, msg)
+            step_details = ProgressHistory(time.perf_counter(), self.current_step, msg)
             self.progress_history.append(step_details)
 
         # process progress callbacks


### PR DESCRIPTION
This should account for time the process spends IO and show the real time taken/left to the user.

Fixes #534 