### PR TITLE
Adds a unique prefix for all allocations of an instance

### DIFF
--- a/mantidimaging/core/parallel/test/utility_test.py
+++ b/mantidimaging/core/parallel/test/utility_test.py
@@ -3,9 +3,10 @@
 
 import mock
 import numpy as np
-
-from mantidimaging.core.parallel.utility import create_array, free_all_owned_by_this_instance, multiprocessing_necessary, execute_impl
 import SharedArray as sa
+
+from mantidimaging.core.parallel.utility import (create_array, execute_impl, free_all_owned_by_this_instance,
+                                                 multiprocessing_necessary)
 
 
 def test_correctly_chooses_parallel():

--- a/mantidimaging/core/parallel/test/utility_test.py
+++ b/mantidimaging/core/parallel/test/utility_test.py
@@ -42,7 +42,6 @@ def test_execute_impl_par(mock_pool):
 
 
 def test_free_all_owned_by_this_instance():
-    [sa.delete(x.name.decode("utf-8")) for x in sa.list()]
     create_array((10, 10), np.float32, random_name=True)
     create_array((10, 10), np.float32, random_name=True)
     create_array((10, 10), np.float32, random_name=True)
@@ -50,9 +49,12 @@ def test_free_all_owned_by_this_instance():
     temp_name = "not_this_instance"
     sa.create("not_this_instance", (10, 10))
 
-    assert len(sa.list()) == 4
+    # these tests run in parallel, this should avoid some race conditions at least
+    initial = len(sa.list())
+    # frees the 3 allocated above
     free_all_owned_by_this_instance()
-    assert len(sa.list()) == 1
+    expected = initial - 3
+    assert len(sa.list()) == expected
     sa.delete(temp_name)
 
 

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -24,9 +24,16 @@ SimpleCType = Union[Type[ctypes.c_uint8], Type[ctypes.c_uint16], Type[ctypes.c_i
 
 NP_DTYPE = Type[np.single]
 
+INSTANCE_PREFIX = str(uuid.uuid4())
+
+
+def free_all_owned_by_this_instance():
+    for arr in [array for array in sa.list() if array.name.decode("utf-8").startswith(INSTANCE_PREFIX)]:
+        sa.delete(arr.name.decode("utf-8"))
+
 
 def create_shared_name(file_name=None) -> str:
-    return f"{uuid.uuid4()}{f'-{os.path.basename(file_name)}' if file_name is not None else ''}"
+    return f"{INSTANCE_PREFIX}-{uuid.uuid4()}{f'-{os.path.basename(file_name)}' if file_name is not None else ''}"
 
 
 def delete_shared_array(name, silent_failure=False):

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -5,12 +5,10 @@
 import argparse
 import atexit
 import logging
-from mantidimaging.core.parallel.utility import INSTANCE_PREFIX, free_all_owned_by_this_instance
 import warnings
 
-import SharedArray as sa
-
 from mantidimaging import helper as h
+from mantidimaging.core.parallel.utility import free_all_owned_by_this_instance
 from mantidimaging.core.utility.optional_imports import safe_import
 
 formatwarning_orig = warnings.formatwarning

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -5,6 +5,7 @@
 import argparse
 import atexit
 import logging
+from mantidimaging.core.parallel.utility import INSTANCE_PREFIX, free_all_owned_by_this_instance
 import warnings
 
 import SharedArray as sa
@@ -42,11 +43,7 @@ def parse_args():
 
 
 def main():
-    def free_all():
-        for arr in sa.list():
-            sa.delete(arr.name.decode("utf-8"))
-
-    atexit.register(free_all)
+    atexit.register(free_all_owned_by_this_instance)
     args = parse_args()
     # Print version number and exit
     if args.version:
@@ -57,7 +54,6 @@ def main():
 
     h.initialise_logging(logging.getLevelName(args.log_level))
     startup_checks()
-    free_all()
 
     from mantidimaging import gui
     gui.execute()


### PR DESCRIPTION
Only deletes the allocation with the instance prefix on shutdown. Will not touch any other arrays. Handling of hard crashes will be done via #774 

To test:
- Start up two mantid imagings
- Load data in each
- Close one
- The second one should still function as usual, try to applying an operation

Fixes #745