### PR TITLE
Compare stacks window function

### DIFF
--- a/mantidimaging/gui/dialogs/multiple_stack_select/view.py
+++ b/mantidimaging/gui/dialogs/multiple_stack_select/view.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
 from typing import TYPE_CHECKING
 from mantidimaging.gui.widgets.stack_selector.view import StackSelectorWidgetView
 from PyQt5.QtWidgets import QDialog, QGridLayout, QPushButton

--- a/mantidimaging/gui/dialogs/multiple_stack_select/view.py
+++ b/mantidimaging/gui/dialogs/multiple_stack_select/view.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 from mantidimaging.gui.widgets.stack_selector.view import StackSelectorWidgetView
-from PyQt5.QtWidgets import QDialog, QGridLayout, QHBoxLayout, QPushButton
+from PyQt5.QtWidgets import QDialog, QGridLayout, QPushButton
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main.view import MainWindowView

--- a/mantidimaging/gui/dialogs/multiple_stack_select/view.py
+++ b/mantidimaging/gui/dialogs/multiple_stack_select/view.py
@@ -1,0 +1,26 @@
+from typing import TYPE_CHECKING
+from mantidimaging.gui.widgets.stack_selector.view import StackSelectorWidgetView
+from PyQt5.QtWidgets import QDialog, QGridLayout, QHBoxLayout, QPushButton
+
+if TYPE_CHECKING:
+    from mantidimaging.gui.windows.main.view import MainWindowView
+
+
+class MultipleStackSelect(QDialog):
+    def __init__(self, main_window: 'MainWindowView') -> None:
+        super().__init__(main_window)
+
+        layout = QGridLayout()
+        self.setLayout(layout)
+
+        self.stack_one = StackSelectorWidgetView(self)
+        self.stack_one.subscribe_to_main_window(main_window)
+        layout.addWidget(self.stack_one, 0, 1)
+
+        self.stack_two = StackSelectorWidgetView(self)
+        self.stack_two.subscribe_to_main_window(main_window)
+        layout.addWidget(self.stack_two, 0, 2)
+
+        self.ok_button = QPushButton("OK", self)
+        self.ok_button.clicked.connect(self.accept)
+        layout.addWidget(self.ok_button, 1, 0, 1, 4)

--- a/mantidimaging/gui/ui/main_window.ui
+++ b/mantidimaging/gui/ui/main_window.ui
@@ -54,8 +54,15 @@
     <addaction name="actionAbout"/>
     <addaction name="actionDebug_Me"/>
    </widget>
+   <widget class="QMenu" name="menuFunctions">
+    <property name="title">
+     <string>Functions</string>
+    </property>
+    <addaction name="actionCompareImages"/>
+   </widget>
    <addaction name="menuFile"/>
    <addaction name="menuWorkflow"/>
+   <addaction name="menuFunctions"/>
    <addaction name="menuHelp"/>
   </widget>
   <action name="actionLoad">
@@ -143,6 +150,16 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+D</string>
+   </property>
+  </action>
+  <action name="actionCompare_Images">
+   <property name="text">
+    <string>Compare Images</string>
+   </property>
+  </action>
+  <action name="actionCompareImages">
+   <property name="text">
+    <string>Compare Images</string>
    </property>
   </action>
  </widget>

--- a/mantidimaging/gui/ui/main_window.ui
+++ b/mantidimaging/gui/ui/main_window.ui
@@ -45,6 +45,7 @@
     </property>
     <addaction name="actionFilters"/>
     <addaction name="actionRecon"/>
+    <addaction name="actionCompareImages"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
@@ -54,15 +55,8 @@
     <addaction name="actionAbout"/>
     <addaction name="actionDebug_Me"/>
    </widget>
-   <widget class="QMenu" name="menuFunctions">
-    <property name="title">
-     <string>Functions</string>
-    </property>
-    <addaction name="actionCompareImages"/>
-   </widget>
    <addaction name="menuFile"/>
    <addaction name="menuWorkflow"/>
-   <addaction name="menuFunctions"/>
    <addaction name="menuHelp"/>
   </widget>
   <action name="actionLoad">

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -5,10 +5,11 @@ from logging import getLogger
 from typing import Optional
 
 from PyQt5 import Qt, QtCore, QtGui, QtWidgets
-from PyQt5.QtWidgets import QAction, QLabel, QInputDialog
+from PyQt5.QtWidgets import QAction, QDialog, QInputDialog, QLabel
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.utility.version_check import find_if_latest_version
+from mantidimaging.gui.dialogs.multiple_stack_select.view import MultipleStackSelect
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.windows.load_dialog import MWLoadDialog
 from mantidimaging.gui.windows.main.presenter import MainWindowPresenter
@@ -17,6 +18,7 @@ from mantidimaging.gui.windows.main.save_dialog import MWSaveDialog
 from mantidimaging.gui.windows.operations import FiltersWindowView
 from mantidimaging.gui.windows.recon import ReconstructWindowView
 from mantidimaging.gui.windows.savu_operations.view import SavuFiltersWindowView
+from mantidimaging.gui.windows.stack_choice.compare_presenter import StackComparePresenter
 from mantidimaging.gui.windows.stack_visualiser import StackVisualiserView
 
 LOG = getLogger(__file__)
@@ -29,6 +31,7 @@ class MainWindowView(BaseMainWindowView):
     actionRecon: QAction
     actionFilters: QAction
     actionSavuFilters: QAction
+    actionCompareImages: QAction
 
     filters: Optional[FiltersWindowView] = None
     savu_filters: Optional[SavuFiltersWindowView] = None
@@ -65,6 +68,8 @@ class MainWindowView(BaseMainWindowView):
 
         self.actionFilters.triggered.connect(self.show_filters_window)
         self.actionRecon.triggered.connect(self.show_recon_window)
+
+        self.actionCompareImages.triggered.connect(self.show_stack_select_dialog)
 
         self.active_stacks_changed.connect(self.update_shortcuts)
 
@@ -227,3 +232,12 @@ class MainWindowView(BaseMainWindowView):
         if accepted:
             import pydevd_pycharm
             pydevd_pycharm.settrace('ndlt1104.isis.cclrc.ac.uk', port=port, stdoutToServer=True, stderrToServer=True)
+
+    def show_stack_select_dialog(self):
+        dialog = MultipleStackSelect(self)
+        if dialog.exec() == QDialog.Accepted:
+            one = self.presenter.get_stack_visualiser(dialog.stack_one.current()).presenter.images
+            two = self.presenter.get_stack_visualiser(dialog.stack_two.current()).presenter.images
+
+            stack_choice = StackComparePresenter(one, two, self)
+            stack_choice.show()

--- a/mantidimaging/gui/windows/stack_choice/compare_presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/compare_presenter.py
@@ -13,6 +13,7 @@ class StackComparePresenter:
 
         # forces the view's closeEvent to not prompt any dialogs, but only free the image views
         self.view.choice_made = True
+        self.view.setWindowTitle("Comparing data")
 
     def show(self):
         self.view.show()

--- a/mantidimaging/gui/windows/stack_choice/compare_presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/compare_presenter.py
@@ -17,3 +17,7 @@ class StackComparePresenter:
 
     def show(self):
         self.view.show()
+
+    def notify(self, notification):
+        # this presenter doesn't handle any notifications
+        pass

--- a/mantidimaging/gui/windows/stack_choice/compare_presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/compare_presenter.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+from mantidimaging.core.data.images import Images
+from mantidimaging.gui.windows.stack_choice.view import StackChoiceView
+
+
+class StackComparePresenter:
+    def __init__(self, stack_one: Images, stack_two: Images, parent):
+        self.view = StackChoiceView(stack_one, stack_two, self, parent)
+        self.view.originalDataButton.hide()
+        self.view.newDataButton.hide()
+
+        # forces the view's closeEvent to not prompt any dialogs, but only free the image views
+        self.view.choice_made = True
+
+    def show(self):
+        self.view.show()

--- a/mantidimaging/gui/windows/stack_choice/presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/presenter.py
@@ -1,10 +1,16 @@
 # Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
+from mantidimaging.core.data.images import Images
 import traceback
 from logging import getLogger
+from typing import List, Optional, TYPE_CHECKING, Tuple, Union
+from uuid import UUID
 
 from mantidimaging.gui.windows.stack_choice.view import StackChoiceView, Notification
+
+if TYPE_CHECKING:
+    from mantidimaging.gui.windows.operations.presenter import FiltersWindowPresenter
 
 
 def _get_stack_from_uuid(original_stack, stack_uuid):
@@ -15,7 +21,12 @@ def _get_stack_from_uuid(original_stack, stack_uuid):
 
 
 class StackChoicePresenter:
-    def __init__(self, original_stack, new_stack, operations_presenter, stack_uuid, view=None):
+    def __init__(self,
+                 original_stack: Union[List[Tuple[Images, UUID]], Images],
+                 new_stack: Images,
+                 operations_presenter: 'FiltersWindowPresenter',
+                 stack_uuid: Optional[UUID],
+                 view: Optional[StackChoiceView] = None):
         self.operations_presenter = operations_presenter
 
         if view is None:
@@ -24,7 +35,7 @@ class StackChoicePresenter:
                 self.stack = _get_stack_from_uuid(original_stack, stack_uuid)
             else:
                 self.stack = original_stack
-            view = StackChoiceView(self.stack, new_stack, self)
+            view = StackChoiceView(self.stack, new_stack, self, parent=operations_presenter.view)
 
         self.view = view
         self.stack_uuid = stack_uuid

--- a/mantidimaging/gui/windows/stack_choice/tests/test_compare_presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/test_compare_presenter.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+import unittest
+from unittest import mock
+
+import mantidimaging.test_helpers.unit_test_helper as th
+from mantidimaging.gui.windows.stack_choice.compare_presenter import StackComparePresenter
+
+
+class StackChoicePresenterTest(unittest.TestCase):
+    def setUp(self):
+        self.stack_one = th.generate_images()
+        self.stack_two = th.generate_images()
+        self.parent = mock.MagicMock()
+
+    @mock.patch("mantidimaging.gui.windows.stack_choice.compare_presenter.StackChoiceView")
+    def test_hides_buttons(self, view):
+        self.presenter = StackComparePresenter(stack_one=self.stack_one, stack_two=self.stack_two, parent=self.parent)
+        view.return_value.originalDataButton.hide.assert_called_once()
+        view.return_value.newDataButton.hide.assert_called_once()
+
+    @mock.patch("mantidimaging.gui.windows.stack_choice.compare_presenter.StackChoiceView")
+    def test_sets_choice_made(self, view):
+        self.presenter = StackComparePresenter(stack_one=self.stack_one, stack_two=self.stack_two, parent=self.parent)
+        self.assertIs(view.return_value.choice_made, True)
+
+    @mock.patch("mantidimaging.gui.windows.stack_choice.compare_presenter.StackChoiceView")
+    def test_show(self, view):
+        self.presenter = StackComparePresenter(stack_one=self.stack_one, stack_two=self.stack_two, parent=self.parent)
+        self.presenter.show()
+
+        view.return_value.show.assert_called_once()

--- a/mantidimaging/gui/windows/stack_choice/tests/test_view.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/test_view.py
@@ -19,8 +19,7 @@ class StackChoiceViewTest(unittest.TestCase):
         self.original_stack = th.generate_images()
         self.new_stack = th.generate_images()
         self.p = mock.MagicMock()
-        self.p.operations_presenter.view = None
-        self.v = StackChoiceView(self.original_stack, self.new_stack, self.p)
+        self.v = StackChoiceView(self.original_stack, self.new_stack, self.p, None)
 
     def test_toggle_roi_show_true(self):
         self.v.roi_shown = True

--- a/mantidimaging/gui/windows/stack_choice/view.py
+++ b/mantidimaging/gui/windows/stack_choice/view.py
@@ -2,15 +2,20 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from enum import Enum, auto
+from typing import TYPE_CHECKING
+from mantidimaging.core.data.images import Images
 
 from PyQt5 import QtCore
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QSizePolicy, QMessageBox
+from PyQt5.QtWidgets import QMainWindow, QPushButton, QSizePolicy, QMessageBox
 from pyqtgraph import ViewBox
 
 from mantidimaging.gui.widgets.pg_image_view import MIImageView
 
 from mantidimaging.gui.mvp_base import BaseMainWindowView
+
+if TYPE_CHECKING:
+    from mantidimaging.gui.windows.stack_choice.presenter import StackChoicePresenter
 
 
 class Notification(Enum):
@@ -19,8 +24,12 @@ class Notification(Enum):
 
 
 class StackChoiceView(BaseMainWindowView):
-    def __init__(self, original_stack, new_stack, presenter):
-        super(StackChoiceView, self).__init__(presenter.operations_presenter.view, "gui/ui/stack_choice_window.ui")
+    originalDataButton: QPushButton
+    newDataButton: QPushButton
+
+    def __init__(self, original_stack: Images, new_stack: Images, presenter: 'StackChoicePresenter',
+                 parent: QMainWindow):
+        super(StackChoiceView, self).__init__(parent, "gui/ui/stack_choice_window.ui")
 
         self.presenter = presenter
 
@@ -145,5 +154,6 @@ class StackChoiceView(BaseMainWindowView):
             else:
                 e.ignore()
                 return
+
         self.original_stack.close()
         self.new_stack.close()

--- a/mantidimaging/gui/windows/stack_choice/view.py
+++ b/mantidimaging/gui/windows/stack_choice/view.py
@@ -2,19 +2,19 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from enum import Enum, auto
-from typing import TYPE_CHECKING
-from mantidimaging.core.data.images import Images
+from typing import TYPE_CHECKING, Union
 
 from PyQt5 import QtCore
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QMainWindow, QPushButton, QSizePolicy, QMessageBox
+from PyQt5.QtWidgets import QMainWindow, QMessageBox, QPushButton, QSizePolicy
 from pyqtgraph import ViewBox
 
+from mantidimaging.core.data.images import Images
+from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.widgets.pg_image_view import MIImageView
 
-from mantidimaging.gui.mvp_base import BaseMainWindowView
-
 if TYPE_CHECKING:
+    from mantidimaging.gui.windows.stack_choice.compare_presenter import StackComparePresenter
     from mantidimaging.gui.windows.stack_choice.presenter import StackChoicePresenter
 
 
@@ -27,8 +27,8 @@ class StackChoiceView(BaseMainWindowView):
     originalDataButton: QPushButton
     newDataButton: QPushButton
 
-    def __init__(self, original_stack: Images, new_stack: Images, presenter: 'StackChoicePresenter',
-                 parent: QMainWindow):
+    def __init__(self, original_stack: Images, new_stack: Images,
+                 presenter: Union['StackComparePresenter', 'StackChoicePresenter'], parent: QMainWindow):
         super(StackChoiceView, self).__init__(parent, "gui/ui/stack_choice_window.ui")
 
         self.presenter = presenter

--- a/mantidimaging/gui/windows/stack_choice/view.py
+++ b/mantidimaging/gui/windows/stack_choice/view.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Union
+from typing import Optional, TYPE_CHECKING, Union
 
 from PyQt5 import QtCore
 from PyQt5.QtCore import Qt
@@ -28,7 +28,7 @@ class StackChoiceView(BaseMainWindowView):
     newDataButton: QPushButton
 
     def __init__(self, original_stack: Images, new_stack: Images,
-                 presenter: Union['StackComparePresenter', 'StackChoicePresenter'], parent: QMainWindow):
+                 presenter: Union['StackComparePresenter', 'StackChoicePresenter'], parent: Optional[QMainWindow]):
         super(StackChoiceView, self).__init__(parent, "gui/ui/stack_choice_window.ui")
 
         self.presenter = presenter


### PR DESCRIPTION
Adds a `functions` menu and compare action in it 

- Adds a new presenter for the `StackChoiceView`, which only shows the view, and makes sure it looks as expected (no buttons for choosing, freeing on close
- Adds a `parent` parameter to `StackChoiceView`, and updates previous call sites to pass in the parent
- Adds some typing hints into the `StackChoicePresenter` and `StackChoiceView`
- Adds test for the new presenter

To test:
- Load >1 stack, although there is currently no prevention of just comparing the same stack to itself
- Go to Functions > Compare
- Select two stacks and click OK

Thoughts:
- Is `Functions` a good label for that menu? Better ideas are welcome

Fixes #661 