### PR TITLE
Recon projection index - remove cap of 99 and start at middle of stack

### DIFF
--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -25,16 +25,7 @@
         <property name="sizeConstraint">
          <enum>QLayout::SetMaximumSize</enum>
         </property>
-        <property name="leftMargin">
-         <number>9</number>
-        </property>
-        <property name="topMargin">
-         <number>9</number>
-        </property>
-        <property name="rightMargin">
-         <number>9</number>
-        </property>
-        <property name="bottomMargin">
+        <property name="margin">
          <number>9</number>
         </property>
         <item>
@@ -46,7 +37,7 @@
            </sizepolicy>
           </property>
           <property name="currentIndex">
-           <number>1</number>
+           <number>0</number>
           </property>
           <widget class="QWidget" name="resultsTab">
            <attribute name="title">
@@ -198,11 +189,11 @@
                    <property name="toolTip">
                     <string>Use the CoR and Tilt above to generate a CoR for each of the slice indices in the table below</string>
                    </property>
-                   <property name="toolTipDuration">
-                    <number>2</number>
-                   </property>
                    <property name="text">
                     <string>Fit from COR/Tilt above</string>
+                   </property>
+                   <property name="toolTipDuration" stdset="0">
+                    <number>2</number>
                    </property>
                   </widget>
                  </item>
@@ -511,12 +502,16 @@
             </widget>
            </item>
            <item row="0" column="1">
-            <widget class="QSpinBox" name="previewProjectionIndex"/>
+            <widget class="QSpinBox" name="previewProjectionIndex">
+             <property name="maximum">
+              <number>99999</number>
+             </property>
+            </widget>
            </item>
            <item row="1" column="1">
             <widget class="QSpinBox" name="previewSliceIndex">
              <property name="maximum">
-              <number>9999</number>
+              <number>99999</number>
              </property>
             </widget>
            </item>

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -158,7 +158,7 @@ class MainWindowPresenter(BasePresenter):
     def stack_names(self):
         return self.model._stack_names
 
-    def get_stack_visualiser(self, stack_uuid: UUID):
+    def get_stack_visualiser(self, stack_uuid: UUID) -> StackVisualiserView:
         return self.model.get_stack_visualiser(stack_uuid)
 
     def get_all_stack_visualisers(self):

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -88,7 +88,7 @@ class ReconstructWindowModel(object):
     def num_points(self):
         return self.data_model.num_points
 
-    def initial_select_data(self, stack: StackVisualiserView):
+    def initial_select_data(self, stack: 'StackVisualiserView'):
         self.data_model.clear_results()
 
         self.stack = stack

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -102,7 +102,7 @@ class ReconstructWindowModel(object):
             return 0, ScalarCoR(0)
 
         first_slice_to_recon = self.images.height // 2
-        cor = ScalarCoR(self.images.v_middle)
+        cor = ScalarCoR(self.images.h_middle)
         return first_slice_to_recon, cor
 
     def do_fit(self):

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -88,7 +88,7 @@ class ReconstructWindowModel(object):
     def num_points(self):
         return self.data_model.num_points
 
-    def initial_select_data(self, stack):
+    def initial_select_data(self, stack: StackVisualiserView):
         self.data_model.clear_results()
 
         self.stack = stack
@@ -101,7 +101,7 @@ class ReconstructWindowModel(object):
         if self.images is None:
             return 0, ScalarCoR(0)
 
-        first_slice_to_recon = 0
+        first_slice_to_recon = self.images.height // 2
         cor = ScalarCoR(self.images.v_middle)
         return first_slice_to_recon, cor
 

--- a/mantidimaging/gui/windows/recon/test/model_test.py
+++ b/mantidimaging/gui/windows/recon/test/model_test.py
@@ -79,7 +79,7 @@ class ReconWindowModelTest(unittest.TestCase):
         self.assertNotEqual(test_cor, self.model.last_cor)
         self.assertNotEqual(test_tilt, self.model.tilt_angle)
         self.assertEqual(0, self.model.preview_projection_idx)
-        self.assertEqual(0, self.model.preview_slice_idx)
+        self.assertEqual(64, self.model.preview_slice_idx)
 
     def test_do_fit(self):
         self.model.images.metadata.clear()

--- a/mantidimaging/gui/windows/recon/test/model_test.py
+++ b/mantidimaging/gui/windows/recon/test/model_test.py
@@ -37,6 +37,12 @@ class ReconWindowModelTest(unittest.TestCase):
         self.assertEqual(first_slice, 0)
         self.assertEqual(initial_cor.value, 0)
 
+    def test_find_initial_cor_returns_middle_with_data(self):
+        self.model.initial_select_data(self.stack)
+        first_slice, initial_cor = self.model.find_initial_cor()
+        self.assertEqual(first_slice, 64)
+        self.assertEqual(initial_cor.value, 128)
+
     def test_tilt_line_data(self):
         # TODO move into data_model test
         self.model.data_model._points = [Point(50, 1), Point(40, 2), Point(30, 3), Point(20, 4)]

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -88,7 +88,7 @@ class ReconWindowPresenterTest(unittest.TestCase):
         # first-time selecting this data after reset
         self.presenter.set_stack_uuid(self.uuid)
 
-        self.assertEqual(5.0, self.view.rotation_centre)
+        self.assertEqual(64.0, self.view.rotation_centre)
         self.assertEqual(TEST_PIXEL_SIZE, self.view.pixel_size)
 
     def test_set_projection_preview_index(self):

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -307,9 +307,10 @@ class ReconstructWindowView(BaseMainWindowView):
     def show_recon_volume(self, data: Images):
         self.main_window.create_new_stack(data, "Recon")
 
-    def get_stack_visualiser(self, uuid)-> 'StackVisualiserView':
+    def get_stack_visualiser(self, uuid) -> Optional['StackVisualiserView']:
         if uuid is not None:
             return self.main_window.get_stack_visualiser(uuid)
+        return None
 
     def hide_tilt(self):
         self.image_view.hide_tilt()

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -18,6 +18,7 @@ from mantidimaging.gui.windows.recon.presenter import ReconstructWindowPresenter
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401
+    from mantidimaging.gui.windows.stack_visualiser.view import StackVisualiserView
 
 
 class ReconstructWindowView(BaseMainWindowView):
@@ -306,7 +307,7 @@ class ReconstructWindowView(BaseMainWindowView):
     def show_recon_volume(self, data: Images):
         self.main_window.create_new_stack(data, "Recon")
 
-    def get_stack_visualiser(self, uuid):
+    def get_stack_visualiser(self, uuid)-> 'StackVisualiserView':
         if uuid is not None:
             return self.main_window.get_stack_visualiser(uuid)
 


### PR DESCRIPTION
To test:

- Load some data
- Open recon window
- The slice index should now be the middle of the stack

Projection index fix:

- Make sure the QSpinBox goes above 99


Also makes the default focussed tab in the recon window the COR tab - make sure that is selected when it is opened.


Fixes #654
Fixes #653 
Fixes #656