### PR TITLE
Fixes broken rescale data type, removes jpg/png from save format choices

### DIFF
--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -45,11 +45,6 @@ def _imread(filename):
 def supported_formats():
     # ignore errors for unused import/variable, we are only checking
     # availability
-    try:
-        import h5py  # noqa: F401
-        h5nxs_available = True
-    except ImportError:
-        h5nxs_available = False
 
     try:
         from skimage import io as skio  # noqa: F401
@@ -64,9 +59,8 @@ def supported_formats():
         fits_available = False
 
     avail_list = \
-        (['nxs'] if h5nxs_available else []) + \
         (['fits', 'fit'] if fits_available else []) + \
-        (['tif', 'tiff', 'png', 'jpg'] if skio_available else [])
+        (['tif', 'tiff'] if skio_available else [])
 
     return avail_list
 

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -156,7 +156,7 @@ def save(images: Images,
 
 
 def rescale_single_image(image: np.ndarray, min_input, max_input, max_output):
-    return RescaleFilter.filter_single_image(image, min_input, max_input, max_output, data_type=np.int16)
+    return RescaleFilter.filter_single_image(image, min_input, max_input, max_output, data_type=np.uint16)
 
 
 def generate_names(name_prefix,

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -198,7 +198,7 @@ def make_dirs_if_needed(dirname=None, overwrite_all=False):
         os.makedirs(path)
     elif os.listdir(path) and not overwrite_all:
         raise RuntimeError("The output directory is NOT empty:{0}\n. This can be "
-                           "overridden with -w/--overwrite-all.".format(path))
+                           "overridden by specifying 'Overwrite on name conflict'.".format(path))
 
 
 class Saver(object):

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -197,7 +197,7 @@ def make_dirs_if_needed(dirname=None, overwrite_all=False):
     if not os.path.exists(path):
         os.makedirs(path)
     elif os.listdir(path) and not overwrite_all:
-        raise RuntimeError("The output directory is NOT empty:{0}\n. This can be "
+        raise RuntimeError("The output directory is NOT empty:{0}\nThis can be "
                            "overridden by specifying 'Overwrite on name conflict'.".format(path))
 
 

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -1,6 +1,6 @@
 from functools import partial
 from typing import Dict, Any
-from numpy import int16, float32, ndarray
+from numpy import uint16, float32, ndarray
 
 from PyQt5.QtWidgets import QDoubleSpinBox, QComboBox
 
@@ -33,8 +33,8 @@ class RescaleFilter(BaseFilter):
         images.data *= (max_output / images.data.max())
 
         if data_type is not None:
-            if data_type == int16 and not images.dtype == int16:
-                images.data = images.data.astype(int16)
+            if data_type == uint16 and not images.dtype == uint16:
+                images.data = images.data.astype(uint16)
             elif data_type == float32 and not images.dtype == float32:
                 images.data = images.data.astype(float32)
 
@@ -48,8 +48,8 @@ class RescaleFilter(BaseFilter):
 
         if data_type == float32:
             return image.astype(float32)
-        elif data_type == int16:
-            return image.astype(int16)
+        elif data_type == uint16:
+            return image.astype(uint16)
         else:
             raise ValueError("Only float32 and int16 data types are supported by single image rescale")
 

--- a/mantidimaging/core/operations/rescale/rescale_test.py
+++ b/mantidimaging/core/operations/rescale/rescale_test.py
@@ -1,5 +1,5 @@
 import pytest
-from numpy import testing as npt, int16, float32, finfo, copy
+from numpy import testing as npt, int16, uint16, float32, finfo, copy
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.rescale import RescaleFilter
@@ -61,7 +61,7 @@ def test_execute_wrapper_with_preset(type: str, expected_max: float):
     assert partial.keywords['max_output'] == expected_max
 
 
-@pytest.mark.parametrize('type, max_value', [(int16, 65535), (float32, finfo(float32).max)])
+@pytest.mark.parametrize('type, max_value', [(uint16, 65535), (float32, finfo(float32).max)])
 def test_type_changes_to_given_type(type, max_value):
     images = th.generate_images((10, 100, 100))
 
@@ -82,8 +82,8 @@ def test_scale_single_image():
     images.data[1] = 1.5
 
     # Scale to int16
-    scaled_image1 = RescaleFilter.filter_single_image(copy(images.data[0]), 0, images.data.max(), 1, data_type=int16)
-    scaled_image2 = RescaleFilter.filter_single_image(copy(images.data[1]), 0, images.data.max(), 1, data_type=int16)
+    scaled_image1 = RescaleFilter.filter_single_image(copy(images.data[0]), 0, images.data.max(), 1, data_type=uint16)
+    scaled_image2 = RescaleFilter.filter_single_image(copy(images.data[1]), 0, images.data.max(), 1, data_type=uint16)
 
     npt.assert_equal(0, scaled_image1)
     npt.assert_equal(1, scaled_image2)
@@ -95,10 +95,14 @@ def test_scale_single_image():
     npt.assert_equal(0.0, scaled_image3)
     npt.assert_equal(2.0, scaled_image4)
 
-    assert scaled_image1.dtype == int16
-    assert scaled_image2.dtype == int16
+    assert scaled_image1.dtype == uint16
+    assert scaled_image2.dtype == uint16
     assert scaled_image3.dtype == float32
     assert scaled_image4.dtype == float32
+    assert scaled_image1.dtype != int16, \
+        "Ensure not using signed int16 - this will make all values over 32768 overflow to negative"
+    assert scaled_image2.dtype != int16, \
+        "Ensure not using signed int16 - this will make all values over 32768 overflow to negative"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes rescale using signed int16 and thus overflowing half the data into negative

- This was messing up loading and rescaling later
- Removes PNG and JPG as save out options, it's unlikely they will be needed
and normal visualisers can't read them anyway as they expect 8-bit png/jpg
- Improves overwrite message to be relevant for GUI

Fixes #516 