### PR TITLE
Fixes wrong help page being opened

### DIFF
--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -203,7 +203,13 @@ class FiltersWindowView(BaseMainWindowView):
         self.notification_text.setText(f"{operation_name} completed successfully!")
 
     def open_help_webpage(self):
-        filter_module_path = self.presenter.get_filter_module_name(self.filterSelector.currentIndex())
+        idx = self.filterSelector.currentIndex()
+        if idx >= 16:
+            idx -= 2
+        elif idx >= 5:
+            idx -= 1
+
+        filter_module_path = self.presenter.get_filter_module_name(idx)
         try:
             open_api_webpage(filter_module_path)
         except RuntimeError as err:


### PR DESCRIPTION
### Description

Subtracts 1 or 2 from the current index depending on how far the selected operation is. This fixes going to the 
wrong page, but due to it not being a good way of fixing this, it will only be for the release 2.0 where we won't be adding any more operations.

### Testing 


- Open Operations window
- Select Divide
- Click the `?` for help
- The web page opened will not be for the divide filter

### Acceptance Criteria 

The correct help page is opened every time.

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*
