### PR TITLE
 Small re-arrangement of the recon layout

### DIFF
--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -50,8 +50,53 @@
                <string>Data</string>
               </property>
               <layout class="QFormLayout" name="formLayout">
+               <property name="fieldGrowthPolicy">
+                <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+               </property>
                <item row="0" column="0" colspan="2">
                 <widget class="StackSelectorWidgetView" name="stackSelector"/>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupBox">
+              <property name="title">
+               <string>Auto COR finding methods</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_3">
+               <item>
+                <widget class="QPushButton" name="correlateBtn">
+                 <property name="toolTip">
+                  <string>Performs a correlation between the 0 and 180 degree projections to find the shift.</string>
+                 </property>
+                 <property name="text">
+                  <string>Correlate 0 and 180</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="minimiseBtn">
+                 <property name="toolTip">
+                  <string>Minimises the square-sum error of the reconstructed slice, for a number of slices. The COR with lowest error will be used.</string>
+                 </property>
+                 <property name="text">
+                  <string>Minimise error</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="corHelpButton">
+                 <property name="maximumSize">
+                  <size>
+                   <width>25</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>?</string>
+                 </property>
+                </widget>
                </item>
               </layout>
              </widget>
@@ -187,10 +232,10 @@
                  <item row="4" column="1">
                   <widget class="QPushButton" name="calculateCors">
                    <property name="toolTip">
-                    <string>Use the CoR and Tilt above to generate a CoR for each of the slice indices in the table below</string>
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter values in the fields COR and Tilt above manually, then click this button to calculate the COR for each slice from the manual values.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                    </property>
                    <property name="text">
-                    <string>Fit from COR/Tilt above</string>
+                    <string>Apply manual values </string>
                    </property>
                    <property name="toolTipDuration" stdset="0">
                     <number>2</number>
@@ -201,48 +246,6 @@
                </item>
                <item>
                 <layout class="QVBoxLayout" name="fitLayout"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox">
-              <property name="title">
-               <string>Auto COR finding methods</string>
-              </property>
-              <layout class="QHBoxLayout" name="horizontalLayout_3">
-               <item>
-                <widget class="QPushButton" name="correlateBtn">
-                 <property name="toolTip">
-                  <string>Performs a correlation between the 0 and 180 degree projections to find the shift.</string>
-                 </property>
-                 <property name="text">
-                  <string>Correlate 0 and 180</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="minimiseBtn">
-                 <property name="toolTip">
-                  <string>Minimises the square-sum error of the reconstructed slice, for a number of slices. The COR with lowest error will be used.</string>
-                 </property>
-                 <property name="text">
-                  <string>Minimise error</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="corHelpButton">
-                 <property name="maximumSize">
-                  <size>
-                   <width>25</width>
-                   <height>16777215</height>
-                  </size>
-                 </property>
-                 <property name="text">
-                  <string>?</string>
-                 </property>
-                </widget>
                </item>
               </layout>
              </widget>


### PR DESCRIPTION
### Description

Small re-arrangement of the recon layout. Also changed the manual fit button text and tooltip.

Now:
![image](https://user-images.githubusercontent.com/9135965/104472633-0ddd1900-55b4-11eb-9d76-391a09c257b6.png)

### Testing & Acceptance Criteria 

Just see if this layout/button text makes sense
