### PR TITLE
Recon - manually moving slice index line now updates QSpinbox

### DIFF
--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -2,13 +2,15 @@ from math import isnan
 from typing import Tuple, Optional
 
 import numpy
-from pyqtgraph import GraphicsLayoutWidget, ImageItem, ViewBox, HistogramLUTItem, LabelItem, InfiniteLine
+from pyqtgraph import GraphicsLayoutWidget, ImageItem, ViewBox, HistogramLUTItem, LabelItem, InfiniteLine, QtCore
 
 from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint
 from mantidimaging.core.utility.data_containers import Degrees
 
 
 class ReconImagesView(GraphicsLayoutWidget):
+    sigSliceIndexChanged = QtCore.pyqtSignal(int)
+
     def __init__(self, parent):
         super().__init__(parent)
         self.parent = parent
@@ -87,11 +89,13 @@ class ReconImagesView(GraphicsLayoutWidget):
 
     def mouse_click(self, ev, line: InfiniteLine):
         line.setPos(ev.pos())
+        slice_index = CloseEnoughPoint(ev.pos()).y
         # don't refresh the histogram on click to stop the contrast for re-adjusting for each slice
         # it's much easier to see what's happening to the reconstruction if the slice doesn't
         # reset after every click
-        self.parent.presenter.do_preview_reconstruct_slice(slice_idx=CloseEnoughPoint(ev.pos()).y,
+        self.parent.presenter.do_preview_reconstruct_slice(slice_idx=slice_index,
                                                            refresh_recon_slice_histogram=False)
+        self.sigSliceIndexChanged.emit(slice_index)
 
     def clear_recon(self):
         self.recon.clear()

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -93,8 +93,7 @@ class ReconImagesView(GraphicsLayoutWidget):
         # don't refresh the histogram on click to stop the contrast for re-adjusting for each slice
         # it's much easier to see what's happening to the reconstruction if the slice doesn't
         # reset after every click
-        self.parent.presenter.do_preview_reconstruct_slice(slice_idx=slice_index,
-                                                           refresh_recon_slice_histogram=False)
+        self.parent.presenter.do_preview_reconstruct_slice(slice_idx=slice_index, refresh_recon_slice_histogram=False)
         self.sigSliceIndexChanged.emit(slice_index)
 
     def clear_recon(self):

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -64,6 +64,7 @@ class ReconstructWindowView(BaseMainWindowView):
 
         self.image_view = ReconImagesView(self)
         self.imageLayout.addWidget(self.image_view)
+        self.image_view.sigSliceIndexChanged.connect(self.presenter.set_preview_slice_idx)
 
         # Point table
         self.tableView.horizontalHeader().setStretchLastSection(True)


### PR DESCRIPTION
Fixes: #667 

Test:
Load Data
Open Recon window
Correlate 0 and 180, minimise error and change the slice on the top left projection image that is being represented.
The slice index QSpinBox should update.