### PR TITLE
Pixel size parameter in reconstruction window

### DIFF
--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -97,6 +97,7 @@ class ReconstructionParameters:
     num_iter: int = 1
     cor: Optional[ScalarCoR] = None
     tilt: Optional[Degrees] = None
+    pixel_size: float = 0.0
 
     def to_dict(self) -> dict:
         return {
@@ -104,7 +105,8 @@ class ReconstructionParameters:
             'filter_name': self.filter_name,
             'num_iter': self.num_iter,
             'cor': str(self.cor),
-            'tilt': str(self.tilt)
+            'tilt': str(self.tilt),
+            'pixel_size': self.pixel_size
         }
 
 

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1578</width>
-    <height>782</height>
+    <height>790</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -46,7 +46,7 @@
            </sizepolicy>
           </property>
           <property name="currentIndex">
-           <number>0</number>
+           <number>1</number>
           </property>
           <widget class="QWidget" name="resultsTab">
            <attribute name="title">
@@ -428,6 +428,16 @@
                  <double>360.000000000000000</double>
                 </property>
                </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="pixelSizeLabel">
+                <property name="text">
+                 <string>Pixel size (microns)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="QDoubleSpinBox" name="pixelSize"/>
               </item>
              </layout>
             </item>

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -25,16 +25,7 @@
         <property name="sizeConstraint">
          <enum>QLayout::SetMaximumSize</enum>
         </property>
-        <property name="leftMargin">
-         <number>9</number>
-        </property>
-        <property name="topMargin">
-         <number>9</number>
-        </property>
-        <property name="rightMargin">
-         <number>9</number>
-        </property>
-        <property name="bottomMargin">
+        <property name="margin">
          <number>9</number>
         </property>
         <item>
@@ -198,11 +189,11 @@
                    <property name="toolTip">
                     <string>Use the CoR and Tilt above to generate a CoR for each of the slice indices in the table below</string>
                    </property>
-                   <property name="toolTipDuration">
-                    <number>2</number>
-                   </property>
                    <property name="text">
                     <string>Fit from COR/Tilt above</string>
+                   </property>
+                   <property name="toolTipDuration" stdset="0">
+                    <number>2</number>
                    </property>
                   </widget>
                  </item>
@@ -437,7 +428,11 @@
                </widget>
               </item>
               <item row="4" column="1">
-               <widget class="QDoubleSpinBox" name="pixelSize"/>
+               <widget class="QDoubleSpinBox" name="pixelSize">
+                <property name="maximum">
+                 <double>99999.000000000000000</double>
+                </property>
+               </widget>
               </item>
              </layout>
             </item>

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -3,8 +3,8 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import numpy as np
 
-from mantidimaging.core.operations.divide import DivideFilter
 from mantidimaging.core.operation_history import const
+from mantidimaging.core.operations.divide import DivideFilter
 from mantidimaging.core.reconstruct import get_reconstructor_for
 from mantidimaging.core.reconstruct.astra_recon import AstraRecon
 from mantidimaging.core.reconstruct.astra_recon import allowed_recon_kwargs as astra_allowed_kwargs
@@ -108,6 +108,8 @@ class ReconstructWindowModel(object):
 
         if recon_params.pixel_size > 0.:
             recon = DivideFilter.filter_func(recon, value=recon_params.pixel_size, unit="micron", progress=progress)
+            # update the reconstructed stack pixel size with the value actually used for division
+            recon.pixel_size = recon_params.pixel_size
             recon.record_operation(DivideFilter.__name__,
                                    DivideFilter.filter_name,
                                    value=recon_params.pixel_size,

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -106,11 +106,11 @@ class ReconstructWindowModel(object):
         recon = reconstructor.full(self.images, self.data_model.get_all_cors_from_regression(self.images.height),
                                    recon_params, progress)
 
-        if recon.pixel_size > 0:
-            recon = DivideFilter.filter_func(recon, value=recon.pixel_size, unit="micron", progress=progress)
+        if recon_params.pixel_size > 0.:
+            recon = DivideFilter.filter_func(recon, value=recon_params.pixel_size, unit="micron", progress=progress)
             recon.record_operation(DivideFilter.__name__,
                                    DivideFilter.filter_name,
-                                   value=recon.pixel_size,
+                                   value=recon_params.pixel_size,
                                    unit="micron")
         return recon
 

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -120,6 +120,12 @@ class ReconstructWindowPresenter(BasePresenter):
     def set_row(self, row):
         self.model.selected_row = row
 
+    def get_pixel_size_from_images(self):
+        if self.model.images is not None and self.model.images.pixel_size is not None:
+            return self.model.images.pixel_size
+        else:
+            return 0.
+
     def do_update_projection(self):
         images = self.model.images
         if images is not None:

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -40,6 +40,7 @@ class ReconstructWindowView(BaseMainWindowView):
     filterName: QComboBox
     numIter: QSpinBox
     maxProjAngle: QDoubleSpinBox
+    pixelSize: QDoubleSpinBox
     resultCor: QDoubleSpinBox
     resultTilt: QDoubleSpinBox
     resultSlope: QDoubleSpinBox
@@ -125,6 +126,9 @@ class ReconstructWindowView(BaseMainWindowView):
         self.filterName.currentTextChanged.connect(
             lambda: self.presenter.notify(PresN.RECONSTRUCT_SLICE))  # type: ignore
         self.numIter.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_SLICE))  # type: ignore
+
+        # Set pixel size from loaded stack
+        self.pixelSize.setValue(self.presenter.get_pixel_size_from_images())
 
     def remove_selected_cor(self):
         return self.tableView.removeSelectedRows()
@@ -263,9 +267,17 @@ class ReconstructWindowView(BaseMainWindowView):
     def num_iter(self):
         return self.numIter.value()
 
+    @property
+    def pixel_size(self):
+        return self.pixelSize.value()
+
     def recon_params(self) -> ReconstructionParameters:
-        return ReconstructionParameters(self.algorithm_name, self.filter_name, self.num_iter,
-                                        ScalarCoR(self.rotation_centre), Degrees(self.tilt))
+        return ReconstructionParameters(algorithm=self.algorithm_name,
+                                        filter_name=self.filter_name,
+                                        num_iter=self.num_iter,
+                                        cor=ScalarCoR(self.rotation_centre),
+                                        tilt=Degrees(self.tilt),
+                                        pixel_size=self.pixel_size)
 
     def set_table_point(self, idx, slice_idx, cor):
         # reset_results=False stops the resetting of the data model on


### PR DESCRIPTION
Now asks for the pixel size in the reconstruction window. It is pre-loaded from the image stack (if the user provided one on load). The final pixel size used for the division post-reconstruction, is recorded in the reconstructed stack.

Fixes #536 