### PR TITLE
Remove outliers set minimum difference to 0

### DIFF
--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -73,7 +73,7 @@ class OutliersFilter(BaseFilter):
         _, diff_field = add_property_to_form('Difference',
                                              'float',
                                              1000,
-                                             valid_values=(-1000000, 1000000),
+                                             valid_values=(0, 1000000),
                                              form=form,
                                              on_change=on_change,
                                              tooltip="Difference between pixels that will be used to spot outliers.\n"

--- a/mantidimaging/core/operations/outliers/test/outliers_test.py
+++ b/mantidimaging/core/operations/outliers/test/outliers_test.py
@@ -5,12 +5,15 @@ import unittest
 from unittest import mock
 
 import numpy as np
+from PyQt5.QtWidgets import QSpinBox, QComboBox, QDoubleSpinBox
+from mantidimaging.test_helpers import start_qapplication
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.outliers import OutliersFilter
 from mantidimaging.core.operations.outliers.outliers import OUTLIERS_BRIGHT
 
 
+@start_qapplication
 class OutliersTest(unittest.TestCase):
     """
     Test outliers filter.
@@ -49,6 +52,20 @@ class OutliersTest(unittest.TestCase):
         self.assertEqual(diff_field.value.call_count, 1)
         self.assertEqual(size_field.value.call_count, 1)
         self.assertEqual(mode_field.currentText.call_count, 1)
+
+    def test_register_gui_returns_correct_types(self):
+        gui_dict = OutliersFilter.register_gui(mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
+
+        assert (isinstance(gui_dict["diff_field"], QDoubleSpinBox))
+        assert (isinstance(gui_dict["size_field"], QSpinBox))
+        assert (isinstance(gui_dict["mode_field"], QComboBox))
+        # use sets because dictionary order isn't guaranteed in Python 3
+        self.assertEqual({'diff_field', 'size_field', 'mode_field'}, set(gui_dict.keys()))
+
+    def test_gui_diff_spin_box_min_is_0(self):
+        gui_dict = OutliersFilter.register_gui(mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
+
+        self.assertEqual(0, gui_dict["diff_field"].minimum())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes: #677 

To test:
- Open operations
- Select Remove outliers operation
- Try to change the difference variable below 0 it shouldn't allow this
