### PR TITLE
Adds "flat" and "dark" as an option in the file finding field

### DIFF
--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -173,6 +173,7 @@ class FlatFieldFilter(BaseFilter):
         assert isinstance(flat_before_widget, StackSelectorWidgetView)
         flat_before_widget.setMaximumWidth(375)
         flat_before_widget.subscribe_to_main_window(view.main_window)
+        try_to_select_relevant_stack("Flat", flat_before_widget)
         try_to_select_relevant_stack("Flat Before", flat_before_widget)
 
         assert isinstance(flat_after_widget, StackSelectorWidgetView)
@@ -184,6 +185,7 @@ class FlatFieldFilter(BaseFilter):
         assert isinstance(dark_before_widget, StackSelectorWidgetView)
         dark_before_widget.setMaximumWidth(375)
         dark_before_widget.subscribe_to_main_window(view.main_window)
+        try_to_select_relevant_stack("Dark", dark_before_widget)
         try_to_select_relevant_stack("Dark Before", dark_before_widget)
 
         assert isinstance(dark_after_widget, StackSelectorWidgetView)


### PR DESCRIPTION
- Now also will be selected in the flat_fielding widget

To test:
- You can copy a few sample/flat/dark images into a new folder and just change the first letter to lower case
- Then try to load them - they should be picked up properly

Fixes #691