### PR TITLE
Median GPU filter add synchronise

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -12,3 +12,4 @@ Fixes
 
 - #816 : Error finding screen size in some dual screen set ups
 - #820 : Help links go to wrong page
+- #836 : Median filter returning data from wrong images

--- a/mantidimaging/core/gpu/utility.py
+++ b/mantidimaging/core/gpu/utility.py
@@ -129,6 +129,8 @@ def _send_arrays_to_gpu_with_pinned_memory(cpu_arrays, streams):
 
         for i in range(len(cpu_arrays)):
             gpu_arrays.append(_send_single_array_to_gpu(cpu_arrays[i], streams[i]))
+            # Synchronise to ensure that the upload has completed
+            streams[i].synchronize()
 
         return gpu_arrays
 


### PR DESCRIPTION
Add synchronize() call during upload to prevent wrong slice being
written.

### Issue

closes #836 

### Description

Add synchronize() call during upload to prevent wrong slice being
written.

### Testing 
GPU tests should pass. Even when other activity on the GPU. For example running `glxgears`

### Acceptance Criteria 

Tests pass

### Documentation

Added to release notes
