### PR TITLE
805: StackVisualiserViewTest prevent docks from being garbage collected

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -43,15 +43,15 @@ jobs:
         run: |
           mypy --ignore-missing-imports mantidimaging
 
-      - name: docs
-        shell: bash -l {0}
-        run: |
-          python setup.py docs
-
       - name: pytest
         shell: bash -l {0}
         run: |
           xvfb-run --auto-servernum python -m pytest --cov --cov-report=xml -n auto --count 10
+
+      - name: docs
+        shell: bash -l {0}
+        run: |
+          python setup.py docs
 
       - name: Coveralls
         shell: bash -l {0}

--- a/.github/workflows/cos7_testing.yml
+++ b/.github/workflows/cos7_testing.yml
@@ -43,14 +43,14 @@ jobs:
         command: mypy --ignore-missing-imports mantidimaging
         label: centos7
 
-    - name: docs
-      uses: ./.github/actions/test
-      with:
-        command: python setup.py docs
-        label: centos7
-
     - name: pytest
       uses: ./.github/actions/test
       with:
         command: xvfb-run pytest -n auto --count 10
+        label: centos7
+
+    - name: docs
+      uses: ./.github/actions/test
+      with:
+        command: python setup.py docs
         label: centos7

--- a/.github/workflows/u18_testing.yml
+++ b/.github/workflows/u18_testing.yml
@@ -39,12 +39,12 @@ jobs:
       with:
         command: mypy --ignore-missing-imports mantidimaging
 
-    - name: docs
-      uses: ./.github/actions/test
-      with:
-        command: python setup.py docs
-
     - name: pytest
       uses: ./.github/actions/test
       with:
         command: xvfb-run pytest -n auto --count 10
+
+    - name: docs
+      uses: ./.github/actions/test
+      with:
+        command: python setup.py docs

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -17,6 +17,7 @@ from mantidimaging.gui.windows.stack_visualiser import StackVisualiserView
 from mantidimaging.test_helpers import start_qapplication
 
 versions._use_test_values()
+docks = []
 
 
 @start_qapplication
@@ -38,6 +39,7 @@ class StackVisualiserViewTest(unittest.TestCase):
             self.window = MainWindowView()
         self.window.remove_stack = mock.Mock()
         self.dock, self.view, self.test_data = self._add_stack_visualiser()
+        docks.append(self.dock)
 
     def _add_stack_visualiser(self) -> Tuple[QDockWidget, StackVisualiserView, Images]:
         test_data = th.generate_images()


### PR DESCRIPTION
Garbage collection of dock widgets is causing a hard to debug crash that
is interfering with testing. It has not been seen in production.

Keep references to the dock widgets to prevent this.

### Issue

Closes #805

### Description

Keep references to the dock widgets to prevent garbage collection of docks.

### Testing

Tests should now pass reliably.

### Acceptance Criteria

Run make test multiple times and observe no errors from StackVisualiserViewTest

When running make test-randomly occasional crashes will still be seen.

### Documentation

I don't think a test fix needs documenting
