### PR TITLE
Focus last added stack

### DIFF
--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -121,7 +121,7 @@ class MainWindowPresenter(BasePresenter):
             if tab_bar is not None:
                 last_stack_pos = len(current_stack_visualisers) - 1
                 # make Qt process the addition of the dock onto the main window
-                QApplication.processEvents()
+                QApplication.sendPostedEvents()
                 tab_bar.setCurrentIndex(last_stack_pos)
 
         self.view.active_stacks_changed.emit()

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -5,7 +5,7 @@ from logging import getLogger
 from typing import TYPE_CHECKING, Union, Tuple
 from uuid import UUID
 
-from PyQt5.QtWidgets import QDockWidget
+from PyQt5.QtWidgets import QDockWidget, QTabBar, QApplication
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.data.dataset import Dataset
@@ -115,6 +115,14 @@ class MainWindowPresenter(BasePresenter):
                 self._add_stack(container.dark, container.dark.filenames[0], sample_dock)
             if container.sample.has_proj180deg() and container.sample.proj180deg.filenames:
                 self._add_stack(container.sample.proj180deg, container.sample.proj180deg.filenames[0], sample_dock)
+
+        if len(current_stack_visualisers) > 1:
+            tab_bar = self.view.findChild(QTabBar)
+            if tab_bar is not None:
+                last_stack_pos = len(current_stack_visualisers) - 1
+                # make Qt process the addition of the dock onto the main window
+                QApplication.processEvents()
+                tab_bar.setCurrentIndex(last_stack_pos)
 
         self.view.active_stacks_changed.emit()
 

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -105,7 +105,8 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.assertEqual(1, len(self.presenter.model.stack_list))
         self.view.active_stacks_changed.emit.assert_called_once()
 
-    def test_create_new_stack_images_focuses_newest_tab(self):
+    @mock.patch("mantidimaging.gui.windows.main.presenter.QApplication")
+    def test_create_new_stack_images_focuses_newest_tab(self, mock_QApp):
         self.view.active_stacks_changed.emit = mock.Mock()
         images = generate_images()
         self.presenter.create_new_stack(images, "My title")
@@ -118,6 +119,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         mock_tab_bar = self.view.findChild.return_value
         expected_position = 1
         mock_tab_bar.setCurrentIndex.assert_called_once_with(expected_position)
+        mock_QApp.sendPostedEvents.assert_called_once()
 
     def test_create_new_stack_dataset(self):
         dock_mock = mock.Mock()

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -89,7 +89,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.model = mock.Mock()
 
         dock_mock.widget.return_value = stack_visualiser_mock
-        self.view._create_stack_window.return_value = dock_mock
+        self.view.create_stack_window.return_value = dock_mock
 
         self.presenter._add_stack(images, "myfilename", sample_dock_mock)
         self.presenter._add_stack(images2, "myfilename2", sample_dock_mock)

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -4,8 +4,8 @@ import mock
 
 from mantidimaging.core.data.dataset import Dataset
 from mantidimaging.gui.dialogs.async_task import TaskWorkerThread
-from mantidimaging.gui.windows.main import MainWindowView, MainWindowPresenter
 from mantidimaging.gui.windows.load_dialog import MWLoadDialog
+from mantidimaging.gui.windows.main import MainWindowView, MainWindowPresenter
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
 
@@ -104,6 +104,20 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.create_new_stack(images, "My title")
         self.assertEqual(1, len(self.presenter.model.stack_list))
         self.view.active_stacks_changed.emit.assert_called_once()
+
+    def test_create_new_stack_images_focuses_newest_tab(self):
+        self.view.active_stacks_changed.emit = mock.Mock()
+        images = generate_images()
+        self.presenter.create_new_stack(images, "My title")
+        self.assertEqual(1, len(self.presenter.model.stack_list))
+        self.view.active_stacks_changed.emit.assert_called_once()
+
+        self.presenter.create_new_stack(images, "My title")
+        self.view.tabifyDockWidget.assert_called_once()
+        self.view.findChild.assert_called_once()
+        mock_tab_bar = self.view.findChild.return_value
+        expected_position = 1
+        mock_tab_bar.setCurrentIndex.assert_called_once_with(expected_position)
 
     def test_create_new_stack_dataset(self):
         dock_mock = mock.Mock()

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -2,7 +2,7 @@ from logging import getLogger
 from typing import Optional
 
 from PyQt5 import Qt, QtCore, QtGui, QtWidgets
-from PyQt5.QtWidgets import QAction, QLabel, QInputDialog, QTabBar
+from PyQt5.QtWidgets import QAction, QLabel, QInputDialog
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.utility.version_check import find_if_latest_version
@@ -225,4 +225,3 @@ class MainWindowView(BaseMainWindowView):
         if accepted:
             import pydevd_pycharm
             pydevd_pycharm.settrace('ndlt1104.isis.cclrc.ac.uk', port=port, stdoutToServer=True, stderrToServer=True)
-

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -2,7 +2,7 @@ from logging import getLogger
 from typing import Optional
 
 from PyQt5 import Qt, QtCore, QtGui, QtWidgets
-from PyQt5.QtWidgets import QAction, QLabel, QInputDialog
+from PyQt5.QtWidgets import QAction, QLabel, QInputDialog, QTabBar
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.utility.version_check import find_if_latest_version
@@ -225,3 +225,4 @@ class MainWindowView(BaseMainWindowView):
         if accepted:
             import pydevd_pycharm
             pydevd_pycharm.settrace('ndlt1104.isis.cclrc.ac.uk', port=port, stdoutToServer=True, stderrToServer=True)
+


### PR DESCRIPTION
Focuses the last added stack to the main window.

Not sure if there's a better way that can avoid calling the `.processEvents()`

Fixes #595