### PR TITLE
Add histograms to image previews, adds button to collapse left side of op window

### DIFF
--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -315,10 +315,16 @@
       </widget>
       <widget class="QWidget" name="layoutWidget_2">
        <layout class="QVBoxLayout" name="previewsPaneLayout">
+        <property name="topMargin">
+         <number>2</number>
+        </property>
         <item>
          <layout class="QHBoxLayout" name="previewsPaneToolbar">
           <property name="sizeConstraint">
            <enum>QLayout::SetMaximumSize</enum>
+          </property>
+          <property name="topMargin">
+           <number>3</number>
           </property>
           <item>
            <widget class="QPushButton" name="collapseToggleButton">
@@ -342,6 +348,9 @@
             </property>
             <property name="toolTip">
              <string extracomment="Collapse the filter section of the window"/>
+            </property>
+            <property name="styleSheet">
+             <string notr="true"/>
             </property>
             <property name="text">
              <string>&lt;&lt;</string>

--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1205</width>
-    <height>600</height>
+    <width>1393</width>
+    <height>733</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -32,7 +32,7 @@
       <widget class="QWidget" name="layoutWidget">
        <layout class="QVBoxLayout" name="filterLayout">
         <property name="sizeConstraint">
-         <enum>QLayout::SetMaximumSize</enum>
+         <enum>QLayout::SetDefaultConstraint</enum>
         </property>
         <property name="margin">
          <number>9</number>
@@ -222,7 +222,7 @@
           <item row="6" column="1">
            <widget class="QTextEdit" name="notification_text">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <sizepolicy hsizetype="Maximum" vsizetype="MinimumExpanding">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>

--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -34,16 +34,7 @@
         <property name="sizeConstraint">
          <enum>QLayout::SetMaximumSize</enum>
         </property>
-        <property name="leftMargin">
-         <number>9</number>
-        </property>
-        <property name="topMargin">
-         <number>9</number>
-        </property>
-        <property name="rightMargin">
-         <number>9</number>
-        </property>
-        <property name="bottomMargin">
+        <property name="margin">
          <number>9</number>
         </property>
         <item>
@@ -327,12 +318,40 @@
         <item>
          <layout class="QHBoxLayout" name="previewsPaneToolbar">
           <property name="sizeConstraint">
-           <enum>QLayout::SetDefaultConstraint</enum>
+           <enum>QLayout::SetMaximumSize</enum>
           </property>
+          <item>
+           <widget class="QPushButton" name="collapseToggleButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>40</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>40</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string extracomment="Collapse the filter section of the window"/>
+            </property>
+            <property name="text">
+             <string>&lt;&lt;</string>
+            </property>
+           </widget>
+          </item>
           <item>
            <widget class="QCheckBox" name="showHistogramLegend">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -351,7 +370,7 @@
           <item>
            <widget class="QCheckBox" name="linkImages">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -367,7 +386,7 @@
           <item>
            <widget class="QCheckBox" name="combinedHistograms">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -389,7 +408,7 @@
           <item>
            <widget class="QCheckBox" name="overlayDifference">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -405,7 +424,7 @@
           <item>
            <widget class="QCheckBox" name="invertDifference">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -3,8 +3,8 @@
 
 from collections import namedtuple
 from typing import Optional
-from PyQt5.QtCore import QCoreApplication, QPoint, QRect
-from PyQt5.QtGui import QGuiApplication, QResizeEvent, QScreen
+from PyQt5.QtCore import QPoint, QRect
+from PyQt5.QtGui import QGuiApplication, QResizeEvent
 
 import numpy as np
 from pyqtgraph import GraphicsLayoutWidget, ImageItem, PlotItem, LegendItem, ViewBox, ColorMap

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -3,9 +3,11 @@
 
 from collections import namedtuple
 from typing import Optional
+from PyQt5.QtGui import QResizeEvent
 
 import numpy as np
 from pyqtgraph import GraphicsLayoutWidget, ImageItem, PlotItem, LegendItem, ViewBox, ColorMap
+from pyqtgraph.graphicsItems.GraphicsLayout import GraphicsLayout
 from pyqtgraph.graphicsItems.HistogramLUTItem import HistogramLUTItem
 
 from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint
@@ -40,7 +42,7 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.histogram = None
         self.before_histogram = None
         self.after_histogram = None
-
+        GraphicsLayout
         self.combined_histograms = True
         self.histogram_legend_visible = True
 
@@ -59,13 +61,13 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.image_after_vb.addItem(self.image_after_overlay)
 
         # Ensure images resize equally
-        image_layout = self.addLayout(colspan=6)
-        image_layout.addItem(self.image_before_vb, 0, 0)
-        image_layout.addItem(self.image_before_hist, 0, 1)
-        image_layout.addItem(self.image_after_vb, 0, 2)
-        image_layout.addItem(self.image_after_hist, 0, 3)
-        image_layout.addItem(self.image_difference_vb, 0, 4)
-        image_layout.addItem(self.image_difference_hist, 0, 5)
+        self.image_layout: GraphicsLayout = self.addLayout(colspan=6)
+        self.image_layout.addItem(self.image_before_vb, 0, 0)
+        self.image_layout.addItem(self.image_before_hist, 0, 1)
+        self.image_layout.addItem(self.image_after_vb, 0, 2)
+        self.image_layout.addItem(self.image_after_hist, 0, 3)
+        self.image_layout.addItem(self.image_difference_vb, 0, 4)
+        self.image_layout.addItem(self.image_difference_hist, 0, 5)
         self.nextRow()
 
         before_details = self.addLabel("")
@@ -82,6 +84,12 @@ class FilterPreviews(GraphicsLayoutWidget):
             img.hoverEvent = lambda ev: self.mouse_over(ev)
 
         self.init_histogram()
+
+    def resizeEvent(self, ev: QResizeEvent):
+        if ev is not None:
+            size = ev.size()
+            self.image_layout.setFixedHeight(min(size.height() * 0.7, 800))
+        super().resizeEvent(ev)
 
     def image_in_vb(self, name=None):
         im = ImageItem()

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -3,11 +3,11 @@
 
 from collections import namedtuple
 from typing import Optional
-from PyQt5.QtCore import QPoint, QRect
-from PyQt5.QtGui import QGuiApplication, QResizeEvent
 
 import numpy as np
-from pyqtgraph import GraphicsLayoutWidget, ImageItem, PlotItem, LegendItem, ViewBox, ColorMap
+from PyQt5.QtCore import QPoint, QRect
+from PyQt5.QtGui import QGuiApplication, QResizeEvent
+from pyqtgraph import ColorMap, GraphicsLayoutWidget, ImageItem, LegendItem, PlotItem, ViewBox
 from pyqtgraph.graphicsItems.GraphicsLayout import GraphicsLayout
 from pyqtgraph.graphicsItems.HistogramLUTItem import HistogramLUTItem
 

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -3,7 +3,8 @@
 
 from collections import namedtuple
 from typing import Optional
-from PyQt5.QtGui import QResizeEvent
+from PyQt5.QtCore import QCoreApplication, QPoint, QRect
+from PyQt5.QtGui import QGuiApplication, QResizeEvent, QScreen
 
 import numpy as np
 from pyqtgraph import GraphicsLayoutWidget, ImageItem, PlotItem, LegendItem, ViewBox, ColorMap
@@ -37,12 +38,16 @@ class FilterPreviews(GraphicsLayoutWidget):
 
     def __init__(self, parent=None, **kwargs):
         super(FilterPreviews, self).__init__(parent, **kwargs)
+
+        widget_location = self.mapToGlobal(QPoint(self.width() / 2, 0))
+        # allow the widget to take up to 80% of the desktop's height
+        self.ALLOWED_HEIGHT: QRect = QGuiApplication.screenAt(widget_location).availableGeometry().height() * 0.8
+
         self.before_histogram_data = None
         self.after_histogram_data = None
         self.histogram = None
         self.before_histogram = None
         self.after_histogram = None
-        GraphicsLayout
         self.combined_histograms = True
         self.histogram_legend_visible = True
 
@@ -88,7 +93,7 @@ class FilterPreviews(GraphicsLayoutWidget):
     def resizeEvent(self, ev: QResizeEvent):
         if ev is not None:
             size = ev.size()
-            self.image_layout.setFixedHeight(min(size.height() * 0.7, 800))
+            self.image_layout.setFixedHeight(min(size.height() * 0.7, self.ALLOWED_HEIGHT))
         super().resizeEvent(ev)
 
     def image_in_vb(self, name=None):

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import numpy as np
 from pyqtgraph import GraphicsLayoutWidget, ImageItem, PlotItem, LegendItem, ViewBox, ColorMap
+from pyqtgraph.graphicsItems.HistogramLUTItem import HistogramLUTItem
 
 from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint
 
@@ -48,19 +49,23 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.addLabel("Image difference")
         self.nextRow()
 
-        self.image_before, self.image_before_vb = self.image_in_vb(name="before")
-        self.image_after, self.image_after_vb = self.image_in_vb(name="after")
-        self.image_difference, self.image_difference_vb = self.image_in_vb(name="difference")
+        self.image_before, self.image_before_vb, self.image_before_hist = self.image_in_vb(name="before")
+        self.image_after, self.image_after_vb, self.image_after_hist = self.image_in_vb(name="after")
+        self.image_difference, self.image_difference_vb, self.image_difference_hist = self.image_in_vb(
+            name="difference")
 
         self.image_after_overlay = ImageItem()
         self.image_after_overlay.setZValue(10)
         self.image_after_vb.addItem(self.image_after_overlay)
 
         # Ensure images resize equally
-        image_layout = self.addLayout(colspan=3)
+        image_layout = self.addLayout(colspan=6)
         image_layout.addItem(self.image_before_vb, 0, 0)
-        image_layout.addItem(self.image_after_vb, 0, 1)
-        image_layout.addItem(self.image_difference_vb, 0, 2)
+        image_layout.addItem(self.image_before_hist, 0, 1)
+        image_layout.addItem(self.image_after_vb, 0, 2)
+        image_layout.addItem(self.image_after_hist, 0, 3)
+        image_layout.addItem(self.image_difference_vb, 0, 4)
+        image_layout.addItem(self.image_difference_hist, 0, 5)
         self.nextRow()
 
         before_details = self.addLabel("")
@@ -80,10 +85,10 @@ class FilterPreviews(GraphicsLayoutWidget):
 
     def image_in_vb(self, name=None):
         im = ImageItem()
-        im.setAutoDownsample(False)
         vb = ViewBox(invertY=True, lockAspect=True, name=name)
         vb.addItem(im)
-        return im, vb
+        hist = HistogramLUTItem(im)
+        return im, vb, hist
 
     def clear_items(self):
         self.image_before.clear()

--- a/mantidimaging/gui/windows/operations/test/test_view.py
+++ b/mantidimaging/gui/windows/operations/test/test_view.py
@@ -1,12 +1,12 @@
 # Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-from mantidimaging.gui.windows.operations.view import FiltersWindowView
 import unittest
 from unittest import mock
 
-from mantidimaging.test_helpers import start_qapplication
 from mantidimaging.gui.windows.main import MainWindowView
+from mantidimaging.gui.windows.operations.view import FiltersWindowView
+from mantidimaging.test_helpers import start_qapplication
 
 
 @start_qapplication

--- a/mantidimaging/gui/windows/operations/test/test_view.py
+++ b/mantidimaging/gui/windows/operations/test/test_view.py
@@ -4,13 +4,8 @@
 from mantidimaging.gui.windows.operations.view import FiltersWindowView
 import unittest
 from unittest import mock
-from uuid import uuid4
-
-from PyQt5.QtWidgets import QMessageBox
-from pyqtgraph import ViewBox
 
 from mantidimaging.test_helpers import start_qapplication
-import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.gui.windows.main import MainWindowView
 
 

--- a/mantidimaging/gui/windows/operations/test/test_view.py
+++ b/mantidimaging/gui/windows/operations/test/test_view.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+from mantidimaging.gui.windows.operations.view import FiltersWindowView
+import unittest
+from unittest import mock
+from uuid import uuid4
+
+from PyQt5.QtWidgets import QMessageBox
+from pyqtgraph import ViewBox
+
+from mantidimaging.test_helpers import start_qapplication
+import mantidimaging.test_helpers.unit_test_helper as th
+from mantidimaging.gui.windows.main import MainWindowView
+
+
+@start_qapplication
+class OperationsWindowsViewTest(unittest.TestCase):
+    def setUp(self):
+        # mock the view so it has the same methods
+        with mock.patch('mantidimaging.gui.windows.main.view.find_if_latest_version'):
+            self.main_window = MainWindowView()
+        self.window = FiltersWindowView(self.main_window)
+
+    def test_collapse(self):
+        self.assertEqual("<<", self.window.collapseToggleButton.text())
+        # check that left column is not 0
+        self.assertNotEqual(0, self.window.splitter.sizes()[0])
+
+        self.window.collapseToggleButton.click()
+
+        self.assertEqual(">>", self.window.collapseToggleButton.text())
+        # check that left column is 0 as expected as it has been collapsed
+        self.assertEqual(0, self.window.splitter.sizes()[0])

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -54,6 +54,7 @@ class FiltersWindowView(BaseMainWindowView):
         self.presenter = FiltersWindowPresenter(self, main_window)
         self.roi_view = None
         self.splitter.setSizes([200, 9999])
+        self.splitter.setStretchFactor(0, 1)
 
         # Populate list of operations and handle filter selection
         self.filterSelector.addItems(self.presenter.model.filter_names)
@@ -68,7 +69,6 @@ class FiltersWindowView(BaseMainWindowView):
         # Handle apply filter
         self.applyButton.clicked.connect(lambda: self.presenter.notify(PresNotification.APPLY_FILTER))
         self.applyToAllButton.clicked.connect(lambda: self.presenter.notify(PresNotification.APPLY_FILTER_TO_ALL))
-        self.splitter.setStretchFactor(0, 0)
 
         self.previews = FilterPreviews(self)
         self.previews.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -26,6 +26,7 @@ class FiltersWindowView(BaseMainWindowView):
     auto_update_triggered = Qt.pyqtSignal()
 
     splitter: QSplitter
+    collapseToggleButton: QPushButton
 
     linkImages: QCheckBox
     showHistogramLegend: QCheckBox
@@ -97,6 +98,7 @@ class FiltersWindowView(BaseMainWindowView):
 
         # Handle help button pressed
         self.filterHelpButton.pressed.connect(self.open_help_webpage)
+        self.collapseToggleButton.pressed.connect(self.toggle_filters_section)
 
     def cleanup(self):
         self.stackSelector.unsubscribe_from_main_window()
@@ -254,3 +256,11 @@ class FiltersWindowView(BaseMainWindowView):
         self.roi_view.ui.gridLayout.addWidget(button)
 
         window.show()
+
+    def toggle_filters_section(self):
+        if self.collapseToggleButton.text() == "<<":
+            self.splitter.setSizes([0, 9999])
+            self.collapseToggleButton.setText(">>")
+        else:
+            self.splitter.setSizes([200, 9999])
+            self.collapseToggleButton.setText("<<")

--- a/mantidimaging/gui/windows/stack_choice/tests/test_view.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/test_view.py
@@ -8,9 +8,9 @@ from uuid import uuid4
 from PyQt5.QtWidgets import QMessageBox
 from pyqtgraph import ViewBox
 
-from mantidimaging.test_helpers import start_qapplication
 import mantidimaging.test_helpers.unit_test_helper as th
-from mantidimaging.gui.windows.stack_choice.view import StackChoiceView, Notification
+from mantidimaging.gui.windows.stack_choice.view import Notification, StackChoiceView
+from mantidimaging.test_helpers import start_qapplication
 
 
 @start_qapplication


### PR DESCRIPTION
Adds contrast-adjustable histograms to the image previews.

Additional:
- Adds a collapse button `<<` next to the collapsible section
- Changes the height of the histograms with windows resize. (rather caps the height of the image previews to a max of 80% of the desktop's height)

To Test:
- Load some data and go to the operations window
- Check that the contrast adjustment works
- Resize the window and check that the bottom histograms can be seen properly 
  - We might want to consider capping the min height of either the window or the image previews, so that on small screen the histogram is still visible
- Test out that the collapse works properly
  - Note if you manually collapse the button doesn't change as I'm not sure there's a Qt event for that
  - If you click the button it should change anyway, then click it again to open the section

Fixes #675 