### PR TITLE
Increase rotate spinbox input range to [-359, 359]

### DIFF
--- a/mantidimaging/core/operations/rotate_stack/rotate_stack.py
+++ b/mantidimaging/core/operations/rotate_stack/rotate_stack.py
@@ -51,7 +51,7 @@ class RotateFilter(BaseFilter):
 
         _, angle = add_property_to_form('Angle of rotation\ncounter clockwise (degrees)',
                                         Type.FLOAT,
-                                        0, (-180, 180),
+                                        0, (-359, 359),
                                         form=form,
                                         on_change=on_change,
                                         tooltip="How much degrees to rotate counter-clockwise")


### PR DESCRIPTION
### Issue
Fixes #809

### Description

*Add a description of the changes made*.

### Testing 

- Load a stack
- Rotate at arbitrary angles and 

### Acceptance Criteria 

Check that output looks OK.

Only expecting `conda` tests to pass as the others' docker images have moved on to Python 3.8 and no sharedarray

Also might be easier to cherry-pick this into master, than rebasing the release branch