### PR TITLE
788: Reconstruct slice not in history

### DIFF
--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -117,7 +117,7 @@ class AstraRecon(BaseRecon):
         progress = Progress.ensure_instance(progress, num_steps=images.height)
         output_shape = (images.num_sinograms, images.width, images.width)
         output_images: Images = Images.create_empty_images(output_shape, images.dtype, images.metadata)
-        output_images.record_operation('AstraRecon.full', 'Reconstruction', **recon_params.to_dict())
+        output_images.record_operation('AstraRecon.full', 'Volume Reconstruction', **recon_params.to_dict())
 
         proj_angles = images.projection_angles(recon_params.max_projection_angle)
         for i in range(images.height):

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -217,7 +217,10 @@ class ReconstructWindowPresenter(BasePresenter):
 
         if images is not None:
             self.view.show_recon_volume(images)
-            images.record_operation('AstraRecon.full', 'Slice Reconstruction', slice_idx=slice_idx, **self.view.recon_params().to_dict())
+            images.record_operation('AstraRecon.full',
+                                    'Slice Reconstruction',
+                                    slice_idx=slice_idx,
+                                    **self.view.recon_params().to_dict())
 
     def _do_refine_selected_cor(self):
         slice_idx = self.model.preview_slice_idx

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -217,6 +217,7 @@ class ReconstructWindowPresenter(BasePresenter):
 
         if images is not None:
             self.view.show_recon_volume(images)
+            images.record_operation('AstraRecon.full', 'Slice Reconstruction', dict())
 
     def _do_refine_selected_cor(self):
         slice_idx = self.model.preview_slice_idx

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -217,7 +217,7 @@ class ReconstructWindowPresenter(BasePresenter):
 
         if images is not None:
             self.view.show_recon_volume(images)
-            images.record_operation('AstraRecon.full',
+            images.record_operation('AstraRecon.single_sino',
                                     'Slice Reconstruction',
                                     slice_idx=slice_idx,
                                     **self.view.recon_params().to_dict())

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -217,7 +217,7 @@ class ReconstructWindowPresenter(BasePresenter):
 
         if images is not None:
             self.view.show_recon_volume(images)
-            images.record_operation('AstraRecon.full', 'Slice Reconstruction', dict())
+            images.record_operation('AstraRecon.full', 'Slice Reconstruction', slice_idx=slice_idx, **self.view.recon_params().to_dict())
 
     def _do_refine_selected_cor(self):
         slice_idx = self.model.preview_slice_idx

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -288,10 +288,17 @@ class ReconWindowPresenterTest(unittest.TestCase):
 
     def test_do_stack_reconstruct_slice(self):
         self.presenter._get_reconstruct_slice = mock.Mock()
-        self.presenter._get_reconstruct_slice.return_value = test_data = np.ndarray(shape=(200, 250), dtype=np.float32)
-        self.presenter.do_stack_reconstruct_slice()
+        self.presenter._get_reconstruct_slice.return_value = test_data = Images(
+            np.ndarray(shape=(200, 250), dtype=np.float32))
+        test_data.record_operation = mock.Mock()
+        slice_idx = 123
+        self.presenter.do_stack_reconstruct_slice(slice_idx=slice_idx)
         self.view.show_recon_volume.assert_called_once()
         np.array_equal(self.view.show_recon_volume.call_args[0][0].data, test_data)
+        test_data.record_operation.assert_called_once_with('AstraRecon.single_sino',
+                                                           'Slice Reconstruction',
+                                                           slice_idx=slice_idx,
+                                                           **self.view.recon_params().to_dict())
 
     def test_do_stack_reconstruct_slice_raises(self):
         self.presenter._get_reconstruct_slice = mock.Mock()


### PR DESCRIPTION
### Issue

Closes #788 

### Description

Records calls to reconstruct slice in the operation history.

### Testing 

Updated the `test_do_stack_reconstruct_slice` test so that it checks `record_operation` is called with the expected arguments.

### Acceptance Criteria 

Use reconstruct slice and check that it's been added to the history. Reconstruct a volume and check that this is also recorded to the history as "Volume Reconstruction." Check that the updated test passes.

### Documentation

n/a
