### PR TITLE
Add parsing for IMAT CSV Log files

### DIFF
--- a/mantidimaging/core/data/test/fake_logfile.py
+++ b/mantidimaging/core/data/test/fake_logfile.py
@@ -25,9 +25,7 @@ def generate_txt_logfile() -> IMATLogFile:
 
 def generate_csv_logfile() -> IMATLogFile:
     data = [
-        TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE,  # checked if exists, but skipped
-        "",  # skipped when parsing
-        # for each row a list with 4 entries is currently expected
+        CSVLogParser.EXPECTED_HEADER_FOR_IMAT_CSV_LOG_FILE,
         "Sun Feb 10 00:22:04 2019,Projection,0,angle: 0.0,Monitor 3 before: 4577907,Monitor 3 after:  4720271",
         "Sun Feb 10 00:22:37 2019,Projection,1,angle: 0.3152,Monitor 3 before: 4729337,Monitor 3 after:  4871319",
         "Sun Feb 10 00:23:10 2019,Projection,2,angle: 0.6304,Monitor 3 before: 4879923,Monitor 3 after:  5022689",

--- a/mantidimaging/core/data/test/fake_logfile.py
+++ b/mantidimaging/core/data/test/fake_logfile.py
@@ -1,53 +1,42 @@
 # Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile, EXPECTED_HEADER_FOR_IMAT_LOG_FILE
+from mantidimaging.core.utility.imat_log_file_parser import CSVLogParser, IMATLogFile, TextLogParser
 
 
-def generate_logfile() -> IMATLogFile:
+def generate_txt_logfile() -> IMATLogFile:
     data = [
-        EXPECTED_HEADER_FOR_IMAT_LOG_FILE,  # checked if exists, but skipped
-        [""],  # skipped when parsing
+        TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE,  # checked if exists, but skipped
+        "",  # skipped when parsing
         # for each row a list with 4 entries is currently expected
-        [
-            "Sun Feb 10 00:22:04 2019", "Projection:  0  angle: 0.0", "Monitor 3 before:  4577907",
-            "Monitor 3 after:  4720271"
-        ],
-        [
-            "Sun Feb 10 00:22:37 2019", "Projection:  1  angle: 0.3152", "Monitor 3 before:  4729337",
-            "Monitor 3 after:  4871319"
-        ],
-        [
-            "Sun Feb 10 00:23:10 2019", "Projection:  2  angle: 0.6304", "Monitor 3 before:  4879923",
-            "Monitor 3 after:  5022689"
-        ],
-        [
-            "Sun Feb 10 00:23:43 2019", "Projection:  3  angle: 0.9456", "Monitor 3 before:  5031423",
-            "Monitor 3 after:  5172216"
-        ],
-        [
-            "Sun Feb 10 00:24:16 2019", "Projection:  4  angle: 1.2608", "Monitor 3 before:  5180904",
-            "Monitor 3 after:  5322691"
-        ],
-        [
-            "Sun Feb 10 00:24:49 2019", "Projection:  5  angle: 1.576", "Monitor 3 before:  5334225",
-            "Monitor 3 after:  5475239"
-        ],
-        [
-            "Sun Feb 10 00:25:22 2019", "Projection:  6  angle: 1.8912", "Monitor 3 before:  5483964",
-            "Monitor 3 after:  5626608"
-        ],
-        [
-            "Sun Feb 10 00:25:55 2019", "Projection:  7  angle: 2.2064", "Monitor 3 before:  5635673",
-            "Monitor 3 after:  5777316"
-        ],
-        [
-            "Sun Feb 10 00:26:29 2019", "Projection:  8  angle: 2.5216", "Monitor 3 before:  5786535",
-            "Monitor 3 after:  5929002"
-        ],
-        [
-            "Sun Feb 10 00:27:02 2019", "Projection:  9  angle: 2.8368", "Monitor 3 before:  5938142",
-            "Monitor 3 after:  6078866"
-        ]
+        "Sun Feb 10 00:22:04 2019   Projection:  0  angle: 0.0   Monitor 3 before:  4577907   Monitor 3 after:  4720271",  # noqa: E501
+        "Sun Feb 10 00:22:37 2019   Projection:  1  angle: 0.3152   Monitor 3 before:  4729337   Monitor 3 after:  4871319",  # noqa: E501
+        "Sun Feb 10 00:23:10 2019   Projection:  2  angle: 0.6304   Monitor 3 before:  4879923   Monitor 3 after:  5022689",  # noqa: E501
+        "Sun Feb 10 00:23:43 2019   Projection:  3  angle: 0.9456   Monitor 3 before:  5031423   Monitor 3 after:  5172216",  # noqa: E501
+        "Sun Feb 10 00:24:16 2019   Projection:  4  angle: 1.2608   Monitor 3 before:  5180904   Monitor 3 after:  5322691",  # noqa: E501
+        "Sun Feb 10 00:24:49 2019   Projection:  5  angle: 1.576   Monitor 3 before:  5334225   Monitor 3 after:  5475239",  # noqa: E501
+        "Sun Feb 10 00:25:22 2019   Projection:  6  angle: 1.8912   Monitor 3 before:  5483964   Monitor 3 after:  5626608",  # noqa: E501
+        "Sun Feb 10 00:25:55 2019   Projection:  7  angle: 2.2064   Monitor 3 before:  5635673   Monitor 3 after:  5777316",  # noqa: E501
+        "Sun Feb 10 00:26:29 2019   Projection:  8  angle: 2.5216   Monitor 3 before:  5786535   Monitor 3 after:  5929002",  # noqa: E501
+        "Sun Feb 10 00:27:02 2019   Projection:  9  angle: 2.8368   Monitor 3 before:  5938142   Monitor 3 after:  6078866",  # noqa: E501
+    ]
+    return IMATLogFile(data, "/tmp/fake")
+
+
+def generate_csv_logfile() -> IMATLogFile:
+    data = [
+        TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE,  # checked if exists, but skipped
+        "",  # skipped when parsing
+        # for each row a list with 4 entries is currently expected
+        "Sun Feb 10 00:22:04 2019,Projection,0,angle: 0.0,Monitor 3 before: 4577907,Monitor 3 after:  4720271",
+        "Sun Feb 10 00:22:37 2019,Projection,1,angle: 0.3152,Monitor 3 before: 4729337,Monitor 3 after:  4871319",
+        "Sun Feb 10 00:23:10 2019,Projection,2,angle: 0.6304,Monitor 3 before: 4879923,Monitor 3 after:  5022689",
+        "Sun Feb 10 00:23:43 2019,Projection,3,angle: 0.9456,Monitor 3 before: 5031423,Monitor 3 after:  5172216",
+        "Sun Feb 10 00:24:16 2019,Projection,4,angle: 1.2608,Monitor 3 before: 5180904,Monitor 3 after:  5322691",
+        "Sun Feb 10 00:24:49 2019,Projection,5,angle: 1.576,Monitor 3 before: 5334225,Monitor 3 after:  5475239",
+        "Sun Feb 10 00:25:22 2019,Projection,6,angle: 1.8912,Monitor 3 before: 5483964,Monitor 3 after:  5626608",
+        "Sun Feb 10 00:25:55 2019,Projection,7,angle: 2.2064,Monitor 3 before: 5635673,Monitor 3 after:  5777316",
+        "Sun Feb 10 00:26:29 2019,Projection,8,angle: 2.5216,Monitor 3 before: 5786535,Monitor 3 after:  5929002",
+        "Sun Feb 10 00:27:02 2019,Projection,9,angle: 2.8368,Monitor 3 before: 5938142,Monitor 3 after:  6078866",
     ]
     return IMATLogFile(data, "/tmp/fake")

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -9,7 +9,7 @@ import numpy as np
 from six import StringIO
 
 from mantidimaging.core.data import Images
-from mantidimaging.core.data.test.fake_logfile import generate_logfile
+from mantidimaging.core.data.test.fake_logfile import generate_csv_logfile, generate_txt_logfile
 from mantidimaging.core.operations.crop_coords import CropCoordinatesFilter
 from mantidimaging.core.operation_history import const
 from mantidimaging.core.utility.sensible_roi import SensibleROI
@@ -101,8 +101,9 @@ class ImagesTest(unittest.TestCase):
         self.assertEqual(cropped_copy, images.data[:, 0:5, 0:5])
 
         self.assertEqual(len(cropped_copy.metadata[const.OPERATION_HISTORY]), 2)
-        self.assertEqual(cropped_copy.metadata[const.OPERATION_HISTORY][-1][const.OPERATION_DISPLAY_NAME],
-                         CropCoordinatesFilter.filter_name)
+        self.assertEqual(
+            cropped_copy.metadata[const.OPERATION_HISTORY][-1][const.OPERATION_DISPLAY_NAME],
+            CropCoordinatesFilter.filter_name)
 
         # remove the extra crop operation
         cropped_copy.metadata[const.OPERATION_HISTORY].pop(-1)
@@ -184,8 +185,20 @@ class ImagesTest(unittest.TestCase):
 
     def test_get_projection_angles_from_logfile(self):
         images = generate_images()
-        images.log_file = generate_logfile()
-        expected = np.deg2rad(np.asarray([0.0, 0.3152, 0.6304, 0.9456, 1.2608, 1.576, 1.8912, 2.2064, 2.5216, 2.8368]))
+        images.log_file = generate_txt_logfile()
+        expected = np.deg2rad(
+            np.asarray([0.0, 0.3152, 0.6304, 0.9456, 1.2608, 1.576, 1.8912, 2.2064, 2.5216,
+                        2.8368]))
+        actual = images.projection_angles(360.0)
+        self.assertEqual(len(actual.value), len(expected))
+        np.testing.assert_equal(actual.value, expected)
+
+    def test_get_projection_angles_from_logfile_csv(self):
+        images = generate_images()
+        images.log_file = generate_csv_logfile()
+        expected = np.deg2rad(
+            np.asarray([0.0, 0.3152, 0.6304, 0.9456, 1.2608, 1.576, 1.8912, 2.2064, 2.5216,
+                        2.8368]))
         actual = images.projection_angles(360.0)
         self.assertEqual(len(actual.value), len(expected))
         np.testing.assert_equal(actual.value, expected)
@@ -202,7 +215,7 @@ class ImagesTest(unittest.TestCase):
 
     def test_metadata_gets_updated_with_logfile(self):
         images = generate_images()
-        images.log_file = generate_logfile()
+        images.log_file = generate_txt_logfile()
         self.assertEqual(images.log_file.source_file, images.metadata[const.LOG_FILE])
 
     def test_set_projection_angles(self):

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -101,9 +101,8 @@ class ImagesTest(unittest.TestCase):
         self.assertEqual(cropped_copy, images.data[:, 0:5, 0:5])
 
         self.assertEqual(len(cropped_copy.metadata[const.OPERATION_HISTORY]), 2)
-        self.assertEqual(
-            cropped_copy.metadata[const.OPERATION_HISTORY][-1][const.OPERATION_DISPLAY_NAME],
-            CropCoordinatesFilter.filter_name)
+        self.assertEqual(cropped_copy.metadata[const.OPERATION_HISTORY][-1][const.OPERATION_DISPLAY_NAME],
+                         CropCoordinatesFilter.filter_name)
 
         # remove the extra crop operation
         cropped_copy.metadata[const.OPERATION_HISTORY].pop(-1)
@@ -186,9 +185,7 @@ class ImagesTest(unittest.TestCase):
     def test_get_projection_angles_from_logfile(self):
         images = generate_images()
         images.log_file = generate_txt_logfile()
-        expected = np.deg2rad(
-            np.asarray([0.0, 0.3152, 0.6304, 0.9456, 1.2608, 1.576, 1.8912, 2.2064, 2.5216,
-                        2.8368]))
+        expected = np.deg2rad(np.asarray([0.0, 0.3152, 0.6304, 0.9456, 1.2608, 1.576, 1.8912, 2.2064, 2.5216, 2.8368]))
         actual = images.projection_angles(360.0)
         self.assertEqual(len(actual.value), len(expected))
         np.testing.assert_equal(actual.value, expected)
@@ -196,9 +193,7 @@ class ImagesTest(unittest.TestCase):
     def test_get_projection_angles_from_logfile_csv(self):
         images = generate_images()
         images.log_file = generate_csv_logfile()
-        expected = np.deg2rad(
-            np.asarray([0.0, 0.3152, 0.6304, 0.9456, 1.2608, 1.576, 1.8912, 2.2064, 2.5216,
-                        2.8368]))
+        expected = np.deg2rad(np.asarray([0.0, 0.3152, 0.6304, 0.9456, 1.2608, 1.576, 1.8912, 2.2064, 2.5216, 2.8368]))
         actual = images.projection_angles(360.0)
         self.assertEqual(len(actual.value), len(expected))
         np.testing.assert_equal(actual.value, expected)

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -27,8 +27,7 @@ def _fitsread(filename):
     import astropy.io.fits as fits
     image = fits.open(filename)
     if len(image) < 1:
-        raise RuntimeError(
-            "Could not load at least one FITS image/table file from: {0}".format(filename))
+        raise RuntimeError("Could not load at least one FITS image/table file from: {0}".format(filename))
 
     # get the image data
     return image[0].data
@@ -166,9 +165,8 @@ def load(input_path=None,
         else:
             load_func = _imread
 
-        dataset = img_loader.execute(load_func, input_file_names, input_path_flat_before,
-                                     input_path_flat_after, input_path_dark_before,
-                                     input_path_dark_after, in_format, dtype, indices, progress)
+        dataset = img_loader.execute(load_func, input_file_names, input_path_flat_before, input_path_flat_after,
+                                     input_path_dark_before, input_path_dark_after, in_format, dtype, indices, progress)
 
     # Search for and load metadata file
     metadata_found_filenames = get_file_names(input_path, 'json', in_prefix, essential=False)

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -27,7 +27,8 @@ def _fitsread(filename):
     import astropy.io.fits as fits
     image = fits.open(filename)
     if len(image) < 1:
-        raise RuntimeError("Could not load at least one FITS image/table file from: {0}".format(filename))
+        raise RuntimeError(
+            "Could not load at least one FITS image/table file from: {0}".format(filename))
 
     # get the image data
     return image[0].data
@@ -98,12 +99,8 @@ def read_in_file_information(input_path,
 
 
 def load_log(log_file: str) -> IMATLogFile:
-    data = []
     with open(log_file, 'r') as f:
-        for line in f:
-            data.append(line.strip().split("   "))
-
-    return IMATLogFile(data, log_file)
+        return IMATLogFile(f.readlines(), log_file)
 
 
 def load_p(parameters: ImageParameters, dtype, progress) -> Images:
@@ -169,8 +166,9 @@ def load(input_path=None,
         else:
             load_func = _imread
 
-        dataset = img_loader.execute(load_func, input_file_names, input_path_flat_before, input_path_flat_after,
-                                     input_path_dark_before, input_path_dark_after, in_format, dtype, indices, progress)
+        dataset = img_loader.execute(load_func, input_file_names, input_path_flat_before,
+                                     input_path_flat_after, input_path_dark_before,
+                                     input_path_dark_after, in_format, dtype, indices, progress)
 
     # Search for and load metadata file
     metadata_found_filenames = get_file_names(input_path, 'json', in_prefix, essential=False)

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -28,16 +28,22 @@ class MonitorNormalisation(BaseFilter):
     @staticmethod
     def filter_func(images: Images, cores=None, chunksize=None, progress=None) -> Images:
         counts = images.counts()
-        if counts is None:
+        if counts is None and images.num_projections > 1:
             raise RuntimeError("No loaded log values for this stack.")
 
         counts_val = counts.value / counts.value[0]
         div_partial = ptsm.create_partial(_divide_by_counts, fwd_function=ptsm.inplace)
-        images, _ = ptsm.execute(images.data, counts_val, div_partial, cores, chunksize, progress=progress)
+        images, _ = ptsm.execute(images.data,
+                                 counts_val,
+                                 div_partial,
+                                 cores,
+                                 chunksize,
+                                 progress=progress)
         return images
 
     @staticmethod
-    def register_gui(form: 'QFormLayout', on_change: Callable, view: 'BaseMainWindowView') -> Dict[str, 'QWidget']:
+    def register_gui(form: 'QFormLayout', on_change: Callable,
+                     view: 'BaseMainWindowView') -> Dict[str, 'QWidget']:
         return {}
 
     @staticmethod

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -38,17 +38,11 @@ class MonitorNormalisation(BaseFilter):
 
         counts_val = counts.value / counts.value[0]
         div_partial = ptsm.create_partial(_divide_by_counts, fwd_function=ptsm.inplace)
-        images, _ = ptsm.execute(images.data,
-                                 counts_val,
-                                 div_partial,
-                                 cores,
-                                 chunksize,
-                                 progress=progress)
+        images, _ = ptsm.execute(images.data, counts_val, div_partial, cores, chunksize, progress=progress)
         return images
 
     @staticmethod
-    def register_gui(form: 'QFormLayout', on_change: Callable,
-                     view: 'BaseMainWindowView') -> Dict[str, 'QWidget']:
+    def register_gui(form: 'QFormLayout', on_change: Callable, view: 'BaseMainWindowView') -> Dict[str, 'QWidget']:
         return {}
 
     @staticmethod

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -27,8 +27,13 @@ class MonitorNormalisation(BaseFilter):
 
     @staticmethod
     def filter_func(images: Images, cores=None, chunksize=None, progress=None) -> Images:
+        if images.num_projections == 1:
+            # we can't really compute the preview as the image stack copy
+            # passed in doesn't have the logfile in it
+            return images
         counts = images.counts()
-        if counts is None and images.num_projections > 1:
+
+        if counts is None:
             raise RuntimeError("No loaded log values for this stack.")
 
         counts_val = counts.value / counts.value[0]

--- a/mantidimaging/core/utility/imat_log_file_parser.py
+++ b/mantidimaging/core/utility/imat_log_file_parser.py
@@ -12,11 +12,11 @@ from mantidimaging.core.utility.data_containers import Counts, ProjectionAngles
 
 
 def _get_projection_number(s: str) -> int:
-    return int(s[s.find(": ") + 1:s.find("a")])
+    return int(s[s.find(":") + 1:s.find("a")].strip())
 
 
-def _get_angle(s: str) -> float:
-    return float(s[s.rfind(": ") + 1:])
+def _get_angle(s: str) -> str:
+    return s[s.rfind(":") + 1:].strip()
 
 
 class IMATLogColumn(Enum):
@@ -50,15 +50,14 @@ class TextLogParser:
         for line in self.data[2:]:
             parsed_log[IMATLogColumn.TIMESTAMP].append(line[0])
             parsed_log[IMATLogColumn.PROJECTION_NUMBER].append(_get_projection_number(line[1]))
-            parsed_log[IMATLogColumn.PROJECTION_ANGLE].append(_get_angle(line[1]))
-            parsed_log[IMATLogColumn.COUNTS_BEFORE].append(line[2])
-            parsed_log[IMATLogColumn.COUNTS_AFTER].append(line[3])
+            parsed_log[IMATLogColumn.PROJECTION_ANGLE].append(float(_get_angle(line[1])))
+            parsed_log[IMATLogColumn.COUNTS_BEFORE].append(int(_get_angle(line[2])))
+            parsed_log[IMATLogColumn.COUNTS_AFTER].append(int(_get_angle(line[3])))
 
         return parsed_log
 
     @staticmethod
     def validate(file_contents) -> bool:
-
         if TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE != file_contents[0]:
             return False
         return True
@@ -87,15 +86,15 @@ class CSVLogParser:
 
         for row in reader:
             parsed_log[IMATLogColumn.TIMESTAMP].append(row[0])
-            parsed_log[IMATLogColumn.PROJECTION_NUMBER].append(row[2])
+            parsed_log[IMATLogColumn.PROJECTION_NUMBER].append(int(row[2]))
             angle_raw = row[3]
-            parsed_log[IMATLogColumn.PROJECTION_ANGLE].append(_get_angle(angle_raw))
+            parsed_log[IMATLogColumn.PROJECTION_ANGLE].append(float(_get_angle(angle_raw)))
 
             counts_before_raw = row[4]
-            parsed_log[IMATLogColumn.COUNTS_BEFORE].append(_get_angle(counts_before_raw))
+            parsed_log[IMATLogColumn.COUNTS_BEFORE].append(int(_get_angle(counts_before_raw)))
 
             counts_after_raw = row[5]
-            parsed_log[IMATLogColumn.COUNTS_AFTER].append(_get_angle(counts_after_raw))
+            parsed_log[IMATLogColumn.COUNTS_AFTER].append(int(_get_angle(counts_after_raw)))
 
         return parsed_log
 
@@ -143,8 +142,6 @@ class IMATLogFile:
                 zip(self._data[IMATLogColumn.COUNTS_BEFORE],
                     self._data[IMATLogColumn.COUNTS_AFTER])):
             # clips the string before the count number
-            before = before[before.rfind(":") + 1:]
-            after = after[after.rfind(":") + 1:]
             counts[i] = float(after) - float(before)
 
         return Counts(counts)

--- a/mantidimaging/core/utility/imat_log_file_parser.py
+++ b/mantidimaging/core/utility/imat_log_file_parser.py
@@ -1,13 +1,22 @@
 # Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
+import csv
 from enum import Enum, auto
 from itertools import zip_longest
-from typing import List, Dict
+from typing import Dict, List
 
 import numpy
 
-from mantidimaging.core.utility.data_containers import ProjectionAngles, Counts
+from mantidimaging.core.utility.data_containers import Counts, ProjectionAngles
+
+
+def _get_projection_number(s: str) -> int:
+    return int(s[s.find(": ") + 1:s.find("a")])
+
+
+def _get_angle(s: str) -> float:
+    return float(s[s.rfind(": ") + 1:])
 
 
 class IMATLogColumn(Enum):
@@ -15,6 +24,8 @@ class IMATLogColumn(Enum):
     # currently these 2 are the same column because
     # the log file formatting is inconsistent
     IMAGE_TYPE_IMAGE_COUNTER = auto()
+    PROJECTION_NUMBER = auto()
+    PROJECTION_ANGLE = auto()
     COUNTS_BEFORE = auto()
     COUNTS_AFTER = auto()
 
@@ -29,16 +40,17 @@ class TextLogParser:
     def parse(self) -> Dict[IMATLogColumn, List]:
         parsed_log: Dict[IMATLogColumn, List] = {
             IMATLogColumn.TIMESTAMP: [],
-            IMATLogColumn.IMAGE_TYPE_IMAGE_COUNTER: [],
+            IMATLogColumn.PROJECTION_NUMBER: [],
+            IMATLogColumn.PROJECTION_ANGLE: [],
             IMATLogColumn.COUNTS_BEFORE: [],
             IMATLogColumn.COUNTS_AFTER: []
         }
-
         # ignores the headers (index 0) as they're not the same as the data anyway
         # and index 1 is an empty line
         for line in self.data[2:]:
             parsed_log[IMATLogColumn.TIMESTAMP].append(line[0])
-            parsed_log[IMATLogColumn.IMAGE_TYPE_IMAGE_COUNTER].append(line[1])
+            parsed_log[IMATLogColumn.PROJECTION_NUMBER].append(_get_projection_number(line[1]))
+            parsed_log[IMATLogColumn.PROJECTION_ANGLE].append(_get_angle(line[1]))
             parsed_log[IMATLogColumn.COUNTS_BEFORE].append(line[2])
             parsed_log[IMATLogColumn.COUNTS_AFTER].append(line[3])
 
@@ -54,10 +66,38 @@ class TextLogParser:
 
 class CSVLogParser:
     EXPECTED_HEADER_FOR_IMAT_CSV_LOG_FILE = \
-        "TIME STAMP,IMAGE TYPE,IMAGE COUNTER,COUNTS BM3 before image,COUNTS BM3 after image"
+        "TIME STAMP,IMAGE TYPE,IMAGE COUNTER,COUNTS BM3 before image,COUNTS BM3 after image\n"
 
     def __init__(self, data: List[str]) -> None:
-        pass
+        self.data = data
+
+    def parse(self) -> Dict[IMATLogColumn, List]:
+        parsed_log: Dict[IMATLogColumn, List] = {
+            IMATLogColumn.TIMESTAMP: [],
+            IMATLogColumn.PROJECTION_NUMBER: [],
+            IMATLogColumn.PROJECTION_ANGLE: [],
+            IMATLogColumn.COUNTS_BEFORE: [],
+            IMATLogColumn.COUNTS_AFTER: []
+        }
+
+        reader = csv.reader(self.data)
+
+        # skip headings
+        next(reader)
+
+        for row in reader:
+            parsed_log[IMATLogColumn.TIMESTAMP].append(row[0])
+            parsed_log[IMATLogColumn.PROJECTION_NUMBER].append(row[2])
+            angle_raw = row[3]
+            parsed_log[IMATLogColumn.PROJECTION_ANGLE].append(_get_angle(angle_raw))
+
+            counts_before_raw = row[4]
+            parsed_log[IMATLogColumn.COUNTS_BEFORE].append(_get_angle(counts_before_raw))
+
+            counts_after_raw = row[5]
+            parsed_log[IMATLogColumn.COUNTS_AFTER].append(_get_angle(counts_after_raw))
+
+        return parsed_log
 
     @staticmethod
     def validate(file_contents) -> bool:
@@ -87,24 +127,14 @@ class IMATLogFile:
         return self._source_file
 
     def projection_numbers(self):
-        proj_nums = numpy.zeros(len(self._data[IMATLogColumn.IMAGE_TYPE_IMAGE_COUNTER]),
+        proj_nums = numpy.zeros(len(self._data[IMATLogColumn.PROJECTION_NUMBER]),
                                 dtype=numpy.uint32)
-        for i, angle_str in enumerate(self._data[IMATLogColumn.IMAGE_TYPE_IMAGE_COUNTER]):
-            if "angle:" not in angle_str:
-                raise ValueError(
-                    "Projection angles loaded from logfile do not have the correct formatting!")
-            proj_nums[i] = int(angle_str[angle_str.find(": ") + 1:angle_str.find("a")])
-
+        proj_nums[:] = self._data[IMATLogColumn.PROJECTION_NUMBER]
         return proj_nums
 
     def projection_angles(self) -> ProjectionAngles:
-        angles = numpy.zeros(len(self._data[IMATLogColumn.IMAGE_TYPE_IMAGE_COUNTER]))
-        for i, angle_str in enumerate(self._data[IMATLogColumn.IMAGE_TYPE_IMAGE_COUNTER]):
-            if "angle:" not in angle_str:
-                raise ValueError(
-                    "Projection angles loaded from logfile do not have the correct formatting!")
-            angles[i] = float(angle_str[angle_str.rfind(": ") + 1:])
-
+        angles = numpy.zeros(len(self._data[IMATLogColumn.PROJECTION_ANGLE]))
+        angles[:] = self._data[IMATLogColumn.PROJECTION_ANGLE]
         return ProjectionAngles(numpy.deg2rad(angles))
 
     def counts(self) -> Counts:

--- a/mantidimaging/core/utility/imat_log_file_parser.py
+++ b/mantidimaging/core/utility/imat_log_file_parser.py
@@ -9,10 +9,6 @@ import numpy
 
 from mantidimaging.core.utility.data_containers import ProjectionAngles, Counts
 
-EXPECTED_HEADER_FOR_IMAT_LOG_FILE = [
-    'TIME STAMP  IMAGE TYPE', 'IMAGE COUNTER', 'COUNTS BM3 before image', 'COUNTS BM3 after image'
-]
-
 
 class IMATLogColumn(Enum):
     TIMESTAMP = auto()
@@ -23,39 +19,80 @@ class IMATLogColumn(Enum):
     COUNTS_AFTER = auto()
 
 
-class IMATLogFile:
-    def __init__(self, data: List[List[str]], source_file: str):
-        self._source_file = source_file
-        self._data: Dict[IMATLogColumn, List] = {
+class TextLogParser:
+    EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE = \
+            ' TIME STAMP  IMAGE TYPE   IMAGE COUNTER   COUNTS BM3 before image   COUNTS BM3 after image\n'
+
+    def __init__(self, data: List[str]) -> None:
+        self.data = [line.strip().split("   ") for line in data]
+
+    def parse(self) -> Dict[IMATLogColumn, List]:
+        parsed_log: Dict[IMATLogColumn, List] = {
             IMATLogColumn.TIMESTAMP: [],
             IMATLogColumn.IMAGE_TYPE_IMAGE_COUNTER: [],
             IMATLogColumn.COUNTS_BEFORE: [],
             IMATLogColumn.COUNTS_AFTER: []
         }
 
-        if EXPECTED_HEADER_FOR_IMAT_LOG_FILE != data[0]:
-            raise RuntimeError(
-                "The Log file found for this dataset does not seem to have the correct header for an IMAT log file.\n"
-                "The header is expected to contain the names of the columns:\n"
-                f"{str(EXPECTED_HEADER_FOR_IMAT_LOG_FILE)}")
-
         # ignores the headers (index 0) as they're not the same as the data anyway
         # and index 1 is an empty line
-        for line in data[2:]:
-            self._data[IMATLogColumn.TIMESTAMP].append(line[0])
-            self._data[IMATLogColumn.IMAGE_TYPE_IMAGE_COUNTER].append(line[1])
-            self._data[IMATLogColumn.COUNTS_BEFORE].append(line[2])
-            self._data[IMATLogColumn.COUNTS_AFTER].append(line[3])
+        for line in self.data[2:]:
+            parsed_log[IMATLogColumn.TIMESTAMP].append(line[0])
+            parsed_log[IMATLogColumn.IMAGE_TYPE_IMAGE_COUNTER].append(line[1])
+            parsed_log[IMATLogColumn.COUNTS_BEFORE].append(line[2])
+            parsed_log[IMATLogColumn.COUNTS_AFTER].append(line[3])
+
+        return parsed_log
+
+    @staticmethod
+    def validate(file_contents) -> bool:
+
+        if TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE != file_contents[0]:
+            return False
+        return True
+
+
+class CSVLogParser:
+    EXPECTED_HEADER_FOR_IMAT_CSV_LOG_FILE = \
+        "TIME STAMP,IMAGE TYPE,IMAGE COUNTER,COUNTS BM3 before image,COUNTS BM3 after image"
+
+    def __init__(self, data: List[str]) -> None:
+        pass
+
+    @staticmethod
+    def validate(file_contents) -> bool:
+        if CSVLogParser.EXPECTED_HEADER_FOR_IMAT_CSV_LOG_FILE != file_contents[0]:
+            return False
+        return True
+
+
+class IMATLogFile:
+    def __init__(self, data: List[str], source_file: str):
+        self._source_file = source_file
+
+        self.parser = self.find_parser(data)
+        self._data = self.parser.parse()
+
+    @staticmethod
+    def find_parser(data: List[str]):
+        if TextLogParser.validate(data):
+            return TextLogParser(data)
+        elif CSVLogParser.validate(data):
+            return CSVLogParser(data)
+        else:
+            raise RuntimeError("The format of the log file is not recognised.")
 
     @property
     def source_file(self) -> str:
         return self._source_file
 
     def projection_numbers(self):
-        proj_nums = numpy.zeros(len(self._data[IMATLogColumn.IMAGE_TYPE_IMAGE_COUNTER]), dtype=numpy.uint32)
+        proj_nums = numpy.zeros(len(self._data[IMATLogColumn.IMAGE_TYPE_IMAGE_COUNTER]),
+                                dtype=numpy.uint32)
         for i, angle_str in enumerate(self._data[IMATLogColumn.IMAGE_TYPE_IMAGE_COUNTER]):
             if "angle:" not in angle_str:
-                raise ValueError("Projection angles loaded from logfile do not have the correct formatting!")
+                raise ValueError(
+                    "Projection angles loaded from logfile do not have the correct formatting!")
             proj_nums[i] = int(angle_str[angle_str.find(": ") + 1:angle_str.find("a")])
 
         return proj_nums
@@ -64,16 +101,17 @@ class IMATLogFile:
         angles = numpy.zeros(len(self._data[IMATLogColumn.IMAGE_TYPE_IMAGE_COUNTER]))
         for i, angle_str in enumerate(self._data[IMATLogColumn.IMAGE_TYPE_IMAGE_COUNTER]):
             if "angle:" not in angle_str:
-                raise ValueError("Projection angles loaded from logfile do not have the correct formatting!")
+                raise ValueError(
+                    "Projection angles loaded from logfile do not have the correct formatting!")
             angles[i] = float(angle_str[angle_str.rfind(": ") + 1:])
 
         return ProjectionAngles(numpy.deg2rad(angles))
 
     def counts(self) -> Counts:
         counts = numpy.zeros(len(self._data[IMATLogColumn.COUNTS_BEFORE]))
-        for i, [before,
-                after] in enumerate(zip(self._data[IMATLogColumn.COUNTS_BEFORE],
-                                        self._data[IMATLogColumn.COUNTS_AFTER])):
+        for i, [before, after] in enumerate(
+                zip(self._data[IMATLogColumn.COUNTS_BEFORE],
+                    self._data[IMATLogColumn.COUNTS_AFTER])):
             # clips the string before the count number
             before = before[before.rfind(":") + 1:]
             after = after[after.rfind(":") + 1:]

--- a/mantidimaging/core/utility/imat_log_file_parser.py
+++ b/mantidimaging/core/utility/imat_log_file_parser.py
@@ -126,8 +126,7 @@ class IMATLogFile:
         return self._source_file
 
     def projection_numbers(self):
-        proj_nums = numpy.zeros(len(self._data[IMATLogColumn.PROJECTION_NUMBER]),
-                                dtype=numpy.uint32)
+        proj_nums = numpy.zeros(len(self._data[IMATLogColumn.PROJECTION_NUMBER]), dtype=numpy.uint32)
         proj_nums[:] = self._data[IMATLogColumn.PROJECTION_NUMBER]
         return proj_nums
 
@@ -138,9 +137,9 @@ class IMATLogFile:
 
     def counts(self) -> Counts:
         counts = numpy.zeros(len(self._data[IMATLogColumn.COUNTS_BEFORE]))
-        for i, [before, after] in enumerate(
-                zip(self._data[IMATLogColumn.COUNTS_BEFORE],
-                    self._data[IMATLogColumn.COUNTS_AFTER])):
+        for i, [before,
+                after] in enumerate(zip(self._data[IMATLogColumn.COUNTS_BEFORE],
+                                        self._data[IMATLogColumn.COUNTS_AFTER])):
             # clips the string before the count number
             counts[i] = float(after) - float(before)
 

--- a/mantidimaging/core/utility/test/imat_log_file_parser_test.py
+++ b/mantidimaging/core/utility/test/imat_log_file_parser_test.py
@@ -7,20 +7,18 @@ import pytest
 from mantidimaging.core.utility.imat_log_file_parser import CSVLogParser, IMATLogFile, TextLogParser
 
 
-@pytest.mark.parametrize(
-    'test_input', [[
-        TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE, "ignored line",
-        "timestamp   Projection:  0  angle: 0.1   counts before: 12345   counts_after: 45678"
-    ],
-                   [
-                       CSVLogParser.EXPECTED_HEADER_FOR_IMAT_CSV_LOG_FILE,
-                       "timestamp,Projection,0,angle:0.1,counts before: 12345,counts_after: 45678"
-                   ]])
+@pytest.mark.parametrize('test_input', [[
+    TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE, "ignored line",
+    "timestamp   Projection:  0  angle: 0.1   counts before: 12345   counts_after: 45678"
+],
+                                        [
+                                            CSVLogParser.EXPECTED_HEADER_FOR_IMAT_CSV_LOG_FILE,
+                                            "timestamp,Projection,0,angle:0.1,counts before: 12345,counts_after: 45678"
+                                        ]])
 def test_parsing_log_file(test_input):
     logfile = IMATLogFile(test_input, "/tmp/fake")
     assert len(logfile.projection_angles().value) == 1
-    assert logfile.projection_angles().value[0] == np.deg2rad(
-        0.1), f"Got: {logfile.projection_angles().value[0]}"
+    assert logfile.projection_angles().value[0] == np.deg2rad(0.1), f"Got: {logfile.projection_angles().value[0]}"
     assert logfile.counts().value[0] == (45678 - 12345)
 
 

--- a/mantidimaging/core/utility/test/imat_log_file_parser_test.py
+++ b/mantidimaging/core/utility/test/imat_log_file_parser_test.py
@@ -3,27 +3,28 @@
 
 import numpy as np
 
-from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile, EXPECTED_HEADER_FOR_IMAT_LOG_FILE
+from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile, TextLogParser
 
 
 def test_parsing_log_file():
     test_input = [
-        EXPECTED_HEADER_FOR_IMAT_LOG_FILE, ["ignored line"],
-        ["timestamp", "Projection:  0  angle: 0.1", "counts before: 12345", "counts_after: 45678"]
+        TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE, "ignored line",
+        "timestamp   Projection:  0  angle: 0.1   counts before: 12345   counts_after: 45678"
     ]
     logfile = IMATLogFile(test_input, "/tmp/fake")
     assert len(logfile.projection_angles().value) == 1
-    assert logfile.projection_angles().value[0] == np.deg2rad(0.1), f"Got: {logfile.projection_angles().value[0]}"
+    assert logfile.projection_angles().value[0] == np.deg2rad(
+        0.1), f"Got: {logfile.projection_angles().value[0]}"
     assert logfile.counts().value[0] == (45678 - 12345)
 
 
 def test_counts():
     test_input = [
-        EXPECTED_HEADER_FOR_IMAT_LOG_FILE,
-        ["ignored line"],
-        ["timestamp", "Projection:  0  angle: 0.0", "counts before: 12345", "counts_after: 45678"],
-        ["timestamp", "Projection:  1  angle: 0.1", "counts before: 45678", "counts_after: 84678"],
-        ["timestamp", "Projection:  2  angle: 0.2", "counts before: 84678", "counts_after: 124333"],
+        TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE,
+        "ignored line",
+        "timestamp   Projection:  0  angle: 0.0   counts before: 12345   counts_after: 45678",
+        "timestamp   Projection:  1  angle: 0.1   counts before: 45678   counts_after: 84678",
+        "timestamp   Projection:  2  angle: 0.2   counts before: 84678   counts_after: 124333",
     ]
     logfile = IMATLogFile(test_input, "/tmp/fake")
     assert len(logfile.counts().value) == 3
@@ -44,11 +45,11 @@ def assert_raises(exc_type, callable, *args, **kwargs):
 
 def test_find_missing_projection_number():
     test_input = [
-        EXPECTED_HEADER_FOR_IMAT_LOG_FILE,
-        ["ignored line"],
-        ["timestamp", "Projection:  0  angle: 0.0", "counts before: 12345", "counts_after: 45678"],
-        ["timestamp", "Projection:  1  angle: 0.1", "counts before: 12345", "counts_after: 45678"],
-        ["timestamp", "Projection:  2  angle: 0.2", "counts before: 12345", "counts_after: 45678"],
+        TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE,
+        "ignored line",
+        "timestamp   Projection:  0  angle: 0.0   counts before: 12345   counts_after: 45678",
+        "timestamp   Projection:  1  angle: 0.1   counts before: 12345   counts_after: 45678",
+        "timestamp   Projection:  2  angle: 0.2   counts before: 12345   counts_after: 45678",
     ]
     logfile = IMATLogFile(test_input, "/tmp/fake")
     assert len(logfile.projection_numbers()) == 3
@@ -64,11 +65,11 @@ def test_find_missing_projection_number():
 
 def test_source_file():
     test_input = [
-        EXPECTED_HEADER_FOR_IMAT_LOG_FILE,
-        ["ignored line"],
-        ["timestamp", "Projection:  0  angle: 0.0", "counts before: 12345", "counts_after: 45678"],
-        ["timestamp", "Projection:  1  angle: 0.1", "counts before: 12345", "counts_after: 45678"],
-        ["timestamp", "Projection:  2  angle: 0.2", "counts before: 12345", "counts_after: 45678"],
+        TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE,
+        "ignored line",
+        "timestamp   Projection:  0  angle: 0.0   counts before: 12345   counts_after: 45678",
+        "timestamp   Projection:  1  angle: 0.1   counts before: 12345   counts_after: 45678",
+        "timestamp   Projection:  2  angle: 0.2   counts before: 12345   counts_after: 45678",
     ]
     logfile = IMATLogFile(test_input, "/tmp/fake")
     assert logfile.source_file == "/tmp/fake"

--- a/mantidimaging/core/utility/test/imat_log_file_parser_test.py
+++ b/mantidimaging/core/utility/test/imat_log_file_parser_test.py
@@ -2,15 +2,21 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import numpy as np
+import pytest
 
-from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile, TextLogParser
+from mantidimaging.core.utility.imat_log_file_parser import CSVLogParser, IMATLogFile, TextLogParser
 
 
-def test_parsing_log_file():
-    test_input = [
+@pytest.mark.parametrize(
+    'test_input', [[
         TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE, "ignored line",
         "timestamp   Projection:  0  angle: 0.1   counts before: 12345   counts_after: 45678"
-    ]
+    ],
+                   [
+                       CSVLogParser.EXPECTED_HEADER_FOR_IMAT_CSV_LOG_FILE,
+                       "timestamp,Projection,0,angle:0.1,counts before: 12345,counts_after: 45678"
+                   ]])
+def test_parsing_log_file(test_input):
     logfile = IMATLogFile(test_input, "/tmp/fake")
     assert len(logfile.projection_angles().value) == 1
     assert logfile.projection_angles().value[0] == np.deg2rad(
@@ -18,19 +24,38 @@ def test_parsing_log_file():
     assert logfile.counts().value[0] == (45678 - 12345)
 
 
-def test_counts():
-    test_input = [
-        TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE,
-        "ignored line",
-        "timestamp   Projection:  0  angle: 0.0   counts before: 12345   counts_after: 45678",
-        "timestamp   Projection:  1  angle: 0.1   counts before: 45678   counts_after: 84678",
-        "timestamp   Projection:  2  angle: 0.2   counts before: 84678   counts_after: 124333",
-    ]
+TXT_LOG_FILE = [
+    TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE,
+    "ignored line",
+    "timestamp   Projection:  0  angle: 0.0   counts before: 12345   counts_after: 45678",
+    "timestamp   Projection:  1  angle: 0.1   counts before: 45678   counts_after: 84678",
+    "timestamp   Projection:  2  angle: 0.2   counts before: 84678   counts_after: 124333",
+]
+CSV_LOG_FILE = [
+    CSVLogParser.EXPECTED_HEADER_FOR_IMAT_CSV_LOG_FILE,
+    "timestamp,Projection,0,angle:0.0,counts before: 12345,counts_after: 45678",
+    "timestamp,Projection,1,angle:0.1,counts before: 45678,counts_after: 84678",
+    "timestamp,Projection,2,angle:0.2,counts before: 84678,counts_after: 124333",
+]
+
+
+@pytest.mark.parametrize('test_input', [TXT_LOG_FILE, CSV_LOG_FILE])
+def test_counts(test_input):
     logfile = IMATLogFile(test_input, "/tmp/fake")
     assert len(logfile.counts().value) == 3
     assert logfile.counts().value[0] == 45678 - 12345
     assert logfile.counts().value[1] == 84678 - 45678
     assert logfile.counts().value[2] == 124333 - 84678
+
+
+def test_counts_compare():
+    logfile = IMATLogFile(TXT_LOG_FILE, "/tmp/fake")
+    logfile_from_csv = IMATLogFile(CSV_LOG_FILE, "/tmp/fake")
+
+    assert len(logfile.counts().value) == len(logfile_from_csv.counts().value)
+    assert logfile.counts().value[0] == logfile_from_csv.counts().value[0]
+    assert logfile.counts().value[1] == logfile_from_csv.counts().value[1]
+    assert logfile.counts().value[2] == logfile_from_csv.counts().value[2]
 
 
 def assert_raises(exc_type, callable, *args, **kwargs):
@@ -43,14 +68,8 @@ def assert_raises(exc_type, callable, *args, **kwargs):
         assert False, "Did not raise expected exception."
 
 
-def test_find_missing_projection_number():
-    test_input = [
-        TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE,
-        "ignored line",
-        "timestamp   Projection:  0  angle: 0.0   counts before: 12345   counts_after: 45678",
-        "timestamp   Projection:  1  angle: 0.1   counts before: 12345   counts_after: 45678",
-        "timestamp   Projection:  2  angle: 0.2   counts before: 12345   counts_after: 45678",
-    ]
+@pytest.mark.parametrize('test_input', [TXT_LOG_FILE, CSV_LOG_FILE])
+def test_find_missing_projection_number(test_input):
     logfile = IMATLogFile(test_input, "/tmp/fake")
     assert len(logfile.projection_numbers()) == 3
     # nothing missing
@@ -63,13 +82,7 @@ def test_find_missing_projection_number():
                   ["file_000.tif", "file_001.tif", "file_002.tif", "file_003.tif"])
 
 
-def test_source_file():
-    test_input = [
-        TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE,
-        "ignored line",
-        "timestamp   Projection:  0  angle: 0.0   counts before: 12345   counts_after: 45678",
-        "timestamp   Projection:  1  angle: 0.1   counts before: 12345   counts_after: 45678",
-        "timestamp   Projection:  2  angle: 0.2   counts before: 12345   counts_after: 45678",
-    ]
+@pytest.mark.parametrize('test_input', [TXT_LOG_FILE, CSV_LOG_FILE])
+def test_source_file(test_input):
     logfile = IMATLogFile(test_input, "/tmp/fake")
     assert logfile.source_file == "/tmp/fake"

--- a/mantidimaging/gui/dialogs/cor_inspection/view.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/view.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-from typing import List
+from typing import List, Union
 
 import numpy as np
 from PyQt5.QtWidgets import QPushButton, QDoubleSpinBox, QSpinBox, QStackedWidget
@@ -23,6 +23,8 @@ class CORInspectionDialogView(BaseDialogView):
     stepIterations: QSpinBox
     stepStackedWidget: QStackedWidget
     instructionStackedWidget: QStackedWidget
+
+    spin_box: Union[QSpinBox, QDoubleSpinBox]
 
     def __init__(self, parent, images: Images, slice_index: int, initial_cor: ScalarCoR,
                  recon_params: ReconstructionParameters, iters_mode: bool):

--- a/mantidimaging/gui/windows/load_dialog/view.py
+++ b/mantidimaging/gui/windows/load_dialog/view.py
@@ -45,8 +45,7 @@ class MWLoadDialog(Qt.QDialog):
         self.tree.setTabKeyNavigation(True)
 
         self.sample, self.select_sample = self.create_file_input(0)
-        self.select_sample.clicked.connect(
-            lambda: self.presenter.notify(Notification.UPDATE_ALL_FIELDS))
+        self.select_sample.clicked.connect(lambda: self.presenter.notify(Notification.UPDATE_ALL_FIELDS))
 
         self.flat_before, self.select_flat_before = self.create_file_input(1)
         self.select_flat_before.clicked.connect(lambda: self.presenter.notify(
@@ -65,32 +64,20 @@ class MWLoadDialog(Qt.QDialog):
             Notification.UPDATE_FLAT_OR_DARK, field=self.dark_after, name="Dark", suffix="After"))
 
         self.proj_180deg, self.select_proj_180deg = self.create_file_input(5)
-        self.select_proj_180deg.clicked.connect(
-            lambda: self.presenter.notify(Notification.UPDATE_SINGLE_FILE,
-                                          field=self.proj_180deg,
-                                          name="180 degree",
-                                          is_image_file=True))
+        self.select_proj_180deg.clicked.connect(lambda: self.presenter.notify(
+            Notification.UPDATE_SINGLE_FILE, field=self.proj_180deg, name="180 degree", is_image_file=True))
 
         self.sample_log, self.select_sample_log = self.create_file_input(6)
-        self.select_sample_log.clicked.connect(
-            lambda: self.presenter.notify(Notification.UPDATE_SAMPLE_LOG,
-                                          field=self.sample_log,
-                                          name="Sample Log",
-                                          is_image_file=False))
+        self.select_sample_log.clicked.connect(lambda: self.presenter.notify(
+            Notification.UPDATE_SAMPLE_LOG, field=self.sample_log, name="Sample Log", is_image_file=False))
 
         self.flat_before_log, self.select_flat_before_log = self.create_file_input(7)
-        self.select_flat_before_log.clicked.connect(
-            lambda: self.presenter.notify(Notification.UPDATE_SINGLE_FILE,
-                                          field=self.flat_before_log,
-                                          name="Flat Before Log",
-                                          image_file=False))
+        self.select_flat_before_log.clicked.connect(lambda: self.presenter.notify(
+            Notification.UPDATE_SINGLE_FILE, field=self.flat_before_log, name="Flat Before Log", image_file=False))
 
         self.flat_after_log, self.select_flat_after_log = self.create_file_input(8)
-        self.select_flat_after_log.clicked.connect(
-            lambda: self.presenter.notify(Notification.UPDATE_SINGLE_FILE,
-                                          field=self.flat_after_log,
-                                          name="Flat After Log",
-                                          image_file=False))
+        self.select_flat_after_log.clicked.connect(lambda: self.presenter.notify(
+            Notification.UPDATE_SINGLE_FILE, field=self.flat_after_log, name="Flat After Log", image_file=False))
 
         self.step_all.clicked.connect(self._set_all_step)
         self.step_preview.clicked.connect(self._set_preview_step)

--- a/mantidimaging/gui/windows/load_dialog/view.py
+++ b/mantidimaging/gui/windows/load_dialog/view.py
@@ -45,7 +45,8 @@ class MWLoadDialog(Qt.QDialog):
         self.tree.setTabKeyNavigation(True)
 
         self.sample, self.select_sample = self.create_file_input(0)
-        self.select_sample.clicked.connect(lambda: self.presenter.notify(Notification.UPDATE_ALL_FIELDS))
+        self.select_sample.clicked.connect(
+            lambda: self.presenter.notify(Notification.UPDATE_ALL_FIELDS))
 
         self.flat_before, self.select_flat_before = self.create_file_input(1)
         self.select_flat_before.clicked.connect(lambda: self.presenter.notify(
@@ -64,20 +65,32 @@ class MWLoadDialog(Qt.QDialog):
             Notification.UPDATE_FLAT_OR_DARK, field=self.dark_after, name="Dark", suffix="After"))
 
         self.proj_180deg, self.select_proj_180deg = self.create_file_input(5)
-        self.select_proj_180deg.clicked.connect(lambda: self.presenter.notify(
-            Notification.UPDATE_SINGLE_FILE, field=self.proj_180deg, name="180 degree", is_image_file=True))
+        self.select_proj_180deg.clicked.connect(
+            lambda: self.presenter.notify(Notification.UPDATE_SINGLE_FILE,
+                                          field=self.proj_180deg,
+                                          name="180 degree",
+                                          is_image_file=True))
 
         self.sample_log, self.select_sample_log = self.create_file_input(6)
-        self.select_sample_log.clicked.connect(lambda: self.presenter.notify(
-            Notification.UPDATE_SAMPLE_LOG, field=self.sample_log, name="Sample Log", is_image_file=False))
+        self.select_sample_log.clicked.connect(
+            lambda: self.presenter.notify(Notification.UPDATE_SAMPLE_LOG,
+                                          field=self.sample_log,
+                                          name="Sample Log",
+                                          is_image_file=False))
 
         self.flat_before_log, self.select_flat_before_log = self.create_file_input(7)
-        self.select_flat_before_log.clicked.connect(lambda: self.presenter.notify(
-            Notification.UPDATE_SINGLE_FILE, field=self.flat_before_log, name="Flat Before Log", image_file=False))
+        self.select_flat_before_log.clicked.connect(
+            lambda: self.presenter.notify(Notification.UPDATE_SINGLE_FILE,
+                                          field=self.flat_before_log,
+                                          name="Flat Before Log",
+                                          image_file=False))
 
         self.flat_after_log, self.select_flat_after_log = self.create_file_input(8)
-        self.select_flat_after_log.clicked.connect(lambda: self.presenter.notify(
-            Notification.UPDATE_SINGLE_FILE, field=self.flat_after_log, name="Flat After Log", image_file=False))
+        self.select_flat_after_log.clicked.connect(
+            lambda: self.presenter.notify(Notification.UPDATE_SINGLE_FILE,
+                                          field=self.flat_after_log,
+                                          name="Flat After Log",
+                                          image_file=False))
 
         self.step_all.clicked.connect(self._set_all_step)
         self.step_preview.clicked.connect(self._set_preview_step)
@@ -115,7 +128,7 @@ class MWLoadDialog(Qt.QDialog):
             file_filter = "Images (*.png *.jpg *.tif *.tiff *.fit *.fits)"
         else:
             # Assume text file
-            file_filter = "Log File (*.txt *.log)"
+            file_filter = "Log File (*.txt *.log *.csv)"
         selected_file, _ = Qt.QFileDialog.getOpenFileName(caption=caption,
                                                           filter=f"{file_filter};;All (*.*)",
                                                           initialFilter=file_filter)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -171,7 +171,7 @@ class MainWindowView(BaseMainWindowView):
         stack_to_add_log_to = stack_selector.selected_stack
 
         # Open file dialog
-        file_filter = "Log File (*.txt *.log)"
+        file_filter = "Log File (*.txt *.log *.csv)"
         selected_file, _ = QFileDialog.getOpenFileName(caption="Log to be loaded",
                                                        filter=f"{file_filter};;All (*.*)",
                                                        initialFilter=file_filter)


### PR DESCRIPTION
### Issue
Fixes #809

### Description

Adds parsing for CSV files. Keeps previous functionality to parse old TXT files

### Testing 

Load the flower dataset, **make sure to check the `Use?` checkbox for the Sample Log!** otherwise logs will not be loaded

- Test that the old logs are still loaded correctly
	- Either hook up a debugger 
	- or on the loaded stack check that `right click > show history` shows a logfile entry
	- or run monitor normalisation and check that the images get normalised
- Test the same steps with this CSV log (converted from the text one): [TomoIMAT00010675_FlowerFine_log.zip](https://github.com/mantidproject/mantidimaging/files/5803429/TomoIMAT00010675_FlowerFine_log.zip)
- The usage and results should be identical

### Acceptance Criteria 

Conda tests should pass. The docker tests will fail as this is based on release 2.0 branch.