### PR TITLE
Adds max angle as argument to projection angle calculation in images

### DIFF
--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -275,9 +275,9 @@ class Images:
     def log_file(self, value: IMATLogFile):
         self._log_file = value
 
-    def projection_angles(self):
+    def projection_angles(self, max_angle: float = 360.0):
         proj_angles = self._log_file.projection_angles() if self._log_file is not None else \
-            ProjectionAngles(np.linspace(0, math.tau, self.num_projections))
+            ProjectionAngles(np.linspace(0, np.deg2rad(max_angle), self.num_projections))
         if self.num_images != len(proj_angles.value):
             raise ValueError(f"Number of projection angles {len(proj_angles.value)} does not equal "
                              f"the number of projections {self.num_images}. This can happen if loading subset of "

--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -3,7 +3,6 @@
 
 import datetime
 import json
-import math
 from copy import deepcopy
 from typing import List, Tuple, Optional, Any, Dict
 

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -11,7 +11,6 @@ from mantidimaging.core.data import Images
 from mantidimaging.core.data.test.fake_logfile import generate_logfile
 from mantidimaging.core.operations.crop_coords import CropCoordinatesFilter
 from mantidimaging.core.operation_history import const
-from mantidimaging.core.utility.data_containers import ProjectionAngles
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.test_helpers.unit_test_helper import generate_images, assert_not_equals
 

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -186,11 +186,16 @@ class ImagesTest(unittest.TestCase):
         images = generate_images()
         images.log_file = generate_logfile()
         expected = np.deg2rad(np.asarray([0.0, 0.3152, 0.6304, 0.9456, 1.2608, 1.576, 1.8912, 2.2064, 2.5216, 2.8368]))
-        actual: ProjectionAngles = images.projection_angles()
+        actual = images.projection_angles(360.0)
         self.assertEqual(len(actual.value), len(expected))
         np.testing.assert_equal(actual.value, expected)
 
     def test_get_projection_angles_no_logfile(self):
         images = generate_images()
-        actual = images.projection_angles()
+        actual = images.projection_angles(360.0)
         self.assertEqual(10, len(actual.value))
+        self.assertAlmostEqual(np.deg2rad(360), actual.value[-1], places=4)
+
+        actual = images.projection_angles(275.69)
+        self.assertEqual(10, len(actual.value))
+        self.assertAlmostEqual(np.deg2rad(275.69), actual.value[-1], places=4)

--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -83,7 +83,7 @@ class AstraRecon(BaseRecon):
         Larger squared sum -> bigger deviance from the mean, i.e. larger distance between noise and data
         """
 
-        proj_angles = images.projection_angles()
+        proj_angles = images.projection_angles(recon_params.max_projection_angle)
 
         def get_sumsq(image: np.ndarray) -> float:
             return np.sum(image**2)
@@ -119,7 +119,7 @@ class AstraRecon(BaseRecon):
         output_images: Images = Images.create_empty_images(output_shape, images.dtype, images.metadata)
         output_images.record_operation('AstraRecon.full', 'Reconstruction', **recon_params.to_dict())
 
-        proj_angles = images.projection_angles()
+        proj_angles = images.projection_angles(recon_params.max_projection_angle)
         for i in range(images.height):
             output_images.data[i] = AstraRecon.single_sino(images.sino(i), cors[i], proj_angles, recon_params)
             progress.update(1, "Reconstructed slice")

--- a/mantidimaging/core/reconstruct/tomopy_recon.py
+++ b/mantidimaging/core/reconstruct/tomopy_recon.py
@@ -20,7 +20,7 @@ class TomopyRecon(BaseRecon):
     @staticmethod
     def find_cor(images: Images, slice_idx: int, start_cor: float, recon_params: ReconstructionParameters) -> float:
         return tomopy.find_center(images.sinograms,
-                                  images.projection_angles().value,
+                                  images.projection_angles(recon_params.max_projection_angle).value,
                                   ind=slice_idx,
                                   init=start_cor,
                                   sinogram_order=True)
@@ -59,7 +59,7 @@ class TomopyRecon(BaseRecon):
             'ncore': ncores,
             'tomo': images.data,
             'sinogram_order': images._is_sinograms,
-            'theta': images.projection_angles().value,
+            'theta': images.projection_angles(recon_params.max_projection_angle).value,
             'center': [cor.value for cor in cors],
             'algorithm': recon_params.algorithm,
             'filter_name': recon_params.filter_name

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -100,6 +100,7 @@ class ReconstructionParameters:
     cor: Optional[ScalarCoR] = None
     tilt: Optional[Degrees] = None
     pixel_size: float = 0.0
+    max_projection_angle: float = 360.0
 
     def to_dict(self) -> dict:
         return {

--- a/mantidimaging/gui/dialogs/cor_inspection/model.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/model.py
@@ -21,7 +21,7 @@ class CORInspectionDialogModel(object):
         self.cor_step = self.image_width * 0.05
 
         # Cache projection angles
-        self.proj_angles = images.projection_angles()
+        self.proj_angles = images.projection_angles(recon_params.max_projection_angle)
         self.recon_params = recon_params
         self.reconstructor = get_reconstructor_for(recon_params.algorithm)
 

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -116,7 +116,7 @@ class MainWindowModel(object):
             stack.presenter.images.free_memory()
             stack.presenter.images = images
 
-    def get_stack_by_name(self, search_name: str) -> Optional[StackVisualiserView]:
+    def get_stack_by_name(self, search_name: str) -> Optional[QDockWidget]:
         for stack_id in self.stack_list:
             if stack_id.name == search_name:
                 return self.get_stack(stack_id.id)

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -130,7 +130,8 @@ class ReconstructWindowModel(object):
         reconstructor = get_reconstructor_for(recon_params.algorithm)
         output_shape = (1, self.images.width, self.images.width)
         recon: Images = Images.create_empty_images(output_shape, self.images.dtype, self.images.metadata)
-        recon.data[0] = reconstructor.single_sino(self.images.sino(slice_idx), cor, self.images.projection_angles(),
+        recon.data[0] = reconstructor.single_sino(self.images.sino(slice_idx), cor,
+                                                  self.images.projection_angles(recon_params.max_projection_angle),
                                                   recon_params)
         recon = self._apply_pixel_size(recon, recon_params)
         return recon

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -132,6 +132,8 @@ class ReconstructWindowView(BaseMainWindowView):
         self.stackSelector.subscribe_to_main_window(main_window)
         self.stackSelector.select_eligible_stack()
 
+        self.maxProjAngle.valueChanged.connect(
+            lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))  # type: ignore
         self.algorithmName.currentTextChanged.connect(
             lambda: self.presenter.notify(PresN.ALGORITHM_CHANGED))  # type: ignore
         self.presenter.notify(PresN.ALGORITHM_CHANGED)
@@ -293,7 +295,8 @@ class ReconstructWindowView(BaseMainWindowView):
                                         num_iter=self.num_iter,
                                         cor=ScalarCoR(self.rotation_centre),
                                         tilt=Degrees(self.tilt),
-                                        pixel_size=self.pixel_size)
+                                        pixel_size=self.pixel_size,
+                                        max_projection_angle=self.max_proj_angle)
 
     def set_table_point(self, idx, slice_idx, cor):
         # reset_results=False stops the resetting of the data model on


### PR DESCRIPTION
- Passes in the max angle argument to the projection angle calculation on all calls from the recon window
- Adds a test for a non-360 degree case.

To test:
- Load in a dataset
- Go to recon window
- See that the recon looks OK
- Change max angle to another number, e.g. 180, 270, anything but 360
- The reconstruction should look wrong now

Fixes #718 