### PR TITLE
Adds a check for available memory before allocating

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     - pyqt
     - pyqtgraph=0.11
     - sarepy
+    - psutil
 
 build:
   number: 0

--- a/environment.yml
+++ b/environment.yml
@@ -27,4 +27,5 @@ dependencies:
       - sphinx
       - pytest-randomly
       - pytest-parallel
+      - psutil
       - isort

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -67,7 +67,7 @@ class RebinFilter(BaseFilter):
                                          0.5, (0.0, 1.0),
                                          on_change=on_change,
                                          tooltip="Factor by which the data will be rebinned, "
-                                                 "e.g. 0.5 is 50% reduced size")
+                                         "e.g. 0.5 is 50% reduced size")
         factor.setSingleStep(0.05)
 
         # Rebin to target shape options

--- a/mantidimaging/core/operations/rebin/test/rebin_test.py
+++ b/mantidimaging/core/operations/rebin/test/rebin_test.py
@@ -15,6 +15,7 @@ class RebinTest(unittest.TestCase):
 
     Tests return value only.
     """
+
     def __init__(self, *args, **kwargs):
         super(RebinTest, self).__init__(*args, **kwargs)
 
@@ -110,6 +111,24 @@ class RebinTest(unittest.TestCase):
 
         npt.assert_equal(result.data.shape[1], expected_x)
         npt.assert_equal(result.data.shape[2], expected_y)
+
+        images.free_memory()
+
+    def test_failure_to_allocate_output_doesnt_free_input_data(self):
+        """
+        Tests for a bug fixed in PR#600 that the input data would be freed
+        if the output data could not be allocated
+        :return:
+        """
+        images = th.generate_images(shape=(500, 10, 10), automatic_free=False)
+        mode = 'reflect'
+
+        input_mfile = images.memory_filename
+
+        # something very huge that shouldn't fit on ANY computer
+        rebin_param = (100000, 100000)
+        self.assertRaises(RuntimeError, RebinFilter.filter_func, images, rebin_param=rebin_param, mode=mode)
+        self.assertEqual(input_mfile, images.memory_filename)
 
         images.free_memory()
 

--- a/mantidimaging/core/operations/rebin/test/rebin_test.py
+++ b/mantidimaging/core/operations/rebin/test/rebin_test.py
@@ -15,7 +15,6 @@ class RebinTest(unittest.TestCase):
 
     Tests return value only.
     """
-
     def __init__(self, *args, **kwargs):
         super(RebinTest, self).__init__(*args, **kwargs)
 

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -48,8 +48,7 @@ def create_array(shape: Tuple[int, int, int], dtype: NP_DTYPE = np.float32, name
     :return: The created Numpy array
     """
     if not enough_memory(shape, dtype):
-        raise RuntimeError(
-            "The machine does not have enough physical memory available to allocate space for this data.")
+        raise RuntimeError("The machine does not have enough RAM available to perform this operation.")
 
     if name is not None:
         return _create_shared_array(shape, dtype, name)

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -10,7 +10,9 @@ from typing import Union, Type, Optional, Tuple
 import SharedArray as sa
 import numpy as np
 
+from mantidimaging.core.utility.memory_usage import system_free_memory
 from mantidimaging.core.utility.progress_reporting import Progress
+from mantidimaging.core.utility.size_calculator import full_size_KB
 
 LOG = getLogger(__name__)
 
@@ -32,6 +34,10 @@ def delete_shared_array(name, silent_failure=False):
             raise e
 
 
+def enough_memory(shape, dtype):
+    return full_size_KB(shape=shape, axis=0, dtype=dtype) < system_free_memory().kb()
+
+
 def create_array(shape: Tuple[int, int, int], dtype: NP_DTYPE = np.float32, name: Optional[str] = None) -> np.ndarray:
     """
     Create an array, either in a memory file (if name provided), or purely in memory (if name is None)
@@ -41,6 +47,10 @@ def create_array(shape: Tuple[int, int, int], dtype: NP_DTYPE = np.float32, name
     :param dtype: Dtype of the array
     :return: The created Numpy array
     """
+    if not enough_memory(shape, dtype):
+        raise RuntimeError(
+            "The machine does not have enough physical memory available to allocate space for this data.")
+
     if name is not None:
         return _create_shared_array(shape, dtype, name)
     else:

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -38,17 +38,34 @@ def enough_memory(shape, dtype):
     return full_size_KB(shape=shape, axis=0, dtype=dtype) < system_free_memory().kb()
 
 
-def create_array(shape: Tuple[int, int, int], dtype: NP_DTYPE = np.float32, name: Optional[str] = None) -> np.ndarray:
+def allocate_output(images, shape):
+    if images.memory_filename is not None:
+        name = create_shared_name()
+        output = create_array(shape, images.dtype, name)
+        images.free_memory(delete_filename=False)
+        images.memory_filename = name
+    else:
+        output = create_array(shape, images.dtype)
+    return output
+
+
+def create_array(shape: Tuple[int, int, int], dtype: NP_DTYPE = np.float32, name: Optional[str] = None,
+                 random_name=False) -> np.ndarray:
     """
     Create an array, either in a memory file (if name provided), or purely in memory (if name is None)
 
-    :param name: Name of the shared memory array. If None, a non-shared array will be created
     :param shape: Shape of the array
     :param dtype: Dtype of the array
+    :param name: Name of the shared memory array. If None, a non-shared array will be created
+    :param random_name: Whether to randomise the name. Will discard anything in the `name` parameter
     :return: The created Numpy array
     """
     if not enough_memory(shape, dtype):
-        raise RuntimeError("The machine does not have enough RAM available to perform this operation.")
+        raise RuntimeError(
+            "The machine does not have enough physical memory available to allocate space for this data.")
+
+    if random_name:
+        name = create_shared_name()
 
     if name is not None:
         return _create_shared_array(shape, dtype, name)

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -49,7 +49,9 @@ def allocate_output(images, shape):
     return output
 
 
-def create_array(shape: Tuple[int, int, int], dtype: NP_DTYPE = np.float32, name: Optional[str] = None,
+def create_array(shape: Tuple[int, int, int],
+                 dtype: NP_DTYPE = np.float32,
+                 name: Optional[str] = None,
                  random_name=False) -> np.ndarray:
     """
     Create an array, either in a memory file (if name provided), or purely in memory (if name is None)

--- a/mantidimaging/core/utility/memory_usage.py
+++ b/mantidimaging/core/utility/memory_usage.py
@@ -35,10 +35,10 @@ def get_memory_usage_linux(kb=False, mb=False):
     tuple_to_return = tuple()  # start with empty tuple
     # meminfo.used gives the size in bytes
     if kb:
-        tuple_to_return += (meminfo.used / 1024,)
+        tuple_to_return += (meminfo.used / 1024, )
 
     if mb:
-        tuple_to_return += (meminfo.used / 1024 / 1024,)
+        tuple_to_return += (meminfo.used / 1024 / 1024, )
     return tuple_to_return
 
 

--- a/mantidimaging/core/utility/memory_usage.py
+++ b/mantidimaging/core/utility/memory_usage.py
@@ -28,10 +28,10 @@ def get_memory_usage_linux(kb=False, mb=False):
     tuple_to_return = tuple()  # start with empty tuple
     # meminfo.used gives the size in bytes
     if kb:
-        tuple_to_return += (meminfo.used / 1024,)
+        tuple_to_return += (meminfo.used / 1024, )
 
     if mb:
-        tuple_to_return += (meminfo.used / 1024 / 1024,)
+        tuple_to_return += (meminfo.used / 1024 / 1024, )
     return tuple_to_return
 
 

--- a/mantidimaging/core/utility/memory_usage.py
+++ b/mantidimaging/core/utility/memory_usage.py
@@ -1,27 +1,37 @@
 from logging import getLogger
 
 
+def system_free_memory():
+    class Value:
+        def __init__(self, bytes):
+            self._bytes = bytes
+
+        def kb(self):
+            return self._bytes / 1024
+
+        def mb(self):
+            return self._bytes / 1024 / 1024
+
+    import psutil
+    meminfo = psutil.virtual_memory()
+    return Value(meminfo.available)
+
+
 def get_memory_usage_linux(kb=False, mb=False):
     """
     :param kb: Return the value in Kilobytes
     :param mb: Return the value in Megabytes
     """
-    log = getLogger(__name__)
+    import psutil
 
-    try:
-        # Windows doesn't seem to have resource package, so this will
-        # silently fail
-        import resource as res
-    except ImportError:
-        log.debug('Resource monitoring is not available on Windows.')
-        return 0, 0
-
+    meminfo = psutil.virtual_memory()
     tuple_to_return = tuple()  # start with empty tuple
+    # meminfo.used gives the size in bytes
     if kb:
-        tuple_to_return += (int(res.getrusage(res.RUSAGE_SELF).ru_maxrss), )
+        tuple_to_return += (meminfo.used / 1024,)
 
     if mb:
-        tuple_to_return += (int(res.getrusage(res.RUSAGE_SELF).ru_maxrss) / 1024, )
+        tuple_to_return += (meminfo.used / 1024 / 1024,)
     return tuple_to_return
 
 
@@ -37,8 +47,8 @@ def get_memory_usage_linux_str():
     else:
         # get memory difference in Megabytes
         delta_memory = (
-            memory_in_kbs - get_memory_usage_linux_str.last_memory_cache) \
-                    / 1024
+                               memory_in_kbs - get_memory_usage_linux_str.last_memory_cache) \
+                       / 1024
 
         # remove cached memory, del removes the reference so that hasattr will
         # work correctly

--- a/mantidimaging/core/utility/memory_usage.py
+++ b/mantidimaging/core/utility/memory_usage.py
@@ -1,5 +1,11 @@
 from logging import getLogger
 
+# Percent memory of the system total to AVOID being allocated by Mantid Imaging shared arrays
+# as taking up nearly, if not exactly, 100% not only makes it more likely to get hit by
+# SIGBUS by the OS, but even if the allocation is permitted it could slow the system down
+# to the point of being unusable
+MEMORY_CAP_PERCENTAGE = 0.025
+
 
 def system_free_memory():
     class Value:
@@ -13,8 +19,9 @@ def system_free_memory():
             return self._bytes / 1024 / 1024
 
     import psutil
+
     meminfo = psutil.virtual_memory()
-    return Value(meminfo.available)
+    return Value(meminfo.available - meminfo.total * MEMORY_CAP_PERCENTAGE)
 
 
 def get_memory_usage_linux(kb=False, mb=False):
@@ -28,10 +35,10 @@ def get_memory_usage_linux(kb=False, mb=False):
     tuple_to_return = tuple()  # start with empty tuple
     # meminfo.used gives the size in bytes
     if kb:
-        tuple_to_return += (meminfo.used / 1024, )
+        tuple_to_return += (meminfo.used / 1024,)
 
     if mb:
-        tuple_to_return += (meminfo.used / 1024 / 1024, )
+        tuple_to_return += (meminfo.used / 1024 / 1024,)
     return tuple_to_return
 
 

--- a/mantidimaging/core/utility/size_calculator.py
+++ b/mantidimaging/core/utility/size_calculator.py
@@ -73,8 +73,10 @@ def full_size(shape=None, axis=None):
 def full_size_MB(shape=None, axis=None, dtype=None):
     return to_MB(full_size(shape, axis), dtype)
 
+
 def full_size_KB(shape=None, axis=None, dtype=None):
     return to_KB(full_size(shape, axis), dtype)
+
 
 def number_of_images_from_indices(start, end, increment):
     return int((end - start) / increment) if increment != 0 else 0

--- a/mantidimaging/core/utility/size_calculator.py
+++ b/mantidimaging/core/utility/size_calculator.py
@@ -73,6 +73,8 @@ def full_size(shape=None, axis=None):
 def full_size_MB(shape=None, axis=None, dtype=None):
     return to_MB(full_size(shape, axis), dtype)
 
+def full_size_KB(shape=None, axis=None, dtype=None):
+    return to_KB(full_size(shape, axis), dtype)
 
 def number_of_images_from_indices(start, end, increment):
     return int((end - start) / increment) if increment != 0 else 0

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -124,7 +124,8 @@ class FiltersWindowPresenter(BasePresenter):
 
         self._do_apply_filter(stacks)
 
-    def _post_filter(self, updated_stacks, _):
+    def _post_filter(self, updated_stacks, task):
+
         for stack in updated_stacks:
             self.view.main_window.update_stack_with_images(stack.presenter.images)
 
@@ -135,9 +136,13 @@ class FiltersWindowPresenter(BasePresenter):
 
         self.do_update_previews()
 
-        # Feedback to user
-        self.view.clear_notification_dialog()
-        self.view.show_operation_completed(self.model.selected_filter.filter_name)
+        if task.error is not None:
+            # task failed, show why
+            self.view.show_error_dialog(f"Operation failed: {task.error}")
+        else:
+            # Feedback to user
+            self.view.clear_notification_dialog()
+            self.view.show_operation_completed(self.model.selected_filter.filter_name)
 
     def _do_apply_filter(self, apply_to):
         self.model.do_apply_filter(apply_to, partial(self._post_filter, apply_to))

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -80,15 +80,28 @@ class FiltersWindowPresenterTest(unittest.TestCase):
                                 partial(self.presenter._post_filter, mock_stack_visualisers))
 
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter.do_update_previews')
-    def test_post_filter(self, update_previews_mock):
+    def test_post_filter_success(self, update_previews_mock):
         mock_stack_visualisers = [mock.Mock(), mock.Mock()]
-        self.presenter._post_filter(mock_stack_visualisers, None)
+        mock_task = mock.Mock()
+        mock_task.error = None
+        self.presenter._post_filter(mock_stack_visualisers, mock_task)
 
         for i, msv in enumerate(mock_stack_visualisers):
             assert msv.presenter.images == self.view.main_window.update_stack_with_images.call_args_list[i].args[0]
         update_previews_mock.assert_called_once()
-        self.view.show_operation_completed.assert_called_once_with("Circular Mask")
+        self.view.clear_notification_dialog.assert_called_once()
+        self.view.show_operation_completed.assert_called_once_with(self.presenter.model.selected_filter.filter_name)
 
+    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter.do_update_previews')
+    def test_post_filter_fail(self, update_previews_mock):
+        mock_stack_visualisers = [mock.Mock(), mock.Mock()]
+        mock_task = mock.Mock()
+        mock_task.error = 123
+        self.presenter._post_filter(mock_stack_visualisers, mock_task)
+
+        for i, msv in enumerate(mock_stack_visualisers):
+            assert msv.presenter.images == self.view.main_window.update_stack_with_images.call_args_list[i].args[0]
+        update_previews_mock.assert_called_once()
     def test_update_previews_no_stack(self):
         self.presenter.do_update_previews()
         self.view.clear_previews.assert_called_once()

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -102,6 +102,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         for i, msv in enumerate(mock_stack_visualisers):
             assert msv.presenter.images == self.view.main_window.update_stack_with_images.call_args_list[i].args[0]
         update_previews_mock.assert_called_once()
+
     def test_update_previews_no_stack(self):
         self.presenter.do_update_previews()
         self.view.clear_previews.assert_called_once()


### PR DESCRIPTION
Adds a free memory getter in memory_usage package, and changes
get_memory_usage_linux to use psutil which should also make it run on Windows

### To test
- Try to load a dataset that's over your available RAM, or duplicate the data a bunch of times to reach that.
- Run Rebin or Crop on data where the temporary necessary for the operation cannot be allocated
  - Rebin to anything that's super big 
  - To get Crop to fail you can just crop by 99% of the image size, so as long you're somewhere above 50% memory usage



Fixes #600