### PR TITLE
Remove Export action from StackVisualiser context menu

### DIFF
--- a/mantidimaging/gui/dialogs/cor_inspection/recon_slice_view.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/recon_slice_view.py
@@ -89,6 +89,18 @@ class CompareSlicesView(GraphicsLayoutWidget):
         for img in self.less_img, self.current_img, self.more_img:
             img.hoverEvent = lambda ev: self.mouse_over(ev)
 
+        # Work around for https://github.com/mantidproject/mantidimaging/issues/565
+        for scene in [
+                self.less_img.scene(),
+                self.less_hist.scene(),
+                self.current_img.scene(),
+                self.current_hist.scene(),
+                self.more_img.scene(),
+                self.more_hist.scene(),
+        ]:
+
+            scene.contextMenu = [item for item in scene.contextMenu if "export" not in item.text().lower()]
+
     def mouse_over(self, ev):
         # Ignore events triggered by leaving window or right clicking
         if ev.exit:

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -94,6 +94,10 @@ class MIImageView(ImageView):
 
         self.imageItem.sigImageChanged.connect(self._refresh_message)
 
+        # Work around for https://github.com/mantidproject/mantidimaging/issues/565
+        for scene in [self.scene, self.ui.roiPlot.sceneObj, self.ui.histogram.sceneObj]:
+            scene.contextMenu = [item for item in scene.contextMenu if "export" not in item.text().lower()]
+
     def toggle_jumping_frame(self, images_to_jump_by=None):
         if not self.shifting_through_images and images_to_jump_by is not None:
             self.shifting_through_images = True

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -90,6 +90,17 @@ class FilterPreviews(GraphicsLayoutWidget):
 
         self.init_histogram()
 
+        # Work around for https://github.com/mantidproject/mantidimaging/issues/565
+        for scene in [
+                self.image_before.scene(),
+                self.image_before_hist.scene(),
+                self.image_after.scene(),
+                self.image_after_hist.scene(),
+                self.image_difference.scene(),
+                self.image_difference_hist.scene(),
+        ]:
+            scene.contextMenu = [item for item in scene.contextMenu if "export" not in item.text().lower()]
+
     def resizeEvent(self, ev: QResizeEvent):
         if ev is not None:
             size = ev.size()

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -52,6 +52,17 @@ class ReconImagesView(GraphicsLayoutWidget):
         self.sinogram.hoverEvent = lambda ev: self.mouse_over(ev, self.sinogram)
         self.recon.hoverEvent = lambda ev: self.mouse_over(ev, self.recon)
 
+        # Work around for https://github.com/mantidproject/mantidimaging/issues/565
+        for scene in [
+                self.projection.scene(),
+                self.projection_hist.scene(),
+                self.sinogram.scene(),
+                self.sinogram_hist.scene(),
+                self.recon.scene(),
+                self.recon_hist.scene(),
+        ]:
+            scene.contextMenu = [item for item in scene.contextMenu if "export" not in item.text().lower()]
+
     def slice_line_moved(self):
         self.slice_changed(int(self.slice_line.value()))
 


### PR DESCRIPTION
To workaround #565 hide the broken Export option

This removes the action for the GraphicsScene instance, so that it does not get
added to the context menu in GraphicsScene.addParentContextMenus()