### PR TITLE
Handles missing projection or projection angle

### DIFF
--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -119,13 +119,13 @@ class Images:
 
         self.metadata[const.OPERATION_HISTORY].append({
             const.TIMESTAMP:
-                datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             const.OPERATION_NAME:
-                func_name,
+            func_name,
             const.OPERATION_KEYWORD_ARGS: {k: prepare(v)
                                            for k, v in kwargs.items() if accepted_type(v)},
             const.OPERATION_DISPLAY_NAME:
-                display_name
+            display_name
         })
 
     def copy(self, flip_axes=False) -> 'Images':
@@ -276,9 +276,9 @@ class Images:
         proj_angles = self._log_file.projection_angles() if self._log_file is not None else \
             ProjectionAngles(np.linspace(0, math.tau, self.num_projections))
         if self.num_images != len(proj_angles.value):
-            raise ValueError(f"Number of projection angles {len(proj_angles.value)} does not equal" \
-                             f" the number of projections {self.num_images}. This can happen if loading subset of" \
-                             f" projections, and using projection angles from a log file.")
+            raise ValueError(f"Number of projection angles {len(proj_angles.value)} does not equal "
+                             f"the number of projections {self.num_images}. This can happen if loading subset of "
+                             "projections, and using projection angles from a log file.")
         return proj_angles
 
     def counts(self) -> Optional[Counts]:

--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -119,13 +119,13 @@ class Images:
 
         self.metadata[const.OPERATION_HISTORY].append({
             const.TIMESTAMP:
-            datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             const.OPERATION_NAME:
-            func_name,
+                func_name,
             const.OPERATION_KEYWORD_ARGS: {k: prepare(v)
                                            for k, v in kwargs.items() if accepted_type(v)},
             const.OPERATION_DISPLAY_NAME:
-            display_name
+                display_name
         })
 
     def copy(self, flip_axes=False) -> 'Images':
@@ -276,9 +276,10 @@ class Images:
         proj_angles = self._log_file.projection_angles() if self._log_file is not None else \
             ProjectionAngles(np.linspace(0, math.tau, self.num_projections))
         if self.num_images != len(proj_angles.value):
-            raise ValueError(f"Number of projection angles {len(proj_angles.value)} does not equal "
-                             f"the number of projections {self.num_images}. This can happen if loading subset of "
-                             f"projections, and using projection angles from a log file.")
+            raise ValueError(f"Number of projection angles {len(proj_angles.value)} does not equal" \
+                             f" the number of projections {self.num_images}. This can happen if loading subset of" \
+                             f" projections, and using projection angles from a log file.")
+        return proj_angles
 
     def counts(self) -> Optional[Counts]:
         if self._log_file is not None:

--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -119,13 +119,13 @@ class Images:
 
         self.metadata[const.OPERATION_HISTORY].append({
             const.TIMESTAMP:
-                datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             const.OPERATION_NAME:
-                func_name,
+            func_name,
             const.OPERATION_KEYWORD_ARGS: {k: prepare(v)
                                            for k, v in kwargs.items() if accepted_type(v)},
             const.OPERATION_DISPLAY_NAME:
-                display_name
+            display_name
         })
 
     def copy(self, flip_axes=False) -> 'Images':
@@ -276,9 +276,9 @@ class Images:
         proj_angles = self._log_file.projection_angles() if self._log_file is not None else \
             ProjectionAngles(np.linspace(0, math.tau, self.num_projections))
         if self.num_images != len(proj_angles.value):
-            raise ValueError(f"Number of projection angles {len(proj_angles.value)} does not equal" \
-                             f" the number of projections {self.num_images}. This can happen if loading subset of" \
-                             f" projections, and using projection angles from a log file.")
+            raise ValueError(f"Number of projection angles {len(proj_angles.value)} does not equal "
+                             f"the number of projections {self.num_images}. This can happen if loading subset of "
+                             f"projections, and using projection angles from a log file.")
 
     def counts(self) -> Optional[Counts]:
         if self._log_file is not None:

--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -119,13 +119,13 @@ class Images:
 
         self.metadata[const.OPERATION_HISTORY].append({
             const.TIMESTAMP:
-            datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             const.OPERATION_NAME:
-            func_name,
+                func_name,
             const.OPERATION_KEYWORD_ARGS: {k: prepare(v)
                                            for k, v in kwargs.items() if accepted_type(v)},
             const.OPERATION_DISPLAY_NAME:
-            display_name
+                display_name
         })
 
     def copy(self, flip_axes=False) -> 'Images':
@@ -273,8 +273,12 @@ class Images:
         self._log_file = value
 
     def projection_angles(self):
-        return self._log_file.projection_angles() if self._log_file is not None else \
+        proj_angles = self._log_file.projection_angles() if self._log_file is not None else \
             ProjectionAngles(np.linspace(0, math.tau, self.num_projections))
+        if self.num_images != len(proj_angles.value):
+            raise ValueError(f"Number of projection angles {len(proj_angles.value)} does not equal" \
+                             f" the number of projections {self.num_images}. This can happen if loading subset of" \
+                             f" projections, and using projection angles from a log file.")
 
     def counts(self) -> Optional[Counts]:
         if self._log_file is not None:

--- a/mantidimaging/core/io/loader/__init__.py
+++ b/mantidimaging/core/io/loader/__init__.py
@@ -1,2 +1,2 @@
 from .loader import (  # noqa: F401
-    load, load_p, load_log, read_in_shape, supported_formats)
+    load, load_p, load_log, read_in_file_information, supported_formats)

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -1,5 +1,6 @@
+from dataclasses import dataclass
 from logging import getLogger
-from typing import Tuple
+from typing import Tuple, List
 
 import numpy as np
 
@@ -65,10 +66,17 @@ def supported_formats():
     return avail_list
 
 
-def read_in_shape(input_path,
-                  in_prefix='',
-                  in_format=DEFAULT_IO_FILE_FORMAT,
-                  data_dtype=np.float32) -> Tuple[Tuple[int, int, int], bool]:
+@dataclass
+class FileInformation:
+    filenames: List[str]
+    shape: Tuple[int, int, int]
+    sinograms: bool
+
+
+def read_in_file_information(input_path,
+                             in_prefix='',
+                             in_format=DEFAULT_IO_FILE_FORMAT,
+                             data_dtype=np.float32) -> FileInformation:
     input_file_names = get_file_names(input_path, in_format, in_prefix)
     dataset = load(input_path,
                    in_prefix=in_prefix,
@@ -79,9 +87,15 @@ def read_in_shape(input_path,
     images = dataset.sample
 
     # construct and return the new shape
-    shape = (len(input_file_names), ) + images.data[0].shape
+    shape = (len(input_file_names),) + images.data[0].shape
     images.free_memory()
-    return shape, images.is_sinograms
+
+    fi = FileInformation(
+        filenames=input_file_names,
+        shape=shape,
+        sinograms=images.is_sinograms
+    )
+    return fi
 
 
 def load_log(log_file) -> IMATLogFile:

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -87,14 +87,10 @@ def read_in_file_information(input_path,
     images = dataset.sample
 
     # construct and return the new shape
-    shape = (len(input_file_names),) + images.data[0].shape
+    shape = (len(input_file_names), ) + images.data[0].shape
     images.free_memory()
 
-    fi = FileInformation(
-        filenames=input_file_names,
-        shape=shape,
-        sinograms=images.is_sinograms
-    )
+    fi = FileInformation(filenames=input_file_names, shape=shape, sinograms=images.is_sinograms)
     return fi
 
 

--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -82,7 +82,7 @@ class AstraRecon(BaseRecon):
         proj_angles = images.projection_angles()
 
         def get_sumsq(image: np.ndarray) -> float:
-            return np.sum(image**2)
+            return np.sum(image ** 2)
 
         def minimizer_function(cor):
             return -get_sumsq(AstraRecon.single_sino(images.sino(slice_idx), ScalarCoR(cor), proj_angles, recon_params))
@@ -93,10 +93,6 @@ class AstraRecon(BaseRecon):
     def single_sino(sino: np.ndarray, cor: ScalarCoR, proj_angles: ProjectionAngles,
                     recon_params: ReconstructionParameters) -> np.ndarray:
         assert sino.ndim == 2, "Sinogram must be a 2D image"
-        assert sino.shape[0] == len(
-            proj_angles.value), f"Number of projection angles {len(proj_angles.value)} does not equal" \
-                                f" the number of projections {sino.shape[0]}. This can happen if loading subset of" \
-                                f" projections, and using projection angles from a log file."
 
         sino = BaseRecon.sino_recon_prep(sino)
         image_width = sino.shape[1]

--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -82,7 +82,7 @@ class AstraRecon(BaseRecon):
         proj_angles = images.projection_angles()
 
         def get_sumsq(image: np.ndarray) -> float:
-            return np.sum(image ** 2)
+            return np.sum(image**2)
 
         def minimizer_function(cor):
             return -get_sumsq(AstraRecon.single_sino(images.sino(slice_idx), ScalarCoR(cor), proj_angles, recon_params))

--- a/mantidimaging/core/utility/test/imat_log_file_parser_test.py
+++ b/mantidimaging/core/utility/test/imat_log_file_parser_test.py
@@ -5,8 +5,53 @@ from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
 
 def test_parsing_log_file():
     test_input = [["ignored line"], ["ignored line"],
-                  ["timestamp", "projection index and angle: 0.100", "counts before: 12345", "counts_after: 45678"]]
+                  ["timestamp", "Projection:  0  angle: 0.1", "counts before: 12345", "counts_after: 45678"]]
     logfile = IMATLogFile(test_input)
     assert len(logfile.projection_angles().value) == 1
     assert logfile.projection_angles().value[0] == np.deg2rad(0.1), f"Got: {logfile.projection_angles().value[0]}"
     assert logfile.counts().value[0] == (45678 - 12345)
+
+
+def test_counts():
+    test_input = [
+        ["ignored line"],
+        ["ignored line"],
+        ["timestamp", "Projection:  0  angle: 0.0", "counts before: 12345", "counts_after: 45678"],
+        ["timestamp", "Projection:  1  angle: 0.1", "counts before: 45678", "counts_after: 84678"],
+        ["timestamp", "Projection:  2  angle: 0.2", "counts before: 84678", "counts_after: 124333"],
+    ]
+    logfile = IMATLogFile(test_input)
+    assert len(logfile.counts().value) == 3
+    assert logfile.counts().value[0] == 45678 - 12345
+    assert logfile.counts().value[1] == 84678 - 45678
+    assert logfile.counts().value[2] == 124333 - 84678
+
+
+def assert_raises(exc_type, callable, *args, **kwargs):
+    try:
+        callable(*args, **kwargs)
+        assert False, "Did not raise"
+    except exc_type:
+        return
+    except Exception:
+        assert False, "Did not raise expected exception."
+
+
+def test_find_missing_projection_number():
+    test_input = [
+        ["ignored line"],
+        ["ignored line"],
+        ["timestamp", "Projection:  0  angle: 0.0", "counts before: 12345", "counts_after: 45678"],
+        ["timestamp", "Projection:  1  angle: 0.1", "counts before: 12345", "counts_after: 45678"],
+        ["timestamp", "Projection:  2  angle: 0.2", "counts before: 12345", "counts_after: 45678"],
+    ]
+    logfile = IMATLogFile(test_input)
+    assert len(logfile.projection_numbers()) == 3
+    # nothing missing
+    logfile.raise_if_angle_missing(["file_000.tif", "file_001.tif", "file_002.tif"])
+    # image file missing
+    assert_raises(RuntimeError, logfile.raise_if_angle_missing, ["file_000.tif", "file_002.tif"])
+    # image file missing
+    assert_raises(RuntimeError, logfile.raise_if_angle_missing, ["file_000.tif", "file_001.tif"])
+    assert_raises(RuntimeError, logfile.raise_if_angle_missing,
+                  ["file_000.tif", "file_001.tif", "file_002.tif", "file_003.tif"])

--- a/mantidimaging/gui/windows/load_dialog/field.py
+++ b/mantidimaging/gui/windows/load_dialog/field.py
@@ -55,7 +55,9 @@ class Field:
 
     @path.setter
     def path(self, value: str):
-        assert isinstance(value, str), "Can only display strings"
+        assert isinstance(value,
+                          str), f"The object passed as path for this field is not a string. " \
+                                f"Instead got {type(value)}"
         if value != "":
             self.path.setText(1, value)
             self.widget.setText(1, self.file())

--- a/mantidimaging/gui/windows/load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/load_dialog/presenter.py
@@ -136,7 +136,7 @@ class LoadPresenter:
         return ""
 
     @staticmethod
-    def _find_log(dirname: Path, log_name: str):
+    def _find_log(dirname: Path, log_name: str) -> str:
         """
 
         :param dirname: The directory in which the sample images were found
@@ -221,13 +221,14 @@ class LoadPresenter:
         if self.last_file_info is None:
             raise RuntimeError("Please select sample data to be loaded first!")
         file_name = self.view.select_file(name, is_image_file)
-        if file_name is None:
-            return
 
         # this is set when the user selects sample data
         self.ensure_sample_log_consistency(field, file_name, self.last_file_info.filenames)
 
     def ensure_sample_log_consistency(self, field: Field, file_name, image_filenames):
+        if file_name is None or file_name == "":
+            return
+
         log = load_log(file_name)
         log.raise_if_angle_missing(image_filenames)
         self._update_field_action(field, file_name)

--- a/mantidimaging/gui/windows/load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/load_dialog/test/presenter_test.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from unittest import mock
 
 from mantidimaging.core.io.loader.loader import FileInformation
-from mantidimaging.core.utility.data_containers import ProjectionAngles
 from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
 from mantidimaging.gui.windows.load_dialog.presenter import LoadPresenter, Notification
 
@@ -44,12 +43,12 @@ class LoadDialogPresenterTest(unittest.TestCase):
 
         self.v.select_file.assert_called_once_with("Sample")
 
-    @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.read_in_file_information",
-                return_value=FileInformation([], (0, 0, 0), True))
-    @mock.patch(
-        "mantidimaging.gui.windows.load_dialog.presenter.get_file_extension", )
+    @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.load_log")
+    @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.read_in_file_information", return_value=
+    FileInformation([], (0, 0, 0), True))
+    @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.get_file_extension", )
     @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.get_prefix")
-    def test_do_update_sample(self, get_prefix, get_file_extension, read_in_file_information):
+    def test_do_update_sample(self, get_prefix, get_file_extension, read_in_file_information, mock_load_log):
         selected_file = "SelectedFile"
         sample_file_name = "SampleFileName"
         path_text = "PathText"
@@ -57,6 +56,8 @@ class LoadDialogPresenterTest(unittest.TestCase):
         prefix = "FilePrefix"
         dirname = "/Dirname"
 
+        mock_log = mock.create_autospec(IMATLogFile)
+        mock_load_log.return_value = mock_log
         self.v.select_file.return_value = selected_file
         self.v.sample.file.return_value = sample_file_name
         self.v.sample.path_text.return_value = path_text
@@ -76,7 +77,7 @@ class LoadDialogPresenterTest(unittest.TestCase):
         get_file_extension.assert_called_once_with(sample_file_name)
         get_prefix.assert_called_once_with(path_text)
         read_in_file_information.assert_called_once_with(dirname, in_prefix=prefix, in_format=image_format)
-        self.assertEqual((0, 0, 0), self.p.last_shape)
+        self.assertEqual((0, 0, 0), self.p.last_file_info.shape)
         self.v.flat_before.set_images.assert_called_once_with(1)
         self.v.dark_before.set_images.assert_called_once_with(1)
         self.v.flat_after.set_images.assert_called_once_with(1)
@@ -90,6 +91,8 @@ class LoadDialogPresenterTest(unittest.TestCase):
         self.v.images_are_sinograms.setChecked.assert_called_once_with(True)
         self.v.sample.update_indices.assert_called_once_with(0)
         self.v.sample.update_shape.assert_called_once_with((0, 0))
+        mock_load_log.assert_called_once()
+        mock_log.raise_if_angle_missing.assert_called_once()
 
     def test_do_update_flat_or_dark_returns_without_setting_anything(self):
         file_name = None
@@ -189,37 +192,12 @@ class LoadDialogPresenterTest(unittest.TestCase):
 
         self.p.last_file_info = FileInformation(test_filenames, (2, 10, 10), False)
 
-        mock_log.projection_angles.return_value = ProjectionAngles([1, 2])
         self.p.ensure_sample_log_consistency(field, file_name, test_filenames)
 
         mock_load_log.assert_called_once_with(file_name)
-        mock_log.projection_angles.assert_called_once()
+        mock_log.raise_if_angle_missing.assert_called_once_with(test_filenames)
         self.assertIsNotNone(field.path)
         self.assertIsNotNone(field.use)
-
-    @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.load_log")
-    def test_ensure_sample_log_consistency_mismatching(self, mock_load_log):
-        """
-        Test behaviour when the number of projection angles and files DOES NOT match
-        """
-        mock_log = mock.create_autospec(IMATLogFile)
-        mock_load_log.return_value = mock_log
-        file_name = "file_name"
-        field = mock.MagicMock()
-        field.path = None
-        field.use = None
-        test_filenames = ["file1", "file2"]
-
-        self.p.last_file_info = FileInformation(test_filenames, (2, 10, 10), False)
-
-        mock_log.projection_angles.return_value = ProjectionAngles([1, 2, 3])
-        mock_log.raise_if_angle_missing.return_value = (5, "006.tif")
-        self.assertRaises(RuntimeError, self.p.ensure_sample_log_consistency, field, file_name, test_filenames)
-
-        mock_load_log.assert_called_once_with(file_name)
-        mock_log.projection_angles.assert_called_once()
-        self.assertIsNone(field.path)
-        self.assertIsNone(field.use)
 
     @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.get_prefix", return_value="/path")
     def test_get_parameters(self, get_prefix):

--- a/mantidimaging/gui/windows/load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/load_dialog/test/presenter_test.py
@@ -200,6 +200,25 @@ class LoadDialogPresenterTest(unittest.TestCase):
         self.assertIsNotNone(field.path)
         self.assertIsNotNone(field.use)
 
+    @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.load_log")
+    def test_ensure_sample_log_consistency_exits_when_none_or_empty_str(self, mock_load_log):
+        mock_log = mock.create_autospec(IMATLogFile)
+        mock_load_log.return_value = mock_log
+        file_name = None
+        field = mock.MagicMock()
+        test_filenames = ["file1", "file2"]
+
+        self.p.ensure_sample_log_consistency(field, file_name, test_filenames)
+
+        mock_load_log.assert_not_called()
+        mock_log.raise_if_angle_missing.assert_not_called()
+
+        file_name = ""
+        self.p.ensure_sample_log_consistency(field, file_name, test_filenames)
+
+        mock_load_log.assert_not_called()
+        mock_log.raise_if_angle_missing.assert_not_called()
+
     @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.get_prefix", return_value="/path")
     def test_get_parameters(self, get_prefix):
         path_text = "/path/text"

--- a/mantidimaging/gui/windows/load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/load_dialog/test/presenter_test.py
@@ -44,9 +44,10 @@ class LoadDialogPresenterTest(unittest.TestCase):
         self.v.select_file.assert_called_once_with("Sample")
 
     @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.load_log")
-    @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.read_in_file_information", return_value=
-    FileInformation([], (0, 0, 0), True))
-    @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.get_file_extension", )
+    @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.read_in_file_information",
+                return_value=FileInformation([], (0, 0, 0), True))
+    @mock.patch(
+        "mantidimaging.gui.windows.load_dialog.presenter.get_file_extension", )
     @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.get_prefix")
     def test_do_update_sample(self, get_prefix, get_file_extension, read_in_file_information, mock_load_log):
         selected_file = "SelectedFile"

--- a/mantidimaging/gui/windows/load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/load_dialog/test/presenter_test.py
@@ -2,6 +2,9 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from mantidimaging.core.io.loader.loader import FileInformation
+from mantidimaging.core.utility.data_containers import ProjectionAngles
+from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
 from mantidimaging.gui.windows.load_dialog.presenter import LoadPresenter, Notification
 
 
@@ -41,11 +44,12 @@ class LoadDialogPresenterTest(unittest.TestCase):
 
         self.v.select_file.assert_called_once_with("Sample")
 
-    @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.read_in_shape", return_value=((0, 0, 0), True))
+    @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.read_in_file_information",
+                return_value=FileInformation([], (0, 0, 0), True))
     @mock.patch(
         "mantidimaging.gui.windows.load_dialog.presenter.get_file_extension", )
     @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.get_prefix")
-    def test_do_update_sample(self, get_prefix, get_file_extension, read_in_shape):
+    def test_do_update_sample(self, get_prefix, get_file_extension, read_in_file_information):
         selected_file = "SelectedFile"
         sample_file_name = "SampleFileName"
         path_text = "PathText"
@@ -71,7 +75,7 @@ class LoadDialogPresenterTest(unittest.TestCase):
         self.assertEqual(image_format, self.p.image_format)
         get_file_extension.assert_called_once_with(sample_file_name)
         get_prefix.assert_called_once_with(path_text)
-        read_in_shape.assert_called_once_with(dirname, in_prefix=prefix, in_format=image_format)
+        read_in_file_information.assert_called_once_with(dirname, in_prefix=prefix, in_format=image_format)
         self.assertEqual((0, 0, 0), self.p.last_shape)
         self.v.flat_before.set_images.assert_called_once_with(1)
         self.v.dark_before.set_images.assert_called_once_with(1)
@@ -113,15 +117,109 @@ class LoadDialogPresenterTest(unittest.TestCase):
 
     def test_do_update_single_file(self):
         file_name = "file_name"
-        image_name = "/ExampleImageName"
         name = "Name"
+        is_image_file = True
         field = mock.MagicMock()
         self.v.select_file.return_value = file_name
 
-        self.p.do_update_single_file(field, name, image_name)
+        self.p.do_update_single_file(field, name, is_image_file)
 
-        self.v.select_file.assert_called_once_with(name, image_name)
+        self.v.select_file.assert_called_once_with(name, is_image_file)
         self.assertEqual(field.path, file_name)
+
+    def test_do_update_single_file_no_file_selected(self):
+        file_name = "file_name"
+        name = "Name"
+        is_image_file = True
+        field = mock.MagicMock()
+        self.v.select_file.return_value = None
+
+        self.p.do_update_single_file(field, name, is_image_file)
+
+        self.v.select_file.assert_called_once_with(name, is_image_file)
+        self.assertNotEqual(field.path, file_name)
+
+    def test_do_update_sample_log_no_sample_selected(self):
+        name = "Name"
+        is_image_file = True
+        field = mock.MagicMock()
+        self.p.last_file_info = None
+        self.assertRaises(RuntimeError, self.p.do_update_sample_log, field, name, is_image_file)
+
+    def test_do_update_sample_log_no_file_selected(self):
+        file_name = "file_name"
+        name = "Name"
+        is_image_file = True
+        field = mock.MagicMock()
+        self.v.select_file.return_value = None
+
+        self.p.last_file_info = FileInformation([], (0, 0, 0), False)
+        self.p.do_update_sample_log(field, name, is_image_file)
+
+        self.v.select_file.assert_called_once_with(name, is_image_file)
+        self.assertNotEqual(field.path, file_name)
+
+    @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.LoadPresenter.ensure_sample_log_consistency")
+    def test_do_update_sample_log(self, mock_ensure):
+        file_name = "file_name"
+        name = "Name"
+
+        is_image_file = True
+        field = mock.MagicMock()
+        self.v.select_file.return_value = file_name
+
+        self.p.last_file_info = FileInformation([], (0, 0, 0), False)
+        self.p.do_update_sample_log(field, name, is_image_file)
+
+        self.v.select_file.assert_called_once_with(name, is_image_file)
+        mock_ensure.assert_called_once_with(field, file_name, [])
+
+    @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.load_log")
+    def test_ensure_sample_log_consistency_matching(self, mock_load_log):
+        """
+        Test behaviour when the number of projection angles and files matches
+        """
+        mock_log = mock.create_autospec(IMATLogFile)
+        mock_load_log.return_value = mock_log
+        file_name = "file_name"
+        field = mock.MagicMock()
+        field.path = None
+        field.use = None
+        test_filenames = ["file1", "file2"]
+
+        self.p.last_file_info = FileInformation(test_filenames, (2, 10, 10), False)
+
+        mock_log.projection_angles.return_value = ProjectionAngles([1, 2])
+        self.p.ensure_sample_log_consistency(field, file_name, test_filenames)
+
+        mock_load_log.assert_called_once_with(file_name)
+        mock_log.projection_angles.assert_called_once()
+        self.assertIsNotNone(field.path)
+        self.assertIsNotNone(field.use)
+
+    @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.load_log")
+    def test_ensure_sample_log_consistency_mismatching(self, mock_load_log):
+        """
+        Test behaviour when the number of projection angles and files DOES NOT match
+        """
+        mock_log = mock.create_autospec(IMATLogFile)
+        mock_load_log.return_value = mock_log
+        file_name = "file_name"
+        field = mock.MagicMock()
+        field.path = None
+        field.use = None
+        test_filenames = ["file1", "file2"]
+
+        self.p.last_file_info = FileInformation(test_filenames, (2, 10, 10), False)
+
+        mock_log.projection_angles.return_value = ProjectionAngles([1, 2, 3])
+        mock_log.raise_if_angle_missing.return_value = (5, "006.tif")
+        self.assertRaises(RuntimeError, self.p.ensure_sample_log_consistency, field, file_name, test_filenames)
+
+        mock_load_log.assert_called_once_with(file_name)
+        mock_log.projection_angles.assert_called_once()
+        self.assertIsNone(field.path)
+        self.assertIsNone(field.use)
 
     @mock.patch("mantidimaging.gui.windows.load_dialog.presenter.get_prefix", return_value="/path")
     def test_get_parameters(self, get_prefix):

--- a/mantidimaging/gui/windows/load_dialog/view.py
+++ b/mantidimaging/gui/windows/load_dialog/view.py
@@ -62,11 +62,11 @@ class MWLoadDialog(Qt.QDialog):
 
         self.proj_180deg, self.select_proj_180deg = self.create_file_input(5)
         self.select_proj_180deg.clicked.connect(lambda: self.presenter.notify(
-            Notification.UPDATE_SINGLE_FILE, field=self.proj_180deg, name="180 degree", image_file=True))
+            Notification.UPDATE_SINGLE_FILE, field=self.proj_180deg, name="180 degree", is_image_file=True))
 
         self.sample_log, self.select_sample_log = self.create_file_input(6)
         self.select_sample_log.clicked.connect(lambda: self.presenter.notify(
-            Notification.UPDATE_SAMPLE_LOG, field=self.sample_log, name="Sample Log", image_file=False))
+            Notification.UPDATE_SAMPLE_LOG, field=self.sample_log, name="Sample Log", is_image_file=False))
 
         self.flat_before_log, self.select_flat_before_log = self.create_file_input(7)
         self.select_flat_before_log.clicked.connect(lambda: self.presenter.notify(
@@ -75,6 +75,7 @@ class MWLoadDialog(Qt.QDialog):
         self.flat_after_log, self.select_flat_after_log = self.create_file_input(8)
         self.select_flat_after_log.clicked.connect(lambda: self.presenter.notify(
             Notification.UPDATE_SINGLE_FILE, field=self.flat_after_log, name="Flat After Log", image_file=False))
+
 
         self.step_all.clicked.connect(self._set_all_step)
         self.step_preview.clicked.connect(self._set_preview_step)

--- a/mantidimaging/gui/windows/load_dialog/view.py
+++ b/mantidimaging/gui/windows/load_dialog/view.py
@@ -66,7 +66,7 @@ class MWLoadDialog(Qt.QDialog):
 
         self.sample_log, self.select_sample_log = self.create_file_input(6)
         self.select_sample_log.clicked.connect(lambda: self.presenter.notify(
-            Notification.UPDATE_SINGLE_FILE, field=self.sample_log, name="Sample Log", image_file=False))
+            Notification.UPDATE_SAMPLE_LOG, field=self.sample_log, name="Sample Log", image_file=False))
 
         self.flat_before_log, self.select_flat_before_log = self.create_file_input(7)
         self.select_flat_before_log.clicked.connect(lambda: self.presenter.notify(

--- a/mantidimaging/gui/windows/load_dialog/view.py
+++ b/mantidimaging/gui/windows/load_dialog/view.py
@@ -76,7 +76,6 @@ class MWLoadDialog(Qt.QDialog):
         self.select_flat_after_log.clicked.connect(lambda: self.presenter.notify(
             Notification.UPDATE_SINGLE_FILE, field=self.flat_after_log, name="Flat After Log", image_file=False))
 
-
         self.step_all.clicked.connect(self._set_all_step)
         self.step_preview.clicked.connect(self._set_preview_step)
         # if accepted load the stack

--- a/mantidimaging/gui/windows/load_dialog/view.py
+++ b/mantidimaging/gui/windows/load_dialog/view.py
@@ -113,11 +113,11 @@ class MWLoadDialog(Qt.QDialog):
         else:
             # Assume text file
             file_filter = "Log File (*.txt *.log)"
-        selected_file, accepted = Qt.QFileDialog.getOpenFileName(caption=caption,
-                                                                 filter=f"{file_filter};;All (*.*)",
-                                                                 initialFilter=file_filter)
+        selected_file, _ = Qt.QFileDialog.getOpenFileName(caption=caption,
+                                                          filter=f"{file_filter};;All (*.*)",
+                                                          initialFilter=file_filter)
 
-        if accepted:
+        if len(selected_file) > 0:
             return selected_file
         else:
             return None
@@ -126,7 +126,8 @@ class MWLoadDialog(Qt.QDialog):
         self.sample.set_step(1)
 
     def _set_preview_step(self):
-        self.sample.set_step(self.presenter.last_shape[0] // 10)
+        # FIXME direct attribute access
+        self.sample.set_step(self.presenter.last_file_info.shape[0] // 10)
 
     def get_parameters(self) -> LoadingParameters:
         return self.presenter.get_parameters()


### PR DESCRIPTION
Verifies the number of images versus the number of proj angles in log 

- If they mismatch it raises a runtime error
- It tries to find the missing projection / image file

It shows an error message and should not select the log. The error message ought to prompt the user to inspect their data and/or logs and fix the change (we can't really do anything!)

### To test
- The flower dataset should have logs in it
- Copy your image files and the sample log, as you'll be editing those and don't want to lose the main copy
- Delete any image file 
- Try loading the data - it should tell you there's a missing image file (projection), and do a best guess as to which one (number might be off by 1 for the image file)
  - Edge cases are: missing first or last image file, try those too

---------------

- Restore the image file and delete a line from the log
- Try loading the data again - this time it should tell you there's a missing angle
  - Same edge case as above

---------------

- Keep the deleted line in the log and delete A DIFFERENT image file 
- Try loading the data - it should fail again

---------------

- Restore the previous projection, keep the deleted line in the log and delete the SAME image file as the line in the log
- This should now load as there is no mismatching information