### PR TITLE
Minimise COR now works with gridrec algorithm

### DIFF
--- a/mantidimaging/core/reconstruct/tomopy_recon.py
+++ b/mantidimaging/core/reconstruct/tomopy_recon.py
@@ -16,7 +16,11 @@ tomopy = safe_import('tomopy')
 class TomopyRecon(BaseRecon):
     @staticmethod
     def find_cor(images: Images, slice_idx: int, start_cor: float, recon_params: ReconstructionParameters) -> float:
-        return tomopy.find_center(images.sinograms, None)
+        return tomopy.find_center(images.sinograms,
+                                  images.projection_angles().value,
+                                  ind=slice_idx,
+                                  init=start_cor,
+                                  sinogram_order=True)
 
     @staticmethod
     def single_sino(sino: np.ndarray, cor: ScalarCoR, proj_angles: ProjectionAngles,

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -6,7 +6,6 @@ import numpy as np
 from mantidimaging.core.operation_history import const
 from mantidimaging.core.operations.divide import DivideFilter
 from mantidimaging.core.reconstruct import get_reconstructor_for
-from mantidimaging.core.reconstruct.astra_recon import AstraRecon
 from mantidimaging.core.reconstruct.astra_recon import allowed_recon_kwargs as astra_allowed_kwargs
 from mantidimaging.core.reconstruct.tomopy_recon import allowed_recon_kwargs as tomopy_allowed_kwargs
 from mantidimaging.core.rotation.polyfit_correlation import find_center
@@ -195,11 +194,12 @@ class ReconstructWindowModel(object):
             # why be efficient when you can be lazy?
             initial_cor = [initial_cor] * len(slices)
 
+        reconstructor = get_reconstructor_for(recon_params.algorithm)
         progress = Progress.ensure_instance(progress, num_steps=len(slices))
         progress.update(0, msg=f"Calculating COR for slice {slices[0]}")
         cors = []
         for idx, slice in enumerate(slices):
-            cor = AstraRecon.find_cor(self.images, slice, initial_cor[idx], recon_params)
+            cor = reconstructor.find_cor(self.images, slice, initial_cor[idx], recon_params)
             cors.append(cor)
             progress.update(msg=f"Calculating COR for slice {slice}")
         return cors

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -216,9 +216,9 @@ class ReconstructWindowPresenter(BasePresenter):
         def completed(task: TaskWorkerThread):
             cor, tilt = task.result
             self._set_precalculated_cor_tilt(cor, tilt)
-            self.view.autoBtn.setDisabled(False)
+            self.view.set_correlate_buttons_enabled(True)
 
-        self.view.autoBtn.setDisabled(True)
+        self.view.set_correlate_buttons_enabled(False)
         start_async_task_view(self.view, self.model.auto_find_correlation, completed)
 
     def _auto_find_minimisation_square_sum(self):
@@ -242,9 +242,9 @@ class ReconstructWindowPresenter(BasePresenter):
             for slice_idx, cor in zip(slice_indices, cors):
                 self.view.add_cor_table_row(selected_row, slice_idx, cor)
             self.do_cor_fit()
-            self.view.autoBtn.setDisabled(False)
+            self.view.set_correlate_buttons_enabled(True)
 
-        self.view.autoBtn.setDisabled(True)
+        self.view.set_correlate_buttons_enabled(False)
         start_async_task_view(self.view, self.model.auto_find_minimisation_sqsum, _completed_finding_cors, {
             'slices': slice_indices,
             'recon_params': self.view.recon_params(),

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -186,9 +186,9 @@ class ReconWindowPresenterTest(unittest.TestCase):
 
     @mock.patch('mantidimaging.gui.windows.recon.presenter.start_async_task_view')
     def test_auto_find_correlation(self, mock_start_async: mock.Mock):
-        self.presenter._auto_find_correlation()
+        self.presenter.notify(PresNotification.AUTO_FIND_COR_CORRELATE)
         mock_start_async.assert_called_once()
         mock_first_call = mock_start_async.call_args[0]
         self.assertEqual(self.presenter.view, mock_first_call[0])
         self.assertEqual(self.presenter.model.auto_find_correlation, mock_first_call[1])
-        self.view.autoBtn.setDisabled.assert_called_once()
+        self.view.set_correlate_buttons_enabled.assert_called_once_with(False)

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -322,3 +322,7 @@ class ReconstructWindowView(BaseMainWindowView):
             return AutoCorMethod.CORRELATION
         else:
             return AutoCorMethod.MINIMISATION_SQUARE_SUM
+
+    def set_correlate_buttons_enabled(self, enabled: bool):
+        self.correlateBtn.setEnabled(enabled)
+        self.minimiseBtn.setEnabled(enabled)


### PR DESCRIPTION
Should be done after #611 

Passes in the correct arguments onwards to `tomopy.find_cor` to receive an output when using the algorithm gridrec.

### To test
- Load some data
- Go to Reconstruction window
- Go to "Recon" tab and select gridrec
- Go back to the first tab and run auto-cor with Minimise
- It should run and some COR/Tilt should show up


Fixes #562 