### PR TITLE
Provide feedback to the user on operation completed

### DIFF
--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -34,7 +34,16 @@
         <property name="sizeConstraint">
          <enum>QLayout::SetMaximumSize</enum>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>9</number>
+        </property>
+        <property name="topMargin">
+         <number>9</number>
+        </property>
+        <property name="rightMargin">
+         <number>9</number>
+        </property>
+        <property name="bottomMargin">
          <number>9</number>
         </property>
         <item>
@@ -122,7 +131,7 @@
           <item row="6" column="0">
            <layout class="QHBoxLayout" name="horizontalLayout">
             <item>
-             <widget class="QLabel" name="error_icon">
+             <widget class="QLabel" name="notification_icon">
               <property name="text">
                <string/>
               </property>
@@ -131,7 +140,7 @@
            </layout>
           </item>
           <item row="6" column="1">
-           <widget class="QTextEdit" name="error_text">
+           <widget class="QTextEdit" name="notification_text">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
               <horstretch>0</horstretch>

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -100,7 +100,7 @@ class FiltersWindowPresenter(BasePresenter):
         filter_widget_kwargs = register_func(self.view.filterPropertiesLayout, self.view.auto_update_triggered.emit,
                                              self.view)
         self.model.setup_filter(filter_idx, filter_widget_kwargs)
-        self.view.clear_error_dialog()
+        self.view.clear_notification_dialog()
 
     def filter_uses_parameter(self, parameter):
         return parameter in self.model.params_needed_from_stack.values() if \
@@ -134,6 +134,10 @@ class FiltersWindowPresenter(BasePresenter):
             self.view.roi_view = None
 
         self.do_update_previews()
+
+        # Feedback to user
+        self.view.clear_notification_dialog()
+        self.view.show_operation_completed(self.model.selected_filter.filter_name)
 
     def _do_apply_filter(self, apply_to):
         self.model.do_apply_filter(apply_to, partial(self._post_filter, apply_to))

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -87,6 +87,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         for i, msv in enumerate(mock_stack_visualisers):
             assert msv.presenter.images == self.view.main_window.update_stack_with_images.call_args_list[i].args[0]
         update_previews_mock.assert_called_once()
+        self.view.show_operation_completed.assert_called_once_with("Circular Mask")
 
     def test_update_previews_no_stack(self):
         self.presenter.do_update_previews()

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -5,6 +5,7 @@ from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QDesktopServices
 from PyQt5.QtWidgets import QMessageBox, QVBoxLayout, QCheckBox, QLabel, QApplication, QSplitter, QPushButton, \
     QSizePolicy, QComboBox, QStyle
+from mantidimaging.gui.widgets.pg_image_view import MIImageView
 from pyqtgraph import ImageItem
 
 from mantidimaging.gui.mvp_base import BaseMainWindowView

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -4,8 +4,7 @@ from PyQt5 import Qt
 from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QDesktopServices
 from PyQt5.QtWidgets import QMessageBox, QVBoxLayout, QCheckBox, QLabel, QApplication, QSplitter, QPushButton, \
-    QSizePolicy, QComboBox
-from mantidimaging.gui.widgets.pg_image_view import MIImageView
+    QSizePolicy, QComboBox, QStyle
 from pyqtgraph import ImageItem
 
 from mantidimaging.gui.mvp_base import BaseMainWindowView
@@ -34,8 +33,8 @@ class FiltersWindowView(BaseMainWindowView):
     previews: FilterPreviews
     stackSelector: StackSelectorWidgetView
 
-    error_icon: QLabel
-    error_text: QLabel
+    notification_icon: QLabel
+    notification_text: QLabel
 
     presenter: FiltersWindowPresenter
 
@@ -126,7 +125,7 @@ class FiltersWindowView(BaseMainWindowView):
         Called when the signal indicating the filter, filter properties or data
         has changed such that the previews are now out of date.
         """
-        self.clear_error_dialog()
+        self.clear_notification_dialog()
         if self.previewAutoUpdate.isChecked() and self.isVisible():
             self.presenter.notify(PresNotification.UPDATE_PREVIEWS)
 
@@ -176,14 +175,19 @@ class FiltersWindowView(BaseMainWindowView):
         return self.previews.image_difference
 
     def show_error_dialog(self, msg=""):
-        self.error_text.show()
-        self.error_icon.setPixmap(QApplication.style().standardPixmap(QApplication.style().SP_MessageBoxCritical))
-        self.error_text.setText(str(msg))
+        self.notification_text.show()
+        self.notification_icon.setPixmap(QApplication.style().standardPixmap(QStyle.SP_MessageBoxCritical))
+        self.notification_text.setText(str(msg))
 
-    def clear_error_dialog(self):
-        self.error_icon.clear()
-        self.error_text.clear()
-        self.error_text.hide()
+    def clear_notification_dialog(self):
+        self.notification_icon.clear()
+        self.notification_text.clear()
+        self.notification_text.hide()
+
+    def show_operation_completed(self, operation_name):
+        self.notification_text.show()
+        self.notification_icon.setPixmap(QApplication.style().standardPixmap(QStyle.SP_DialogYesButton))
+        self.notification_text.setText(f"{operation_name} completed successfully!")
 
     def open_help_webpage(self):
         filter_module_path = self.presenter.get_filter_module_name(self.filterSelector.currentIndex())


### PR DESCRIPTION
Fixed #549 

To test:
- Load data
- Perform operation
- Notice feedback in the bottom left of the window