### PR TITLE
Allows tuning of installation script to different env name or repo label

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,12 @@
 # To run this script use source ./install.sh, or the version on master
 # source <(curl -s https://raw.githubusercontent.com/mantidproject/mantidimaging/master/install.sh)
 # source is used so that the shell environment is inherited - this is needed for conda access!
+#
+# Supported configuration:
+# - ENVIRONMENT_NAME - specifies the environment name, default `mantidimaging`
+#   - For nightly it will be called `mantidimaging_unstable`
+# - REPO_LABEL - specifies the label from which it will be installed, default `main`,
+#   - For nightly it will use `unstable`
 
 if ! command -v conda &> /dev/null
 then
@@ -8,18 +14,23 @@ then
     return
 fi
 
+env_name=${ENVIRONMENT_NAME:-mantidimaging}
+repo_label=${REPO_LABEL:-main}
+
+echo "Installing mantidimaging in environment with name '${env_name}' and repo label '${repo_label}'"
+
 conda config --set always_yes yes
 
-conda remove -n mantidimaging --all
+conda remove -n ${env_name} --all
 
 conda config --prepend channels conda-forge  # for most of the deps
 conda config --prepend channels astra-toolbox/label/dev # for astra
 conda config --prepend channels dtasev  # for sarepy
-conda config --prepend channels mantid  # for mantidimaging
+conda config --prepend channels mantid # for mantidimaging
 
-conda create -n mantidimaging mantidimaging
+conda create -c mantid/label/${repo_label} -n ${env_name} mantidimaging
 
-conda activate mantidimaging
+conda activate ${env_name}
 pip install pyqt5==5.15
 
 conda config --set always_yes no


### PR DESCRIPTION
Supported configuration is:
- ENVIRONMENT_NAME - for specifying the name of the environment
- REPO_LABEL - the label from which the package should be installed

If not provided it defaults to `mantidimaging`.

Intent is to be able to use this for installing a `main` and an `unstable` versions on IDAaaS - from which the `unstable` one will be updated nightly.

### To test:
#### With parameters
Run this locally:

- Activate anaconda for the shell
  - Note: this might fail if you are not using bash!
- `ENVIRONMENT_NAME=mantidimaging_pr_test_601 REPO_LABEL=unstable source <(curl -s https://github.com/mantidproject/mantidimaging/blob/601_specify_env_name_in_install_script/install.sh)`
- Check that there is an environment called `mantidimaging_pr_test_601`
	- You should be in it automatically after it finishes executing
- Check that `conda list | grep mantidimaging` lists the source as `... mantid/label/unstable ...`
- Run mantidimaging in the same terminal via typing `mantidimaging` - it should open

#### With defaults
- Run the install again this time without parameters: 
	- Note: if you have an environment called `mantidimaging` this will be removed and re-installed!
	- `source <(curl -s https://github.com/mantidproject/mantidimaging/blob/601_specify_env_name_in_install_script/install.sh)`
- Check that there is an environment called `mantidimaging`
	- You should be in it automatically after it finishes executing
- Check that `conda list | grep mantidimaging` lists the source as `... mantid/label/main...` and the version ends in 860ish (`mantidimaging-1.1.0_860...`)
- Run mantidimaging in the same terminal via typing `mantidimaging` - it should open
	

Progresses #601 a bit further