### PR TITLE
Compare Window - Ensure the range is the same on both histograms

### DIFF
--- a/mantidimaging/gui/windows/stack_choice/tests/test_view.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/test_view.py
@@ -166,3 +166,25 @@ class StackChoiceViewTest(unittest.TestCase):
         self.assertIn(mock.call(ViewBox.XAxis, "view"), self.v.original_stack.view.linkView.call_args_list)
         self.assertIn(mock.call(ViewBox.YAxis, "view"), self.v.original_stack.view.linkView.call_args_list)
         self.assertEqual(2, self.v.original_stack.view.linkView.call_count)
+
+    def test_ensure_range_is_the_same_new_stack_min_original_stack_max(self):
+        self.v.new_stack.ui.histogram.vb = mock.MagicMock()
+        self.v.original_stack.ui.histogram.vb = mock.MagicMock()
+        self.v.new_stack.ui.histogram.vb.viewRange = mock.MagicMock(return_value=[[0, 1], [0, 100]])
+        self.v.original_stack.ui.histogram.vb.viewRange = mock.MagicMock(return_value=[[0, 2], [0, 200]])
+
+        self.v._ensure_range_is_the_same()
+
+        self.v.new_stack.ui.histogram.vb.setRange.assert_called_once_with(yRange=(1, 200))
+        self.v.original_stack.ui.histogram.vb.setRange.assert_called_once_with(yRange=(1, 200))
+
+    def test_ensure_range_is_the_same_new_stack_max_original_stack_min(self):
+        self.v.new_stack.ui.histogram.vb = mock.MagicMock()
+        self.v.original_stack.ui.histogram.vb = mock.MagicMock()
+        self.v.new_stack.ui.histogram.vb.viewRange = mock.MagicMock(return_value=[[0, 2], [0, 200]])
+        self.v.original_stack.ui.histogram.vb.viewRange = mock.MagicMock(return_value=[[0, 1], [0, 100]])
+
+        self.v._ensure_range_is_the_same()
+
+        self.v.new_stack.ui.histogram.vb.setRange.assert_called_once_with(yRange=(1, 200))
+        self.v.original_stack.ui.histogram.vb.setRange.assert_called_once_with(yRange=(1, 200))

--- a/mantidimaging/gui/windows/stack_choice/view.py
+++ b/mantidimaging/gui/windows/stack_choice/view.py
@@ -60,9 +60,24 @@ class StackChoiceView(BaseMainWindowView):
         self.new_stack.roi.sigRegionChanged.connect(self._sync_roi_plot_for_old_stack_with_new_stack)
 
         self._sync_both_image_axis()
+        self._ensure_range_is_the_same()
 
         self.choice_made = False
         self.roi_shown = False
+
+    def _ensure_range_is_the_same(self):
+        new_range = self.new_stack.ui.histogram.vb.viewRange()
+        original_range = self.original_stack.ui.histogram.vb.viewRange()
+
+        new_max_y = max(new_range[0][1], new_range[1][1])
+        new_min_y = min(new_range[0][1], new_range[1][1])
+        original_max_y = max(original_range[0][1], original_range[1][1])
+        original_min_y = min(original_range[0][1], original_range[1][1])
+        y_range_min = min(new_min_y, original_min_y)
+        y_range_max = max(new_max_y, original_max_y)
+
+        self.new_stack.ui.histogram.vb.setRange(yRange=(y_range_min, y_range_max))
+        self.original_stack.ui.histogram.vb.setRange(yRange=(y_range_min, y_range_max))
 
     def _toggle_roi(self):
         if self.roi_shown:


### PR DESCRIPTION
Fixes #646 

Test:
- Load Data
- Perform Flat Field with safe apply checked
- Both histograms should have the same range