### PR TITLE
Add 180 degree projection to stack option

### DIFF
--- a/mantidimaging/gui/ui/main_window.ui
+++ b/mantidimaging/gui/ui/main_window.ui
@@ -36,6 +36,7 @@
     </property>
     <addaction name="actionLoad"/>
     <addaction name="actionSampleLoadLog"/>
+    <addaction name="actionLoad180deg"/>
     <addaction name="separator"/>
     <addaction name="actionSave"/>
     <addaction name="separator"/>
@@ -161,6 +162,11 @@
   <action name="actionSampleLoadLog">
    <property name="text">
     <string>Load log for stack...</string>
+   </property>
+  </action>
+  <action name="actionLoad180deg">
+   <property name="text">
+    <string>Load 180 deg projection...</string>
    </property>
   </action>
  </widget>

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -8,7 +8,6 @@ from logging import getLogger
 from typing import Dict, List, Optional, Any
 
 from PyQt5.QtWidgets import QDockWidget
-from mantidimaging.core.io.loader.img_loader import ImageLoader
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.data.dataset import Dataset

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -8,6 +8,7 @@ from logging import getLogger
 from typing import Dict, List, Optional, Any
 
 from PyQt5.QtWidgets import QDockWidget
+from mantidimaging.core.io.loader.img_loader import ImageLoader
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.data.dataset import Dataset
@@ -165,3 +166,9 @@ class MainWindowModel(object):
         stack = self.get_stack_by_name(stack_name).widget()  # type: ignore
         stack.presenter.images.log_file = loader.load_log(log_file)
         stack.presenter.images.log_file.raise_if_angle_missing(stack.presenter.images.filenames)
+
+    def add_180_deg_to_stack(self, stack_name, _180_deg_file):
+        stack = self.get_stack_by_name(stack_name).widget()  # type: ignore
+        _180_deg = loader.load(file_names=[_180_deg_file])
+        stack.presenter.images.proj180deg = _180_deg.sample
+        return _180_deg

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -187,3 +187,9 @@ class MainWindowPresenter(BasePresenter):
 
     def set_images_in_stack(self, uuid: UUID, images: Images):
         self.model.set_images_in_stack(uuid, images)
+
+    def add_180_deg_to_sample(self, stack_name: str, _180_deg_file: str):
+        return self.model.add_180_deg_to_stack(stack_name, _180_deg_file)
+
+    def create_stack_name(self, filename: str):
+        return self.model.create_name(os.path.basename(filename))

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -251,5 +251,6 @@ class MainWindowModelTest(unittest.TestCase):
         stack_mock.assert_called_with(stack_name)
         self.assertEqual(_180_stack, stack_mock.return_value.widget.return_value.presenter.images.proj180deg)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -238,6 +238,18 @@ class MainWindowModelTest(unittest.TestCase):
         stack_mock.return_value.widget.return_value.presenter.images.log_file.raise_if_angle_missing \
             .assert_called_once_with(stack_mock.return_value.widget.return_value.presenter.images.filenames)
 
+    @mock.patch('mantidimaging.core.io.loader.load')
+    def test_add_180_deg_to_stack(self, load: mock.Mock):
+        _180_file = "180 file"
+        stack_name = "stack name"
+        stack_mock = mock.MagicMock()
+        self.model.get_stack_by_name = stack_mock
+
+        _180_stack = self.model.add_180_deg_to_stack(stack_name=stack_name, _180_deg_file=_180_file).sample
+
+        load.assert_called_with(file_names=[_180_file])
+        stack_mock.assert_called_with(stack_name)
+        self.assertEqual(_180_stack, stack_mock.return_value.widget.return_value.presenter.images.proj180deg)
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+import unittest
+from unittest import mock
+
+from PyQt5.QtWidgets import QDialog
+
+from mantidimaging.test_helpers import start_qapplication
+
+from mantidimaging.gui.windows.main import MainWindowView
+
+
+@start_qapplication
+class MainWindowViewTest(unittest.TestCase):
+    def setUp(self) -> None:
+        with mock.patch("mantidimaging.gui.windows.main.view.check_version_and_label") as check_version_and_label:
+            self.v = MainWindowView()
+            self.p = mock.MagicMock()
+            self.v.presenter = self.p
+            self.check_version_and_label = check_version_and_label
+
+    @mock.patch("mantidimaging.gui.windows.main.view.StackSelectorDialog")
+    @mock.patch("mantidimaging.gui.windows.main.view.Qt.QFileDialog.getOpenFileName")
+    def test_load_180_deg_dialog(self, get_open_file_name: mock.Mock(), stack_selector_diag: mock.Mock()):
+        stack_selector_diag.return_value.exec.return_value = QDialog.Accepted
+        selected_stack = "selected_stack"
+        stack_selector_diag.return_value.selected_stack = selected_stack
+        selected_file = "~/home/test/directory/selected_file.tif"
+        get_open_file_name.return_value = (selected_file, None)
+        _180_dataset = mock.MagicMock()
+        self.p.add_180_deg_to_sample.return_value = _180_dataset
+        self.v.create_new_stack = mock.MagicMock()
+        selected_filename = "selected_file.tif"
+        self.p.create_stack_name = mock.MagicMock(return_value=selected_filename)
+
+        self.v.load_180_deg_dialog()
+
+        stack_selector_diag.assert_called_once_with(main_window=self.v,
+                                                    title='Stack Selector',
+                                                    message='Which stack is the 180 degree projection being loaded '
+                                                            'for?')
+        get_open_file_name.assert_called_once_with(caption="180 Degree Image",
+                                                   filter="Image File (*.tif *.tiff);;All (*.*)",
+                                                   initialFilter="Image File (*.tif *.tiff)")
+        self.p.add_180_deg_to_sample.assert_called_once_with(stack_name=selected_stack, _180_deg_file=selected_file)
+        self.p.create_stack_name.assert_called_once_with(selected_file)
+        self.v.create_new_stack.assert_called_once_with(_180_dataset, selected_filename)

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -21,7 +21,7 @@ class MainWindowViewTest(unittest.TestCase):
 
     @mock.patch("mantidimaging.gui.windows.main.view.StackSelectorDialog")
     @mock.patch("mantidimaging.gui.windows.main.view.Qt.QFileDialog.getOpenFileName")
-    def test_load_180_deg_dialog(self, get_open_file_name: mock.Mock(), stack_selector_diag: mock.Mock()):
+    def test_load_180_deg_dialog(self, get_open_file_name: mock.Mock, stack_selector_diag: mock.Mock):
         stack_selector_diag.return_value.exec.return_value = QDialog.Accepted
         selected_stack = "selected_stack"
         stack_selector_diag.return_value.selected_stack = selected_stack

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -29,7 +29,7 @@ class MainWindowViewTest(unittest.TestCase):
         get_open_file_name.return_value = (selected_file, None)
         _180_dataset = mock.MagicMock()
         self.p.add_180_deg_to_sample.return_value = _180_dataset
-        self.v.create_new_stack = mock.MagicMock()
+        self.v.create_new_stack = mock.MagicMock()  # type: ignore
         selected_filename = "selected_file.tif"
         self.p.create_stack_name = mock.MagicMock(return_value=selected_filename)
 

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -38,7 +38,7 @@ class MainWindowViewTest(unittest.TestCase):
         stack_selector_diag.assert_called_once_with(main_window=self.v,
                                                     title='Stack Selector',
                                                     message='Which stack is the 180 degree projection being loaded '
-                                                            'for?')
+                                                    'for?')
         get_open_file_name.assert_called_once_with(caption="180 Degree Image",
                                                    filter="Image File (*.tif *.tiff);;All (*.*)",
                                                    initialFilter="Image File (*.tif *.tiff)")

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -37,6 +37,7 @@ class MainWindowView(BaseMainWindowView):
     actionSavuFilters: QAction
     actionCompareImages: QAction
     actionLoadLog: QAction
+    actionLoad180deg: QAction
     actionLoad: QAction
     actionSave: QAction
     actionExit: QAction
@@ -73,6 +74,7 @@ class MainWindowView(BaseMainWindowView):
     def setup_shortcuts(self):
         self.actionLoad.triggered.connect(self.show_load_dialogue)
         self.actionSampleLoadLog.triggered.connect(self.load_sample_log_dialog)
+        self.actionLoad180deg.triggered.connect(self.load_180_deg_dialog)
         self.actionSave.triggered.connect(self.show_save_dialogue)
         self.actionExit.triggered.connect(self.close)
 
@@ -134,6 +136,28 @@ class MainWindowView(BaseMainWindowView):
 
         QMessageBox.information(self, "Load complete", f"{selected_file} was loaded as a log into "
                                 f"{stack_to_add_log_to}.")
+
+    def load_180_deg_dialog(self):
+        stack_selector = StackSelectorDialog(main_window=self,
+                                             title="Stack Selector",
+                                             message="Which stack is the 180 degree projection being loaded for?")
+        # Was closed without accepting (e.g. via x button or ESC)
+        if QDialog.Accepted != stack_selector.exec():
+            return
+        stack_to_add_180_deg_to = stack_selector.selected_stack
+
+        # Open file dialog
+        file_filter = f"Image File (*.tif *.tiff)"
+        selected_file, _ = Qt.QFileDialog.getOpenFileName(caption="180 Degree Image",
+                                                          filter=f"{file_filter};;All (*.*)",
+                                                          initialFilter=file_filter)
+        # Cancel/Close was clicked
+        if selected_file == "":
+            return
+
+        _180_dataset = self.presenter.add_180_deg_to_sample(stack_name=stack_to_add_180_deg_to,
+                                                            _180_deg_file=selected_file)
+        self.create_new_stack(_180_dataset, self.presenter.create_stack_name(selected_file))
 
     def execute_save(self):
         self.presenter.notify(PresNotification.SAVE)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -147,7 +147,7 @@ class MainWindowView(BaseMainWindowView):
         stack_to_add_180_deg_to = stack_selector.selected_stack
 
         # Open file dialog
-        file_filter = f"Image File (*.tif *.tiff)"
+        file_filter = "Image File (*.tif *.tiff)"
         selected_file, _ = Qt.QFileDialog.getOpenFileName(caption="180 Degree Image",
                                                           filter=f"{file_filter};;All (*.*)",
                                                           initialFilter=file_filter)


### PR DESCRIPTION
Fixes #689 

To Test:
- Load data that has a 180 degree projection but without the 180 degree projection
- Click File -> Load 180 deg projection...
- Select the sample stack
- Select that data's 180 degree projection
- The stack should then have loaded a new stack as the 180 degree projection stack
- Open operations and attempt to perform an operation on the new stack - it should complain
- Try to close the 180 degree projection stack - it should complain again
- Perform an operation on the sample stack, and the same operation should be performed on the 180 degree projection