### PR TITLE
Uses the histogram levels to set the ViewBox range

### DIFF
--- a/mantidimaging/gui/windows/stack_choice/tests/test_view.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/test_view.py
@@ -172,21 +172,21 @@ class StackChoiceViewTest(unittest.TestCase):
     def test_ensure_range_is_the_same_new_stack_min_original_stack_max(self):
         self.v.new_stack.ui.histogram.vb = mock.MagicMock()
         self.v.original_stack.ui.histogram.vb = mock.MagicMock()
-        self.v.new_stack.ui.histogram.vb.viewRange = mock.MagicMock(return_value=[[0, 1], [0, 100]])
-        self.v.original_stack.ui.histogram.vb.viewRange = mock.MagicMock(return_value=[[0, 2], [0, 200]])
+        self.v.new_stack.ui.histogram.getLevels = mock.MagicMock(return_value=[0, 100])
+        self.v.original_stack.ui.histogram.getLevels = mock.MagicMock(return_value=[0, 200])
 
         self.v._ensure_range_is_the_same()
 
-        self.v.new_stack.ui.histogram.vb.setRange.assert_called_once_with(yRange=(1, 200))
-        self.v.original_stack.ui.histogram.vb.setRange.assert_called_once_with(yRange=(1, 200))
+        self.v.new_stack.ui.histogram.vb.setRange.assert_called_once_with(yRange=(0, 200))
+        self.v.original_stack.ui.histogram.vb.setRange.assert_called_once_with(yRange=(0, 200))
 
     def test_ensure_range_is_the_same_new_stack_max_original_stack_min(self):
         self.v.new_stack.ui.histogram.vb = mock.MagicMock()
         self.v.original_stack.ui.histogram.vb = mock.MagicMock()
-        self.v.new_stack.ui.histogram.vb.viewRange = mock.MagicMock(return_value=[[0, 2], [0, 200]])
-        self.v.original_stack.ui.histogram.vb.viewRange = mock.MagicMock(return_value=[[0, 1], [0, 100]])
+        self.v.new_stack.ui.histogram.getLevels = mock.MagicMock(return_value=[0, 200])
+        self.v.original_stack.ui.histogram.getLevels = mock.MagicMock(return_value=[0, 100])
 
         self.v._ensure_range_is_the_same()
 
-        self.v.new_stack.ui.histogram.vb.setRange.assert_called_once_with(yRange=(1, 200))
-        self.v.original_stack.ui.histogram.vb.setRange.assert_called_once_with(yRange=(1, 200))
+        self.v.new_stack.ui.histogram.vb.setRange.assert_called_once_with(yRange=(0, 200))
+        self.v.original_stack.ui.histogram.vb.setRange.assert_called_once_with(yRange=(0, 200))

--- a/mantidimaging/gui/windows/stack_choice/view.py
+++ b/mantidimaging/gui/windows/stack_choice/view.py
@@ -7,6 +7,7 @@ from typing import Optional, TYPE_CHECKING, Union
 from PyQt5 import QtCore
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QMainWindow, QMessageBox, QPushButton, QSizePolicy
+import numpy as np
 from pyqtgraph import ViewBox
 
 from mantidimaging.core.data.images import Images
@@ -78,13 +79,13 @@ class StackChoiceView(BaseMainWindowView):
         self.roi_shown = False
 
     def _ensure_range_is_the_same(self):
-        new_range = self.new_stack.ui.histogram.vb.viewRange()
-        original_range = self.original_stack.ui.histogram.vb.viewRange()
+        new_range = self.new_stack.ui.histogram.getLevels()
+        original_range = self.original_stack.ui.histogram.getLevels()
 
-        new_max_y = max(new_range[0][1], new_range[1][1])
-        new_min_y = min(new_range[0][1], new_range[1][1])
-        original_max_y = max(original_range[0][1], original_range[1][1])
-        original_min_y = min(original_range[0][1], original_range[1][1])
+        new_max_y = max(new_range[0], new_range[1])
+        new_min_y = min(new_range[0], new_range[1])
+        original_max_y = max(original_range[0], original_range[1])
+        original_min_y = min(original_range[0], original_range[1])
         y_range_min = min(new_min_y, original_min_y)
         y_range_max = max(new_max_y, original_max_y)
 
@@ -105,7 +106,7 @@ class StackChoiceView(BaseMainWindowView):
             self.original_stack.roiClicked()
             self.new_stack.roiClicked()
 
-    def _setup_stack_for_view(self, stack, data):
+    def _setup_stack_for_view(self, stack: MIImageView, data: np.ndarray):
         stack.setContentsMargins(4, 4, 4, 4)
         stack.setImage(data)
         stack.ui.menuBtn.hide()


### PR DESCRIPTION
This gives more accurate values to the ViewBox range, and doesn't zoom out far away on images with low values.

To test:
- Load unprocessed data
- Go to operations and apply Remove Outliers with Safe Apply
- The compare ranges should look OK, with the processed one being smaller range
- Apply the remove outliers and do Flat Fielding, check the Compare looks OK and use the processed data
- Open compare with the flat fielded stack twice - the range should be around 0-1.2ish, or higher if you have outliers
	- In the case of outliers - if you right click the histogram and View All, the range shouldn't change

Fixes #720