### PR TITLE
Use percentage for Cor Step

### DIFF
--- a/mantidimaging/gui/dialogs/cor_inspection/model.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/model.py
@@ -15,7 +15,7 @@ class CORInspectionDialogModel(object):
 
         # Initial parameters
         self.centre_cor = initial_cor.value
-        self.cor_step = images.width
+        self.cor_step = self.image_width * 0.05
 
         # Cache projection angles
         self.proj_angles = images.projection_angles()

--- a/mantidimaging/gui/dialogs/cor_inspection/model.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/model.py
@@ -15,7 +15,7 @@ class CORInspectionDialogModel(object):
 
         # Initial parameters
         self.centre_cor = initial_cor.value
-        self.cor_step = 50
+        self.cor_step = images.width
 
         # Cache projection angles
         self.proj_angles = images.projection_angles()

--- a/mantidimaging/gui/dialogs/cor_inspection/test/model_test.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/test/model_test.py
@@ -16,6 +16,11 @@ class CORInspectionDialogModelTest(unittest.TestCase):
         self.assertEqual(m.cor_extents, (0, 9))
         self.assertEqual(m.proj_angles.value.shape, (10, ))
 
+    def test_start_cor_step(self):
+        images = generate_images()
+        m = CORInspectionDialogModel(images, 5, ScalarCoR(20), ReconstructionParameters('FBP_CUDA', 'ram-lak'))
+        self.assertEqual(images.width, m.cor_step)
+
     def test_current_cor(self):
         images = generate_images()
         m = CORInspectionDialogModel(images, 5, ScalarCoR(20), ReconstructionParameters('FBP_CUDA', 'ram-lak'))

--- a/mantidimaging/gui/dialogs/cor_inspection/test/model_test.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/test/model_test.py
@@ -19,7 +19,7 @@ class CORInspectionDialogModelTest(unittest.TestCase):
     def test_start_cor_step(self):
         images = generate_images()
         m = CORInspectionDialogModel(images, 5, ScalarCoR(20), ReconstructionParameters('FBP_CUDA', 'ram-lak'))
-        self.assertEqual(images.width, m.cor_step)
+        self.assertEqual(images.width * 0.05, m.cor_step)
 
     def test_current_cor(self):
         images = generate_images()


### PR DESCRIPTION
Fixes #568 

Test:
- Load Data
- go to recon
- Do Minimise Sqr auto correlation
- Click Refine
- The step field should not be 50 but whatever 5% of the images width is