### PR TITLE
Disable SAVU window and apply history to new stack

### DIFF
--- a/mantidimaging/gui/ui/main_window.ui
+++ b/mantidimaging/gui/ui/main_window.ui
@@ -45,7 +45,6 @@
     </property>
     <addaction name="actionFilters"/>
     <addaction name="actionRecon"/>
-    <addaction name="actionSavuFilters"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -61,7 +61,7 @@ class MainWindowView(BaseMainWindowView):
         self.actionAbout.triggered.connect(self.show_about)
 
         self.actionFilters.triggered.connect(self.show_filters_window)
-        self.actionSavuFilters.triggered.connect(self.show_savu_filters_window)
+        # self.actionSavuFilters.triggered.connect(self.show_savu_filters_window)
         self.actionRecon.triggered.connect(self.show_recon_window)
 
         self.active_stacks_changed.connect(self.update_shortcuts)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -61,7 +61,6 @@ class MainWindowView(BaseMainWindowView):
         self.actionAbout.triggered.connect(self.show_about)
 
         self.actionFilters.triggered.connect(self.show_filters_window)
-        # self.actionSavuFilters.triggered.connect(self.show_savu_filters_window)
         self.actionRecon.triggered.connect(self.show_recon_window)
 
         self.active_stacks_changed.connect(self.update_shortcuts)

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -108,20 +108,14 @@ class StackVisualiserView(BaseMainWindowView):
         self.close()
 
     def build_context_menu(self) -> QMenu:
-        actions = [
-            ("Set ROI", self.set_roi),
-            ("Copy ROI to clipboard", self.copy_roi_to_clipboard),
-            ("Toggle show averaged image", lambda: self.presenter.notify(SVNotification.TOGGLE_IMAGE_MODE)),
-            ("Create sinograms from stack", lambda: self.presenter.notify(SVNotification.SWAP_AXES)),
-            ("Duplicate whole data", lambda: self.presenter.notify(SVNotification.DUPE_STACK)),
-            ("Duplicate current ROI of data", lambda: self.presenter.notify(SVNotification.DUPE_STACK_ROI)),
-            ("Show history", self.show_image_metadata),
-            #    ("Apply history from another stack", self.show_op_history_copy_dialog),
-            ("Mark as projections/sinograms", self.mark_as_),
-            ("Change window name", self.change_window_name_clicked),
-            ("Goto projection", self.goto_projection),
-            ("Goto angle", self.goto_angle)
-        ]
+        actions = [("Set ROI", self.set_roi), ("Copy ROI to clipboard", self.copy_roi_to_clipboard),
+                   ("Toggle show averaged image", lambda: self.presenter.notify(SVNotification.TOGGLE_IMAGE_MODE)),
+                   ("Create sinograms from stack", lambda: self.presenter.notify(SVNotification.SWAP_AXES)),
+                   ("Duplicate whole data", lambda: self.presenter.notify(SVNotification.DUPE_STACK)),
+                   ("Duplicate current ROI of data", lambda: self.presenter.notify(SVNotification.DUPE_STACK_ROI)),
+                   ("Show history", self.show_image_metadata), ("Mark as projections/sinograms", self.mark_as_),
+                   ("Change window name", self.change_window_name_clicked), ("Goto projection", self.goto_projection),
+                   ("Goto angle", self.goto_angle)]
 
         menu = QMenu(self)
 

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -108,16 +108,20 @@ class StackVisualiserView(BaseMainWindowView):
         self.close()
 
     def build_context_menu(self) -> QMenu:
-        actions = [("Set ROI", self.set_roi), ("Copy ROI to clipboard", self.copy_roi_to_clipboard),
-                   ("Toggle show averaged image", lambda: self.presenter.notify(SVNotification.TOGGLE_IMAGE_MODE)),
-                   ("Create sinograms from stack", lambda: self.presenter.notify(SVNotification.SWAP_AXES)),
-                   ("Duplicate whole data", lambda: self.presenter.notify(SVNotification.DUPE_STACK)),
-                   ("Duplicate current ROI of data", lambda: self.presenter.notify(SVNotification.DUPE_STACK_ROI)),
-                   ("Show history", self.show_image_metadata),
-                   ("Apply history from another stack", self.show_op_history_copy_dialog),
-                   ("Mark as projections/sinograms", self.mark_as_),
-                   ("Change window name", self.change_window_name_clicked), ("Goto projection", self.goto_projection),
-                   ("Goto angle", self.goto_angle)]
+        actions = [
+            ("Set ROI", self.set_roi),
+            ("Copy ROI to clipboard", self.copy_roi_to_clipboard),
+            ("Toggle show averaged image", lambda: self.presenter.notify(SVNotification.TOGGLE_IMAGE_MODE)),
+            ("Create sinograms from stack", lambda: self.presenter.notify(SVNotification.SWAP_AXES)),
+            ("Duplicate whole data", lambda: self.presenter.notify(SVNotification.DUPE_STACK)),
+            ("Duplicate current ROI of data", lambda: self.presenter.notify(SVNotification.DUPE_STACK_ROI)),
+            ("Show history", self.show_image_metadata),
+            #    ("Apply history from another stack", self.show_op_history_copy_dialog),
+            ("Mark as projections/sinograms", self.mark_as_),
+            ("Change window name", self.change_window_name_clicked),
+            ("Goto projection", self.goto_projection),
+            ("Goto angle", self.goto_angle)
+        ]
 
         menu = QMenu(self)
 


### PR DESCRIPTION
These features are disabled as they are unfinished/unstable and are not essential for the project delivery

### To test
- Check that the GUI still opens and all the buttons from the main window menus still work
- Load some data
- Right click on the image and check that the Apply history option is gone

Fixes #614