### PR TITLE
Save dialog sort stack names based on tomo and recon

### DIFF
--- a/mantidimaging/gui/windows/main/save_dialog.py
+++ b/mantidimaging/gui/windows/main/save_dialog.py
@@ -5,6 +5,15 @@ from mantidimaging.core.io.utility import DEFAULT_IO_FILE_FORMAT
 from mantidimaging.gui.utility import (compile_ui, select_directory)
 
 
+def sort_by_tomo_and_recon(string):
+    if "Recon" in string:
+        return 1
+    elif "Tomo" in string:
+        return 2
+    else:
+        return 3
+
+
 class MWSaveDialog(Qt.QDialog):
     def __init__(self, parent, stack_list):
         super(MWSaveDialog, self).__init__(parent)
@@ -23,6 +32,10 @@ class MWSaveDialog(Qt.QDialog):
 
         if stack_list:  # we will just show an empty drop down if no stacks
             self.stack_uuids, user_friendly_names = zip(*stack_list)
+
+            # Sort stacknames using Recon and Tomo as preference
+            user_friendly_names = sorted(user_friendly_names, key=sort_by_tomo_and_recon)
+
             # the stacklist is created in the main windows presenter and has
             # format [(uuid, title)...], doing zip(*stack_list) unzips the
             # tuples into separate lists

--- a/mantidimaging/gui/windows/main/test/save_test.py
+++ b/mantidimaging/gui/windows/main/test/save_test.py
@@ -1,0 +1,15 @@
+import unittest
+
+from gui.windows.main.save_dialog import sort_by_tomo_and_recon
+
+
+class SaveDialogTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(SaveDialogTest, self).__init__(*args, **kwargs)
+
+    def test_sort_stack_names_order(self):
+        names = ["Dark", "Dark1", "Flat", "Recon", "Tomo"]
+        new_names = sorted(names, key=sort_by_tomo_and_recon)
+
+        self.assertEqual("Recon", new_names[0])
+        self.assertEqual("Tomo", new_names[1])

--- a/mantidimaging/gui/windows/main/test/save_test.py
+++ b/mantidimaging/gui/windows/main/test/save_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from gui.windows.main.save_dialog import sort_by_tomo_and_recon
+from mantidimaging.gui.windows.main.save_dialog import sort_by_tomo_and_recon
 
 
 class SaveDialogTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #561 

Test:
- Load Data
- Perform Recon
- Open save window
- Ensure stacks go by named "Recon"s and then "Tomo"s before any other stacks