### PR TITLE
Load images when only flat or dark is selected

### DIFF
--- a/mantidimaging/core/io/loader/__init__.py
+++ b/mantidimaging/core/io/loader/__init__.py
@@ -2,4 +2,4 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .loader import (  # noqa: F401
-    load, load_p, load_log, read_in_file_information, supported_formats)
+    load, load_stack, load_p, load_log, read_in_file_information, supported_formats)

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-
+import os
 from dataclasses import dataclass
 from logging import getLogger
 from typing import Tuple, List
@@ -10,7 +10,7 @@ import numpy as np
 from mantidimaging.core.data import Images
 from mantidimaging.core.data.dataset import Dataset
 from mantidimaging.core.io.loader import img_loader
-from mantidimaging.core.io.utility import (DEFAULT_IO_FILE_FORMAT, get_file_names)
+from mantidimaging.core.io.utility import (DEFAULT_IO_FILE_FORMAT, get_file_names, get_prefix, get_file_extension)
 from mantidimaging.core.utility.data_containers import ImageParameters
 from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
 
@@ -112,6 +112,14 @@ def load_p(parameters: ImageParameters, dtype, progress) -> Images:
                 indices=parameters.indices,
                 dtype=dtype,
                 progress=progress).sample
+
+
+def load_stack(file_path: str, progress=None) -> Images:
+    image_format = get_file_extension(file_path)
+    prefix = get_prefix(file_path)
+    file_names = get_file_names(path=os.path.dirname(file_path), img_format=image_format, prefix=prefix)
+
+    return load(file_names=file_names, progress=progress).sample
 
 
 def load(input_path=None,

--- a/mantidimaging/core/io/loader/test/loader_test.py
+++ b/mantidimaging/core/io/loader/test/loader_test.py
@@ -23,5 +23,6 @@ class LoaderTest(unittest.TestCase):
         load_stack(file_path, progress)
 
         load_mock.assert_called_once_with(file_names=file_names, progress=progress)
-        get_file_names_mock.assert_called_once_with(path="/path/to/file/that/is", img_format="tif",
+        get_file_names_mock.assert_called_once_with(path="/path/to/file/that/is",
+                                                    img_format="tif",
                                                     prefix="/path/to/file/that/is/fake.ti")

--- a/mantidimaging/core/io/loader/test/loader_test.py
+++ b/mantidimaging/core/io/loader/test/loader_test.py
@@ -2,10 +2,26 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest
+from unittest import mock
 
+from mantidimaging.core.io.loader import load_stack
 from mantidimaging.core.io import loader
 
 
 class LoaderTest(unittest.TestCase):
     def test_raise_on_invalid_format(self):
         self.assertRaises(ValueError, loader.load, "/some/path", file_names=["/somefile"], in_format='txt')
+
+    @mock.patch("mantidimaging.core.io.loader.loader.load")
+    @mock.patch("mantidimaging.core.io.loader.loader.get_file_names")
+    def test_load_stack(self, get_file_names_mock: mock.Mock, load_mock: mock.Mock):
+        file_names = mock.Mock()
+        progress = mock.Mock()
+        file_path = "/path/to/file/that/is/fake.tif"
+        get_file_names_mock.return_value = file_names
+
+        load_stack(file_path, progress)
+
+        load_mock.assert_called_once_with(file_names=file_names, progress=progress)
+        get_file_names_mock.assert_called_once_with(path="/path/to/file/that/is", img_format="tif",
+                                                    prefix="/path/to/file/that/is/fake.ti")

--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -94,7 +94,8 @@ def get_file_names(path, img_format, prefix='', essential=True) -> List[str]:
     return files_match
 
 
-def find_images_in_same_directory(sample_dirname: Path, type: str, suffix: str, image_format: str) -> Optional[List[str]]:
+def find_images_in_same_directory(sample_dirname: Path, type: str, suffix: str,
+                                  image_format: str) -> Optional[List[str]]:
     prefix_list = [f"*{type}", f"*{type.lower()}", f"*{type}_{suffix}", f"*{type.lower()}_{suffix}"]
 
     for prefix in prefix_list:

--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -7,7 +7,8 @@ import os
 import re
 
 from logging import getLogger
-from typing import List
+from pathlib import Path
+from typing import List, Optional
 
 DEFAULT_IO_FILE_FORMAT = 'tif'
 
@@ -91,6 +92,19 @@ def get_file_names(path, img_format, prefix='', essential=True) -> List[str]:
     log.debug(f'Found {len(files_match)} files with common prefix: {os.path.commonprefix(files_match)}')
 
     return files_match
+
+
+def find_images_in_same_directory(sample_dirname: Path, type: str, suffix: str, image_format: str) -> Optional[List[str]]:
+    prefix_list = [f"*{type}", f"*{type.lower()}", f"*{type}_{suffix}", f"*{type.lower()}_{suffix}"]
+
+    for prefix in prefix_list:
+        try:
+            if suffix != "After":
+                return get_file_names(sample_dirname.absolute(), image_format, prefix=prefix)
+        except RuntimeError:
+            getLogger(__name__).info(f"Could not find {prefix} files in {sample_dirname.absolute()}")
+
+    return None
 
 
 def get_folder_names(path):

--- a/mantidimaging/gui/ui/main_window.ui
+++ b/mantidimaging/gui/ui/main_window.ui
@@ -35,6 +35,7 @@
      <string>File</string>
     </property>
     <addaction name="actionLoad"/>
+    <addaction name="actionLoadImages"/>
     <addaction name="actionSampleLoadLog"/>
     <addaction name="actionLoadProjectionAngles"/>
     <addaction name="actionLoad180deg"/>
@@ -76,7 +77,7 @@
   </widget>
   <action name="actionLoad">
    <property name="text">
-    <string>Load</string>
+    <string>Load dataset</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+O</string>
@@ -191,6 +192,11 @@
    </property>
    <property name="text">
     <string>Load projection angles...</string>
+   </property>
+  </action>
+  <action name="actionLoadImages">
+   <property name="text">
+    <string>Load images stack</string>
    </property>
   </action>
  </widget>

--- a/mantidimaging/gui/ui/main_window.ui
+++ b/mantidimaging/gui/ui/main_window.ui
@@ -196,7 +196,7 @@
   </action>
   <action name="actionLoadImages">
    <property name="text">
-    <string>Load images stack</string>
+    <string>Load images</string>
    </property>
   </action>
  </widget>

--- a/mantidimaging/gui/ui/main_window.ui
+++ b/mantidimaging/gui/ui/main_window.ui
@@ -34,7 +34,7 @@
     <property name="title">
      <string>File</string>
     </property>
-    <addaction name="actionLoad"/>
+    <addaction name="actionLoadDataset"/>
     <addaction name="actionLoadImages"/>
     <addaction name="actionSampleLoadLog"/>
     <addaction name="actionLoadProjectionAngles"/>
@@ -75,7 +75,7 @@
    <addaction name="menuImage"/>
    <addaction name="menuHelp"/>
   </widget>
-  <action name="actionLoad">
+  <action name="actionLoadDataset">
    <property name="text">
     <string>Load dataset</string>
    </property>

--- a/mantidimaging/gui/windows/load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/load_dialog/presenter.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 from mantidimaging.core.io.loader import load_log
 from mantidimaging.core.io.loader.loader import read_in_file_information, FileInformation
-from mantidimaging.core.io.utility import get_file_extension, get_prefix, get_file_names
+from mantidimaging.core.io.utility import get_file_extension, get_prefix, get_file_names, find_images_in_same_directory
 from mantidimaging.core.utility.data_containers import LoadingParameters, ImageParameters
 from mantidimaging.gui.windows.load_dialog.field import Field
 
@@ -104,21 +104,9 @@ class LoadPresenter:
         self.view.sample.update_indices(self.last_file_info.shape[0])
         self.view.sample.update_shape(self.last_file_info.shape[1:])
 
-    def _find_images_in_same_directory(self, sample_dirname: Path, type: str, suffix: str) -> Optional[List[str]]:
-        prefix_list = [f"*{type}", f"*{type.lower()}", f"*{type}_{suffix}", f"*{type.lower()}_{suffix}"]
-
-        for prefix in prefix_list:
-            try:
-                if suffix != "After":
-                    return get_file_names(sample_dirname.absolute(), self.image_format, prefix=prefix)
-            except RuntimeError:
-                logger.info(f"Could not find {prefix} files in {sample_dirname.absolute()}")
-
-        return None
-
     def _find_images(self, sample_dirname: Path, type: str, suffix: str, look_without_suffix=False) -> List[str]:
         # same folder
-        file_names = self._find_images_in_same_directory(sample_dirname, type, suffix)
+        file_names = find_images_in_same_directory(sample_dirname, type, suffix, self.image_format)
         if file_names is not None:
             return file_names
 

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -51,6 +51,10 @@ class MainWindowModel(object):
 
         return ds
 
+    @staticmethod
+    def load_stack(file_path: str, progress) -> Images:
+        return loader.load_stack(file_path, progress)
+
     def do_saving(self, stack_uuid, output_dir, name_prefix, image_format, overwrite, pixel_depth, progress):
         svp = self.get_stack_visualiser(stack_uuid).presenter
         filenames = saver.save(svp.images,

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -302,6 +302,11 @@ class MainWindowModelTest(unittest.TestCase):
         stack_mock.return_value.widget.return_value.presenter.images.set_projection_angles.assert_called_once_with(
             proj_angles)
 
+    @mock.patch("mantidimaging.gui.windows.main.model.loader")
+    def test_load_stack(self, loader: mock.MagicMock):
+        file_path = "file_path"
+        progress = mock.Mock()
 
-if __name__ == '__main__':
-    unittest.main()
+        self.model.load_stack(file_path, progress)
+
+        loader.load_stack.assert_called_once_with(file_path, progress)

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -46,7 +46,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.show_error_dialog.assert_called_once_with(self.presenter.SAVE_ERROR_STRING.format(task.error))
 
     @mock.patch("mantidimaging.gui.windows.main.presenter.start_async_task_view")
-    def test_load_stack(self, start_async_mock: mock.Mock):
+    def test_dataset_stack(self, start_async_mock: mock.Mock):
         parameters_mock = mock.Mock()
         parameters_mock.sample.input_path.return_value = "123"
         self.view.load_dialogue.get_parameters.return_value = parameters_mock
@@ -54,7 +54,16 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.load_dataset()
 
         start_async_mock.assert_called_once_with(self.view, self.presenter.model.do_load_stack,
-                                                 self.presenter._on_stack_load_done, {'parameters': parameters_mock})
+                                                 self.presenter._on_dataset_load_done, {'parameters': parameters_mock})
+
+    @mock.patch("mantidimaging.gui.windows.main.presenter.start_async_task_view")
+    def test_load_stack(self, start_async_mock: mock.Mock):
+        file_path = mock.Mock()
+
+        self.presenter.load_image_stack(file_path)
+
+        start_async_mock.assert_called_once_with(self.view, self.presenter.model.load_stack,
+                                                 self.presenter._on_stack_load_done, {'file_path': file_path})
 
     def test_make_stack_window(self):
         images = generate_images()

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -51,7 +51,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         parameters_mock.sample.input_path.return_value = "123"
         self.view.load_dialogue.get_parameters.return_value = parameters_mock
 
-        self.presenter.load_stack()
+        self.presenter.load_dataset()
 
         start_async_mock.assert_called_once_with(self.view, self.presenter.model.do_load_stack,
                                                  self.presenter._on_stack_load_done, {'parameters': parameters_mock})

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -306,3 +306,12 @@ class MainWindowViewTest(unittest.TestCase):
 
         self.presenter.get_stack_visualiser.assert_called_once_with(uuid)
         self.assertEqual(images, return_value)
+
+    def test_load_image_stack(self):
+        selected_file = "file_name"
+        self.view._get_file_name = mock.MagicMock(return_value=selected_file)
+
+        self.view.load_image_stack()
+
+        self.presenter.load_image_stack.assert_called_once_with(selected_file)
+        self.view._get_file_name.assert_called_once_with("Image", "Image File (*.tif *.tiff)")

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -49,7 +49,7 @@ class MainWindowView(BaseMainWindowView):
     actionSampleLoadLog: QAction
     actionLoadProjectionAngles: QAction
     actionLoad180deg: QAction
-    actionLoad: QAction
+    actionLoadDataset: QAction
     actionLoadImages: QAction
     actionSave: QAction
     actionExit: QAction
@@ -83,7 +83,7 @@ class MainWindowView(BaseMainWindowView):
             self.show_about()
 
     def setup_shortcuts(self):
-        self.actionLoad.triggered.connect(self.show_load_dialogue)
+        self.actionLoadDataset.triggered.connect(self.show_load_dialogue)
         self.actionLoadImages.triggered.connect(self.load_image_stack)
         self.actionSampleLoadLog.triggered.connect(self.load_sample_log_dialog)
         self.actionLoad180deg.triggered.connect(self.load_180_deg_dialog)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -154,7 +154,7 @@ class MainWindowView(BaseMainWindowView):
         if selected_file == "":
             return
 
-        stack = self.presenter.load_image_stack(selected_file)
+        self.presenter.load_image_stack(selected_file)
 
     def load_sample_log_dialog(self):
         stack_selector = StackSelectorDialog(main_window=self,

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -50,6 +50,7 @@ class MainWindowView(BaseMainWindowView):
     actionLoadProjectionAngles: QAction
     actionLoad180deg: QAction
     actionLoad: QAction
+    actionLoadImages: QAction
     actionSave: QAction
     actionExit: QAction
 
@@ -83,6 +84,7 @@ class MainWindowView(BaseMainWindowView):
 
     def setup_shortcuts(self):
         self.actionLoad.triggered.connect(self.show_load_dialogue)
+        self.actionLoadImages.triggered.connect(self.load_image_stack)
         self.actionSampleLoadLog.triggered.connect(self.load_sample_log_dialog)
         self.actionLoad180deg.triggered.connect(self.load_180_deg_dialog)
         self.actionLoadProjectionAngles.triggered.connect(self.load_projection_angles)
@@ -137,6 +139,23 @@ class MainWindowView(BaseMainWindowView):
         self.load_dialogue = MWLoadDialog(self)
         self.load_dialogue.show()
 
+    @staticmethod
+    def _get_file_name(caption: str, file_filter: str) -> str:
+        selected_file, _ = QFileDialog.getOpenFileName(caption=caption,
+                                                       filter=f"{file_filter};;All (*.*)",
+                                                       initialFilter=file_filter)
+        return selected_file
+
+    def load_image_stack(self):
+        # Open file dialog
+        selected_file = self._get_file_name("Image", "Image File (*.tif *.tiff)")
+
+        # Cancel/Close was clicked
+        if selected_file == "":
+            return
+
+        stack = self.presenter.load_image_stack(selected_file)
+
     def load_sample_log_dialog(self):
         stack_selector = StackSelectorDialog(main_window=self,
                                              title="Stack Selector",
@@ -147,10 +166,8 @@ class MainWindowView(BaseMainWindowView):
         stack_to_add_log_to = stack_selector.selected_stack
 
         # Open file dialog
-        file_filter = "Log File (*.txt *.log)"
-        selected_file, _ = QFileDialog.getOpenFileName(caption="Log to be loaded",
-                                                       filter=f"{file_filter};;All (*.*)",
-                                                       initialFilter=file_filter)
+        selected_file = self._get_file_name("Log to be loaded", "Log File (*.txt *.log)")
+
         # Cancel/Close was clicked
         if selected_file == "":
             return
@@ -170,10 +187,8 @@ class MainWindowView(BaseMainWindowView):
         stack_to_add_180_deg_to = stack_selector.selected_stack
 
         # Open file dialog
-        file_filter = "Image File (*.tif *.tiff)"
-        selected_file, _ = QFileDialog.getOpenFileName(caption="180 Degree Image",
-                                                       filter=f"{file_filter};;All (*.*)",
-                                                       initialFilter=file_filter)
+        selected_file = self._get_file_name("180 Degree Image", "Image File (*.tif *.tiff)")
+
         # Cancel/Close was clicked
         if selected_file == "":
             return


### PR DESCRIPTION
Added functionality that allows users to load an individual stack instead of as a "sample" as part of a dataset.

Wonder if we have too many load options now, wizard time for loading?

To test:
- Open Imaging
- Click File->Load images stack
- Select an image from a stack and it should load the full stack from the same directory

Fixes #648