### PR TITLE
Adds projection angles load option

### DIFF
--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -2,6 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import io
+from mantidimaging.core.utility.data_containers import ProjectionAngles
 import unittest
 
 import numpy as np
@@ -203,3 +204,15 @@ class ImagesTest(unittest.TestCase):
         images = generate_images()
         images.log_file = generate_logfile()
         self.assertEqual(images.log_file.source_file, images.metadata[const.LOG_FILE])
+
+    def test_set_projection_angles(self):
+        images = generate_images()
+        images.set_projection_angles(ProjectionAngles(list(range(0, 10))))
+
+        actual = images.projection_angles()
+        self.assertEqual(10, len(actual.value))
+        self.assertAlmostEqual(np.deg2rad(360), actual.value[-1], places=4)
+
+        actual = images.projection_angles(275.69)
+        self.assertEqual(10, len(actual.value))
+        self.assertAlmostEqual(np.deg2rad(275.69), actual.value[-1], places=4)

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -207,12 +207,9 @@ class ImagesTest(unittest.TestCase):
 
     def test_set_projection_angles(self):
         images = generate_images()
-        images.set_projection_angles(ProjectionAngles(list(range(0, 10))))
+        pangles = ProjectionAngles(list(range(0, 10)))
+        images.set_projection_angles(pangles)
 
         actual = images.projection_angles()
         self.assertEqual(10, len(actual.value))
-        self.assertAlmostEqual(np.deg2rad(360), actual.value[-1], places=4)
-
-        actual = images.projection_angles(275.69)
-        self.assertEqual(10, len(actual.value))
-        self.assertAlmostEqual(np.deg2rad(275.69), actual.value[-1], places=4)
+        self.assertAlmostEqual(images.projection_angles().value, pangles.value, places=4)

--- a/mantidimaging/core/utility/projection_angle_parser.py
+++ b/mantidimaging/core/utility/projection_angle_parser.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+import numpy as np
+from mantidimaging.core.utility.data_containers import ProjectionAngles
+
+
+class ProjectionAngleFileParser:
+    ERROR_MESSAGE = "The provided file cannot be read. Angles are expected in DEGREES as comma \
+                    separated values on a single line, or a single angle value per line"
+
+    def __init__(self, file: str) -> None:
+        with open(file, 'r') as f:
+            self.contents = f.readlines()
+
+    def get_projection_angles(self) -> ProjectionAngles:
+        if "," in self.contents[0]:
+            if len(self.contents) > 2:
+                # allows a file that has a single line of CSV angles,
+                # and a new line after it
+                raise RuntimeError(self.ERROR_MESSAGE)
+            string_content = self.contents[0]
+            # Handles the angles provided as comma separated values
+
+            # angles are in CSV format 0,0.1,0.2...
+            values = np.deg2rad([float(angle.strip()) for angle in string_content.split(",")])
+        else:
+            # Handles the angles provided as a value per line
+            values = np.deg2rad([float(angle.strip()) for angle in self.contents])
+
+        return ProjectionAngles(values)

--- a/mantidimaging/core/utility/test/projection_angle_parser_test.py
+++ b/mantidimaging/core/utility/test/projection_angle_parser_test.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+import os
+import tempfile
+from contextlib import contextmanager
+
+import numpy as np
+import pytest
+
+from mantidimaging.core.utility.projection_angle_parser import ProjectionAngleFileParser
+
+
+@contextmanager
+def tempinput(data):
+    temp = tempfile.NamedTemporaryFile(delete=False)
+    temp.write(data.encode("ascii"))
+    temp.close()
+    try:
+        yield temp.name
+    finally:
+        os.unlink(temp.name)
+
+
+@pytest.mark.parametrize(
+    'input',
+    ["0,0.1,0.2,0.3,0.4,0.5", "0,0.1,0.2,0.3,0.4,0.5\n", "0\n0.1\n0.2\n0.3\n0.4\n0.5", "0\n0.1\n0.2\n0.3\n0.4\n0.5\n"])
+def test_angles_as_csv(input: str):
+    expected = np.array([
+        0.0, 0.0017453292519943296, 0.003490658503988659, 0.005235987755982988, 0.006981317007977318,
+        0.008726646259971648
+    ])
+    with tempinput(input) as tempfilename:
+        pafp = ProjectionAngleFileParser(tempfilename)
+        result = pafp.get_projection_angles().value
+        np.testing.assert_array_almost_equal(expected, result, err_msg="Arrays not equal")
+
+
+# def test_angles_as_file_newline_list():
+#     angles =
+#     with tempinput(angles) as tempfilename:
+#         pafp = ProjectionAngleFileParser(tempfilename)
+#         assert [0, 0.1, 0.2, 0.3, 0.4, 0.5] == pafp.get_projection_angles().value
+
+#     # with a new empty line
+#     angles = "0\n0.1\n0.2\n0.3\n0.4\n0.5\n"
+#     with tempinput(angles) as tempfilename:
+#         pafp = ProjectionAngleFileParser(tempfilename)
+#         assert [0, 0.1, 0.2, 0.3, 0.4, 0.5] == pafp.get_projection_angles().value

--- a/mantidimaging/core/utility/test/projection_angle_parser_test.py
+++ b/mantidimaging/core/utility/test/projection_angle_parser_test.py
@@ -34,16 +34,3 @@ def test_angles_as_csv(input: str):
         pafp = ProjectionAngleFileParser(tempfilename)
         result = pafp.get_projection_angles().value
         np.testing.assert_array_almost_equal(expected, result, err_msg="Arrays not equal")
-
-
-# def test_angles_as_file_newline_list():
-#     angles =
-#     with tempinput(angles) as tempfilename:
-#         pafp = ProjectionAngleFileParser(tempfilename)
-#         assert [0, 0.1, 0.2, 0.3, 0.4, 0.5] == pafp.get_projection_angles().value
-
-#     # with a new empty line
-#     angles = "0\n0.1\n0.2\n0.3\n0.4\n0.5\n"
-#     with tempinput(angles) as tempfilename:
-#         pafp = ProjectionAngleFileParser(tempfilename)
-#         assert [0, 0.1, 0.2, 0.3, 0.4, 0.5] == pafp.get_projection_angles().value

--- a/mantidimaging/gui/ui/main_window.ui
+++ b/mantidimaging/gui/ui/main_window.ui
@@ -27,7 +27,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>22</height>
+     <height>25</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -36,6 +36,7 @@
     </property>
     <addaction name="actionLoad"/>
     <addaction name="actionSampleLoadLog"/>
+    <addaction name="actionLoadProjectionAngles"/>
     <addaction name="actionLoad180deg"/>
     <addaction name="separator"/>
     <addaction name="actionSave"/>
@@ -167,6 +168,11 @@
   <action name="actionLoad180deg">
    <property name="text">
     <string>Load 180 deg projection...</string>
+   </property>
+  </action>
+  <action name="actionLoadProjectionAngles">
+   <property name="text">
+    <string>Load projection angles...</string>
    </property>
   </action>
  </widget>

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -5,14 +5,14 @@ import os
 import uuid
 from collections import namedtuple
 from logging import getLogger
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, List, Optional
 
 from PyQt5.QtWidgets import QDockWidget
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.data.dataset import Dataset
 from mantidimaging.core.io import loader, saver
-from mantidimaging.core.utility.data_containers import LoadingParameters
+from mantidimaging.core.utility.data_containers import LoadingParameters, ProjectionAngles
 from mantidimaging.gui.windows.stack_visualiser import StackVisualiserView
 
 StackId = namedtuple('StackId', ['id', 'name'])
@@ -180,3 +180,12 @@ class MainWindowModel(object):
         _180_deg = loader.load(file_names=[_180_deg_file])
         stack.presenter.images.proj180deg = _180_deg.sample
         return _180_deg
+
+    def add_projection_angles_to_sample(self, stack_name: str, proj_angles: ProjectionAngles):
+        stack_dock = self.get_stack_by_name(stack_name)
+        if stack_dock is None:
+            raise RuntimeError(f"Failed to get stack with name {stack_name}")
+
+        stack: StackVisualiserView = stack_dock.widget()  # type: ignore
+        images: Images = stack.presenter.images
+        images.set_projection_angles(proj_angles)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
+from mantidimaging.core.utility.data_containers import ProjectionAngles
 import os
 import traceback
 from enum import Enum, auto
@@ -193,3 +194,6 @@ class MainWindowPresenter(BasePresenter):
 
     def create_stack_name(self, filename: str):
         return self.model.create_name(os.path.basename(filename))
+
+    def add_projection_angles_to_sample(self, stack_name: str, proj_angles: ProjectionAngles):
+        self.model.add_projection_angles_to_sample(stack_name, proj_angles)

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -5,8 +5,9 @@ import unittest
 import uuid
 
 import mock
+import numpy as np
 
-from mantidimaging.core.utility.data_containers import LoadingParameters
+from mantidimaging.core.utility.data_containers import LoadingParameters, ProjectionAngles
 from mantidimaging.gui.windows.main import MainWindowModel
 from mantidimaging.gui.windows.main.model import StackId
 
@@ -276,9 +277,30 @@ class MainWindowModelTest(unittest.TestCase):
         stack_mock = mock.MagicMock()
         self.model.get_stack_by_name = stack_mock
         stack_mock.return_value = None
-
         self.assertRaises(RuntimeError, self.model.add_180_deg_to_stack, stack_name=stack_name, _180_deg_file=_180_file)
         stack_mock.assert_called_with(stack_name)
+
+    def test_add_projection_angles_to_sample_no_stack(self):
+        proj_angles = ProjectionAngles(np.arange(0, 10))
+        stack_name = "stack name"
+        stack_mock = mock.MagicMock()
+        self.model.get_stack_by_name = stack_mock
+        stack_mock.return_value = None
+        self.assertRaises(RuntimeError, self.model.add_projection_angles_to_sample, stack_name, proj_angles)
+
+        stack_mock.assert_called_with(stack_name)
+
+    def test_add_projection_angles_to_sample(self):
+        proj_angles = ProjectionAngles(np.arange(0, 10))
+        stack_name = "stack name"
+        stack_mock = mock.MagicMock()
+        self.model.get_stack_by_name = stack_mock
+
+        self.model.add_projection_angles_to_sample(stack_name, proj_angles)
+
+        stack_mock.assert_called_with(stack_name)
+        stack_mock.return_value.widget.return_value.presenter.images.set_projection_angles.assert_called_once_with(
+            proj_angles)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
+import numpy as np
+from mantidimaging.core.utility.data_containers import ProjectionAngles
 import unittest
 import mock
 
@@ -38,10 +40,10 @@ class MainWindowViewTest(unittest.TestCase):
 
     @mock.patch("mantidimaging.gui.windows.main.view.StackSelectorDialog")
     @mock.patch("mantidimaging.gui.windows.main.view.Qt.QFileDialog.getOpenFileName")
-    def test_load_180_deg_dialog(self, get_open_file_name: mock.Mock, stack_selector_diag: mock.Mock):
-        stack_selector_diag.return_value.exec.return_value = QDialog.Accepted
+    def test_load_180_deg_dialog(self, get_open_file_name: mock.Mock, stack_selector_dialog: mock.Mock):
+        stack_selector_dialog.return_value.exec.return_value = QDialog.Accepted
         selected_stack = "selected_stack"
-        stack_selector_diag.return_value.selected_stack = selected_stack
+        stack_selector_dialog.return_value.selected_stack = selected_stack
         selected_file = "~/home/test/directory/selected_file.tif"
         get_open_file_name.return_value = (selected_file, None)
         _180_dataset = mock.MagicMock()
@@ -52,10 +54,10 @@ class MainWindowViewTest(unittest.TestCase):
 
         self.view.load_180_deg_dialog()
 
-        stack_selector_diag.assert_called_once_with(main_window=self.view,
-                                                    title='Stack Selector',
-                                                    message='Which stack is the 180 degree projection being loaded '
-                                                    'for?')
+        stack_selector_dialog.assert_called_once_with(main_window=self.view,
+                                                      title='Stack Selector',
+                                                      message='Which stack is the 180 degree projection being loaded '
+                                                      'for?')
         get_open_file_name.assert_called_once_with(caption="180 Degree Image",
                                                    filter="Image File (*.tif *.tiff);;All (*.*)",
                                                    initialFilter="Image File (*.tif *.tiff)")
@@ -208,3 +210,31 @@ class MainWindowViewTest(unittest.TestCase):
         mock_sv.assert_called_once_with(self.view, dock, images)
         dock.setWidget.assert_called_once_with(mock_sv.return_value)
         dock.setFloating.assert_called_once_with(floating)
+
+    @mock.patch("mantidimaging.gui.windows.main.view.QMessageBox")
+    @mock.patch("mantidimaging.gui.windows.main.view.ProjectionAngleFileParser")
+    @mock.patch("mantidimaging.gui.windows.main.view.StackSelectorDialog")
+    @mock.patch("mantidimaging.gui.windows.main.view.Qt.QFileDialog.getOpenFileName")
+    def test_load_projection_angles(self, getOpenFileName: mock.Mock, StackSelectorDialog: mock.Mock,
+                                    ProjectionAngleFileParser: Mock, QMessageBox: Mock):
+        StackSelectorDialog.return_value.exec.return_value = QDialog.Accepted
+        selected_stack = "selected_stack"
+        StackSelectorDialog.return_value.selected_stack = selected_stack
+
+        selected_file = "~/home/test/directory/selected_file.txt"
+        getOpenFileName.return_value = (selected_file, None)
+
+        proj_angles = ProjectionAngles(np.arange(0, 10))
+        ProjectionAngleFileParser.return_value.get_projection_angles.return_value = proj_angles
+
+        self.presenter.add_projection_angles_to_sample
+        self.view.load_projection_angles()
+
+        StackSelectorDialog.assert_called_once_with(main_window=self.view,
+                                                    title='Stack Selector',
+                                                    message=self.view.LOAD_PROJECTION_ANGLES_DIALOG_MESSAGE)
+        getOpenFileName.assert_called_once_with(caption=self.view.LOAD_PROJECTION_ANGLES_FILE_DIALOG_CAPTION,
+                                                filter="All (*.*)")
+
+        self.presenter.add_projection_angles_to_sample.assert_called_once_with(selected_stack, proj_angles)
+        QMessageBox.information.assert_called_once()


### PR DESCRIPTION
Adds the option to load a projection angles file from the main window.

Also:
- Adds projection angles handling in images. Projection angles from logs are still top priority.
- Adds a simple parser for 2 formats of projection angles

The supported formats are comma separated or new-line separated:
```
0,0.1,0.2,0.3...
```
and
```
0
0.1
0.2
...
```

To test:
- Load a preview stack (only 11 images)
- To test either of the two formats copy and paste this into some file that you can select as a projection angle from File > Load proj angles
	- Test with/without a new line at the end. 

```
0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0
```
and
```
0
0.1
0.2
0.3
0.4
0.5
0.6
0.7
0.8
0.9
1.0
```
- Try adding/removing angles. It should show an error with the number of each (angles provided and images available)

Fixes #674 