### PR TITLE
Fix help link lookup for operations

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -11,3 +11,4 @@ Fixes
 -----
 
 - #816 : Error finding screen size in some dual screen set ups
+- #820 : Help links go to wrong page

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -203,7 +203,9 @@ class FiltersWindowView(BaseMainWindowView):
         self.notification_text.setText(f"{operation_name} completed successfully!")
 
     def open_help_webpage(self):
-        filter_module_path = self.presenter.get_filter_module_name(self.filterSelector.currentIndex())
+        filter_id = self.presenter.model._find_filter_index_from_filter_name(self.filterSelector.currentText())
+        filter_module_path = self.presenter.get_filter_module_name(filter_id)
+
         try:
             open_api_webpage(filter_module_path)
         except RuntimeError as err:


### PR DESCRIPTION
### Issue

Fixes #820
Fixes #815

### Description

Use `_find_filter_index_from_filter_name()` to find by name rather than menu index.

### Testing 

From the operations window use the ? button to open the help pages for operations. Check that operations from each of the groups opens the correct page

### Acceptance Criteria 

Check that operations from each of the groups opens the correct page

### Documentation

Updated release notes.
