### PR TITLE
Use the pixel size provided in recon preview image

### DIFF
--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -115,3 +115,6 @@ class ReconImagesView(GraphicsLayoutWidget):
                 self.tilt_line.setPos(pos)
             self.tilt_line.setAngle(90 + tilt.value)
         self.projection_vb.addItem(self.tilt_line)
+
+    def reset_recon_histogram(self):
+        self.recon_hist.autoHistogramRange()

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -175,17 +175,16 @@ class ReconstructWindowPresenter(BasePresenter):
         slice_idx = self._get_slice_index(slice_idx)
         self.view.update_sinogram(self.model.images.sino(slice_idx))
         try:
-            data = self._get_reconstruct_slice(cor, slice_idx)
-            self.view.update_recon_preview(data, refresh_recon_slice_histogram)
+            images = self._get_reconstruct_slice(cor, slice_idx)
+            self.view.update_recon_preview(images.data[0], refresh_recon_slice_histogram)
         except ValueError as err:
             self.view.show_error_dialog(f"Encountered error while trying to reconstruct: {str(err)}")
 
     def do_stack_reconstruct_slice(self, cor=None, slice_idx: Optional[int] = None):
         slice_idx = self._get_slice_index(slice_idx)
         try:
-            data = self._get_reconstruct_slice(cor, slice_idx)
-            data = data.reshape((1, data.shape[0], data.shape[1]))
-            self.view.show_recon_volume(Images(data))
+            images = self._get_reconstruct_slice(cor, slice_idx)
+            self.view.show_recon_volume(images)
         except ValueError as err:
             self.view.show_error_dialog(f"Encountered error while trying to reconstruct: {str(err)}")
 

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -152,7 +152,7 @@ class ReconstructWindowPresenter(BasePresenter):
         start_async_task_view(self.view, self.model.run_full_recon, self._on_volume_recon_done,
                               {'recon_params': self.view.recon_params()})
 
-    def _get_reconstruct_slice(self, cor, slice_idx: Optional[int]):
+    def _get_reconstruct_slice(self, cor, slice_idx: Optional[int]) -> Optional[Images]:
         # If no COR is provided and there are regression results then calculate
         # the COR for the selected preview slice
         cor = self.model.get_me_a_cor(cor)
@@ -174,19 +174,25 @@ class ReconstructWindowPresenter(BasePresenter):
 
         slice_idx = self._get_slice_index(slice_idx)
         self.view.update_sinogram(self.model.images.sino(slice_idx))
+        images = None
         try:
             images = self._get_reconstruct_slice(cor, slice_idx)
-            self.view.update_recon_preview(images.data[0], refresh_recon_slice_histogram)
         except ValueError as err:
             self.view.show_error_dialog(f"Encountered error while trying to reconstruct: {str(err)}")
 
+        if images is not None:
+            self.view.update_recon_preview(images.data[0], refresh_recon_slice_histogram)
+
     def do_stack_reconstruct_slice(self, cor=None, slice_idx: Optional[int] = None):
         slice_idx = self._get_slice_index(slice_idx)
+        images = None
         try:
             images = self._get_reconstruct_slice(cor, slice_idx)
-            self.view.show_recon_volume(images)
         except ValueError as err:
             self.view.show_error_dialog(f"Encountered error while trying to reconstruct: {str(err)}")
+
+        if images is not None:
+            self.view.show_recon_volume(images)
 
     def _do_refine_selected_cor(self):
         slice_idx = self.model.preview_slice_idx

--- a/mantidimaging/gui/windows/recon/test/model_test.py
+++ b/mantidimaging/gui/windows/recon/test/model_test.py
@@ -90,6 +90,7 @@ class ReconWindowModelTest(unittest.TestCase):
     def test_run_preview_recon(self, mock_get_reconstructor_for):
         mock_reconstructor = mock.Mock()
         mock_reconstructor.single_sino = mock.Mock()
+        mock_reconstructor.single_sino.return_value = np.random.rand(256, 256)
         mock_get_reconstructor_for.return_value = mock_reconstructor
 
         expected_idx = 5

--- a/mantidimaging/gui/windows/recon/test/model_test.py
+++ b/mantidimaging/gui/windows/recon/test/model_test.py
@@ -9,7 +9,7 @@ from mantidimaging.core.rotation.data_model import Point
 from mantidimaging.core.utility.data_containers import Degrees, ScalarCoR, ReconstructionParameters
 from mantidimaging.gui.windows.recon import (ReconstructWindowModel, CorTiltPointQtModel)
 from mantidimaging.gui.windows.stack_visualiser import (StackVisualiserView, StackVisualiserPresenter)
-from mantidimaging.test_helpers.unit_test_helper import assert_called_once_with
+from mantidimaging.test_helpers.unit_test_helper import assert_called_once_with, generate_images
 
 
 class ReconWindowModelTest(unittest.TestCase):
@@ -101,6 +101,20 @@ class ReconWindowModelTest(unittest.TestCase):
         mock_get_reconstructor_for.assert_called_once_with(expected_recon_params.algorithm)
         assert_called_once_with(mock_reconstructor.single_sino, expected_sino, expected_cor,
                                 self.model.images.projection_angles(), expected_recon_params)
+
+    def test_apply_pixel_size(self):
+        images = generate_images()
+
+        initial_value = images.data[0][0, 0]
+        test_pixel_size = 100
+        recon_params = ReconstructionParameters("FBP", "ram-lak", test_pixel_size, pixel_size=test_pixel_size)
+        images = self.model._apply_pixel_size(images, recon_params)
+
+        # converts the number we put for pixel size to microns
+        expected_value = initial_value / (test_pixel_size * 1e-4)
+        self.assertAlmostEqual(expected_value, images.data[0][0, 0], places=4)
+        self.assertEqual(test_pixel_size, images.metadata[const.PIXEL_SIZE])
+        self.assertEqual(1, len(images.metadata[const.OPERATION_HISTORY]))
 
     def test_tilt_angle(self):
         self.assertIsNone(self.model.tilt_angle)

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.rotation.data_model import Point
-from mantidimaging.core.utility.data_containers import ScalarCoR
+from mantidimaging.core.utility.data_containers import ScalarCoR, ReconstructionParameters
 from mantidimaging.gui.windows.recon import ReconstructWindowPresenter, ReconstructWindowView
 from mantidimaging.gui.windows.recon.presenter import Notifications as PresNotification
 from mantidimaging.gui.windows.stack_visualiser import StackVisualiserPresenter, StackVisualiserView
@@ -47,7 +47,11 @@ class ReconWindowPresenterTest(unittest.TestCase):
 
         mock_reconstructor = mock.Mock()
         mock_reconstructor.single_sino = mock.Mock()
+        mock_reconstructor.single_sino.return_value = np.random.rand(128, 128)
         mock_get_reconstructor_for.return_value = mock_reconstructor
+
+        recon_params = ReconstructionParameters("FBP", "ram-lak", 10)
+        self.view.recon_params.return_value = recon_params
 
         # first-time selecting this data after reset
         self.presenter.set_stack_uuid(self.uuid)
@@ -60,6 +64,7 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.view.update_recon_preview.assert_called_once()
         mock_get_reconstructor_for.assert_called_once()
         mock_reconstructor.single_sino.assert_called_once()
+        self.view.recon_params.assert_called_once()
 
         # calling again with the same stack shouldn't re-do everything
         self.presenter.set_stack_uuid(self.uuid)
@@ -92,13 +97,18 @@ class ReconWindowPresenterTest(unittest.TestCase):
     def test_set_slice_preview_index(self, mock_get_reconstructor_for):
         mock_reconstructor = mock.Mock()
         mock_reconstructor.single_sino = mock.Mock()
+        mock_reconstructor.single_sino.return_value = np.random.rand(128, 128)
         mock_get_reconstructor_for.return_value = mock_reconstructor
+
+        recon_params = ReconstructionParameters("FBP", "ram-lak", 10)
+        self.view.recon_params.return_value = recon_params
 
         self.presenter.set_preview_slice_idx(5)
         self.assertEqual(self.presenter.model.preview_slice_idx, 5)
         self.view.update_projection.assert_called_once()
         self.view.update_sinogram.assert_called_once()
         self.view.update_recon_preview.assert_called_once()
+        self.view.recon_params.assert_called_once()
 
         mock_get_reconstructor_for.assert_called_once()
         mock_reconstructor.single_sino.assert_called_once()
@@ -117,7 +127,12 @@ class ReconWindowPresenterTest(unittest.TestCase):
     def test_do_reconstruct_slice(self, mock_get_reconstructor_for):
         mock_reconstructor = mock.Mock()
         mock_reconstructor.single_sino = mock.Mock()
+        mock_reconstructor.single_sino.return_value = np.random.rand(128, 128)
         mock_get_reconstructor_for.return_value = mock_reconstructor
+
+        recon_params = ReconstructionParameters("FBP", "ram-lak", 10)
+        self.view.recon_params.return_value = recon_params
+
         self.presenter.model.preview_slice_idx = 0
         self.presenter.model.last_cor = ScalarCoR(150)
         self.presenter.model.data_model._cached_gradient = None
@@ -125,6 +140,7 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.presenter.do_preview_reconstruct_slice()
         self.view.update_sinogram.assert_called_once()
         self.view.update_recon_preview.assert_called_once()
+        self.view.recon_params.assert_called_once()
 
         mock_get_reconstructor_for.assert_called_once()
         mock_reconstructor.single_sino.assert_called_once()

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Optional, List
 
 from PyQt5.QtWidgets import QAbstractItemView, QWidget, QDoubleSpinBox, QComboBox, QSpinBox, QPushButton, QVBoxLayout, \
     QInputDialog
+import numpy
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.utility.data_containers import ScalarCoR, Degrees, Slope, ReconstructionParameters
@@ -194,13 +195,12 @@ class ReconstructWindowView(BaseMainWindowView):
     def update_sinogram(self, image_data):
         self.image_view.update_sinogram(image_data)
 
-    def update_recon_preview(self, image_data, refresh_recon_slice_histogram: bool):
+    def update_recon_preview(self, image_data: numpy.ndarray, refresh_recon_slice_histogram: bool):
         """
         Updates the reconstruction preview image with new data.
         """
         # Plot image
-        if image_data is not None:
-            self.image_view.update_recon(image_data, refresh_recon_slice_histogram)
+        self.image_view.update_recon(image_data, refresh_recon_slice_histogram)
 
     def reset_image_recon_preview(self):
         """

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -280,7 +280,7 @@ class ReconstructWindowView(BaseMainWindowView):
 
     @pixel_size.setter
     def pixel_size(self, value: int):
-        return self.pixelSize.setValue(value)
+        self.pixelSize.setValue(value)
 
     def recon_params(self) -> ReconstructionParameters:
         return ReconstructionParameters(algorithm=self.algorithm_name,

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -131,6 +131,12 @@ class ReconstructWindowView(BaseMainWindowView):
         self.numIter.valueChanged.connect(
             lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))  # type: ignore
 
+        def refresh_preview_and_histogram():
+            self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE)
+            self.image_view.reset_recon_histogram()
+
+        self.pixelSize.valueChanged.connect(refresh_preview_and_histogram)
+
     def remove_selected_cor(self):
         return self.tableView.removeSelectedRows()
 


### PR DESCRIPTION
Now uses pixel size in recon preview and reconstruct slice. Reconstruct volume already used it so nothing should be changed there.

Changing the histogram also resets the histogram range on the recon slice, so if you manually scroll up the pixel size you should see the range remaining at the edges of the data range.

Fixes #626 