### PR TITLE
Disable fields that are not currented used flat fielding operations

### DIFF
--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -18,6 +18,26 @@ MINIMUM_PIXEL_VALUE = 1e-9
 MAXIMUM_PIXEL_VALUE = 1e9
 
 
+def enable_correct_fields_only(text, flat_before_widget, flat_after_widget, dark_before_widget, dark_after_widget):
+    if text == "Only Before":
+        flat_before_widget.setEnabled(True)
+        flat_after_widget.setEnabled(False)
+        dark_before_widget.setEnabled(True)
+        dark_after_widget.setEnabled(False)
+    elif text == "Only After":
+        flat_before_widget.setEnabled(False)
+        flat_after_widget.setEnabled(True)
+        dark_before_widget.setEnabled(False)
+        dark_after_widget.setEnabled(True)
+    elif text == "Both, concatenated":
+        flat_before_widget.setEnabled(True)
+        flat_after_widget.setEnabled(True)
+        dark_before_widget.setEnabled(True)
+        dark_after_widget.setEnabled(True)
+    else:
+        raise RuntimeError("Unknown field parameter")
+
+
 class FlatFieldFilter(BaseFilter):
     """Uses the flat (open beam) and dark images to reduce the noise in the
     projection images.
@@ -155,6 +175,7 @@ class FlatFieldFilter(BaseFilter):
         flat_after_widget.setMaximumWidth(375)
         flat_after_widget.subscribe_to_main_window(view.main_window)
         try_to_select_relevant_stack("Flat After", flat_after_widget)
+        flat_after_widget.setEnabled(False)
 
         assert isinstance(dark_before_widget, StackSelectorWidgetView)
         dark_before_widget.setMaximumWidth(375)
@@ -165,6 +186,12 @@ class FlatFieldFilter(BaseFilter):
         dark_after_widget.setMaximumWidth(375)
         dark_after_widget.subscribe_to_main_window(view.main_window)
         try_to_select_relevant_stack("Dark After", dark_after_widget)
+        dark_after_widget.setEnabled(False)
+
+        # Ensure that fields that are not currently used are disabled
+        selected_flat_fielding_widget.currentTextChanged.connect(
+            lambda text: enable_correct_fields_only(text, flat_before_widget, flat_after_widget, dark_before_widget,
+                                                    dark_after_widget))
 
         return {
             'selected_flat_fielding_widget': selected_flat_fielding_widget,

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -1,6 +1,6 @@
 from functools import partial
 from typing import Any, Dict
-from pyqt5.QtWidgets import QComboBox
+from PyQt5.QtWidgets import QComboBox
 
 import numpy as np
 
@@ -190,7 +190,7 @@ class FlatFieldFilter(BaseFilter):
         dark_after_widget.setEnabled(False)
 
         # Ensure that fields that are not currently used are disabled
-        assert(isinstance(selected_flat_fielding_widget, QComboBox)
+        assert (isinstance(selected_flat_fielding_widget, QComboBox))
         selected_flat_fielding_widget.currentTextChanged.connect(lambda text: enable_correct_fields_only(
             text, flat_before_widget, flat_after_widget, dark_before_widget, dark_after_widget))
 

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -189,9 +189,8 @@ class FlatFieldFilter(BaseFilter):
         dark_after_widget.setEnabled(False)
 
         # Ensure that fields that are not currently used are disabled
-        selected_flat_fielding_widget.currentTextChanged.connect(
-            lambda text: enable_correct_fields_only(text, flat_before_widget, flat_after_widget, dark_before_widget,
-                                                    dark_after_widget))
+        selected_flat_fielding_widget.currentTextChanged.connect(lambda text: enable_correct_fields_only(
+            text, flat_before_widget, flat_after_widget, dark_before_widget, dark_after_widget))
 
         return {
             'selected_flat_fielding_widget': selected_flat_fielding_widget,

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -1,5 +1,6 @@
 from functools import partial
 from typing import Any, Dict
+from pyqt5.QtWidgets import QComboBox
 
 import numpy as np
 
@@ -189,6 +190,7 @@ class FlatFieldFilter(BaseFilter):
         dark_after_widget.setEnabled(False)
 
         # Ensure that fields that are not currently used are disabled
+        assert(isinstance(selected_flat_fielding_widget, QComboBox)
         selected_flat_fielding_widget.currentTextChanged.connect(lambda text: enable_correct_fields_only(
             text, flat_before_widget, flat_after_widget, dark_before_widget, dark_after_widget))
 

--- a/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
+++ b/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
@@ -6,6 +6,7 @@ import numpy as np
 import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
+from mantidimaging.core.operations.flat_fielding.flat_fielding import enable_correct_fields_only
 from mantidimaging.core.data import Images
 from mantidimaging.core.operations.flat_fielding import FlatFieldFilter
 
@@ -114,6 +115,64 @@ class FlatFieldingTest(unittest.TestCase):
                                                        selected_flat_fielding_widget=selected_flat_fielding_widget)
         images = th.generate_images()
         execute_func(images)
+
+    def test_enable_correct_fields_only_before(self):
+        text = "Only Before"
+        flat_before_widget = mock.MagicMock()
+        flat_after_widget = mock.MagicMock()
+        dark_before_widget = mock.MagicMock()
+        dark_after_widget = mock.MagicMock()
+
+        enable_correct_fields_only(text, flat_before_widget, flat_after_widget, dark_before_widget, dark_after_widget)
+
+        flat_before_widget.setEnabled.assert_called_once_with(True)
+        flat_after_widget.setEnabled.assert_called_once_with(False)
+        dark_before_widget.setEnabled.assert_called_once_with(True)
+        dark_after_widget.setEnabled.assert_called_once_with(False)
+
+    def test_enable_correct_fields_only_after(self):
+        text = "Only After"
+        flat_before_widget = mock.MagicMock()
+        flat_after_widget = mock.MagicMock()
+        dark_before_widget = mock.MagicMock()
+        dark_after_widget = mock.MagicMock()
+
+        enable_correct_fields_only(text, flat_before_widget, flat_after_widget, dark_before_widget, dark_after_widget)
+
+        flat_before_widget.setEnabled.assert_called_once_with(False)
+        flat_after_widget.setEnabled.assert_called_once_with(True)
+        dark_before_widget.setEnabled.assert_called_once_with(False)
+        dark_after_widget.setEnabled.assert_called_once_with(True)
+
+    def test_enable_correct_fields_both(self):
+        text = "Both, concatenated"
+        flat_before_widget = mock.MagicMock()
+        flat_after_widget = mock.MagicMock()
+        dark_before_widget = mock.MagicMock()
+        dark_after_widget = mock.MagicMock()
+
+        enable_correct_fields_only(text, flat_before_widget, flat_after_widget, dark_before_widget, dark_after_widget)
+
+        flat_before_widget.setEnabled.assert_called_once_with(True)
+        flat_after_widget.setEnabled.assert_called_once_with(True)
+        dark_before_widget.setEnabled.assert_called_once_with(True)
+        dark_after_widget.setEnabled.assert_called_once_with(True)
+
+    def test_enable_correct_fields_runtime_error(self):
+        text = "BANANA"
+        flat_before_widget = mock.MagicMock()
+        flat_after_widget = mock.MagicMock()
+        dark_before_widget = mock.MagicMock()
+        dark_after_widget = mock.MagicMock()
+
+        with self.assertRaises(RuntimeError):
+            enable_correct_fields_only(text, flat_before_widget, flat_after_widget, dark_before_widget,
+                                       dark_after_widget)
+
+        flat_before_widget.setEnabled.assert_not_called()
+        flat_after_widget.setEnabled.asser_not_called()
+        dark_before_widget.setEnabled.assert_not_called()
+        dark_after_widget.setEnabled.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes: #642 

To test:
- Load data
- Open operations windows
- select flat fielding
- Ensure that only before fields are available when "Only Before" is selected
- Ensure only after fields are available when "Only After" is selected
- Ensure all fields are available when "Both, concatenated" is selected.