### PR TITLE
Adds ROI field to Crop and ROI Norm 

### DIFF
--- a/mantidimaging/core/operations/crop_coords/crop_coords.py
+++ b/mantidimaging/core/operations/crop_coords/crop_coords.py
@@ -10,7 +10,6 @@ from mantidimaging.core.parallel import utility as pu
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.utility.qt_helpers import Type
-from mantidimaging.gui.windows.operations import FiltersWindowView
 
 
 class CropCoordinatesFilter(BaseFilter):
@@ -72,7 +71,7 @@ class CropCoordinatesFilter(BaseFilter):
         return images
 
     @staticmethod
-    def register_gui(form, on_change, view: FiltersWindowView):
+    def register_gui(form, on_change, view):
         from mantidimaging.gui.utility import add_property_to_form
         label, roi_field = add_property_to_form("ROI",
                                                 Type.STR,

--- a/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
+++ b/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
@@ -1,5 +1,6 @@
 import unittest
 
+import mock
 import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
@@ -76,7 +77,21 @@ class CropCoordsTest(unittest.TestCase):
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
         """
         images = th.generate_images(automatic_free=False)
-        CropCoordinatesFilter.execute_wrapper()(images, [1, 1, 5, 5])
+        roi_mock = mock.Mock()
+        roi_mock.text.return_value = "0, 0, 5, 5"
+        CropCoordinatesFilter.execute_wrapper(roi_mock)(images)
+        roi_mock.text.assert_called_once()
+        images.free_memory()
+
+    def test_execute_wrapper_bad_roi_raises_valueerror(self):
+        """
+        Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
+        """
+        images = th.generate_images(automatic_free=False)
+        roi_mock = mock.Mock()
+        roi_mock.text.return_value = "apples"
+        self.assertRaises(ValueError, CropCoordinatesFilter.execute_wrapper, roi_mock)
+        roi_mock.text.assert_called_once()
         images.free_memory()
 
 

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -1,6 +1,5 @@
 from functools import partial
 from logging import getLogger
-from typing import Any, Dict
 
 import numpy as np
 
@@ -15,7 +14,6 @@ from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.utility import add_property_to_form
 from mantidimaging.gui.utility.qt_helpers import Type
-from mantidimaging.gui.windows.stack_visualiser import SVParameters
 
 
 class RoiNormalisationFilter(BaseFilter):
@@ -100,7 +98,7 @@ class RoiNormalisationFilter(BaseFilter):
         return partial(value_scaling.apply_factor)
 
 
-def _calc_sum(data, air_sums, air_left=None, air_top=None, air_right=None, air_bottom=None):
+def _calc_sum(data, _, air_left=None, air_top=None, air_right=None, air_bottom=None):
     return data[air_top:air_bottom, air_left:air_right].mean()
 
 

--- a/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
@@ -1,5 +1,6 @@
 import unittest
 
+import mock
 import numpy as np
 import numpy.testing as npt
 
@@ -52,7 +53,10 @@ class ROINormalisationTest(unittest.TestCase):
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
         """
         images = th.generate_images()
-        RoiNormalisationFilter.execute_wrapper()(images)
+        roi_mock = mock.Mock()
+        roi_mock.text.return_value = "0, 0, 5, 5"
+        RoiNormalisationFilter.execute_wrapper(roi_mock)(images)
+        roi_mock.text.assert_called_once()
 
     def test_roi_normalisation_performs_rescale(self):
         images = th.generate_images()
@@ -64,6 +68,17 @@ class ROINormalisationTest(unittest.TestCase):
 
         th.assert_not_equals(result.data[0], original)
         self.assertAlmostEqual(result.data.max(), images_max, places=6)
+
+    def test_execute_wrapper_bad_roi_raises_valueerror(self):
+        """
+        Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
+        """
+        images = th.generate_images(automatic_free=False)
+        roi_mock = mock.Mock()
+        roi_mock.text.return_value = "apples"
+        self.assertRaises(ValueError, RoiNormalisationFilter.execute_wrapper, roi_mock)
+        roi_mock.text.assert_called_once()
+        images.free_memory()
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/utility/sensible_roi.py
+++ b/mantidimaging/core/utility/sensible_roi.py
@@ -31,6 +31,9 @@ class SensibleROI(Iterable):
     def __str__(self):
         return f"Left: {self.left}, Top: {self.top}, Right: {self.right}, Bottom: {self.bottom}"
 
+    def to_list_string(self) -> str:
+        return f"{', '.join([str(e) for e in self])}"
+
     @property
     def width(self) -> int:
         return self.right - self.left

--- a/mantidimaging/gui/utility/qt_helpers.py
+++ b/mantidimaging/gui/utility/qt_helpers.py
@@ -129,8 +129,7 @@ def add_property_to_form(label: str,
             box.setValue(cast_func(default_value))
 
     # some of these are used dynamically by Savu Operations GUI and will not show up in a grep
-    if dtype == 'str' or dtype == 'tuple' or dtype == "NoneType" or dtype == "list" or \
-            dtype == Type.STR or dtype == Type.TUPLE or dtype == Type.NONETYPE or dtype == Type.LIST:
+    if dtype in ['str', Type.STR, 'tuple', Type.TUPLE, 'NoneType', Type.NONETYPE, 'list', Type.LIST]:
         # TODO for tuple with numbers add N combo boxes, N = number of tuple members
         right_widget = Qt.QLineEdit()
         right_widget.setToolTip(tooltip)

--- a/mantidimaging/gui/utility/qt_helpers.py
+++ b/mantidimaging/gui/utility/qt_helpers.py
@@ -129,7 +129,8 @@ def add_property_to_form(label: str,
             box.setValue(cast_func(default_value))
 
     # some of these are used dynamically by Savu Operations GUI and will not show up in a grep
-    if dtype == 'str' or dtype == 'tuple' or dtype == "NoneType" or dtype == "list":
+    if dtype == 'str' or dtype == 'tuple' or dtype == "NoneType" or dtype == "list" or \
+            dtype == Type.STR or dtype == Type.TUPLE or dtype == Type.NONETYPE or dtype == Type.LIST:
         # TODO for tuple with numbers add N combo boxes, N = number of tuple members
         right_widget = Qt.QLineEdit()
         right_widget.setToolTip(tooltip)

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -129,7 +129,6 @@ class FiltersWindowPresenter(BasePresenter):
         for stack in updated_stacks:
             self.view.main_window.update_stack_with_images(stack.presenter.images)
 
-        self.roi = None
         if self.view.roi_view is not None:
             self.view.roi_view.close()
             self.view.roi_view = None

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -37,7 +37,6 @@ class FiltersWindowPresenter(BasePresenter):
 
         self.model = FiltersWindowModel(self)
         self.main_window = main_window
-        self.roi = None
 
     def notify(self, signal):
         try:
@@ -155,14 +154,8 @@ class FiltersWindowPresenter(BasePresenter):
             # Update image before
             self._update_preview_image(before_image, self.view.preview_image_before)
 
-            # Generate sub-stack and run filter
-            if self.roi is not None and self.needs_roi():
-                exec_kwargs = {"region_of_interest": self.roi}
-            else:
-                exec_kwargs = {}
-
             try:
-                self.model.apply_to_images(subset, exec_kwargs)
+                self.model.apply_to_images(subset)
             except Exception as e:
                 msg = f"Error applying filter for preview: {e}"
                 self.show_error(msg, traceback.format_exc())
@@ -186,9 +179,6 @@ class FiltersWindowPresenter(BasePresenter):
 
             # Ensure all of it is visible
             self.view.previews.auto_range()
-
-    def needs_roi(self):
-        return self.model.selected_filter.filter_name in ["ROI Normalisation", "Crop Coordinates"]
 
     @staticmethod
     def _update_preview_image(image_data: Optional[np.ndarray], image: ImageItem):

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -234,7 +234,8 @@ class FiltersWindowView(BaseMainWindowView):
         self.roi_view.ui.gridLayout.setRowStretch(0, 95)
         self.roi_view.button_stack_right.hide()
         self.roi_view.button_stack_left.hide()
-
-        self.roi_view.show()
+        button = QPushButton("OK", window)
+        button.clicked.connect(lambda: window.close())
+        self.roi_view.ui.gridLayout.addWidget(button)
 
         window.show()

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -4,12 +4,12 @@ from PyQt5 import Qt
 from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QDesktopServices
 from PyQt5.QtWidgets import QMessageBox, QVBoxLayout, QCheckBox, QLabel, QApplication, QSplitter, QPushButton, \
-    QSizePolicy, QComboBox, QStyle
-from mantidimaging.gui.widgets.pg_image_view import MIImageView
+    QSizePolicy, QComboBox, QStyle, QMainWindow
 from pyqtgraph import ImageItem
 
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.utility import (delete_all_widgets_from_layout)
+from mantidimaging.gui.widgets.pg_image_view import MIImageView
 from mantidimaging.gui.widgets.stack_selector import StackSelectorWidgetView
 from .filter_previews import FilterPreviews
 from .presenter import FiltersWindowPresenter
@@ -200,19 +200,29 @@ class FiltersWindowView(BaseMainWindowView):
         response = QMessageBox.question(self, "Confirm action", msg, QMessageBox.Ok | QMessageBox.Cancel)  # type:ignore
         return response == QMessageBox.Ok
 
-    def roi_visualiser(self):
+    def roi_visualiser(self, roi_field):
         # Start the stack visualiser and ensure that it uses the ROI from here in the rest of this
         try:
             images = self.presenter.stack.presenter.get_image(self.presenter.model.preview_image_idx)
-        except IndexError:
+        except Exception:
             # Happens if nothing has been loaded, so do nothing as nothing can't be visualised
             return
 
-        self.roi_view = MIImageView()
+        window = QMainWindow(self)
+        window.setWindowTitle("Select ROI")
+        window.setMinimumHeight(600)
+        window.setMinimumWidth(600)
+        self.roi_view = MIImageView(window)
+        window.setCentralWidget(self.roi_view)
         self.roi_view.setWindowTitle("Select ROI for operation")
 
         self.roi_view.setImage(images.data)
-        self.roi_view.roi_changed_callback = lambda callback: self.roi_changed_callback(callback)
+
+        def roi_changed_callback(callback):
+            roi_field.setText(callback.to_list_string())
+            roi_field.editingFinished.emit()
+
+        self.roi_view.roi_changed_callback = lambda callback: roi_changed_callback(callback)
 
         # prep the MIImageView to display in this context
         self.roi_view.ui.roiBtn.hide()
@@ -227,6 +237,4 @@ class FiltersWindowView(BaseMainWindowView):
 
         self.roi_view.show()
 
-    def roi_changed_callback(self, callback):
-        self.presenter.roi = callback
-        self.presenter.notify(PresNotification.UPDATE_PREVIEWS)
+        window.show()


### PR DESCRIPTION
Adds a ROI field that takes a string - this allows users to paste a known ROI, or use Select ROI to find a good one.

- No longer uses "stack parameters" concept - all params used for the operation should be coming from a field
- The Select ROI is now in a separate window, which is a child of the Operation View
- Moving the ROI in the Select ROI now updates the roi_field, and updates the previews


### To test
1. Load a dataset
1. Open Operations (CTRL+F)
1. Go to Crop, click select ROI, moving the red ROI square should update the preview image
1. Clicking OK should close the ROI select
1. Applying the filter should crop the data properly
1. Check that the history properly reflects the ROI used
1. Repeat 3 onwards but with ROI Normalise