### PR TITLE
Pin all dependency versions

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -15,27 +15,27 @@ source:
 
 requirements:
   build:
-    - python==3.6.*
-    - pip==20.3.3
-    - setuptools==50.0.0
-    - sphinx==3.3.1
+    - python=3.6.*
+    - pip=20.3.3
+    - setuptools=50.0.0
+    - sphinx=3.3.1
   run:
-    - python==3.6.*
-    - pip==20.3.3
-    - astropy==4.2
-    - scipy==1.5.3
+    - python=3.6.*
+    - pip=20.3.3
+    - astropy=4.2
+    - scipy=1.5.3
     - scikit-image=0.17.2
     - sharedarray=3.2.1
-    - numpy==1.19.4
+    - numpy=1.19.4
     - tomopy=1.7.1=cuda*
     - cudatoolkit=10.2*
-    - astra-toolbox==1.8.3
-    - requests==2.25.1
-    - requests-futures==1.0.0
-    - python-socketio==5.0.3
-    - h5py==3.1.0
-    - sarepy==2020.07
-    - psutil==5.7.3
+    - astra-toolbox=1.9.9.dev4
+    - requests=2.25.1
+    - requests-futures=1.0.0
+    - python-socketio=5.0.3
+    - h5py=3.1.0
+    - sarepy=2020.07
+    - psutil=5.7.3
 
 build:
   number: 1

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -15,27 +15,27 @@ source:
 
 requirements:
   build:
-    - python
-    - pip
-    - setuptools
-    - sphinx
+    - python==3.6.*
+    - pip==20.3.3
+    - setuptools==50.0.0
+    - sphinx==3.3.1
   run:
-    - python
-    - pip
-    - astropy
-    - scipy
+    - python==3.6.*
+    - pip==20.3.3
+    - astropy==4.2
+    - scipy==1.5.3
     - scikit-image=0.17.2
-    - sharedarray
-    - numpy
+    - sharedarray=3.2.1
+    - numpy==1.19.4
     - tomopy=1.7.1=cuda*
     - cudatoolkit=10.2*
-    - astra-toolbox
-    - requests
-    - requests-futures
-    - python-socketio
-    - h5py
-    - sarepy
-    - psutil
+    - astra-toolbox==1.8.3
+    - requests==2.25.1
+    - requests-futures==1.0.0
+    - python-socketio==5.0.3
+    - h5py==3.1.0
+    - sarepy==2020.07
+    - psutil==5.7.3
 
 build:
   number: 1

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -15,12 +15,12 @@ source:
 
 requirements:
   build:
-    - python=3.6.*
+    - python=3.7.*
     - pip=20.3.3
     - setuptools=50.0.0
     - sphinx=3.3.1
   run:
-    - python=3.6.*
+    - python=3.7.*
     - pip=20.3.3
     - astropy=4.2
     - scipy=1.5.3

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -17,7 +17,7 @@ requirements:
   build:
     - python=3.7.*
     - pip=20.3.3
-    - setuptools=50.0.0
+    - setuptools=49.6.0
     - sphinx=3.3.1
   run:
     - python=3.7.*

--- a/environment.yml
+++ b/environment.yml
@@ -7,9 +7,9 @@ channels:
   - defaults
 dependencies:
   - mantidimaging
-  - pip==20.3.3
-  - sarepy==2020.07
-  - astra-toolbox==1.8.3
+  - pip=20.3.3
+  - sarepy=2020.07
+  - astra-toolbox=1.9.9.dev4
   - pip:
       - pytest==6.2.1
       - pytest-cov==2.10.1

--- a/environment.yml
+++ b/environment.yml
@@ -7,27 +7,27 @@ channels:
   - defaults
 dependencies:
   - mantidimaging
-  - pip
-  - sharedarray
-  - sarepy
-  - astra-toolbox
+  - pip==20.3.3
+  - sarepy==2020.07
+  - astra-toolbox==1.8.3
   - pip:
-      - pytest
-      - pytest-cov
-      - coveralls
+      - pytest==6.2.1
+      - pytest-cov==2.10.1
+      - coveralls==2.2.0
       - pyqt5==5.15
       - pyqtgraph==0.11
-      - yapf
-      - mypy
-      - flake8
-      - testfixtures
-      - coverage
-      - hazelnut
-      - gitpython
-      - mock
-      - pylint
-      - sphinx
-      - pytest-randomly
-      - pytest-parallel
-      - psutil
-      - isort
+      - yapf==0.30.0
+      - mypy==0.790
+      - flake8==3.8.4
+      - testfixtures==6.17.0
+      - coverage==5.3
+      - hazelnut==0.4.1
+      - gitpython==3.1.11
+      - mock==4.0.3
+      - pylint==2.6.0
+      - sphinx==3.3.1
+      - git+https://github.com/samtygier-stfc/sphinx-multiversion.git@prebuild_command
+      - pytest-randomly==3.5.0
+      - pytest-parallel==0.1.0
+      - psutil==5.7.3
+      - isort==5.6.4

--- a/environment.yml
+++ b/environment.yml
@@ -32,3 +32,4 @@ dependencies:
       - pytest-parallel==0.1.0
       - psutil==5.7.3
       - isort==5.6.4
+      - sharedarray=3.2.1

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ channels:
   - defaults
 dependencies:
   - mantidimaging
+  - python=3.7.*
   - pip=20.3.3
   - sarepy=2020.07
   - astra-toolbox=1.9.9.dev4

--- a/environment.yml
+++ b/environment.yml
@@ -32,4 +32,4 @@ dependencies:
       - pytest-parallel==0.1.0
       - psutil==5.7.3
       - isort==5.6.4
-      - sharedarray=3.2.1
+      - sharedarray==3.2.1

--- a/setup.py
+++ b/setup.py
@@ -140,5 +140,5 @@ setup(
         "docs_publish": PublishDocsToGitHubPages,
         "compile_ui": CompilePyQtUiFiles,
     },
-    install_requires=["h5py", "numpy", "python-socketio", "pyqt5==5.15", "pyqtgraph==0.11"],
+    install_requires=["h5py==3.1.0", "numpy==1.19.4", "python-socketio==5.0.3", "pyqt5==5.15", "pyqtgraph==0.11"],
 )


### PR DESCRIPTION
Pinning versions so we control when an update change happens, should help with regression management.

Test is just checking builds pass on PR and on master afterwards.