### PR TITLE
Allow users to cancel a task in progress

### DIFF
--- a/mantidimaging/gui/dialogs/async_task/model.py
+++ b/mantidimaging/gui/dialogs/async_task/model.py
@@ -19,6 +19,14 @@ class AsyncTaskDialogModel(Qt.QObject):
 
         self.on_complete_function: Callable = lambda: None
 
+    def do_cancel_task(self):
+        try:
+            self.task.terminate()
+            self.task.wait()
+        except Exception as e:
+            # This is going to throw
+            getLogger(__name__).exception("Terminated thread: " + str(e))
+
     def do_execute_async(self):
         """
         Start asynchronous execution.

--- a/mantidimaging/gui/dialogs/async_task/presenter.py
+++ b/mantidimaging/gui/dialogs/async_task/presenter.py
@@ -30,14 +30,12 @@ class AsyncTaskDialogPresenter(Qt.QObject, ProgressHandler):
                 self.do_start_processing()
             elif signal == Notification.CANCEL:
                 self.do_cancel_processing()
-
         except Exception as e:
-            getLogger(__name__).exception("Notification handler failed")
+            getLogger(__name__).exception("Notification handler failed: " + str(e))
 
     def do_cancel_processing(self):
         # Ensure the user is sure this is what they want to do
-        response = self.view.ask_user_if_they_are_sure_destructive()
-        if response:
+        if self.view.ask_user_if_they_are_sure_destructive():
             self.model.do_cancel_task()
 
     def set_task(self, f):

--- a/mantidimaging/gui/dialogs/async_task/test/model_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/model_test.py
@@ -31,7 +31,8 @@ class AsyncTaskDialogModelTest(unittest.TestCase):
         def long_task():
             for ii in range(0, 100):
                 time.sleep(0.1)
-            raise Exception("It should not get here")
+            # Should not get here
+            self.assertFalse(True)
 
         self.m.task.task_function = long_task
         self.assertFalse(self.m.task_is_running)

--- a/mantidimaging/gui/dialogs/async_task/test/model_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/model_test.py
@@ -7,21 +7,37 @@ from mantidimaging.gui.dialogs.async_task import AsyncTaskDialogModel
 
 
 class AsyncTaskDialogModelTest(unittest.TestCase):
+    def setUp(self):
+        done_func = mock.MagicMock()
+        self.m = AsyncTaskDialogModel()
+        self.m.on_complete_function = done_func
+
     def test_basic_happy_case(self):
         def f(a, b):
             time.sleep(0.1)
             return a + b
 
-        done_func = mock.MagicMock()
+        self.m.task.task_function = f
+        self.m.task.kwargs = {'a': 5, 'b': 4}
+        self.assertFalse(self.m.task_is_running)
 
-        m = AsyncTaskDialogModel()
-        m.task.task_function = f
-        m.task.kwargs = {'a': 5, 'b': 4}
-        m.on_complete_function = done_func
-        self.assertFalse(m.task_is_running)
+        self.m.do_execute_async()
+        self.assertTrue(self.m.task_is_running)
 
-        m.do_execute_async()
-        self.assertTrue(m.task_is_running)
+        self.m.task.wait()
+        self.assertFalse(self.m.task_is_running)
 
-        m.task.wait()
-        self.assertFalse(m.task_is_running)
+    def test_async_task_cancelled(self):
+        def long_task():
+            for ii in range(0, 100):
+                time.sleep(0.1)
+            raise Exception("It should not get here")
+
+        self.m.task.task_function = long_task
+        self.assertFalse(self.m.task_is_running)
+
+        self.m.do_execute_async()
+        self.assertTrue(self.m.task_is_running)
+
+        self.m.do_cancel_task()
+        self.assertFalse(self.m.task_is_running)

--- a/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
@@ -33,38 +33,3 @@ class AsyncTaskDialogPresenterTest(unittest.TestCase):
 
         self.p.model.task.wait()
         self.assertFalse(self.p.task_is_running)
-
-    def test_async_task_cancelled(self):
-        # Setup
-        self.p.set_task(self._long_task)
-        self.v.ask_user_if_they_are_sure_destructive.return_value = True
-        self.assertFalse(self.p.task_is_running)
-
-        # Start task
-        self.p.notify(Notification.START)
-        self.v.show.assert_called_once()
-        self.assertTrue(self.p.task_is_running)
-
-        # Cancel running task
-        self.p.notify(Notification.CANCEL)
-        self.assertFalse(self.p.task_is_running)
-        self.v.ask_user_if_they_are_sure_destructive.assert_called_once()
-
-    def test_async_task_doesnt_cancel(self):
-        # Setup
-        self.p.set_task(self._long_task)
-        self.v.ask_user_if_they_are_sure_destructive.return_value = False
-        self.assertFalse(self.p.task_is_running)
-
-        # Start task
-        self.p.notify(Notification.START)
-        self.v.show.assert_called_once()
-        self.assertTrue(self.p.task_is_running)
-
-        # Cancel running task
-        self.p.notify(Notification.CANCEL)
-        self.assertTrue(self.p.task_is_running)
-        self.v.ask_user_if_they_are_sure_destructive.assert_called_once()
-
-        # Cleanup
-        self.p.model.do_cancel_task()

--- a/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
@@ -8,21 +8,43 @@ from mantidimaging.gui.dialogs.async_task.presenter import Notification
 
 
 class AsyncTaskDialogPresenterTest(unittest.TestCase):
+    def setUp(self):
+        self.v = mock.create_autospec(AsyncTaskDialogView)
+        self.p = AsyncTaskDialogPresenter(self.v)
+
     def test_basic_happy_case(self):
         def f(a, b):
             time.sleep(0.1)
             return a + b
 
-        v = mock.create_autospec(AsyncTaskDialogView)
+        self.p.set_task(f)
+        self.p.set_parameters([5], {'b': 4})
+        self.assertFalse(self.p.task_is_running)
 
-        p = AsyncTaskDialogPresenter(v)
-        p.set_task(f)
-        p.set_parameters([5], {'b': 4})
-        self.assertFalse(p.task_is_running)
+        self.p.notify(Notification.START)
+        self.v.show.assert_called_once()
+        self.assertTrue(self.p.task_is_running)
 
-        p.notify(Notification.START)
-        v.show.assert_called_once()
-        self.assertTrue(p.task_is_running)
+        self.p.model.task.wait()
+        self.assertFalse(self.p.task_is_running)
 
-        p.model.task.wait()
-        self.assertFalse(p.task_is_running)
+    def test_async_task_cancelled(self):
+        def long_task():
+            for ii in range(0, 100):
+                time.sleep(0.1)
+            raise Exception("It should not get here")
+
+        # Setup
+        self.p.set_task(long_task)
+        self.v.ask_user_if_they_are_sure_destructive.return_value = True
+        self.assertFalse(self.p.task_is_running)
+
+        # Start task
+        self.p.notify(Notification.START)
+        self.v.show.assert_called_once()
+        self.assertTrue(self.p.task_is_running)
+
+        # Cancel running task
+        self.p.notify(Notification.CANCEL)
+        self.assertFalse(self.p.task_is_running)
+        self.v.ask_user_if_they_are_sure_destructive.assert_called_once()

--- a/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
@@ -8,6 +8,12 @@ from mantidimaging.gui.dialogs.async_task.presenter import Notification
 
 
 class AsyncTaskDialogPresenterTest(unittest.TestCase):
+    def _long_task(self):
+        for ii in range(0, 10):
+            time.sleep(1)
+        # Shouldn't get here.
+        self.assertTrue(False)
+
     def setUp(self):
         self.v = mock.create_autospec(AsyncTaskDialogView)
         self.p = AsyncTaskDialogPresenter(self.v)
@@ -29,13 +35,8 @@ class AsyncTaskDialogPresenterTest(unittest.TestCase):
         self.assertFalse(self.p.task_is_running)
 
     def test_async_task_cancelled(self):
-        def long_task():
-            for ii in range(0, 100):
-                time.sleep(0.1)
-            raise Exception("It should not get here")
-
         # Setup
-        self.p.set_task(long_task)
+        self.p.set_task(self._long_task)
         self.v.ask_user_if_they_are_sure_destructive.return_value = True
         self.assertFalse(self.p.task_is_running)
 
@@ -48,3 +49,22 @@ class AsyncTaskDialogPresenterTest(unittest.TestCase):
         self.p.notify(Notification.CANCEL)
         self.assertFalse(self.p.task_is_running)
         self.v.ask_user_if_they_are_sure_destructive.assert_called_once()
+
+    def test_async_task_doesnt_cancel(self):
+        # Setup
+        self.p.set_task(self._long_task)
+        self.v.ask_user_if_they_are_sure_destructive.return_value = False
+        self.assertFalse(self.p.task_is_running)
+
+        # Start task
+        self.p.notify(Notification.START)
+        self.v.show.assert_called_once()
+        self.assertTrue(self.p.task_is_running)
+
+        # Cancel running task
+        self.p.notify(Notification.CANCEL)
+        self.assertTrue(self.p.task_is_running)
+        self.v.ask_user_if_they_are_sure_destructive.assert_called_once()
+
+        # Cleanup
+        self.p.model.do_cancel_task()

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -52,14 +52,14 @@ class AsyncTaskDialogView(BaseDialogView):
         # Update progress bar
         self.progressBar.setValue(progress * 1000)
 
-
     def ask_user_if_they_are_sure_destructive(self):
-        response = QMessageBox.warning(parent=self, title="Destructive Action",
+        response = QMessageBox.warning(parent=self,
+                                       title="Destructive Action",
                                        text="Cancelling a task in progress has the potential to cause unknown side "
-                                            "effects, and destroy data, are you sure?", button0=QMessageBox.No,
+                                       "effects, and destroy data, are you sure?",
+                                       button0=QMessageBox.No,
                                        button1=QMessageBox.Yes)
         return response == QMessageBox.Yes
-
 
 
 def start_async_task_view(parent: 'Qt.QMainWindow', task: Callable, on_complete: Callable, kwargs=None):

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -53,12 +53,12 @@ class AsyncTaskDialogView(BaseDialogView):
         self.progressBar.setValue(progress * 1000)
 
     def ask_user_if_they_are_sure_destructive(self):
-        response = QMessageBox.warning(parent=self,
-                                       title="Destructive Action",
-                                       text="Cancelling a task in progress has the potential to cause unknown side "
-                                       "effects, and destroy data, are you sure?",
-                                       button0=QMessageBox.No,
-                                       button1=QMessageBox.Yes)
+        response = QMessageBox.warning(self,
+                                       "Destructive Action",
+                                       "Cancelling a task in progress has the potential to cause unknown side effects, "
+                                       "and destroy data, are you sure?",
+                                       QMessageBox.No | QMessageBox.Yes,
+                                       QMessageBox.No)
         return response == QMessageBox.Yes
 
 

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -53,12 +53,10 @@ class AsyncTaskDialogView(BaseDialogView):
         self.progressBar.setValue(progress * 1000)
 
     def ask_user_if_they_are_sure_destructive(self):
-        response = QMessageBox.warning(self,
-                                       "Destructive Action",
-                                       "Cancelling a task in progress has the potential to cause unknown side effects, "
-                                       "and destroy data, are you sure?",
-                                       QMessageBox.No | QMessageBox.Yes,
-                                       QMessageBox.No)
+        response = QMessageBox.warning(
+            self, "Destructive Action",
+            "Cancelling a task in progress has the potential to cause unknown side effects, "
+            "and destroy data, are you sure?", QMessageBox.No | QMessageBox.Yes, QMessageBox.No)
         return response == QMessageBox.Yes
 
 


### PR DESCRIPTION
Work:
Currently you can abort an in progress task, this literally terminates the thread in place and stops execution, it is destructive so a user must be sure so a second dialog is used to confirm this choice.

To Test:

- Load some data
- Open Operations window
- Start a "long" (enough) operation where you have the chance to click the x button on the progress window
- Click yes and observe it stops the operation
- Repeat but clicking No and observe it doesn't stop the operation

Fixed #544 