### PR TITLE
Fixes for Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Create a report to help us improve.
+about: Report an issue that you've encountered.
 title: ''
 labels: 'bug'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,3 +34,4 @@ assignees: ''
 ### Screenshot(s)
 
 <!--- [Optional] Include screenshots that illustrate the problem. -->
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,36 @@
 ---
-name: Bug report
-about: Create a report to help us improve
+name: Bug Report
+about: Create a report to help us improve.
 title: ''
 labels: ''
 assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+### Summary
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+<!--- Please provide information about the failure. -->
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+### Steps To Reproduce
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!--- Please provide detailed steps for reproducing this issue. -->
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+### Expected Behaviour
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+<!--- Explain how the program should behave once the issue has been resolved. -->
 
-**Additional context**
-Add any other context about the problem here.
+### Current Behaviour
+
+<!--- Please provide information about the undesired current behaviour. -->
+
+### Context
+
+<!--- Please provide any relevant information about your system setup. Mantid Imaging version can be obtained by running `conda list mantidimaging` and system information can be obtained by running `uname -a`. -->
+
+### Failure Logs
+
+<!--- [Optional] Please include any relevant log snippets here. -->
+
+### Screenshot(s)
+
+<!--- [Optional] Include screenshots that illustrate the problem. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug Report
 about: Create a report to help us improve.
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,4 +34,3 @@ assignees: ''
 ### Screenshot(s)
 
 <!--- [Optional] Include screenshots that illustrate the problem. -->
-

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,27 +1,38 @@
-### Summary
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
 
-<!--- Please provide information about the failure. -->
+---
 
-### Steps To Reproduce
+**Describe the bug**
+A clear and concise description of what the bug is.
 
-<!--- Please provide detailed steps for reproducing this issue. -->
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
 
-### Expected Behaviour
+**Expected behavior**
+A clear and concise description of what you expected to happen.
 
-<!--- Explain how the program should behave once the issue has been resolved. -->
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
 
-### Current Behaviour
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
 
-<!--- Please provide information about the undesired current behaviour. -->
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
 
-### Context
-
-<!--- Please provide any relevant information about your system setup. Mantid Imaging version can be obtained by running `conda list mantidimaging` and system information can be obtained by running `uname -a`. -->
-
-### Failure Logs
-
-<!--- [Optional] Please include any relevant log snippets here. -->
-
-### Screenshot(s)
-
-<!--- [Optional] Include screenshots that illustrate the problem. -->
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature / Improvement Request
-about: Suggest an idea for this project.
+about: Request an improvement or a new feature.
 title: ''
 labels: 'enhancement'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,16 @@
 ---
-name: Feature request
-about: Suggest an idea for this project
+name: Feature / Improvement Request
+about: Suggest an idea for this project.
 title: ''
 labels: ''
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+### Desired Behaviour
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!--- Explain how the program should behave once the issue has been resolved. -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+### Current Behaviour
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+<!--- Please provide information about the undesired current behaviour. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,20 @@
-### Desired Behaviour
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
 
-<!--- Explain how the program should behave once the issue has been resolved. -->
+---
 
-### Current Behaviour
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-<!--- Please provide information about the undesired current behaviour. -->
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
 
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature / Improvement Request
 about: Suggest an idea for this project.
 title: ''
-labels: ''
+labels: 'enhancement'
 assignees: ''
 
 ---


### PR DESCRIPTION
### Issue

Closes #795 

### Description

Allows issue templates to be selected from a menu when you click on new issue.

### Testing 

n/a

### Acceptance Criteria 

Create issues in my fork: https://github.com/DolicaAkelloEgwel/mantidimaging

You should then see this:
![image](https://user-images.githubusercontent.com/43887608/103666521-a6e4b200-4f6c-11eb-9af2-4b3a640d2ba5.png)

Check that the bug and enhancement tags are automatically added to the corresponding issue types.

### Documentation

n/a
