### PR TITLE
Option to Apply to all loaded stacks

### DIFF
--- a/mantidimaging/core/operations/crop_coords/crop_coords.py
+++ b/mantidimaging/core/operations/crop_coords/crop_coords.py
@@ -47,6 +47,9 @@ class CropCoordinatesFilter(BaseFilter):
 
         sample = images.data
         shape = (sample.shape[0], region_of_interest.height, region_of_interest.width)
+        if any((s < 0 for s in shape)):
+            raise ValueError("It seems the Region of Interest is outside of the current image dimensions.\n"
+                             "This can happen on the image preview right after a previous Crop Coordinates.")
         sample_name = images.memory_filename
         if sample_name is not None:
             images.free_memory(delete_filename=False)

--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1100</width>
+    <width>1131</width>
     <height>600</height>
    </rect>
   </property>
@@ -34,16 +34,7 @@
         <property name="sizeConstraint">
          <enum>QLayout::SetMaximumSize</enum>
         </property>
-        <property name="leftMargin">
-         <number>9</number>
-        </property>
-        <property name="topMargin">
-         <number>9</number>
-        </property>
-        <property name="rightMargin">
-         <number>9</number>
-        </property>
-        <property name="bottomMargin">
+        <property name="margin">
          <number>9</number>
         </property>
         <item>
@@ -263,6 +254,13 @@
              </size>
             </property>
            </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="applyToAllButton">
+            <property name="text">
+             <string>Apply to ALL stacks</string>
+            </property>
+           </widget>
           </item>
           <item>
            <widget class="QPushButton" name="applyButton">

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -114,6 +114,9 @@ class MainWindowModel(object):
         """
         return self.active_stacks[stack_uuid].widget()
 
+    def get_all_stack_visualisers(self) -> List[StackVisualiserView]:
+        return [stack.widget() for stack in self.active_stacks.values()]
+
     def get_stack_history(self, stack_uuid: uuid.UUID) -> Optional[Dict[str, Any]]:
         return self.get_stack_visualiser(stack_uuid).presenter.images.metadata
 

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -153,5 +153,8 @@ class MainWindowPresenter(BasePresenter):
         return self.model.have_active_stacks
 
     def update_stack_with_images(self, images):
-        sv = self.model.get_stack_by_images(images)
+        sv = self.get_stack_with_images(images)
         sv.presenter.notify(SVNotification.REFRESH_IMAGE)
+
+    def get_stack_with_images(self, images):
+        return self.model.get_stack_by_images(images)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -142,6 +142,9 @@ class MainWindowPresenter(BasePresenter):
     def get_stack_visualiser(self, stack_uuid: UUID):
         return self.model.get_stack_visualiser(stack_uuid)
 
+    def get_all_stack_visualisers(self):
+        return self.model.get_all_stack_visualisers()
+
     def get_stack_history(self, stack_uuid: UUID):
         return self.model.get_stack_history(stack_uuid)
 

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -7,11 +7,11 @@ from PyQt5.QtWidgets import QAction, QLabel, QInputDialog
 from mantidimaging.core.data import Images
 from mantidimaging.core.utility.version_check import find_if_latest_version
 from mantidimaging.gui.mvp_base import BaseMainWindowView
-from mantidimaging.gui.windows.operations import FiltersWindowView
 from mantidimaging.gui.windows.load_dialog import MWLoadDialog
 from mantidimaging.gui.windows.main.presenter import MainWindowPresenter
 from mantidimaging.gui.windows.main.presenter import Notification as PresNotification
 from mantidimaging.gui.windows.main.save_dialog import MWSaveDialog
+from mantidimaging.gui.windows.operations import FiltersWindowView
 from mantidimaging.gui.windows.recon import ReconstructWindowView
 from mantidimaging.gui.windows.savu_operations.view import SavuFiltersWindowView
 from mantidimaging.gui.windows.stack_visualiser import StackVisualiserView
@@ -151,6 +151,9 @@ class MainWindowView(BaseMainWindowView):
 
     def update_stack_with_images(self, images: Images):
         self.presenter.update_stack_with_images(images)
+
+    def get_stack_with_images(self, images: Images):
+        return self.presenter.get_stack_with_images(images)
 
     def _create_stack_window(self,
                              stack: Images,

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -140,6 +140,9 @@ class MainWindowView(BaseMainWindowView):
     def get_stack_visualiser(self, stack_uuid):
         return self.presenter.get_stack_visualiser(stack_uuid)
 
+    def get_all_stack_visualisers(self):
+        return self.presenter.get_all_stack_visualisers()
+
     def get_stack_history(self, stack_uuid):
         return self.presenter.get_stack_history(stack_uuid)
 

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 def ensure_tuple(val):
-    return val if isinstance(val, tuple) else (val,)
+    return val if isinstance(val, tuple) else (val, )
 
 
 class FiltersWindowModel(object):
@@ -66,7 +66,6 @@ class FiltersWindowModel(object):
         """
         for stack in stacks:
             self.apply_to_images(stack.presenter.images, stack_params, progress=progress)
-
 
     def apply_to_images(self, images, stack_params, progress=None):
         input_kwarg_widgets = self.filter_widget_kwargs.copy()

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -140,14 +140,14 @@ class FiltersWindowPresenter(BasePresenter):
 
         self._do_apply_filter(stacks)
 
+    def _post_filter(self, updated_stacks, _):
+        for stack in updated_stacks:
+            self.view.main_window.update_stack_with_images(stack.presenter.images)
+
+        self.do_update_previews()
+
     def _do_apply_filter(self, apply_to):
-        def post_filter(updated_stacks, _):
-            for stack in updated_stacks:
-                self.view.main_window.update_stack_with_images(stack.presenter.images)
-
-            self.do_update_previews()
-
-        self.model.do_apply_filter(apply_to, partial(post_filter, apply_to))
+        self.model.do_apply_filter(apply_to, partial(self._post_filter, apply_to))
 
     def do_update_previews(self):
         self.view.clear_previews()

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -134,6 +134,9 @@ class FiltersWindowPresenter(BasePresenter):
         self.model.do_apply_filter(self.stack, self.stack.presenter, post_filter)
 
     def do_apply_filter_to_all(self):
+        confirmed = self.view.ask_confirmation("Are you sure you want to apply this filter to \n\nALL OPEN STACKS?")
+        if not confirmed:
+            return
         stacks = self.main_window.get_all_stack_visualisers()
 
         def post_filter(stack, task):

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -147,7 +147,7 @@ class FiltersWindowPresenter(BasePresenter):
                 self.do_update_previews()
 
         for stack in stacks:
-            self.model.do_apply_filter(stack, stack.presenter, partial(post_filter, stack))
+            self.model.do_apply_filter(stack, stack.presenter, partial(post_filter, stack), ignore_180deg=True)
 
     def do_update_previews(self):
         self.view.clear_previews()

--- a/mantidimaging/gui/windows/operations/test/model_test.py
+++ b/mantidimaging/gui/windows/operations/test/model_test.py
@@ -143,7 +143,7 @@ class FiltersWindowModelTest(unittest.TestCase):
 
         selected_filter_mock.execute_wrapper.return_value = partial(callback_mock)
         self.model.selected_filter = selected_filter_mock
-        self.model.apply_filter(images, stack_params, progress=progress_mock)
+        self.model.apply_to_stacks(images, stack_params, progress=progress_mock)
 
         selected_filter_mock.validate_execute_kwargs.assert_called_once()
         callback_mock.assert_called_once_with(images, progress=progress_mock, **stack_params)
@@ -166,7 +166,7 @@ class FiltersWindowModelTest(unittest.TestCase):
 
         selected_filter_mock.execute_wrapper.return_value = partial(callback_mock)
         self.model.selected_filter = selected_filter_mock
-        self.model.apply_filter(images, stack_params, progress=progress_mock)
+        self.model.apply_to_stacks(images, stack_params, progress=progress_mock)
 
         selected_filter_mock.validate_execute_kwargs.assert_called_once()
         callback_mock.assert_has_calls([

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -1,9 +1,10 @@
 import unittest
+from functools import partial
 
 import mock
 
-from mantidimaging.gui.windows.operations import FiltersWindowPresenter
 from mantidimaging.gui.windows.main import MainWindowView
+from mantidimaging.gui.windows.operations import FiltersWindowPresenter
 from mantidimaging.test_helpers.unit_test_helper import assert_called_once_with, generate_images
 
 
@@ -29,20 +30,72 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         stack = mock.Mock()
         presenter = mock.Mock()
         stack.presenter = presenter
+        presenter.images.has_proj180deg.return_value = False
         self.presenter.stack = stack
         self.presenter.do_apply_filter()
         self.view.clear_previews.assert_called_once()
-        assert_called_once_with(apply_filter_mock, stack, presenter)
+
+        expected_apply_to = [stack]
+        assert_called_once_with(apply_filter_mock, expected_apply_to,
+                                partial(self.presenter._post_filter, expected_apply_to))
+
+    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.do_apply_filter')
+    def test_apply_filter_with_180degree_proj_stack(self, apply_filter_mock: mock.Mock):
+        stack = mock.Mock()
+        stack_proj180 = mock.Mock()
+        presenter = mock.Mock()
+        stack.presenter = presenter
+
+        presenter.images.has_proj180deg.return_value = True
+        presenter.images.proj180deg = stack_proj180
+        self.view.main_window.get_stack_with_images.return_value = stack_proj180
+
+        self.presenter.stack = stack
+        self.presenter.do_apply_filter()
+
+        self.view.clear_previews.assert_called_once()
+        self.view.main_window.get_stack_with_images.assert_called_once_with(stack_proj180)
+
+        expected_apply_to = [stack, stack_proj180]
+        assert_called_once_with(apply_filter_mock, expected_apply_to,
+                                partial(self.presenter._post_filter, expected_apply_to))
+
+    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.do_apply_filter')
+    def test_apply_filter_to_all(self, apply_filter_mock: mock.Mock):
+        self.view.ask_confirmation.return_value = False
+        self.presenter.do_apply_filter_to_all()
+
+        self.view.ask_confirmation.assert_called_once()
+
+        self.view.ask_confirmation.reset_mock()
+        self.view.ask_confirmation.return_value = True
+        mock_stack_visualisers = [mock.Mock(), mock.Mock()]
+        self.presenter.main_window = mock.Mock()
+        self.presenter.main_window.get_all_stack_visualisers = mock.Mock()
+        self.presenter.main_window.get_all_stack_visualisers.return_value = mock_stack_visualisers
+
+        self.presenter.do_apply_filter_to_all()
+
+        assert_called_once_with(apply_filter_mock, mock_stack_visualisers,
+                                partial(self.presenter._post_filter, mock_stack_visualisers))
+
+    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter.do_update_previews')
+    def test_post_filter(self, update_previews_mock):
+        mock_stack_visualisers = [mock.Mock(), mock.Mock()]
+        self.presenter._post_filter(mock_stack_visualisers, None)
+
+        for i, msv in enumerate(mock_stack_visualisers):
+            assert msv.presenter.images == self.view.main_window.update_stack_with_images.call_args_list[i].args[0]
+        update_previews_mock.assert_called_once()
 
     def test_update_previews_no_stack(self):
         self.presenter.do_update_previews()
         self.view.clear_previews.assert_called_once()
 
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter._update_preview_image')
-    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.apply_filter')
-    def test_update_previews_apply_throws_exception(self, apply_filter_mock: mock.Mock,
-                                                    update_preview_image_mock: mock.Mock):
-        apply_filter_mock.side_effect = Exception
+    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.apply_to_images')
+    def test_update_previews_apply_throws_exception(self, apply_mock: mock.Mock, update_preview_image_mock: mock.Mock):
+        apply_mock.side_effect = Exception
         stack = mock.Mock()
         presenter = mock.Mock()
         stack.presenter = presenter
@@ -55,11 +108,11 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         presenter.get_image.assert_called_once_with(self.presenter.model.preview_image_idx)
         self.view.clear_previews.assert_called_once()
         update_preview_image_mock.assert_called_once()
-        apply_filter_mock.assert_called_once()
+        apply_mock.assert_called_once()
 
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter._update_preview_image')
-    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.apply_filter')
-    def test_update_previews(self, apply_filter_mock: mock.Mock, update_preview_image_mock: mock.Mock):
+    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.apply_to_images')
+    def test_update_previews(self, apply_mock: mock.Mock, update_preview_image_mock: mock.Mock):
         stack = mock.Mock()
         presenter = mock.Mock()
         stack.presenter = presenter
@@ -71,7 +124,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         presenter.get_image.assert_called_once_with(self.presenter.model.preview_image_idx)
         self.view.clear_previews.assert_called_once()
         self.assertEqual(3, update_preview_image_mock.call_count)
-        apply_filter_mock.assert_called_once()
+        apply_mock.assert_called_once()
 
     def test_get_filter_module_name(self):
         self.presenter.model.filters = mock.MagicMock()

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -1,9 +1,10 @@
 from typing import TYPE_CHECKING
 
 from PyQt5 import Qt
-from PyQt5.QtWidgets import QVBoxLayout, QCheckBox, QLabel, QApplication, QSplitter, QPushButton, QSizePolicy, QComboBox
-from PyQt5.QtGui import QDesktopServices
 from PyQt5.QtCore import QUrl
+from PyQt5.QtGui import QDesktopServices
+from PyQt5.QtWidgets import QMessageBox, QVBoxLayout, QCheckBox, QLabel, QApplication, QSplitter, QPushButton, \
+    QSizePolicy, QComboBox
 from pyqtgraph import ImageItem
 
 from mantidimaging.gui.mvp_base import BaseMainWindowView
@@ -185,3 +186,7 @@ class FiltersWindowView(BaseMainWindowView):
         url = QUrl("https://mantidproject.github.io/mantidimaging/api/" + filter_module_path + ".html")
         if not QDesktopServices.openUrl(url):
             self.show_error_dialog("Url could not be opened: " + url.toString())
+
+    def ask_confirmation(self, msg: str):
+        response = QMessageBox.question(self, "Confirm action", msg, QMessageBox.Ok | QMessageBox.Cancel)
+        return response == QMessageBox.Ok

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -188,5 +188,5 @@ class FiltersWindowView(BaseMainWindowView):
             self.show_error_dialog("Url could not be opened: " + url.toString())
 
     def ask_confirmation(self, msg: str):
-        response = QMessageBox.question(self, "Confirm action", msg, QMessageBox.Ok | QMessageBox.Cancel)
+        response = QMessageBox.question(self, "Confirm action", msg, QMessageBox.Ok | QMessageBox.Cancel)  # type:ignore
         return response == QMessageBox.Ok

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -38,6 +38,7 @@ class FiltersWindowView(BaseMainWindowView):
     presenter: FiltersWindowPresenter
 
     applyButton: QPushButton
+    applyToAllButton: QPushButton
     filterSelector: QComboBox
 
     def __init__(self, main_window: 'MainWindowView'):
@@ -58,6 +59,7 @@ class FiltersWindowView(BaseMainWindowView):
 
         # Handle apply filter
         self.applyButton.clicked.connect(lambda: self.presenter.notify(PresNotification.APPLY_FILTER))
+        self.applyToAllButton.clicked.connect(lambda: self.presenter.notify(PresNotification.APPLY_FILTER_TO_ALL))
         self.splitter.setStretchFactor(0, 0)
 
         self.previews = FilterPreviews(self)

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from functools import partial
 from typing import Tuple
 
 import mock
@@ -188,5 +189,8 @@ def assert_called_once_with(mock: mock.Mock, *args):
             np.testing.assert_equal(actual.value, expected.value)
         elif isinstance(actual, Images):
             assert actual is expected, f"Expected {expected}, got {actual}"
+        elif isinstance(actual, partial):
+            assert actual.args == expected.args
+            assert actual.keywords == expected.keywords
         else:
             assert actual == expected, f"Expected {expected}, got {actual}"


### PR DESCRIPTION
This PR adds the option to Apply an operation to all stacks. 

Currently there is no prevention for destructive operations, apart from a confirmation dialog on apply to all. It's not clear whether we should prevent some operations from being allowed to be "Applied to all" (e.g. flat-fielding should only be applied to the sample and 180 degree projection, applying it to anything else will produce garbage). This will be something to keep in mind for the next user workshop.

To test:
- Load any dataset with Sample, Flat and Dark images
- Apply to all: remove outliers, crop
- Then apply flat-fielding to the sample

--------------

- Load a dataset with a sample and 180 degree projection
  - Note that operations that are not ran with `Apply to all` will be applied to the 180 degree projection by default! This is to ensure that they are with the same dimensions and value ranges so that Correlate COR finding works best. 
- Repeat steps above, at the end the sample and 180 degree projection should look the same, maybe run a correlate COR find in the recon GUI and see that it produces sensible result

Fixes #539 