### PR TITLE
Overrides timeLineChanges to remove the updateImage(autoHistogramRange=True) call

### DIFF
--- a/mantidimaging/gui/widgets/pg_image_view.py
+++ b/mantidimaging/gui/widgets/pg_image_view.py
@@ -130,6 +130,20 @@ class MIImageView(ImageView):
         if self.roi_changed_callback and roi is not None:
             self.roi_changed_callback(roi)
 
+    def timeLineChanged(self):
+        """
+        Re-implements timeLineChanged function, and the only change
+        is that now self.updateImage will NOT auto range the histogram
+        """
+        if not self.ignorePlaying:
+            self.play(0)
+
+        (ind, time) = self.timeIndex(self.timeLine)
+        if ind != self.currentIndex:
+            self.currentIndex = ind
+            self.updateImage(autoHistogramRange=False)
+        self.sigTimeChanged.emit(ind, time)
+
     def _update_roi_region_avg(self) -> Optional[SensibleROI]:
         if self.image.ndim != 3:
             return None


### PR DESCRIPTION
This also affects the stack visualiser in the main window - but I think this is an OK change.

To test:

- Load some data
- On main stack visualiser - zoom in the histogram
- Change the projection by clicking on the timeline/dragging the line
- Histogram should remain unchanged - you can reset with right click > View All
- Open Workflow > Compare Images
- Zoom in histogram
- Change the timeline, should remain the same
	- The two histograms will be synced as follow up work in #705 

Fixes #704