### PR TITLE
versioned docs using sphinx_multiversion

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -46,7 +46,7 @@ jobs:
       - name: docs
         shell: bash -l {0}
         run: |
-          python setup.py docs_api && python setup.py docs
+          python setup.py docs
 
       - name: pytest
         shell: bash -l {0}

--- a/.github/workflows/cos7_testing.yml
+++ b/.github/workflows/cos7_testing.yml
@@ -46,7 +46,7 @@ jobs:
     - name: docs
       uses: ./.github/actions/test
       with:
-        command: python setup.py docs_api && python setup.py docs
+        command: python setup.py docs
         label: centos7
 
     - name: pytest

--- a/.github/workflows/u18_testing.yml
+++ b/.github/workflows/u18_testing.yml
@@ -42,7 +42,7 @@ jobs:
     - name: docs
       uses: ./.github/actions/test
       with:
-        command: python setup.py docs_api && python setup.py docs
+        command: python setup.py docs
 
     - name: pytest
       uses: ./.github/actions/test

--- a/deps/dev-requirements.pip
+++ b/deps/dev-requirements.pip
@@ -6,6 +6,7 @@ mock==3.0.5
 flake8
 pylint
 sphinx
+sphinx-multiversion
 mypy
 yapf
 pytest

--- a/deps/dev-requirements.pip
+++ b/deps/dev-requirements.pip
@@ -6,7 +6,8 @@ mock==3.0.5
 flake8
 pylint
 sphinx
-sphinx-multiversion
+#sphinx-multiversion
+git+https://github.com/samtygier-stfc/sphinx-multiversion.git@prebuild_command
 mypy
 yapf
 pytest

--- a/docs/_static/extra.css
+++ b/docs/_static/extra.css
@@ -1,0 +1,1 @@
+div.versions {margin-top: 10px}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,17 @@
+{%- extends "!layout.html" %}
+{%- block htmltitle %}
+  {% if versions %}
+    <title>{{ title|striptags|e }} - {{ project }} {{ current_version.name }} Documentation</title>
+  {% else %}
+    <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
+  {% endif %}
+{%- endblock %}
+
+{%- block rootrellink %}
+  {% if versions %}
+        <li class="nav-item nav-item-0"><a href="{{ pathto(master_doc)|e }}">{{ project }} {{ current_version.name }} Documentation</a>{{ reldelim1 }}</li>
+  {% else %}
+        <li class="nav-item nav-item-0"><a href="{{ pathto(master_doc)|e }}">{{ shorttitle|e }}</a>{{ reldelim1 }}</li>
+  {% endif %}
+{%- endblock %}
+

--- a/docs/_templates/versioning.html
+++ b/docs/_templates/versioning.html
@@ -1,0 +1,21 @@
+{% if versions %}
+<div class="versions">
+<h3>{{ _('Versions') }}</h3>
+<ul>
+  <li><a href="../{{ pathto("",1)}}index.html">Latest</a></li>
+  {%- for item in versions %}
+  <li><a href="{{ item.url }}">{{ item.name }}</a></li>
+  {%- endfor %}
+</ul>
+</div>
+{% else %}
+<div class="versions">
+<h3>{{ _('Versions') }}</h3>
+<ul>
+  <li><a href="{{ pathto("",1)}}index.html">Latest</a></li>
+  {%- for item in ['0.9.0', '1.0.0', '1.1.0'] %}
+  <li><a href="{{ pathto("",1)}}{{ item }}/index.html">{{ item }}</a></li>
+  {%- endfor %}
+</ul>
+</div>
+{% endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,8 +33,15 @@
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.coverage',
-    'sphinx.ext.viewcode', 'sphinx.ext.githubpages', 'sphinx.ext.imgmath'
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.todo',
+    'sphinx.ext.coverage',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.githubpages',
+    'sphinx.ext.imgmath',
+    'sphinx_multiversion',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -87,13 +94,7 @@ todo_include_todos = True
 # a list of builtin themes.
 html_theme = 'classic'
 
-html_sidebars = {
-    '**': [
-        'localtoc.html',
-        'relations.html',
-        'searchbox.html',
-    ]
-}
+html_sidebars = {'**': ['localtoc.html', 'relations.html', 'searchbox.html', 'versioning.html']}
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -106,6 +107,7 @@ html_theme_options = {}
 html_static_path = ['_static']
 
 # -- Options for HTMLHelp output ------------------------------------------
+html_css_files = ['extra.css']
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'MantidImagingdoc'
@@ -158,3 +160,9 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 
 # Stop sphinx from being a smartypants and merging the -- into a single unicode dash
 html_use_smartypants = False
+
+# sphinx-multiversion
+smv_tag_whitelist = r'^\d+\.\d+\.\d+$'  # tags that look like versions
+smv_branch_whitelist = None  # No branches
+smv_released_pattern = r''
+smv_prebuild_command = "python setup.py docs_api"

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
       - mock
       - pylint
       - sphinx
-      - sphinx-multiversion
+      - git+https://github.com/samtygier-stfc/sphinx-multiversion.git@prebuild_command
       - pytest-randomly
       - pytest-parallel
       - psutil

--- a/environment.yml
+++ b/environment.yml
@@ -27,6 +27,7 @@ dependencies:
       - mock
       - pylint
       - sphinx
+      - sphinx-multiversion
       - pytest-randomly
       - pytest-parallel
       - psutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ max-line-length = 120
 column_limit = 120
 based_on_style = pep8
 
-[docs]
+[internal_docs]
 build-dir = docs/build
 
 [isort]

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ import fnmatch
 import os
 import subprocess
 from distutils.core import Command
+import sys
 
 from setuptools import find_packages, setup
 from sphinx.setup_command import BuildDoc
@@ -81,6 +82,31 @@ class GenerateSphinxApidoc(Command):
         subprocess.call(self.sphinx_options)
 
 
+class GenerateSphinxVersioned(Command):
+    description = "Generate API documentation with versions in directories"
+    user_options = []
+
+    def initialize_options(self):
+        self.sphinx_multiversion_executable = None
+        self.sphinx_multiversion_options = None
+
+    def finalize_options(self):
+        self.sphinx_multiversion_executable = "sphinx-multiversion"
+        self.sphinx_multiversion_options = ["docs", "docs/build/html"]
+
+    def run(self):
+        print("Running setup.py internal_docs_api")
+        command_docs_api = [sys.executable, "setup.py", "internal_docs_api"]
+        subprocess.check_call(command_docs_api)
+        print("Running setup.py internal_docs")
+        command_docs = [sys.executable, "setup.py", "internal_docs"]
+        subprocess.check_call(command_docs)
+        print("Running sphinx-multiversion")
+        command_sphinx_multiversion = [self.sphinx_multiversion_executable]
+        command_sphinx_multiversion.extend(self.sphinx_multiversion_options)
+        subprocess.check_call(command_sphinx_multiversion)
+
+
 class CompilePyQtUiFiles(Command):
     description = "Compiles any PyQt .ui files found in the source tree"
     user_options = []
@@ -135,8 +161,9 @@ setup(
         "Topic :: Scientific/Engineering",
     ],
     cmdclass={
-        "docs_api": GenerateSphinxApidoc,
-        "docs": BuildDoc,
+        "internal_docs_api": GenerateSphinxApidoc,
+        "internal_docs": BuildDoc,
+        "docs": GenerateSphinxVersioned,
         "docs_publish": PublishDocsToGitHubPages,
         "compile_ui": CompilePyQtUiFiles,
     },


### PR DESCRIPTION
Fixes #743

sphinx-multiversion can build a copy of the documentation for each tag
and place in a subfolder. The existing spinx setup can build the top
level latest version. versioning.html gives links to version in the
sidebar. layout.html overrides the main template to use correct versions
in the title and top navigation bar.

Note this requires a patch to sphinx_multiversion to allow calling a
prebuild command. This is used to call the docs_api for each checkout.
Holzhaus/sphinx-multiversion#62

To build the versioned docs:

```
python setup.py docs_versioned
```

This will build the api files, then the top level docs, then the
versioned docs.