### PR TITLE
Adds do_apply_filter_sync which applies synchronously

### DIFF
--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -9,7 +9,7 @@ import scipy.ndimage as scipy_ndimage
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
-from mantidimaging.core.parallel import utility as pu, shared as ps
+from mantidimaging.core.parallel import shared as ps
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.utility import add_property_to_form
 from mantidimaging.gui.utility.qt_helpers import Type

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -20,7 +20,6 @@ _default_radius = 3
 _default_mode = OUTLIERS_BRIGHT
 DIM_2D = "2D"
 DIM_1D = "1D"
-_default_dim = DIM_2D
 
 
 class OutliersFilter(BaseFilter):
@@ -60,17 +59,13 @@ class OutliersFilter(BaseFilter):
 
         :return: The processed 3D numpy.ndarray
         """
-        if not pu.multiprocessing_necessary(images.data.shape, cores):
-            cores = 1
-
         if diff and radius and diff > 0 and radius > 0:
             func = ps.create_partial(OutliersFilter._execute, ps.return_to_self1, diff=diff, radius=radius, mode=mode)
             ps.shared_list = [images.data]
             ps.execute(func,
                        images.num_projections,
                        progress=progress,
-                       msg=f"Outliers with threshold {diff} and kernel {radius}",
-                       cores=cores)
+                       msg=f"Outliers with threshold {diff} and kernel {radius}")
         return images
 
     @staticmethod

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -177,3 +177,6 @@ class MainWindowPresenter(BasePresenter):
 
     def get_stack_with_images(self, images):
         return self.model.get_stack_by_images(images)
+
+    def set_images_in_stack(self, uuid: UUID, images: Images):
+        self.model.set_images_in_stack(uuid, images)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -3,6 +3,7 @@
 
 from logging import getLogger
 from typing import Optional
+from uuid import UUID
 
 from PyQt5 import Qt, QtCore, QtGui, QtWidgets
 from PyQt5.QtGui import QIcon
@@ -246,3 +247,6 @@ class MainWindowView(BaseMainWindowView):
 
             stack_choice = StackComparePresenter(one, two, self)
             stack_choice.show()
+
+    def set_images_in_stack(self, uuid: UUID, images: Images):
+        self.presenter.set_images_in_stack(uuid, images)

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -130,6 +130,17 @@ class FiltersWindowModel(object):
         apply_func = partial(self.apply_to_stacks, stacks)
         start_async_task_view(self.presenter.view, apply_func, post_filter)
 
+    def do_apply_filter_sync(self, stacks: List['StackVisualiserView'], post_filter: Callable[[Any], None]):
+        """
+        Applies the selected filter to the selected stack in a synchronous manner
+        """
+        if len(stacks) == 0:
+            raise ValueError('No stack selected')
+
+        # Get auto parameters
+        # Generate sub-stack and run filter
+        self.apply_to_stacks(stacks)
+
     def get_filter_module_name(self, filter_idx):
         """
         Returns the class name of the filter index passed to it

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -5,6 +5,7 @@ import unittest
 from functools import partial
 
 import mock
+from mock import DEFAULT, Mock, call
 
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.operations import FiltersWindowPresenter
@@ -37,7 +38,6 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.presenter.stack = stack
         self.presenter.view.safeApply.isChecked.return_value = False
         self.presenter.do_apply_filter()
-        self.view.clear_previews.assert_called_once()
 
         expected_apply_to = [stack]
         assert_called_once_with(apply_filter_mock, expected_apply_to,
@@ -54,46 +54,81 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.view.ask_confirmation.reset_mock()
         self.view.ask_confirmation.return_value = True
         mock_stack_visualisers = [mock.Mock(), mock.Mock()]
-        self.presenter.main_window = mock.Mock()
-        self.presenter.main_window.get_all_stack_visualisers = mock.Mock()
-        self.presenter.main_window.get_all_stack_visualisers.return_value = mock_stack_visualisers
+        self.presenter._main_window = mock.Mock()
+        self.presenter._main_window.get_all_stack_visualisers = mock.Mock()
+        self.presenter._main_window.get_all_stack_visualisers.return_value = mock_stack_visualisers
 
         self.presenter.do_apply_filter_to_all()
 
         assert_called_once_with(apply_filter_mock, mock_stack_visualisers,
                                 partial(self.presenter._post_filter, mock_stack_visualisers))
 
-    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter.do_update_previews')
-    def test_post_filter_success(self, update_previews_mock):
+    @mock.patch.multiple('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter',
+                         do_update_previews=DEFAULT,
+                         _wait_for_stack_choice=DEFAULT,
+                         _do_apply_filter_sync=DEFAULT)
+    def test_post_filter_success(self,
+                                 do_update_previews: Mock = Mock(),
+                                 _wait_for_stack_choice: Mock = Mock(),
+                                 _do_apply_filter_sync: Mock = Mock()):
+        """
+        Tests when the operation has applied successfuly.
+        """
         self.presenter.view.safeApply.isChecked.return_value = False
         mock_stack_visualisers = [mock.Mock(), mock.Mock()]
         mock_task = mock.Mock()
         mock_task.error = None
-        self.presenter._do_apply_filter = mock.MagicMock()
         self.presenter._post_filter(mock_stack_visualisers, mock_task)
 
         for i, msv in enumerate(mock_stack_visualisers):
-            assert msv.presenter.images == self.view.main_window.update_stack_with_images.call_args_list[i].args[0]
-        update_previews_mock.assert_called_once()
+            assert msv.presenter.images == self.main_window.update_stack_with_images.call_args_list[i].args[0]
+
+        do_update_previews.assert_called_once()
+        _wait_for_stack_choice.assert_not_called()
+        _do_apply_filter_sync.assert_has_calls([
+            call([self.main_window.get_stack_with_images.return_value]),
+            call([self.main_window.get_stack_with_images.return_value])
+        ])
+
         self.view.clear_notification_dialog.assert_called_once()
         self.view.show_operation_completed.assert_called_once_with(self.presenter.model.selected_filter.filter_name)
 
-    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter.do_update_previews')
-    def test_post_filter_fail(self, update_previews_mock):
+    @mock.patch.multiple('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter',
+                         do_update_previews=DEFAULT,
+                         _do_apply_filter=DEFAULT)
+    def test_post_filter_fail(self, do_update_previews: Mock = Mock(), _do_apply_filter: Mock = Mock()):
+        """
+        Tests when the operation has encountered an error.
+        """
         self.presenter.view.safeApply.isChecked.return_value = False
-        mock_stack_visualisers = [mock.Mock(), mock.Mock()]
+        mock_stack_visualisers = [mock.MagicMock(), mock.MagicMock()]
         mock_task = mock.Mock()
         mock_task.error = 123
-        self.presenter._do_apply_filter = mock.MagicMock()
         self.presenter._post_filter(mock_stack_visualisers, mock_task)
 
         for i, msv in enumerate(mock_stack_visualisers):
-            assert msv.presenter.images == self.view.main_window.update_stack_with_images.call_args_list[i].args[0]
-        update_previews_mock.assert_called_once()
+            assert msv.presenter.images == self.main_window.set_images_in_stack.call_args_list[i].args[1]
 
-    def test_images_with_180_deg_proj_calls_filter_on_the_180_deg(self):
+        self.main_window.update_stack_with_images.assert_not_called()
+        _do_apply_filter.assert_not_called()
+
+        # still refreshes the previews to ensure we haven't left them blank
+        do_update_previews.assert_called_once()
+
+    @mock.patch.multiple(
+        'mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter',
+        _do_apply_filter=DEFAULT,
+        _do_apply_filter_sync=DEFAULT,
+    )
+    def test_images_with_180_deg_proj_calls_filter_on_the_180_deg(self,
+                                                                  _do_apply_filter: Mock = Mock(),
+                                                                  _do_apply_filter_sync: Mock = Mock()):
+        """
+        Test that when an `Images` stack is encountered which also has a
+        180deg projection stack reference, that 180deg stack is also processed
+        with the same operation, to ensure consistency between the two images
+        """
         self.presenter.view.safeApply.isChecked.return_value = False
-        self.presenter._do_apply_filter = mock.MagicMock()
         self.presenter.applying_to_all = False
         mock_stack = mock.MagicMock()
         mock_stack.presenter.images.has_proj180deg.return_value = True
@@ -103,7 +138,8 @@ class FiltersWindowPresenterTest(unittest.TestCase):
 
         self.presenter._post_filter(mock_stack_visualisers, mock_task)
 
-        self.presenter._do_apply_filter.assert_called_once()
+        _do_apply_filter.assert_not_called()
+        _do_apply_filter_sync.assert_called_once()
 
     def test_update_previews_no_stack(self):
         self.presenter.do_update_previews()
@@ -151,14 +187,26 @@ class FiltersWindowPresenterTest(unittest.TestCase):
 
         self.assertEqual("mock.mock", module_name)
 
+    @mock.patch.multiple(
+        'mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter',
+        _do_apply_filter=DEFAULT,
+        _do_apply_filter_sync=DEFAULT,
+    )
     @mock.patch('mantidimaging.gui.windows.operations.presenter.StackChoicePresenter')
-    def test_safe_apply_starts_stack_choice_presenter(self, stack_choice_presenter):
+    def test_safe_apply_starts_stack_choice_presenter(self,
+                                                      stack_choice_presenter: Mock,
+                                                      _do_apply_filter: Mock = Mock(),
+                                                      _do_apply_filter_sync: Mock = Mock()):
+        task = Mock()
+        task.error = None
+
         self.presenter.view.safeApply.isChecked.return_value = True
         stack_choice_presenter.done = True
-        self.presenter._do_apply_filter = mock.MagicMock()
-        self.presenter._post_filter([mock.MagicMock(), mock.MagicMock()], mock.MagicMock())
+
+        self.presenter._post_filter([mock.MagicMock(), mock.MagicMock()], task)
 
         self.assertEqual(2, stack_choice_presenter.call_count)
+        self.assertEqual(2, stack_choice_presenter.return_value.show.call_count)
 
     @mock.patch('mantidimaging.gui.windows.operations.presenter.StackChoicePresenter')
     def test_unchecked_safe_apply_does_not_start_stack_choice_presenter(self, stack_choice_presenter):


### PR DESCRIPTION
This works around a limitation in the parallel package which can't tolerate multiple async functions accessing the global share.

Not the best fix but I thought it the lowest risk one.

It removes a race condition between starting a new async task that applies the operation to the 180 projection [here](https://github.com/mantidproject/mantidimaging/compare/711_remove_outliers_error?expand=1#diff-9e8d013fe381afb54266289b0993d21f2f1567c6425cc59fde3a486e0b1feca5R182-R183) and the `self.do_update_previews()` which also runs an operation to produce the result preview

A better solution could be to instead move the proj180 handling logic
into `do_apply_filter` and remove it from `_post_filter`, but that
requires a decent refactor and is a higher risk of breaking functionality.

#### Minor changes
- Some type hints cleanup
- Removes some unnecessary `clear_previews` calls


### To test:
- Load some data
- Go to remove outliers
- Remove safe apply and do apply a few times
- No error should show up

If you want you can try to replicate the error on `master` - it is a race condition so success is not guaranteed!

Fixes #711