### PR TITLE
Reverts shared array creation to python multiprocessing

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - astropy
     - scipy
     - scikit-image=0.17.2
-    - sharedarray
     - numpy
     - tomopy=1.7.1=cuda*
     - cudatoolkit=10.2*

--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -67,25 +67,6 @@ class Images:
     def count(self) -> int:
         return len(self._filenames) if self._filenames else 0
 
-    def free_memory(self, delete_filename=True):
-        """
-        Delete the memory file containing the data, and the references to it within this class.
-
-        The memory will not be freed until _all_ references to it are gone, so local variables
-        can safely keep a reference even after deletion. This is used in unit testing data
-        generation, and ROI normalisation.
-
-        :param delete_filename: Whether to reset the memory filename attribute.
-                                Set this to False in cases where the data will be replaced with
-                                data with a new shape (rebin, crop), but the memory filename
-                                ought to remain the same.
-        """
-        if self.memory_filename is not None:
-            pu.delete_shared_array(self.memory_filename)
-            if delete_filename:
-                self.memory_filename = None
-        self.data = None
-
     @property
     def filenames(self) -> Optional[List[str]]:
         return self._filenames

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -54,7 +54,7 @@ class ImagesTest(unittest.TestCase):
         self.assertEqual(imgs.metadata, expected)
 
     def test_copy(self):
-        images = generate_images(automatic_free=False)
+        images = generate_images()
         images.record_operation("Test", "Display", 123)
         self.assertFalse(images.is_sinograms)
         copy = images.copy()
@@ -68,7 +68,7 @@ class ImagesTest(unittest.TestCase):
         self.assertNotEqual(images, copy)
 
     def test_copy_flip_axes(self):
-        images = generate_images(automatic_free=False)
+        images = generate_images()
         images.record_operation("Test", "Display", 123)
         self.assertFalse(images.is_sinograms)
         copy = images.copy(flip_axes=True)
@@ -82,7 +82,7 @@ class ImagesTest(unittest.TestCase):
         self.assertNotEqual(images.sinograms, copy)
 
     def test_copy_roi(self):
-        images = generate_images(automatic_free=False)
+        images = generate_images()
         images.record_operation("Test", "Display", 123)
         self.assertFalse(images.is_sinograms)
         cropped_copy = images.copy_roi(SensibleROI(0, 0, 5, 5))

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -53,14 +53,6 @@ class ImagesTest(unittest.TestCase):
         imgs.metadata[const.OPERATION_HISTORY][0].pop(const.TIMESTAMP)
         self.assertEqual(imgs.metadata, expected)
 
-    def test_free_memory(self):
-        images = generate_images(automatic_free=False)
-        self.assertIsNotNone(images.memory_filename)
-        self.assertIsNotNone(images.data)
-        images.free_memory()
-        self.assertIsNone(images.memory_filename)
-        self.assertIsNone(images.data)
-
     def test_copy(self):
         images = generate_images(automatic_free=False)
         images.record_operation("Test", "Display", 123)
@@ -73,7 +65,6 @@ class ImagesTest(unittest.TestCase):
         copy.data[:] = 150
 
         self.assertEqual(images.metadata, copy.metadata)
-        self.assertNotEqual(images.memory_filename, copy.memory_filename)
         self.assertNotEqual(images, copy)
 
     def test_copy_flip_axes(self):
@@ -88,7 +79,6 @@ class ImagesTest(unittest.TestCase):
         copy.data[:] = 150
 
         self.assertEqual(images.metadata, copy.metadata)
-        self.assertNotEqual(images.memory_filename, copy.memory_filename)
         self.assertNotEqual(images.sinograms, copy)
 
     def test_copy_roi(self):
@@ -107,7 +97,6 @@ class ImagesTest(unittest.TestCase):
         cropped_copy.metadata[const.OPERATION_HISTORY].pop(-1)
         # the two metadatas show now be equal again
         self.assertEqual(images.metadata, cropped_copy.metadata)
-        self.assertNotEqual(images.memory_filename, cropped_copy.memory_filename)
         self.assertNotEqual(images, cropped_copy)
 
     def test_filenames_set(self):

--- a/mantidimaging/core/gpu/test/gpu_test.py
+++ b/mantidimaging/core/gpu/test/gpu_test.py
@@ -24,16 +24,6 @@ class GPUTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(GPUTest, self).__init__(*args, **kwargs)
 
-    @staticmethod
-    def run_serial(data, size, mode):
-        """
-        Run the median filter in serial.
-        """
-        th.switch_mp_off()
-        cpu_result = MedianFilter.filter_func(data, size, mode)
-        th.switch_mp_on()
-        return cpu_result
-
     @unittest.skipIf(GPU_NOT_AVAIL, reason=GPU_SKIP_REASON)
     def test_numpy_pad_modes_match_scipy_median_modes(self):
         """
@@ -47,7 +37,7 @@ class GPUTest(unittest.TestCase):
                 images = th.generate_shared_array()
 
                 gpu_result = MedianFilter.filter_func(images.copy(), size, mode, force_cpu=False)
-                cpu_result = self.run_serial(images.copy(), size, mode)
+                cpu_result = MedianFilter.filter_func(images.copy(), size, mode, force_cpu=True)
 
                 npt.assert_almost_equal(gpu_result[0], cpu_result[0])
 
@@ -80,7 +70,7 @@ class GPUTest(unittest.TestCase):
         images = th.generate_shared_array(shape=(20, N, N))
 
         gpu_result = MedianFilter.filter_func(images.copy(), size, mode, force_cpu=False)
-        cpu_result = self.run_serial(images.copy(), size, mode)
+        cpu_result = MedianFilter.filter_func(images.copy(), size, mode, force_cpu=True)
 
         npt.assert_almost_equal(gpu_result, cpu_result)
 
@@ -95,7 +85,7 @@ class GPUTest(unittest.TestCase):
         images = th.generate_shared_array(dtype="float64")
 
         gpu_result = MedianFilter.filter_func(images.copy(), size, mode, force_cpu=False)
-        cpu_result = self.run_serial(images.copy(), size, mode)
+        cpu_result = MedianFilter.filter_func(images.copy(), size, mode, force_cpu=True)
 
         npt.assert_almost_equal(gpu_result, cpu_result)
 
@@ -115,7 +105,7 @@ class GPUTest(unittest.TestCase):
         images = th.generate_shared_array(shape=(n_images, N, N))
 
         gpu_result = MedianFilter.filter_func(images.copy(), size, mode, force_cpu=False)
-        cpu_result = self.run_serial(images.copy(), size, mode)
+        cpu_result = MedianFilter.filter_func(images.copy(), size, mode, force_cpu=True)
 
         npt.assert_almost_equal(gpu_result, cpu_result)
 

--- a/mantidimaging/core/io/loader/img_loader.py
+++ b/mantidimaging/core/io/loader/img_loader.py
@@ -62,21 +62,18 @@ def execute(load_func,
 
     # we load the flat and dark first, because if they fail we don't want to
     # fail after we've loaded a big stack into memory
-    flat_before_data, flat_before_filenames, flat_before_mfname = il.load_data(flat_before_path)
-    flat_after_data, flat_after_filenames, flat_after_mfname = il.load_data(flat_after_path)
-    dark_before_data, dark_before_filenames, dark_before_mfname = il.load_data(dark_before_path)
-    dark_after_data, dark_after_filenames, dark_after_mfname = il.load_data(dark_after_path)
-    sample_data, sample_mfname = il.load_sample_data(chosen_input_filenames)
+    flat_before_data, flat_before_filenames = il.load_data(flat_before_path)
+    flat_after_data, flat_after_filenames = il.load_data(flat_after_path)
+    dark_before_data, dark_before_filenames = il.load_data(dark_before_path)
+    dark_after_data, dark_after_filenames = il.load_data(dark_after_path)
+    sample_data = il.load_sample_data(chosen_input_filenames)
 
-    return Dataset(Images(sample_data, chosen_input_filenames, indices, memory_filename=sample_mfname),
-                   flat_before=Images(flat_before_data, flat_before_filenames, memory_filename=flat_before_mfname)
-                   if flat_before_data is not None else None,
-                   flat_after=Images(flat_after_data, flat_after_filenames, memory_filename=flat_after_mfname)
-                   if flat_after_data is not None else None,
-                   dark_before=Images(dark_before_data, dark_before_filenames, memory_filename=dark_before_mfname)
-                   if dark_before_data is not None else None,
-                   dark_after=Images(dark_after_data, dark_after_filenames, memory_filename=dark_after_mfname)
-                   if dark_after_data is not None else None)
+    return Dataset(
+        Images(sample_data, chosen_input_filenames, indices),
+        flat_before=Images(flat_before_data, flat_before_filenames) if flat_before_data is not None else None,
+        flat_after=Images(flat_after_data, flat_after_filenames) if flat_after_data is not None else None,
+        dark_before=Images(dark_before_data, dark_before_filenames) if dark_before_data is not None else None,
+        dark_after=Images(dark_after_data, dark_after_filenames) if dark_after_data is not None else None)
 
 
 class ImageLoader(object):
@@ -91,9 +88,8 @@ class ImageLoader(object):
     def load_sample_data(self, input_file_names):
         # determine what the loaded data was
         if len(self.img_shape) == 2:
-            memory_file_name = pu.create_shared_name(input_file_names[0])
             # the loaded file was a single image
-            sample_data = self.load_files(input_file_names, memory_file_name), memory_file_name
+            sample_data = self.load_files(input_file_names)
         elif len(self.img_shape) == 3:
             # the loaded file was a file containing a stack of images
             sample_data = stack_loader.execute(self.load_func,
@@ -107,15 +103,14 @@ class ImageLoader(object):
 
         return sample_data
 
-    def load_data(self, file_path) -> Tuple[Optional[np.ndarray], Optional[List[str]], Optional[str]]:
+    def load_data(self, file_path) -> Tuple[Optional[np.ndarray], Optional[List[str]]]:
         if file_path:
             file_names = get_file_names(os.path.dirname(file_path), self.img_format, get_prefix(file_path))
-            memory_file_name = pu.create_shared_name(file_names[0])
-            return self.load_files(file_names, memory_file_name), file_names, memory_file_name
-        return None, None, None
+            return self.load_files(file_names), file_names
+        return None, None
 
-    def _do_files_load_seq(self, data, files, name):
-        progress = Progress.ensure_instance(self.progress, num_steps=len(files), task_name=f'Load {name}')
+    def _do_files_load_seq(self, data, files):
+        progress = Progress.ensure_instance(self.progress, num_steps=len(files), task_name='Loading')
 
         with progress:
             for idx, in_file in enumerate(files):
@@ -132,13 +127,13 @@ class ImageLoader(object):
 
         return data
 
-    def load_files(self, files, memory_name=None) -> np.ndarray:
+    def load_files(self, files) -> np.ndarray:
         # Zeroing here to make sure that we can allocate the memory.
         # If it's not possible better crash here than later.
         num_images = len(files)
         shape = (num_images, self.img_shape[0], self.img_shape[1])
-        data = pu.create_array(shape, self.data_dtype, memory_name)
-        return self._do_files_load_seq(data, files, memory_name)
+        data = pu.create_array(shape, self.data_dtype)
+        return self._do_files_load_seq(data, files)
 
 
 def _get_data_average(data):

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -91,7 +91,6 @@ def read_in_file_information(input_path,
 
     # construct and return the new shape
     shape = (len(input_file_names), ) + images.data[0].shape
-    images.free_memory()
 
     fi = FileInformation(filenames=input_file_names, shape=shape, sinograms=images.is_sinograms)
     return fi

--- a/mantidimaging/core/io/loader/stack_loader.py
+++ b/mantidimaging/core/io/loader/stack_loader.py
@@ -64,7 +64,7 @@ def execute(load_func, file_name, dtype, name, indices=None, progress=None):
         new_data = new_data[indices[0]:indices[1]:indices[2]]
 
     img_shape = new_data.shape
-    data = pu.create_array(img_shape, dtype=dtype, name=f"{file_name}-Stack")
+    data = pu.create_array(img_shape, dtype=dtype)
 
     # we could just move with data[:] = new_data[:] but then we don't get
     # loading bar information, and I doubt there's any performance gain

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -135,15 +135,6 @@ class IOTest(FileOutputtingTestCase):
             expected_images.data = expected_images.data[loader_indices[0]:loader_indices[1]]
 
         npt.assert_equal(loaded_images.data, expected_images.data)
-        loaded_images.free_memory()
-        if dataset.dark_before:
-            dataset.dark_before.free_memory()
-        if dataset.dark_after:
-            dataset.dark_after.free_memory()
-        if dataset.flat_before:
-            dataset.flat_before.free_memory()
-        if dataset.flat_after:
-            dataset.flat_after.free_memory()
 
     def test_load_sample_flat_and_dark(self,
                                        img_format='tiff',
@@ -221,16 +212,6 @@ class IOTest(FileOutputtingTestCase):
         npt.assert_equal(dataset.flat_after.data, flat_after.data)
         npt.assert_equal(dataset.dark_after.data, dark_after.data)
 
-        loaded_images.free_memory()
-        if dataset.dark_before:
-            dataset.dark_before.free_memory()
-        if dataset.flat_before:
-            dataset.flat_before.free_memory()
-        if dataset.dark_after:
-            dataset.dark_after.free_memory()
-        if dataset.flat_after:
-            dataset.flat_after.free_memory()
-
     def test_metadata_round_trip(self):
         # Create dummy image stack
         sample = th.gen_img_shared_array_with_val(42.)
@@ -246,16 +227,6 @@ class IOTest(FileOutputtingTestCase):
 
         # Ensure properties have been preserved
         self.assertEqual(loaded_images.metadata, images.metadata)
-
-        loaded_images.free_memory()
-        if dataset.dark_before:
-            dataset.dark_before.free_memory()
-        if dataset.dark_after:
-            dataset.dark_after.free_memory()
-        if dataset.flat_before:
-            dataset.flat_before.free_memory()
-        if dataset.flat_after:
-            dataset.flat_after.free_memory()
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -21,16 +21,6 @@ class IOTest(FileOutputtingTestCase):
         # force silent outputs
         initialise_logging()
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        import SharedArray as sa
-        for arr in sa.list():
-            sa.delete(arr.name.decode("utf-8"))
-
-    def tearDown(self):
-        import SharedArray as sa
-        assert len(sa.list()) == 0
-
     def assert_files_exist(self, base_name, file_format, stack=True, num_images=1, indices=None):
 
         if not stack:

--- a/mantidimaging/core/operations/crop_coords/crop_coords.py
+++ b/mantidimaging/core/operations/crop_coords/crop_coords.py
@@ -68,7 +68,7 @@ class CropCoordinatesFilter(BaseFilter):
         # allocate output first BEFORE freeing the original data,
         # otherwise it's possible to free and then fail allocation for output
         # at which point you're left with no data
-        output = pu.allocate_output(images, shape)
+        output = pu.create_array(shape, images.dtype)
         images.data = execute_single(sample, region_of_interest, progress, out=output)
 
         return images

--- a/mantidimaging/core/operations/crop_coords/crop_coords.py
+++ b/mantidimaging/core/operations/crop_coords/crop_coords.py
@@ -65,9 +65,6 @@ class CropCoordinatesFilter(BaseFilter):
             raise ValueError("It seems the Region of Interest is outside of the current image dimensions.\n"
                              "This can happen on the image preview right after a previous Crop Coordinates.")
 
-        # allocate output first BEFORE freeing the original data,
-        # otherwise it's possible to free and then fail allocation for output
-        # at which point you're left with no data
         output = pu.create_array(shape, images.dtype)
         images.data = execute_single(sample, region_of_interest, progress, out=output)
 
@@ -116,4 +113,4 @@ def execute_single(data, roi, progress=None, out=None):
 
             output = out[:] if out is not None else data[:]
             output[:] = data[:, roi.top:roi.bottom, roi.left:roi.right]
-    return output
+        return output

--- a/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
+++ b/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
@@ -87,7 +87,6 @@ class CropCoordsTest(unittest.TestCase):
         """
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
         """
-        images = th.generate_images()
         roi_mock = mock.Mock()
         roi_mock.text.return_value = "apples"
         self.assertRaises(ValueError, CropCoordinatesFilter.execute_wrapper, roi_mock)

--- a/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
+++ b/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
@@ -46,7 +46,6 @@ class CropCoordsTest(unittest.TestCase):
         npt.assert_equal(result.data.shape, expected_shape)
         # check that the data has been modified
         th.assert_not_equals(result.data, sample)
-        images.free_memory()
 
     def test_memory_change_acceptable(self):
         """
@@ -73,7 +72,6 @@ class CropCoordsTest(unittest.TestCase):
         expected_shape = (10, 4, 4)
 
         npt.assert_equal(result.data.shape, expected_shape)
-        result.free_memory()
 
     def test_execute_wrapper_return_is_runnable(self):
         """
@@ -84,7 +82,6 @@ class CropCoordsTest(unittest.TestCase):
         roi_mock.text.return_value = "0, 0, 5, 5"
         CropCoordinatesFilter.execute_wrapper(roi_mock)(images)
         roi_mock.text.assert_called_once()
-        images.free_memory()
 
     def test_execute_wrapper_bad_roi_raises_valueerror(self):
         """
@@ -95,7 +92,6 @@ class CropCoordsTest(unittest.TestCase):
         roi_mock.text.return_value = "apples"
         self.assertRaises(ValueError, CropCoordinatesFilter.execute_wrapper, roi_mock)
         roi_mock.text.assert_called_once()
-        images.free_memory()
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
+++ b/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
@@ -37,7 +37,7 @@ class CropCoordsTest(unittest.TestCase):
         #   - no flat or dark images are provided
 
         roi = SensibleROI.from_list([1, 1, 5, 5])
-        images = th.generate_images(automatic_free=False)
+        images = th.generate_images()
         # store a reference here so it doesn't get freed inside the filter execute
         sample = images.data
         result = CropCoordinatesFilter.filter_func(images, roi)
@@ -60,7 +60,7 @@ class CropCoordsTest(unittest.TestCase):
 
         This will still capture if the data is doubled, which is the main goal.
         """
-        images = th.generate_images(automatic_free=False)
+        images = th.generate_images()
         roi = SensibleROI.from_list([1, 1, 5, 5])
 
         cached_memory = get_memory_usage_linux(mb=True)[0]
@@ -77,7 +77,7 @@ class CropCoordsTest(unittest.TestCase):
         """
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
         """
-        images = th.generate_images(automatic_free=False)
+        images = th.generate_images()
         roi_mock = mock.Mock()
         roi_mock.text.return_value = "0, 0, 5, 5"
         CropCoordinatesFilter.execute_wrapper(roi_mock)(images)
@@ -87,7 +87,7 @@ class CropCoordsTest(unittest.TestCase):
         """
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
         """
-        images = th.generate_images(automatic_free=False)
+        images = th.generate_images()
         roi_mock = mock.Mock()
         roi_mock.text.return_value = "apples"
         self.assertRaises(ValueError, CropCoordinatesFilter.execute_wrapper, roi_mock)

--- a/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
+++ b/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
@@ -21,16 +21,6 @@ class CropCoordsTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(CropCoordsTest, self).__init__(*args, **kwargs)
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        import SharedArray as sa
-        for arr in sa.list():
-            sa.delete(arr.name.decode("utf-8"))
-
-    def tearDown(self):
-        import SharedArray as sa
-        assert len(sa.list()) == 0
-
     def test_executed_only_volume(self):
         # Check that the filter is  executed when:
         #   - valid Region of Interest is provided

--- a/mantidimaging/core/operations/median_filter/test/median_filter_test.py
+++ b/mantidimaging/core/operations/median_filter/test/median_filter_test.py
@@ -7,8 +7,9 @@ from unittest import mock
 import numpy as np
 
 import mantidimaging.test_helpers.unit_test_helper as th
-from mantidimaging.core.operations.median_filter import MedianFilter
+from mantidimaging.core.data.images import Images
 from mantidimaging.core.gpu import utility as gpu
+from mantidimaging.core.operations.median_filter import MedianFilter
 from mantidimaging.core.utility.memory_usage import get_memory_usage_linux
 
 GPU_UTIL_LOC = "mantidimaging.core.gpu.utility.gpu_available"
@@ -57,17 +58,18 @@ class MedianTest(unittest.TestCase):
 
         th.assert_not_equals(result.data, original)
 
-    def test_executed_no_helper_seq(self):
-        images = th.generate_images()
+    def test_executed_seq(self):
+        self.do_execute(th.generate_images())
 
+    def test_executed_par(self):
+        self.do_execute(th.generate_images_for_parallel())
+
+    def do_execute(self, images: Images):
         size = 3
         mode = 'reflect'
 
         original = np.copy(images.data[0])
-        th.switch_mp_off()
         result = MedianFilter.filter_func(images, size, mode)
-        th.switch_mp_on()
-
         th.assert_not_equals(result.data, original)
 
     def test_memory_change_acceptable(self):

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -174,4 +174,4 @@ def _create_reshaped_array(images, rebin_param):
 
     # allocate memory for images with new dimensions
     shape = (num_images, expected_dimy, expected_dimx)
-    return pu.allocate_output(images, shape)
+    return pu.create_array(shape, images.dtype)

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -2,9 +2,6 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial
-from typing import Optional
-
-import numpy
 import skimage.transform
 
 from mantidimaging import helper as h

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -52,10 +52,6 @@ class RebinFilter(BaseFilter):
 
         if param_valid:
             sample = images.data
-            sample_name: Optional[str]
-            # allocate output first BEFORE freeing the original data,
-            # otherwise it's possible to free and then fail allocation for output
-            # at which point you're left with no data
             empty_resized_data = _create_reshaped_array(images, rebin_param)
 
             f = ptsm.create_partial(skimage.transform.resize,
@@ -148,15 +144,6 @@ class RebinFilter(BaseFilter):
 
 def modes():
     return ["constant", "edge", "wrap", "reflect", "symmetric"]
-
-
-def _execute_par(data: numpy.ndarray, resized_data, mode, cores=None, chunksize=None, progress=None):
-    f = ptsm.create_partial(skimage.transform.resize,
-                            ptsm.return_to_second_but_dont_use_it,
-                            mode=mode,
-                            output_shape=resized_data.shape[1:])
-    ptsm.execute(data, resized_data, f, cores, chunksize, progress=progress, msg="Applying Rebin")
-    return resized_data
 
 
 def _create_reshaped_array(images, rebin_param):

--- a/mantidimaging/core/operations/rebin/test/rebin_test.py
+++ b/mantidimaging/core/operations/rebin/test/rebin_test.py
@@ -48,19 +48,13 @@ class RebinTest(unittest.TestCase):
         self.do_execute_uniform(5.0)
 
     def test_executed_uniform_seq_2(self):
-        th.switch_mp_off()
         self.do_execute_uniform(2.0)
-        th.switch_mp_on()
 
     def test_executed_uniform_seq_5(self):
-        th.switch_mp_off()
         self.do_execute_uniform(5.0)
-        th.switch_mp_on()
 
     def test_executed_uniform_seq_5_int(self):
-        th.switch_mp_off()
         self.do_execute_uniform(5.0, np.int32)
-        th.switch_mp_on()
 
     def do_execute_uniform(self, val=2.0, dtype=np.float32):
         images = th.generate_images(dtype=dtype)
@@ -78,31 +72,28 @@ class RebinTest(unittest.TestCase):
         self.assertEqual(result.data.dtype, dtype)
 
     def test_executed_xy_par_128_256(self):
-        self.do_execute_xy((128, 256))
+        self.do_execute_xy(True, (128, 256))
 
     def test_executed_xy_par_512_256(self):
-        self.do_execute_xy((512, 256))
+        self.do_execute_xy(True, (512, 256))
 
     def test_executed_xy_par_1024_1024(self):
-        self.do_execute_xy((1024, 1024))
+        self.do_execute_xy(True, (1024, 1024))
 
     def test_executed_xy_seq_128_256(self):
-        th.switch_mp_off()
-        self.do_execute_xy((128, 256))
-        th.switch_mp_on()
+        self.do_execute_xy(False, (128, 256))
 
     def test_executed_xy_seq_512_256(self):
-        th.switch_mp_off()
-        self.do_execute_xy((512, 256))
-        th.switch_mp_on()
+        self.do_execute_xy(False, (512, 256))
 
     def test_executed_xy_seq_1024_1024(self):
-        th.switch_mp_off()
-        self.do_execute_xy((1024, 1024))
-        th.switch_mp_on()
+        self.do_execute_xy(False, (1024, 1024))
 
-    def do_execute_xy(self, val=(512, 512)):
-        images = th.generate_images()
+    def do_execute_xy(self, is_parallel: bool, val=(512, 512)):
+        if is_parallel:
+            images = th.generate_images((15, 8, 10))
+        else:
+            images = th.generate_images()
         mode = 'reflect'
 
         expected_x = int(val[0])

--- a/mantidimaging/core/operations/rebin/test/rebin_test.py
+++ b/mantidimaging/core/operations/rebin/test/rebin_test.py
@@ -63,7 +63,7 @@ class RebinTest(unittest.TestCase):
         th.switch_mp_on()
 
     def do_execute_uniform(self, val=2.0, dtype=np.float32):
-        images = th.generate_images(dtype=dtype, automatic_free=False)
+        images = th.generate_images(dtype=dtype)
         mode = 'reflect'
 
         expected_x = int(images.data.shape[1] * val)
@@ -102,7 +102,7 @@ class RebinTest(unittest.TestCase):
         th.switch_mp_on()
 
     def do_execute_xy(self, val=(512, 512)):
-        images = th.generate_images(automatic_free=False)
+        images = th.generate_images()
         mode = 'reflect'
 
         expected_x = int(val[0])
@@ -119,22 +119,19 @@ class RebinTest(unittest.TestCase):
         if the output data could not be allocated
         :return:
         """
-        images = th.generate_images(shape=(500, 10, 10), automatic_free=False)
+        images = th.generate_images(shape=(500, 10, 10))
         mode = 'reflect'
-
-        input_mfile = images.memory_filename
 
         # something very huge that shouldn't fit on ANY computer
         rebin_param = (100000, 100000)
         self.assertRaises(RuntimeError, RebinFilter.filter_func, images, rebin_param=rebin_param, mode=mode)
-        self.assertEqual(input_mfile, images.memory_filename)
 
     def test_memory_change_acceptable(self):
         """
         This filter will increase the memory usage as it has to allocate memory
         for the new resized shape
         """
-        images = th.generate_images(automatic_free=False)
+        images = th.generate_images()
 
         mode = 'reflect'
         # This about doubles the memory. Value found from running the test
@@ -169,7 +166,7 @@ class RebinTest(unittest.TestCase):
                                                    factor=factor,
                                                    mode_field=mode_field)
 
-        images = th.generate_images(automatic_free=False)
+        images = th.generate_images()
         execute_func(images)
 
         self.assertEqual(rebin_to_dimensions_radio.isChecked.call_count, 1)

--- a/mantidimaging/core/operations/rebin/test/rebin_test.py
+++ b/mantidimaging/core/operations/rebin/test/rebin_test.py
@@ -76,7 +76,6 @@ class RebinTest(unittest.TestCase):
 
         self.assertEqual(images.data.dtype, dtype)
         self.assertEqual(result.data.dtype, dtype)
-        images.free_memory()
 
     def test_executed_xy_par_128_256(self):
         self.do_execute_xy((128, 256))
@@ -114,8 +113,6 @@ class RebinTest(unittest.TestCase):
         npt.assert_equal(result.data.shape[1], expected_x)
         npt.assert_equal(result.data.shape[2], expected_y)
 
-        images.free_memory()
-
     def test_failure_to_allocate_output_doesnt_free_input_data(self):
         """
         Tests for a bug fixed in PR#600 that the input data would be freed
@@ -131,8 +128,6 @@ class RebinTest(unittest.TestCase):
         rebin_param = (100000, 100000)
         self.assertRaises(RuntimeError, RebinFilter.filter_func, images, rebin_param=rebin_param, mode=mode)
         self.assertEqual(input_mfile, images.memory_filename)
-
-        images.free_memory()
 
     def test_memory_change_acceptable(self):
         """
@@ -157,8 +152,6 @@ class RebinTest(unittest.TestCase):
         npt.assert_equal(result.data.shape[1], expected_x)
         npt.assert_equal(result.data.shape[2], expected_y)
 
-        images.free_memory()
-
     def test_execute_wrapper_return_is_runnable(self):
         """
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
@@ -178,7 +171,6 @@ class RebinTest(unittest.TestCase):
 
         images = th.generate_images(automatic_free=False)
         execute_func(images)
-        images.free_memory()
 
         self.assertEqual(rebin_to_dimensions_radio.isChecked.call_count, 1)
         self.assertEqual(rebin_by_factor_radio.isChecked.call_count, 1)

--- a/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
@@ -10,6 +10,7 @@ import numpy.testing as npt
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.data.images import Images
 from mantidimaging.core.operations.roi_normalisation import RoiNormalisationFilter
+from mantidimaging.core.utility.sensible_roi import SensibleROI
 
 
 class ROINormalisationTest(unittest.TestCase):
@@ -42,9 +43,9 @@ class ROINormalisationTest(unittest.TestCase):
         self.do_execute(th.generate_images())
 
     def do_execute(self, images: Images):
-
         original = np.copy(images.data[0])
-        air = [3, 3, 4, 4]
+
+        air = SensibleROI.from_list([3, 3, 4, 4])
         result = RoiNormalisationFilter.filter_func(images, air)
 
         th.assert_not_equals(result.data[0], original)

--- a/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
@@ -76,7 +76,7 @@ class ROINormalisationTest(unittest.TestCase):
         """
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
         """
-        images = th.generate_images(automatic_free=False)
+        images = th.generate_images()
         roi_mock = mock.Mock()
         roi_mock.text.return_value = "apples"
         self.assertRaises(ValueError, RoiNormalisationFilter.execute_wrapper, roi_mock)

--- a/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
@@ -81,7 +81,6 @@ class ROINormalisationTest(unittest.TestCase):
         roi_mock.text.return_value = "apples"
         self.assertRaises(ValueError, RoiNormalisationFilter.execute_wrapper, roi_mock)
         roi_mock.text.assert_called_once()
-        images.free_memory()
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
@@ -76,7 +76,6 @@ class ROINormalisationTest(unittest.TestCase):
         """
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
         """
-        images = th.generate_images()
         roi_mock = mock.Mock()
         roi_mock.text.return_value = "apples"
         self.assertRaises(ValueError, RoiNormalisationFilter.execute_wrapper, roi_mock)

--- a/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
@@ -2,12 +2,13 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest
-
 from unittest import mock
+
 import numpy as np
 import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
+from mantidimaging.core.data.images import Images
 from mantidimaging.core.operations.roi_normalisation import RoiNormalisationFilter
 
 
@@ -35,15 +36,12 @@ class ROINormalisationTest(unittest.TestCase):
         npt.assert_raises(ValueError, RoiNormalisationFilter.filter_func, images, air)
 
     def test_executed_par(self):
-        self.do_execute()
+        self.do_execute(th.generate_images_for_parallel())
 
     def test_executed_seq(self):
-        th.switch_mp_off()
-        self.do_execute()
-        th.switch_mp_on()
+        self.do_execute(th.generate_images())
 
-    def do_execute(self):
-        images = th.generate_images()
+    def do_execute(self, images: Images):
 
         original = np.copy(images.data[0])
         air = [3, 3, 4, 4]

--- a/mantidimaging/core/parallel/shared_mem.py
+++ b/mantidimaging/core/parallel/shared_mem.py
@@ -7,7 +7,6 @@ from mantidimaging.core.parallel import utility as pu
 
 # this global is necessary for the child processes to access the original
 # array and overwrite the values in-place
-# TODO: now uses SharedArray so this shared_data global might not be necessary anymore. Needs testing
 
 shared_data = None
 

--- a/mantidimaging/core/parallel/test/utility_test.py
+++ b/mantidimaging/core/parallel/test/utility_test.py
@@ -2,11 +2,8 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from unittest import mock
-import numpy as np
-import SharedArray as sa
 
-from mantidimaging.core.parallel.utility import (create_array, create_shared_name, execute_impl,
-                                                 free_all_owned_by_this_instance, multiprocessing_necessary)
+from mantidimaging.core.parallel.utility import execute_impl, multiprocessing_necessary
 
 
 def test_correctly_chooses_parallel():
@@ -39,25 +36,6 @@ def test_execute_impl_par(mock_pool):
     execute_impl(15, mock_partial, 10, 1, mock_progress, "Test")
     mock_pool_instance.imap.assert_called_once()
     assert mock_progress.update.call_count == 15
-
-
-def test_free_all_owned_by_this_instance():
-    name1 = create_shared_name()
-    name2 = create_shared_name()
-    name3 = create_shared_name()
-    create_array((10, 10), np.float32, name=name1)
-    create_array((10, 10), np.float32, name=name2)
-    create_array((10, 10), np.float32, name=name3)
-
-    temp_name = "not_this_instance"
-    sa.create("not_this_instance", (10, 10))
-
-    free_all_owned_by_this_instance()
-    assert name1 not in [arr.name.decode("utf-8") for arr in sa.list()]
-    assert name2 not in [arr.name.decode("utf-8") for arr in sa.list()]
-    assert name3 not in [arr.name.decode("utf-8") for arr in sa.list()]
-    assert temp_name in [arr.name.decode("utf-8") for arr in sa.list()]
-    sa.delete(temp_name)
 
 
 if __name__ == "__main__":

--- a/mantidimaging/core/parallel/test/utility_test.py
+++ b/mantidimaging/core/parallel/test/utility_test.py
@@ -1,20 +1,32 @@
 # Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
+from typing import List, Tuple, Union
 from unittest import mock
+
+import pytest
 
 from mantidimaging.core.parallel.utility import execute_impl, multiprocessing_necessary
 
 
-def test_correctly_chooses_parallel():
-    # forcing 1 core should always return False
-    assert multiprocessing_necessary((100, 10, 10), cores=1) is False
-    # shapes less than 10 should return false
-    assert multiprocessing_necessary((10, 10, 10), cores=12) is False
-    assert multiprocessing_necessary(10, cores=12) is False
-    # shapes over 10 should return True
-    assert multiprocessing_necessary((11, 10, 10), cores=12) is True
-    assert multiprocessing_necessary(11, cores=12) is True
+@pytest.mark.parametrize(
+    'shape,cores,should_be_parallel',
+    (
+        [(100, 10, 10), 1, False],  # forcing 1 core should always return False
+        # shapes <= 10 should return False
+        [(10, 10, 10), 12, False],
+        [10, 12, False],
+        # shapes over 10 should return True
+        [(11, 10, 10), 12, True],
+        [11, 12, True],
+        # repeat from above but with list, to cover that branch of the if
+        [[100, 10, 10], 1, False],
+        [[10, 10, 10], 12, False],
+        [[11, 10, 10], 12, True],
+    ))
+def test_correctly_chooses_parallel(shape: Union[int, List, Tuple[int, int, int]], cores: int,
+                                    should_be_parallel: bool):
+    assert multiprocessing_necessary(shape, cores) is should_be_parallel
 
 
 @mock.patch('mantidimaging.core.parallel.utility.Pool')

--- a/mantidimaging/core/parallel/two_shared_mem.py
+++ b/mantidimaging/core/parallel/two_shared_mem.py
@@ -6,7 +6,6 @@ from mantidimaging.core.parallel import utility as pu
 
 # this global is necessary for the child processes to access the original
 # array and overwrite the values in-place
-# TODO: now uses SharedArray so this shared_data global might not be necessary anymore. Needs testing
 
 shared_data = None
 second_shared_data = None

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -3,16 +3,14 @@
 
 import ctypes
 import os
-import uuid
 from contextlib import contextmanager
 from functools import partial
 from logging import getLogger
-from multiprocessing.pool import Pool
 # for some reason mypy can't find this import, nor can IDE suggestions
 from multiprocessing import heap  # type: ignore
-from typing import Union, Type, Optional, Tuple
+from multiprocessing.pool import Pool
+from typing import Any, Tuple, Type, Union
 
-import SharedArray as sa
 import numpy as np
 
 from mantidimaging.core.utility.memory_usage import system_free_memory
@@ -51,7 +49,7 @@ def allocate_output(images, shape):
     return create_array(shape, images.dtype)
 
 
-def create_array(shape: Tuple[int, int, int], dtype: NP_DTYPE = np.float32) -> np.ndarray:
+def create_array(shape: Tuple[Any, ...], dtype: NP_DTYPE = np.float32) -> np.ndarray:
     """
     Create an array, either in a memory file (if name provided), or purely in memory (if name is None)
 

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -2,6 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import ctypes
+import multiprocessing
 import os
 from contextlib import contextmanager
 from functools import partial
@@ -96,22 +97,8 @@ def temp_shared_array(shape, dtype: NP_DTYPE = np.float32) -> np.ndarray:
         pass
 
 
-def multiprocessing_available():
-    try:
-        # ignore error about unused import
-        import multiprocessing  # noqa: F401
-        return multiprocessing
-    except ImportError:
-        return False
-
-
 def get_cores():
-    mp = multiprocessing_available()
-    # get max cores on the system as default
-    if not mp:
-        return 1
-    else:
-        return mp.cpu_count()
+    return multiprocessing.cpu_count()
 
 
 def generate_indices(num_images):

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -6,7 +6,8 @@ import os
 from contextlib import contextmanager
 from functools import partial
 from logging import getLogger
-# for some reason mypy can't find this import, nor can IDE suggestions
+# COMPAT python 3.7 : Using heap instead of Array,
+# see https://github.com/mantidproject/mantidimaging/pull/762#issuecomment-741663482
 from multiprocessing import heap  # type: ignore
 from multiprocessing.pool import Pool
 from typing import Any, Tuple, Type, Union

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -45,10 +45,6 @@ def enough_memory(shape, dtype):
     return full_size_KB(shape=shape, axis=0, dtype=dtype) < system_free_memory().kb()
 
 
-def allocate_output(images, shape):
-    return create_array(shape, images.dtype)
-
-
 def create_array(shape: Tuple[Any, ...], dtype: NP_DTYPE = np.float32) -> np.ndarray:
     """
     Create an array, either in a memory file (if name provided), or purely in memory (if name is None)

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -4,7 +4,6 @@
 import ctypes
 import multiprocessing
 import os
-from contextlib import contextmanager
 from functools import partial
 from logging import getLogger
 # COMPAT python 3.7 : Using heap instead of Array,
@@ -88,26 +87,8 @@ def _create_shared_array(shape, dtype: Union[str, np.dtype] = np.float32):
     return data.reshape(shape)
 
 
-@contextmanager
-def temp_shared_array(shape, dtype: NP_DTYPE = np.float32) -> np.ndarray:
-    array = _create_shared_array(shape, dtype)
-    try:
-        yield array
-    finally:
-        pass
-
-
 def get_cores():
     return multiprocessing.cpu_count()
-
-
-def generate_indices(num_images):
-    """
-    Generate indices for each image.
-
-    :param num_images: The number of images.
-    """
-    return range(num_images)
 
 
 def calculate_chunksize(cores):
@@ -143,7 +124,7 @@ def multiprocessing_necessary(shape: Union[int, Tuple[int, int, int]], cores) ->
 def execute_impl(img_num: int, partial_func: partial, cores: int, chunksize: int, progress: Progress, msg: str):
     task_name = f"{msg} {cores}c {chunksize}chs"
     progress = Progress.ensure_instance(progress, num_steps=img_num, task_name=task_name)
-    indices_list = generate_indices(img_num)
+    indices_list = range(img_num)
     if multiprocessing_necessary(img_num, cores):
         with Pool(cores) as pool:
             for _ in pool.imap(partial_func, indices_list, chunksize=chunksize):

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -25,22 +25,6 @@ SimpleCType = Union[Type[ctypes.c_uint8], Type[ctypes.c_uint16], Type[ctypes.c_i
 
 NP_DTYPE = Type[np.single]
 
-INSTANCE_PREFIX = str(uuid.uuid4())
-
-
-def free_all_owned_by_this_instance():
-    for arr in [array for array in sa.list() if array.name.decode("utf-8").startswith(INSTANCE_PREFIX)]:
-        sa.delete(arr.name.decode("utf-8"))
-
-
-def has_other_shared_arrays() -> bool:
-    return len(sa.list()) > 0
-
-
-def free_all():
-    for arr in [array for array in sa.list()]:
-        sa.delete(arr.name.decode("utf-8"))
-
 
 def enough_memory(shape, dtype):
     return full_size_KB(shape=shape, axis=0, dtype=dtype) < system_free_memory().kb()

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -63,14 +63,7 @@ def enough_memory(shape, dtype):
 
 
 def allocate_output(images, shape):
-    if images.memory_filename is not None:
-        name = create_shared_name()
-        output = create_array(shape, images.dtype, name)
-        images.free_memory(delete_filename=False)
-        images.memory_filename = name
-    else:
-        output = create_array(shape, images.dtype)
-    return output
+    return create_array(shape, images.dtype)
 
 
 def create_array(shape: Tuple[int, int, int],

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -10,7 +10,7 @@ from logging import getLogger
 # see https://github.com/mantidproject/mantidimaging/pull/762#issuecomment-741663482
 from multiprocessing import heap  # type: ignore
 from multiprocessing.pool import Pool
-from typing import Any, Tuple, Type, Union
+from typing import Any, List, Tuple, Type, Union
 
 import numpy as np
 
@@ -97,7 +97,7 @@ def calculate_chunksize(cores):
     return 1
 
 
-def multiprocessing_necessary(shape: Union[int, Tuple[int, int, int]], cores) -> bool:
+def multiprocessing_necessary(shape: Union[int, Tuple[int, int, int], List], cores) -> bool:
     # This environment variable will be present when running PYDEVD from PyCharm
     # and that has the bug that multiprocessing Pools can never finish `.join()` ing
     # thus never actually finish their processing.

--- a/mantidimaging/core/utility/value_scaling.py
+++ b/mantidimaging/core/utility/value_scaling.py
@@ -27,19 +27,17 @@ def create_factors(data: np.ndarray, roi=None, cores=None, chunksize=None, progr
     with progress:
         img_num = data.shape[0]
         # make sure to clean up if for some reason the scale factor array still exists
-        with pu.temp_shared_array((img_num, 1, 1)) as scale_factors:
-            # turn into a 1D array, from the 3D that is returned
-            scale_factors = scale_factors.reshape(img_num)
+        scale_factors = pu.create_array((img_num, ))
 
-            # calculate the scale factor from original image
-            calc_sums_partial = ptsm.create_partial(_calc_avg,
-                                                    fwd_function=ptsm.return_to_second,
-                                                    roi_left=roi[0] if roi else 0,
-                                                    roi_top=roi[1] if roi else 0,
-                                                    roi_right=roi[2] if roi else data[0].shape[1] - 1,
-                                                    roi_bottom=roi[3] if roi else data[0].shape[0] - 1)
+        # calculate the scale factor from original image
+        calc_sums_partial = ptsm.create_partial(_calc_avg,
+                                                fwd_function=ptsm.return_to_second,
+                                                roi_left=roi[0] if roi else 0,
+                                                roi_top=roi[1] if roi else 0,
+                                                roi_right=roi[2] if roi else data[0].shape[1] - 1,
+                                                roi_bottom=roi[3] if roi else data[0].shape[0] - 1)
 
-            data, scale_factors = ptsm.execute(data, scale_factors, calc_sums_partial, cores, chunksize)
+        data, scale_factors = ptsm.execute(data, scale_factors, calc_sums_partial, cores, chunksize)
 
         return scale_factors
 

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -113,7 +113,6 @@ class MainWindowModel(object):
             stack.image_view.setImage(images.data)
 
             # Free previous images stack before reassignment
-            stack.presenter.images.free_memory()
             stack.presenter.images = images
 
     def get_stack_by_name(self, search_name: str) -> Optional[QDockWidget]:

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -148,12 +148,6 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.assertEqual(5, len(self.presenter.model.stack_list))
         self.view.active_stacks_changed.emit.assert_called_once()
 
-        ds.sample.free_memory()
-        ds.flat_before.free_memory()
-        ds.dark_before.free_memory()
-        ds.flat_after.free_memory()
-        ds.dark_after.free_memory()
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -133,11 +133,11 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.create_stack_window.return_value = dock_mock
         self.view.active_stacks_changed.emit = mock.Mock()
 
-        ds = Dataset(sample=generate_images(automatic_free=False),
-                     flat_before=generate_images(automatic_free=False),
-                     flat_after=generate_images(automatic_free=False),
-                     dark_before=generate_images(automatic_free=False),
-                     dark_after=generate_images(automatic_free=False))
+        ds = Dataset(sample=generate_images(),
+                     flat_before=generate_images(),
+                     flat_after=generate_images(),
+                     dark_before=generate_images(),
+                     dark_after=generate_images())
         ds.flat_before.filenames = ["filename"] * 10
         ds.dark_before.filenames = ["filename"] * 10
         ds.flat_after.filenames = ["filename"] * 10

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -23,8 +23,7 @@ versions._use_test_values()
 class MainWindowViewTest(unittest.TestCase):
     def setUp(self) -> None:
         with mock.patch("mantidimaging.gui.windows.main.view.WelcomeScreenPresenter"):
-            with mock.patch("mantidimaging.gui.windows.main.view.has_other_shared_arrays", return_value=False):
-                self.view = MainWindowView()
+            self.view = MainWindowView()
         self.presenter = mock.MagicMock()
         self.view.presenter = self.presenter
 
@@ -307,34 +306,3 @@ class MainWindowViewTest(unittest.TestCase):
 
         self.presenter.get_stack_visualiser.assert_called_once_with(uuid)
         self.assertEqual(images, return_value)
-
-    @mock.patch("mantidimaging.gui.windows.main.view.has_other_shared_arrays")
-    @mock.patch("mantidimaging.gui.windows.main.view.free_all")
-    @mock.patch("mantidimaging.gui.windows.main.view.QMessageBox")
-    def test_ask_user_to_free_data(self, QMessageBox: Mock, free_all: Mock, has_other_shared_arrays: Mock):
-        has_other_shared_arrays.return_value = True
-        # makes the clickedButton the same return value mock as the addButton return
-        QMessageBox.return_value.clickedButton.return_value = QMessageBox.return_value.addButton.return_value
-
-        self.view.ask_user_to_free_data()
-
-        QMessageBox.return_value.setWindowTitle.assert_called_once()
-        QMessageBox.return_value.setText.assert_called_once()
-        self.assertEquals(QMessageBox.return_value.addButton.call_count, 2)
-        QMessageBox.return_value.exec.assert_called_once()
-        free_all.assert_called_once()
-
-    @mock.patch("mantidimaging.gui.windows.main.view.has_other_shared_arrays")
-    @mock.patch("mantidimaging.gui.windows.main.view.free_all")
-    @mock.patch("mantidimaging.gui.windows.main.view.QMessageBox")
-    def test_ask_user_to_free_data_ignore_pressed(self, QMessageBox: Mock, free_all: Mock,
-                                                  has_other_shared_arrays: Mock):
-        has_other_shared_arrays.return_value = True
-
-        self.view.ask_user_to_free_data()
-
-        QMessageBox.return_value.setWindowTitle.assert_called_once()
-        QMessageBox.return_value.setText.assert_called_once()
-        self.assertEquals(QMessageBox.return_value.addButton.call_count, 2)
-        QMessageBox.return_value.exec.assert_called_once()
-        free_all.assert_not_called()

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -2,7 +2,6 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from logging import getLogger
-from mantidimaging.core.parallel.utility import free_all, has_other_shared_arrays
 from mantidimaging.core.utility.projection_angle_parser import ProjectionAngleFileParser
 from typing import Optional
 from uuid import UUID
@@ -81,23 +80,6 @@ class MainWindowView(BaseMainWindowView):
 
         if WelcomeScreenPresenter.show_today():
             self.show_about()
-
-        if has_other_shared_arrays():
-            self.ask_user_to_free_data()
-
-    def ask_user_to_free_data(self):
-        msg_box = QMessageBox(self)
-        msg_box.setWindowTitle("Previously loaded data found")
-        msg_box.setText("This can happen if Mantid Imaging crashes, or there are multiple instances running.\n\n"
-                        "If Mantid Imaging crashed it is recommended to just 'Release all previous data'.\n\n"
-                        "If you have another instance running it is recommended you 'Ignore' "
-                        "otherwise the other instance will be corrupted.")
-        delete_all = msg_box.addButton("Release all previous data", QMessageBox.ActionRole)
-        _ = msg_box.addButton(QMessageBox.Ignore)
-        msg_box.exec()
-
-        if msg_box.clickedButton() == delete_all:
-            free_all()
 
     def setup_shortcuts(self):
         self.actionLoad.triggered.connect(self.show_load_dialogue)

--- a/mantidimaging/gui/windows/operations/test/test_view.py
+++ b/mantidimaging/gui/windows/operations/test/test_view.py
@@ -17,8 +17,7 @@ class OperationsWindowsViewTest(unittest.TestCase):
     def setUp(self):
         # mock the view so it has the same methods
         with mock.patch("mantidimaging.gui.windows.main.view.WelcomeScreenPresenter"):
-            with mock.patch("mantidimaging.gui.windows.main.view.has_other_shared_arrays", return_value=False):
-                self.main_window = MainWindowView()
+            self.main_window = MainWindowView()
         self.window = FiltersWindowView(self.main_window)
 
     def test_collapse(self):

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -19,8 +19,7 @@ versions._use_test_values()
 class ReconstructWindowViewTest(unittest.TestCase):
     def setUp(self) -> None:
         with mock.patch("mantidimaging.gui.windows.main.view.WelcomeScreenPresenter"):
-            with mock.patch("mantidimaging.gui.windows.main.view.has_other_shared_arrays", return_value=False):
-                self.main_window = MainWindowView()
+            self.main_window = MainWindowView()
         self.view = ReconstructWindowView(self.main_window)
         self.view.presenter = self.presenter = mock.Mock()
         self.view.image_view = self.image_view = mock.Mock()

--- a/mantidimaging/gui/windows/stack_choice/presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/presenter.py
@@ -80,4 +80,5 @@ class StackChoicePresenter(StackChoicePresenterMixin):
 
     def close_view(self):
         self.view.close()
+        self.stack = None
         self.done = True

--- a/mantidimaging/gui/windows/stack_choice/presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/presenter.py
@@ -75,7 +75,6 @@ class StackChoicePresenter(StackChoicePresenterMixin):
 
     def do_clean_up_original_data(self):
         self._clean_up_original_images_stack()
-        self.stack.free_memory()
         self.view.choice_made = True
         self.close_view()
 

--- a/mantidimaging/gui/windows/stack_choice/tests/test_presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/test_presenter.py
@@ -96,7 +96,6 @@ class StackChoicePresenterTest(unittest.TestCase):
         self.p.do_clean_up_original_data()
 
         self.p._clean_up_original_images_stack.assert_called_once()
-        self.p.stack.free_memory.assert_called_once()
         self.assertTrue(self.v.choice_made)
         self.p.close_view.assert_called_once()
 

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -66,7 +66,6 @@ class StackVisualiserPresenter(BasePresenter):
             getLogger(__name__).exception("Notification handler failed")
 
     def delete_data(self):
-        self.images.free_memory()
         self.images = None
 
     def get_image(self, index) -> Images:

--- a/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
@@ -2,9 +2,8 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest
-
-import SharedArray as sa
 from unittest import mock
+
 import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
@@ -24,15 +23,6 @@ class StackVisualiserPresenterTest(unittest.TestCase):
         # mock the view so it has the same methods
         self.view = mock.create_autospec(StackVisualiserView)
         self.presenter = StackVisualiserPresenter(self.view, self.test_data)
-
-    @classmethod
-    def setUpClass(cls) -> None:
-        for a in sa.list():
-            sa.delete(a.name.decode("utf-8"))
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        assert len(sa.list()) == 0, f"Not all shared arrays have been freed. Leftover: {sa.list()}"
 
     def test_get_image(self):
         index = 3

--- a/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
@@ -43,7 +43,7 @@ class StackVisualiserPresenterTest(unittest.TestCase):
         npt.assert_equal(test_data.data[index], img.data[0])
 
     def test_delete_data(self):
-        self.presenter.images = th.generate_images(automatic_free=False)
+        self.presenter.images = th.generate_images()
         self.presenter.delete_data()
         self.assertIsNone(self.presenter.images, None)
 

--- a/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
@@ -25,13 +25,6 @@ class StackVisualiserPresenterTest(unittest.TestCase):
         self.view = mock.create_autospec(StackVisualiserView)
         self.presenter = StackVisualiserPresenter(self.view, self.test_data)
 
-    def tearDown(self) -> None:
-        try:
-            self.test_data.free_memory()
-        except FileNotFoundError:
-            # the test has deleted the data manually
-            pass
-
     @classmethod
     def setUpClass(cls) -> None:
         for a in sa.list():

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -5,8 +5,9 @@ from typing import Tuple
 import unittest
 
 from unittest import mock
+from unittest.mock import Mock
+
 from PyQt5.QtWidgets import QDockWidget
-from mock import Mock
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.data import Images
@@ -34,8 +35,7 @@ class StackVisualiserViewTest(unittest.TestCase):
 
     def setUp(self):
         with mock.patch("mantidimaging.gui.windows.main.view.WelcomeScreenPresenter"):
-            with mock.patch("mantidimaging.gui.windows.main.view.has_other_shared_arrays", return_value=False):
-                self.window = MainWindowView()
+            self.window = MainWindowView()
         self.window.remove_stack = mock.Mock()
         self.dock, self.view, self.test_data = self._add_stack_visualiser()
 

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -28,10 +28,6 @@ class StackVisualiserViewTest(unittest.TestCase):
         super(StackVisualiserViewTest, self).__init__(*args, **kwargs)
 
     def tearDown(self) -> None:
-        try:
-            self.test_data.free_memory()
-        except FileNotFoundError:
-            pass
         self.view = None
         self.window = None  # type: ignore[assignment]
         self.dock = None

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -40,7 +40,7 @@ class StackVisualiserViewTest(unittest.TestCase):
         self.dock, self.view, self.test_data = self._add_stack_visualiser()
 
     def _add_stack_visualiser(self) -> Tuple[QDockWidget, StackVisualiserView, Images]:
-        test_data = th.generate_images(automatic_free=False)
+        test_data = th.generate_images()
         self.window.create_new_stack(test_data, "Test Data")
         view = self.window.get_stack_with_images(test_data)
         return view.dock, view, test_data

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -132,8 +132,8 @@ class StackVisualiserView(BaseMainWindowView):
             self.hide()
             self.image_view.close()
 
-            # this removes all references to the data, allowing it to be GC'ed
-            # otherwise there is a hanging reference
+            # this removes a hanging reference from the presenter to the data
+            # allowing it to be GC'ed
             self.presenter.delete_data()
             window.remove_stack(self)
             self.deleteLater()

--- a/mantidimaging/helper.py
+++ b/mantidimaging/helper.py
@@ -53,17 +53,3 @@ def check_data_stack(data, expected_dims=3, expected_class=Images):
 
     if expected_dims != data.data.ndim:
         raise ValueError("Invalid data format. It does not have 3 dimensions. " "Shape: {0}".format(data.data.shape))
-
-
-def run_import_checks(config):
-    """
-    Run the import checks to notify the user which features are available in
-    the execution.
-    """
-    from mantidimaging.core.parallel import utility as pu
-
-    log = logging.getLogger(__name__)
-    if not pu.multiprocessing_available():
-        log.info("Multiprocessing not available.")
-    else:
-        log.info("Running process on {0} cores.".format(config.func.cores))

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -3,12 +3,10 @@
 
 # !/usr/bin/env python
 import argparse
-import atexit
 import logging
 import warnings
 
 from mantidimaging import helper as h
-from mantidimaging.core.parallel.utility import free_all_owned_by_this_instance
 from mantidimaging.core.utility.optional_imports import safe_import
 
 formatwarning_orig = warnings.formatwarning
@@ -41,7 +39,6 @@ def parse_args():
 
 
 def main():
-    atexit.register(free_all_owned_by_this_instance)
     args = parse_args()
     # Print version number and exit
     if args.version:

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -40,6 +40,15 @@ def generate_images(shape=g_shape, dtype=np.float32) -> Images:
     return _set_random_data(d, shape)
 
 
+def generate_images_for_parallel(shape=(15, 8, 10), dtype=np.float32) -> Images:
+    """
+    Doesn't do anything special, just makes a number of images big enough to be
+    ran in parallel from the logic of multiprocessing_necessary
+    """
+    d = pu.create_array(shape, dtype)
+    return _set_random_data(d, shape)
+
+
 def _set_random_data(data, shape):
     n = np.random.rand(*shape)
     # move the data in the shared array
@@ -88,31 +97,6 @@ def vsdebug():
     # Enable the below line of code only if you want the application to wait
     # untill the debugger has attached to it
     ptvsd.wait_for_attach()
-
-
-def switch_mp_off():
-    """
-    This function does very bad things that should never be replicated.
-    But it's a unit test so it's fine.
-    """
-    # backup function so we can restore it
-    global backup_mp_avail
-    backup_mp_avail = pu.multiprocessing_available
-
-    def simple_return_false():
-        return False
-
-    # do bad things, swap out the function to one that returns false
-    pu.multiprocessing_available = simple_return_false
-
-
-def switch_mp_on():
-    """
-    This function does very bad things that should never be replicated.
-    But it's a unit test so it's fine.
-    """
-    # restore the original backed up function from switch_mp_off
-    pu.multiprocessing_available = backup_mp_avail
 
 
 def assert_files_exist(cls, base_name, file_extension, file_extension_separator='.', single_file=True, num_images=1):

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -35,25 +35,17 @@ def generate_shared_array(shape=g_shape, dtype=np.float32) -> np.ndarray:
         return generated_array
 
 
-def generate_images(shape=g_shape, dtype=np.float32, automatic_free=True) -> Images:
-    import inspect
-    import uuid
-    array_name = f"{str(uuid.uuid4())}{inspect.stack()[1].function}"
-    if automatic_free:
-        with pu.temp_shared_array(shape, dtype, force_name=array_name) as d:
-            return _set_random_data(d, shape, array_name)
-    else:
-        d = pu.create_array(shape, dtype, array_name)
-        return _set_random_data(d, shape, array_name)
+def generate_images(shape=g_shape, dtype=np.float32) -> Images:
+    d = pu.create_array(shape, dtype)
+    return _set_random_data(d, shape)
 
 
-def _set_random_data(data, shape, array_name):
+def _set_random_data(data, shape):
     n = np.random.rand(*shape)
     # move the data in the shared array
     data[:] = n[:]
 
     images = Images(data)
-    images.memory_filename = array_name
     return images
 
 

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -30,9 +30,9 @@ def generate_shared_array_and_copy(shape=g_shape) -> Tuple[np.ndarray, np.ndarra
 
 
 def generate_shared_array(shape=g_shape, dtype=np.float32) -> np.ndarray:
-    with pu.temp_shared_array(shape, dtype) as generated_array:
-        np.copyto(generated_array, np.random.rand(shape[0], shape[1], shape[2]).astype(dtype))
-        return generated_array
+    generated_array = pu.create_array(shape, dtype)
+    np.copyto(generated_array, np.random.rand(shape[0], shape[1], shape[2]).astype(dtype))
+    return generated_array
 
 
 def generate_images(shape=g_shape, dtype=np.float32) -> Images:
@@ -49,17 +49,12 @@ def _set_random_data(data, shape):
     return images
 
 
-def gen_empty_shared_array(shape=g_shape):
-    with pu.temp_shared_array(shape) as d:
-        return d
-
-
 def gen_img_shared_array_with_val(val=1., shape=g_shape):
-    with pu.temp_shared_array(shape) as d:
-        n = np.full(shape, val)
-        # move the data in the shared array
-        d[:] = n[:]
-        return d
+    d = pu.create_array(shape)
+    n = np.full(shape, val)
+    # move the data in the shared array
+    d[:] = n[:]
+    return d
 
 
 def assert_not_equals(one: np.ndarray, two: np.ndarray):
@@ -167,12 +162,6 @@ class IgnoreOutputStreams(object):
         # Restore the default streams
         sys.stdout = self.stdout
         sys.stderr = self.stderr
-
-
-def shared_deepcopy(images: Images) -> np.ndarray:
-    with pu.temp_shared_array(images.data.shape) as copy:
-        np.copyto(copy, images.data)
-        return copy
 
 
 def assert_called_once_with(mock: mock.Mock, *args):


### PR DESCRIPTION
I had some time over the weekend to consider the best way to fix the issues on IDAaaS caused by SharedArray. Namely https://github.com/mantidproject/mantidimaging/issues/745 and https://github.com/mantidproject/mantidimaging/issues/747.

Then I remembered that I changed it from `multiprocessing` to `SharedArray` as I suspected that the former was leaking the memory, but this turned out to be wrong after the change [1]. It was just never reverted as it took a bit of time to implement in the first place (I definitely fell into the [sunk cost fallacy](https://www.behavioraleconomics.com/resources/mini-encyclopedia-of-be/sunk-cost-fallacy/) here, and hopefully I learned my lesson!).

But now it's time for it to go, as it's caused a lot of issues for it's supposed "benefits" that we may never use.

This PR reverts the shared array creation to implementation from https://github.com/mantidproject/mantidimaging/commit/df4b3e2a6983d299c9ce71ff53efeceb575d0c97#diff-6b06bb41e81d5a3b1ccac6da5b0f4098583cf306a3194550caa1a169fe1182b4 (look at `parallel/utility.py`)

The core of this change is in the first commit https://github.com/mantidproject/mantidimaging/commit/24d5b31388e8beb45d3835e8dfa070d638d6ecb4. The rest is just cleanup to `free_memory` and all the workarounds added for deleting arrays.

Interestingly, Python itself is adding a built-in module, much like `SharedArray`, called [`shared_memory`](https://docs.python.org/3/library/multiprocessing.shared_memory.html) which provides a similar functionality to `SharedArray`. Perhaps if we ever require the machine global named arrays in the future, that should be the way to go.

### To test

Before starting make sure to open `htop` or another RAM monitoring tool - you'll need to keep an eye on it.

#### Load and kill
- Load a stack
- Rebin it to dims 9999, 9999
	- If the stack is too big, this will fail with Not enough memory warning. Then just use `4096, 4096`, or skip and just duplicate data until you are close to 100% memory
- Once you get to 100%, open operations window, open recon window, and open and **close** a stack comparison window (from workflow -> compare)
- Close some of the stacks - memory usage should go down
- Copy it again or just kill the process from `htop` or similar
	- Note: this must be SIGKILL to prevent any `atexit`s running, although this PR also removes that

#### Safe apply
- Load a stack
- Keep an eye on used RAM post load
- Apply remove outliers (or anything else) with Safe Apply
- The RAM usage should double
- Choose the original - it should fall back to the post-load value
- Redo and choose the new stack, it should also fall back


[1] The real culprit was `ImageItem`, and it has bitten us again - if you [don't call imageItem.close()](https://github.com/mantidproject/mantidimaging/blob/master/mantidimaging/gui/windows/stack_choice/view.py#L164-L165) the memory gets leaked, even if you close the widget.