### PR TITLE
Fixes sorting only sorting the names but not the UUID

### DIFF
--- a/mantidimaging/gui/windows/main/save_dialog.py
+++ b/mantidimaging/gui/windows/main/save_dialog.py
@@ -3,12 +3,13 @@ from PyQt5 import Qt
 from mantidimaging.core.io.loader import supported_formats
 from mantidimaging.core.io.utility import DEFAULT_IO_FILE_FORMAT
 from mantidimaging.gui.utility import (compile_ui, select_directory)
+from mantidimaging.gui.windows.main.model import StackId
 
 
-def sort_by_tomo_and_recon(string):
-    if "Recon" in string:
+def sort_by_tomo_and_recon(stack_id: StackId):
+    if "Recon" in stack_id.name:
         return 1
-    elif "Tomo" in string:
+    elif "Tomo" in stack_id.name:
         return 2
     else:
         return 3
@@ -31,14 +32,13 @@ class MWSaveDialog(Qt.QDialog):
         self.formats.setCurrentIndex(formats.index(DEFAULT_IO_FILE_FORMAT))
 
         if stack_list:  # we will just show an empty drop down if no stacks
-            self.stack_uuids, user_friendly_names = zip(*stack_list)
-
             # Sort stacknames using Recon and Tomo as preference
-            user_friendly_names = sorted(user_friendly_names, key=sort_by_tomo_and_recon)
-
+            user_friendly_stack_list = sorted(stack_list, key=sort_by_tomo_and_recon)
             # the stacklist is created in the main windows presenter and has
             # format [(uuid, title)...], doing zip(*stack_list) unzips the
             # tuples into separate lists
+            self.stack_uuids, user_friendly_names = zip(*user_friendly_stack_list)
+
             self.stackNames.addItems(user_friendly_names)
 
         self.selected_stack = None

--- a/mantidimaging/gui/windows/main/test/save_test.py
+++ b/mantidimaging/gui/windows/main/test/save_test.py
@@ -1,6 +1,9 @@
 import unittest
+import uuid
 
-from mantidimaging.gui.windows.main.save_dialog import sort_by_tomo_and_recon
+from mantidimaging.gui.windows.main.model import StackId
+from mantidimaging.gui.windows.main.save_dialog import sort_by_tomo_and_recon, MWSaveDialog
+from mantidimaging.test_helpers.start_qapplication import start_qapplication
 
 
 class SaveDialogTest(unittest.TestCase):
@@ -13,3 +16,21 @@ class SaveDialogTest(unittest.TestCase):
 
         self.assertEqual("Recon", new_names[0])
         self.assertEqual("Tomo", new_names[1])
+
+
+@start_qapplication
+class SaveDialogQtTest(unittest.TestCase):
+    def test_init(self):
+        stack_list = [
+            StackId(uuid.uuid4(), "Stack 1"),
+            StackId(uuid.uuid4(), "Stack 2"),
+            StackId(uuid.uuid4(), "Stack 3"),
+            StackId(uuid.uuid4(), "Stack Tomo"),
+            StackId(uuid.uuid4(), "Stack Recon"),
+        ]
+        mwsd = MWSaveDialog(None, stack_list)
+
+        # the Recon stack is top choice
+        self.assertEqual(mwsd.stack_uuids[0], stack_list[4].id)
+        # the Tomo stack is 2nd choice
+        self.assertEqual(mwsd.stack_uuids[1], stack_list[3].id)

--- a/mantidimaging/gui/windows/main/test/save_test.py
+++ b/mantidimaging/gui/windows/main/test/save_test.py
@@ -11,11 +11,17 @@ class SaveDialogTest(unittest.TestCase):
         super(SaveDialogTest, self).__init__(*args, **kwargs)
 
     def test_sort_stack_names_order(self):
-        names = ["Dark", "Dark1", "Flat", "Recon", "Tomo"]
-        new_names = sorted(names, key=sort_by_tomo_and_recon)
+        stack_list = [
+            StackId(uuid.uuid4(), "Stack 1"),
+            StackId(uuid.uuid4(), "Stack 2"),
+            StackId(uuid.uuid4(), "Stack 3"),
+            StackId(uuid.uuid4(), "Tomo"),
+            StackId(uuid.uuid4(), "Recon"),
+        ]
+        new_names = sorted(stack_list, key=sort_by_tomo_and_recon)
 
-        self.assertEqual("Recon", new_names[0])
-        self.assertEqual("Tomo", new_names[1])
+        self.assertEqual("Recon", new_names[0].name)
+        self.assertEqual("Tomo", new_names[1].name)
 
 
 @start_qapplication

--- a/mantidimaging/gui/windows/main/test/save_test.py
+++ b/mantidimaging/gui/windows/main/test/save_test.py
@@ -26,7 +26,7 @@ class SaveDialogTest(unittest.TestCase):
 
 @start_qapplication
 class SaveDialogQtTest(unittest.TestCase):
-    def test_init(self):
+    def test_init_sorts_stack_list_correctly(self):
         stack_list = [
             StackId(uuid.uuid4(), "Stack 1"),
             StackId(uuid.uuid4(), "Stack 2"),


### PR DESCRIPTION
This led to saving the wrong stacks

### To test

- Load 4 or more stacks (easiest is to load the flower dataset with flat + dark + proj180)
  - The sample stack had to be loaded LAST! in order to trigger the bad behaviour
  - Another way to replicate this is to have a "Recon" stack - maybe recon a single slice or a small volume
- Open save dialog
- The selected stack should be the one with Tomo/Recon in the name
- Try saving it - it should save out the correct stack. Without this fix it will save out the first loaded stack instead