### PR TITLE
Rescale now uses image.data.min() for offset to translate negative values

### DIFF
--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -102,9 +102,9 @@ def save(images: Images,
     make_dirs_if_needed(output_dir, overwrite_all)
 
     # Define current parameters
-    min_value = images.data.min()
+    min_value = np.nanmin(images.data)
     offset = abs(min_value)
-    max_value = images.data.max()
+    max_value = np.nanmax(images.data)
     int_16_slope = max_value / INT16_SIZE
 
     # Do rescale if needed.

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -103,7 +103,6 @@ def save(images: Images,
 
     # Define current parameters
     min_value = np.nanmin(images.data)
-    offset = abs(min_value)
     max_value = np.nanmax(images.data)
     int_16_slope = max_value / INT16_SIZE
 
@@ -112,7 +111,7 @@ def save(images: Images,
         rescale_params = None
     elif pixel_depth == "int16":
         # turn the offset to string otherwise json throws a TypeError when trying to save float32
-        rescale_params = {"offset": str(offset), "slope": int_16_slope}
+        rescale_params = {"offset": str(min_value), "slope": int_16_slope}
     else:
         raise ValueError("The pixel depth given is not handled: " + pixel_depth)
 
@@ -155,8 +154,7 @@ def save(images: Images,
                         rescale_single_image(np.copy(images.data[idx]),
                                              min_input=min_value,
                                              max_input=max_value,
-                                             max_output=INT16_SIZE - 1,
-                                             offset=offset), names[idx], overwrite_all)
+                                             max_output=INT16_SIZE - 1), names[idx], overwrite_all)
                 else:
                     write_func(data[idx, :, :], names[idx], overwrite_all)
 
@@ -165,8 +163,8 @@ def save(images: Images,
         return names
 
 
-def rescale_single_image(image: np.ndarray, min_input: float, max_input: float, max_output: float, offset: float):
-    return RescaleFilter.filter_single_image(image, min_input, max_input, max_output, offset, data_type=np.uint16)
+def rescale_single_image(image: np.ndarray, min_input: float, max_input: float, max_output: float):
+    return RescaleFilter.filter_single_image(image, min_input, max_input, max_output, data_type=np.uint16)
 
 
 def generate_names(name_prefix,

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -3,10 +3,8 @@
 
 from functools import partial
 from typing import Dict, Any
-from numpy import uint16, float32, ndarray
-
+from numpy import uint16, float32, ndarray, nanmax, nanmin
 from PyQt5.QtWidgets import QDoubleSpinBox, QComboBox
-
 from mantidimaging.core.data import Images
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.gui.utility.qt_helpers import Type
@@ -35,9 +33,10 @@ class RescaleFilter(BaseFilter):
         images.data[images.data > max_input] = 0
 
         # offset - it removes any negative values so that they don't overflow when in uint16 range
-        images.data += abs(images.data.min())
+        images.data += abs(nanmin(images.data))
+        data_max = nanmax(images.data)
         # slope
-        images.data *= (max_output / images.data.max())
+        images.data *= (max_output / data_max)
 
         if data_type is not None:
             if data_type == uint16 and not images.dtype == uint16:

--- a/mantidimaging/gui/utility/qt_helpers.py
+++ b/mantidimaging/gui/utility/qt_helpers.py
@@ -7,18 +7,14 @@ Module containing helper functions relating to PyQt.
 import os
 from enum import IntEnum, auto
 from logging import getLogger
-from typing import Tuple, Union, TYPE_CHECKING, List, Optional
+from typing import Any, Tuple, Union, List
 
 from PyQt5 import Qt
 from PyQt5 import uic  # type: ignore
 from PyQt5.QtCore import QObject
-from PyQt5.QtWidgets import QLabel, QLineEdit, QPushButton, QSpinBox, QDoubleSpinBox, QCheckBox, QComboBox, QWidget, \
-    QSizePolicy, QAction, QMenu
+from PyQt5.QtWidgets import QLabel, QLineEdit, QSpinBox, QDoubleSpinBox, QCheckBox, QWidget, QSizePolicy, QAction, QMenu
 
 from mantidimaging.core.utility import finder
-
-if TYPE_CHECKING:
-    from mantidimaging.gui.widgets.stack_selector import StackSelectorWidgetView  # pragma: no cover
 
 
 class BlockQtSignals(object):
@@ -66,9 +62,6 @@ def get_value_from_qwidget(widget: QWidget):
         return widget.isChecked()
 
 
-ReturnTypes = Union[QPushButton, QLineEdit, QSpinBox, QDoubleSpinBox, QCheckBox, QComboBox, 'StackSelectorWidgetView']
-
-
 class Type(IntEnum):
     STR = auto()
     TUPLE = auto()
@@ -91,7 +84,7 @@ def add_property_to_form(label: str,
                          on_change=None,
                          form=None,
                          filters_view=None,
-                         run_on_press=None) -> Tuple[Union[QLabel, QLineEdit], Optional[ReturnTypes]]:
+                         run_on_press=None) -> Tuple[Union[QLabel, QLineEdit], Any]:
     """
     Adds a property to the algorithm dialog.
 


### PR DESCRIPTION


Fixes #808 

### Description

Rescale now adds the `abs(min_value)` to the image to translate all the values in range [0, ...]. This prevents issues with negative values overflowing when converted to `uint16` before saving or during Rescale.

The single image takes this offset as a parameter, so that the same one can be used for all images.

Tests have been added for the new functionality.

### Testing 

- Load a stack and reconstruct it
- Check the histogram of the reconstructed images - they're likely to have some pixels with negative values
- Rescale manually to int16
	- Make sure you have a min input that takes the negative values as well, by default it starts at 0 so they will be cropped out
- The whole distribution should look the same, except now it will be in [0, 65535] value range
- Try rescaling to float32 and check that the distribution remains the same

### Acceptance Criteria 

`Conda` tests should pass. The others will fail due to Docker image incompatibility.

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*
Single image takes offset as parameter, so that the same one can be used for all images