### PR TITLE
Sync safe apply images

### DIFF
--- a/mantidimaging/gui/windows/stack_choice/tests/test_view.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/test_view.py
@@ -3,6 +3,7 @@ from unittest import mock
 from uuid import uuid4
 
 from PyQt5.QtWidgets import QMessageBox
+from pyqtgraph import ViewBox
 
 from mantidimaging.test_helpers import start_qapplication
 import mantidimaging.test_helpers.unit_test_helper as th
@@ -154,3 +155,14 @@ class StackChoiceViewTest(unittest.TestCase):
         self.v.original_stack.close.assert_not_called()
         self.v.new_stack.close.assert_not_called()
         mock_event.ignore.assert_called_once()
+
+    def test_images_are_synced(self):
+        self.v.original_stack = mock.MagicMock()
+        self.v.new_stack = mock.MagicMock()
+        self.v.new_stack.view = "view"
+
+        self.v._sync_both_image_axis()
+
+        self.assertIn(mock.call(ViewBox.XAxis, "view"), self.v.original_stack.view.linkView.call_args_list)
+        self.assertIn(mock.call(ViewBox.YAxis, "view"), self.v.original_stack.view.linkView.call_args_list)
+        self.assertEqual(2, self.v.original_stack.view.linkView.call_count)

--- a/mantidimaging/gui/windows/stack_choice/view.py
+++ b/mantidimaging/gui/windows/stack_choice/view.py
@@ -3,6 +3,7 @@ from enum import Enum, auto
 from PyQt5 import QtCore
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QSizePolicy, QMessageBox
+from pyqtgraph import ViewBox
 
 from mantidimaging.gui.widgets.pg_image_view import MIImageView
 
@@ -58,6 +59,8 @@ class StackChoiceView(BaseMainWindowView):
         self.original_stack.roi.sigRegionChanged.connect(self._sync_roi_plot_for_new_stack_with_old_stack)
         self.new_stack.roi.sigRegionChanged.connect(self._sync_roi_plot_for_old_stack_with_new_stack)
 
+        self._sync_both_image_axis()
+
         self.choice_made = False
         self.roi_shown = False
 
@@ -108,6 +111,10 @@ class StackChoiceView(BaseMainWindowView):
         self.original_stack.sigTimeChanged.disconnect(self._sync_timelines_for_new_stack_with_old_stack)
         self.original_stack.setCurrentIndex(index)
         self.original_stack.sigTimeChanged.connect(self._sync_timelines_for_new_stack_with_old_stack)
+
+    def _sync_both_image_axis(self):
+        self.original_stack.view.linkView(ViewBox.XAxis, self.new_stack.view)
+        self.original_stack.view.linkView(ViewBox.YAxis, self.new_stack.view)
 
     def closeEvent(self, e):
         # Confirm exit is actually wanted as it will lead to data loss


### PR DESCRIPTION
Fixes #652 

To Test:
- Load Data
- Perform operation with safe apply checked
- Ensure the two stacks are synced up.