### PR TITLE
Don't pass NaN as argument to RescaleFilter.filter_func()

### DIFF
--- a/mantidimaging/core/operations/rescale/rescale_test.py
+++ b/mantidimaging/core/operations/rescale/rescale_test.py
@@ -122,7 +122,7 @@ def test_rescale_ignores_nans(value):
     expected_min_input = 0.0
     images = RescaleFilter.filter_func(images,
                                        min_input=expected_min_input,
-                                       max_input=images.data.max(),
+                                       max_input=np.nanmax(images.data),
                                        max_output=value)
 
     # below min_input has been clipped to 0


### PR DESCRIPTION
### Issue

Closes #844 

### Description

Use nanmax to avoid passing a NaN as max_input. In the GUI the value
would come from a FLOAT input box, so this would not happen in normal usage

### Testing 

Run `python -m pytest -k test_rescale_ignores_nans`

### Acceptance Criteria 

Check that `DeprecationWarning: Passing `np.nan` to mean no clipping in np.clip` does not show during test.

### Documentation

Small fix to test, docs not needed.
