### PR TITLE
Ensure "after" plot clears whilst redrawing seperate histograms

### DIFF
--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -110,7 +110,7 @@ class FilterPreviews(GraphicsLayoutWidget):
                 self.before_histogram.plot(*before_data, pen=before_pen, clear=True)
         if _data_valid_for_histogram(after_data):
             if self.combined_histograms:
-                after_plot = self.histogram.plot(*after_data, pen=after_pen, clear=True)
+                after_plot = self.histogram.plot(*after_data, pen=after_pen)
                 self.legend.addItem(after_plot, "After")
             else:
                 self.after_histogram.plot(*after_data, pen=after_pen, clear=True)

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -110,10 +110,10 @@ class FilterPreviews(GraphicsLayoutWidget):
                 self.before_histogram.plot(*before_data, pen=before_pen, clear=True)
         if _data_valid_for_histogram(after_data):
             if self.combined_histograms:
-                after_plot = self.histogram.plot(*after_data, pen=after_pen)
+                after_plot = self.histogram.plot(*after_data, pen=after_pen, clear=True)
                 self.legend.addItem(after_plot, "After")
             else:
-                self.after_histogram.plot(*after_data, pen=after_pen)
+                self.after_histogram.plot(*after_data, pen=after_pen, clear=True)
 
     def init_separate_histograms(self):
         hc = histogram_coords


### PR DESCRIPTION
Fixes #570 

To test:
- Load data
- Open operations window
- Toggle separate histograms box so there are 2
- Ensure as you click between different operations that the green "after" plot works
- As long as there is only one line on the "after" plot then it is working properly