### PR TITLE
Add Rescale to ROI Normalisation

### DIFF
--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -7,6 +7,7 @@ import numpy as np
 from mantidimaging import helper as h
 from mantidimaging.core.data import Images
 from mantidimaging.core.operations.base_filter import BaseFilter
+from mantidimaging.core.operations.rescale.rescale import RescaleFilter
 from mantidimaging.core.parallel import two_shared_mem as ptsm
 from mantidimaging.core.parallel import utility as pu
 from mantidimaging.core.utility import value_scaling
@@ -46,8 +47,13 @@ class RoiNormalisationFilter(BaseFilter):
 
         # just get data reference
         if region_of_interest:
+            initial_image_max = images.data.max()
+
             progress = Progress.ensure_instance(progress, task_name='ROI Normalisation')
             _execute(images.data, region_of_interest, cores, chunksize, progress)
+
+            images = RescaleFilter.filter_func(images, min_input=images.data.min(), max_input=images.data.max(),
+                                               max_output=initial_image_max, progress=progress)
         h.check_data_stack(images)
         return images
 

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -51,7 +51,7 @@ class RoiNormalisationFilter(BaseFilter):
 
             progress = Progress.ensure_instance(progress, task_name='ROI Normalisation')
             _execute(images.data, region_of_interest, cores, chunksize, progress)
-
+            progress.update(1, "Rescaling to input value range")
             images = RescaleFilter.filter_func(images,
                                                min_input=images.data.min(),
                                                max_input=images.data.max(),

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -52,8 +52,11 @@ class RoiNormalisationFilter(BaseFilter):
             progress = Progress.ensure_instance(progress, task_name='ROI Normalisation')
             _execute(images.data, region_of_interest, cores, chunksize, progress)
 
-            images = RescaleFilter.filter_func(images, min_input=images.data.min(), max_input=images.data.max(),
-                                               max_output=initial_image_max, progress=progress)
+            images = RescaleFilter.filter_func(images,
+                                               min_input=images.data.min(),
+                                               max_input=images.data.max(),
+                                               max_output=initial_image_max,
+                                               progress=progress)
         h.check_data_stack(images)
         return images
 

--- a/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
@@ -54,6 +54,17 @@ class ROINormalisationTest(unittest.TestCase):
         images = th.generate_images()
         RoiNormalisationFilter.execute_wrapper()(images)
 
+    def test_roi_normalisation_performs_rescale(self):
+        images = th.generate_images()
+        images_max = images.data.max()
+
+        original = np.copy(images.data[0])
+        air = [3, 3, 4, 4]
+        result = RoiNormalisationFilter.filter_func(images, air)
+
+        th.assert_not_equals(result.data[0], original)
+        self.assertAlmostEqual(result.data.max(), images_max)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #548 

To Test:
- Load data
- Open operations
- Perform a ROI normalization operation
- Perform a Flat-fielding operation
- The stack should not look like garbage