### PR TITLE
Fix disabling the COR buttons

### DIFF
--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -36,7 +36,6 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.view.filterNameLabel = mock.Mock()
         self.view.numIter = mock.Mock()
         self.view.numIterLabel = mock.Mock()
-        self.view.autoBtn = mock.Mock()
 
     @mock.patch('mantidimaging.gui.windows.recon.model.get_reconstructor_for')
     def test_set_stack_uuid(self, mock_get_reconstructor_for):
@@ -191,4 +190,4 @@ class ReconWindowPresenterTest(unittest.TestCase):
         mock_first_call = mock_start_async.call_args[0]
         self.assertEqual(self.presenter.view, mock_first_call[0])
         self.assertEqual(self.presenter.model.auto_find_correlation, mock_first_call[1])
-        self.view.autoBtn.setDisabled.assert_called_once()
+        self.view.set_correlate_buttons_enabled.assert_called_once_with(False)


### PR DESCRIPTION
The Auto find COR button was disabled during operation in #590, but the layout was changed in a PR at the same time #588 so the disabling of the buttons ended up out of sync with the layout.

This PR fixes this

### To test
- Load a dataset and go into the recon window
- Check that correlate and minimise auto-find COR buttons execute

No associated issue