### PR TITLE
Replaces the np.where with ndarray.argmin()

### DIFF
--- a/mantidimaging/core/rotation/test/polyfit_correlation_test.py
+++ b/mantidimaging/core/rotation/test/polyfit_correlation_test.py
@@ -1,8 +1,8 @@
 import mock
 import numpy as np
 
-from mantidimaging.test_helpers.unit_test_helper import generate_images
-from ..polyfit_correlation import do_search, get_search_range, find_center
+from mantidimaging.test_helpers.unit_test_helper import generate_images, assert_not_equals
+from ..polyfit_correlation import do_calculate_correlation_err, get_search_range, find_center, _find_shift
 from ...data import Images
 from ...utility.progress_reporting import Progress
 
@@ -13,15 +13,15 @@ def test_do_search():
 
     search_range = get_search_range(test_p0.shape[1])
     result = []
-    do_search(result, search_range[0], [test_p0, test_p180], test_p0.shape[1])
+    do_calculate_correlation_err(result, search_range[0], (test_p0, test_p180), test_p0.shape[1])
     expected = [0.2, 0.2, 0.0, 0.2, 0.2, 0.2, 0.2, 0.0, 0.2, 0.2]
     assert result == expected, f"Found {result}"
 
-    do_search(result, search_range[1], [test_p0, test_p180], test_p0.shape[1])
+    do_calculate_correlation_err(result, search_range[1], (test_p0, test_p180), test_p0.shape[1])
     expected = [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2]
     assert result == expected, f"Found {result}"
 
-    do_search(result, search_range[8], [test_p0, test_p180], test_p0.shape[1])
+    do_calculate_correlation_err(result, search_range[8], (test_p0, test_p180), test_p0.shape[1])
     expected = [0.2, 0.2, 0.2, 0.0, 0.2, 0.2, 0.2, 0.2, 0.0, 0.2]
     assert result == expected, f"Found {result}"
 
@@ -35,3 +35,24 @@ def test_find_center():
     assert mock_progress.update.call_count == 11
     assert res_cor.value == 5.0, f"Found {res_cor.value}"
     assert res_tilt.value == 0.0, f"Found {res_tilt.value}"
+
+
+def test_find_shift():
+    images = generate_images((10, 10, 10))
+    search_range = get_search_range(images.width)
+    min_correlation_error = np.random.rand(len(search_range), images.height)
+    shift = np.zeros((images.height, ))
+    _find_shift(images, search_range, min_correlation_error, shift)
+    # check that the shift has been changed
+    assert_not_equals(shift, np.zeros((images.height, )))
+
+
+def test_find_shift_multiple_argmin():
+    images = generate_images((10, 10, 10))
+    search_range = get_search_range(images.width)
+    min_correlation_error = np.random.rand(len(search_range), images.height)
+    min_correlation_error.T[0][3] = min_correlation_error.T[0][4] = 0
+    shift = np.zeros((images.height, ))
+    _find_shift(images, search_range, min_correlation_error, shift)
+    # check that the shift has been changed
+    assert_not_equals(shift, np.zeros((images.height, )))


### PR DESCRIPTION
Also handles the case where `argmin()` returns an `ndarray` because there are multiple equally minimal values, and just picks the first one.

Fixes #555