### PR TITLE
Only rescale histogram when data is changed and some random improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,21 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Python: Pytest",
+      "type": "python",
+      "request": "launch",
+      "module": "pytest",
+      "args": [
+        "-pno:django",
+        "${file}"
+      ],
+      "presentation": {
+        "hidden": false,
+        "group": "Mantid Imaging",
+        "order": 4
+      }
+    },
+    {
       "name": "Python: Current File",
       "type": "python",
       "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,12 @@
       "type": "python",
       "request": "launch",
       "program": "${file}",
-      "console": "integratedTerminal"
+      "console": "integratedTerminal",
+      "presentation": {
+        "hidden": false,
+        "group": "Mantid Imaging",
+        "order": 3
+      }
     },
     {
       "name": "Mantid Imaging Attach",
@@ -26,8 +31,8 @@
       ],
       "presentation": {
         "hidden": false,
-        "group": "debug",
-        "order": 1
+        "group": "Mantid Imaging",
+        "order": 2
       }
     },
     {
@@ -40,9 +45,14 @@
         "DEBUG"
       ],
       "env": {
-        "DISPLAY": ":0",
+        "DISPLAY": ":1",
         "PYTHONPATH": "${workspaceFolder}",
         "XDG_CURRENT_DESKTOP": "XFCE",
+      },
+      "presentation": {
+        "hidden": false,
+        "group": "Mantid Imaging",
+        "order": 1
       }
     },
   ]

--- a/mantidimaging/core/data/test/fake_logfile.py
+++ b/mantidimaging/core/data/test/fake_logfile.py
@@ -1,12 +1,12 @@
 # Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
+from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile, EXPECTED_HEADER_FOR_IMAT_LOG_FILE
 
 
 def generate_logfile() -> IMATLogFile:
     data = [
-        ["column headers"],  # skipped when parsing
+        EXPECTED_HEADER_FOR_IMAT_LOG_FILE,  # checked if exists, but skipped
         [""],  # skipped when parsing
         # for each row a list with 4 entries is currently expected
         [

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -77,7 +77,7 @@ class OutliersFilter(BaseFilter):
     def register_gui(form, on_change, view):
         _, diff_field = add_property_to_form('Difference',
                                              'float',
-                                             1,
+                                             1000,
                                              valid_values=(-1000000, 1000000),
                                              form=form,
                                              on_change=on_change,

--- a/mantidimaging/core/utility/imat_log_file_parser.py
+++ b/mantidimaging/core/utility/imat_log_file_parser.py
@@ -27,6 +27,16 @@ class IMATLogFile:
             IMATLogColumn.COUNTS_BEFORE: [],
             IMATLogColumn.COUNTS_AFTER: []
         }
+        expected_header_for_IMAT_log_file = [
+            'TIME STAMP  IMAGE TYPE', 'IMAGE COUNTER', 'COUNTS BM3 before image', 'COUNTS BM3 after image'
+        ]
+
+        if expected_header_for_IMAT_log_file != data[0]:
+            raise RuntimeError(
+                "The Log file found for this dataset does not seem to have the correct header for an IMAT log file.\n"
+                "The header is expected to contain the names of the columns:\n"
+                f"{str(expected_header_for_IMAT_log_file)}")
+
         # ignores the headers (index 0) as they're not the same as the data anyway
         # and index 1 is an empty line
         for line in data[2:]:

--- a/mantidimaging/core/utility/imat_log_file_parser.py
+++ b/mantidimaging/core/utility/imat_log_file_parser.py
@@ -9,6 +9,10 @@ import numpy
 
 from mantidimaging.core.utility.data_containers import ProjectionAngles, Counts
 
+EXPECTED_HEADER_FOR_IMAT_LOG_FILE = [
+    'TIME STAMP  IMAGE TYPE', 'IMAGE COUNTER', 'COUNTS BM3 before image', 'COUNTS BM3 after image'
+]
+
 
 class IMATLogColumn(Enum):
     TIMESTAMP = auto()
@@ -27,15 +31,12 @@ class IMATLogFile:
             IMATLogColumn.COUNTS_BEFORE: [],
             IMATLogColumn.COUNTS_AFTER: []
         }
-        expected_header_for_IMAT_log_file = [
-            'TIME STAMP  IMAGE TYPE', 'IMAGE COUNTER', 'COUNTS BM3 before image', 'COUNTS BM3 after image'
-        ]
 
-        if expected_header_for_IMAT_log_file != data[0]:
+        if EXPECTED_HEADER_FOR_IMAT_LOG_FILE != data[0]:
             raise RuntimeError(
                 "The Log file found for this dataset does not seem to have the correct header for an IMAT log file.\n"
                 "The header is expected to contain the names of the columns:\n"
-                f"{str(expected_header_for_IMAT_log_file)}")
+                f"{str(EXPECTED_HEADER_FOR_IMAT_LOG_FILE)}")
 
         # ignores the headers (index 0) as they're not the same as the data anyway
         # and index 1 is an empty line

--- a/mantidimaging/core/utility/test/imat_log_file_parser_test.py
+++ b/mantidimaging/core/utility/test/imat_log_file_parser_test.py
@@ -3,12 +3,14 @@
 
 import numpy as np
 
-from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
+from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile, EXPECTED_HEADER_FOR_IMAT_LOG_FILE
 
 
 def test_parsing_log_file():
-    test_input = [["ignored line"], ["ignored line"],
-                  ["timestamp", "Projection:  0  angle: 0.1", "counts before: 12345", "counts_after: 45678"]]
+    test_input = [
+        EXPECTED_HEADER_FOR_IMAT_LOG_FILE, ["ignored line"],
+        ["timestamp", "Projection:  0  angle: 0.1", "counts before: 12345", "counts_after: 45678"]
+    ]
     logfile = IMATLogFile(test_input)
     assert len(logfile.projection_angles().value) == 1
     assert logfile.projection_angles().value[0] == np.deg2rad(0.1), f"Got: {logfile.projection_angles().value[0]}"
@@ -17,7 +19,7 @@ def test_parsing_log_file():
 
 def test_counts():
     test_input = [
-        ["ignored line"],
+        EXPECTED_HEADER_FOR_IMAT_LOG_FILE,
         ["ignored line"],
         ["timestamp", "Projection:  0  angle: 0.0", "counts before: 12345", "counts_after: 45678"],
         ["timestamp", "Projection:  1  angle: 0.1", "counts before: 45678", "counts_after: 84678"],
@@ -42,7 +44,7 @@ def assert_raises(exc_type, callable, *args, **kwargs):
 
 def test_find_missing_projection_number():
     test_input = [
-        ["ignored line"],
+        EXPECTED_HEADER_FOR_IMAT_LOG_FILE,
         ["ignored line"],
         ["timestamp", "Projection:  0  angle: 0.0", "counts before: 12345", "counts_after: 45678"],
         ["timestamp", "Projection:  1  angle: 0.1", "counts before: 12345", "counts_after: 45678"],

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -117,7 +117,7 @@ class ReconstructWindowPresenter(BasePresenter):
         self.view.rotation_centre = self.model.last_cor.value
         self.view.pixel_size = self.get_pixel_size_from_images()
         self.do_update_projection()
-        self.do_preview_reconstruct_slice()
+        self.do_preview_reconstruct_slice(refresh_recon_slice_histogram=True)
 
     def set_preview_projection_idx(self, idx):
         self.model.preview_projection_idx = idx
@@ -171,7 +171,7 @@ class ReconstructWindowPresenter(BasePresenter):
     def do_preview_reconstruct_slice(self,
                                      cor=None,
                                      slice_idx: Optional[int] = None,
-                                     refresh_recon_slice_histogram: bool = True):
+                                     refresh_recon_slice_histogram: bool = False):
         if self.model.images is None:
             return
 

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -137,11 +137,7 @@ class ReconstructWindowView(BaseMainWindowView):
         self.numIter.valueChanged.connect(
             lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))  # type: ignore
 
-        def refresh_preview_and_histogram():
-            self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE)
-            self.image_view.reset_recon_histogram()
-
-        self.pixelSize.valueChanged.connect(refresh_preview_and_histogram)
+        self.pixelSize.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
 
     def remove_selected_cor(self):
         return self.tableView.removeSelectedRows()

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -184,7 +184,13 @@ def shared_deepcopy(images: Images) -> np.ndarray:
 
 
 def assert_called_once_with(mock: mock.Mock, *args):
+    """
+    Custom assert function that checks different parameter types
+    with the correct assert function (i.e. numpy arrays, partials)
+    """
     assert 1 == mock.call_count
+    assert len(args) == len(mock.call_args[0])
+
     for actual, expected in zip(mock.call_args[0], args):
         if isinstance(actual, np.ndarray):
             np.testing.assert_equal(actual, expected)


### PR DESCRIPTION
Only rescales recon histogram when the data is changed

Minor fixes:
- Improves VSCode debug task presentation
- Better default value for outliers (1000). Seems like it should fit most data that's not super noisy, but for that we leave it to the user
- Now checks if the header (first line) of the log file is as expected, and throws an exception if now, rather than parsing it wrong (it skipped the first two lines so the projection angles would always be wrong)



Fixes #660
Fixes #662