### PR TITLE
833 update licenses

### DIFF
--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,3 +1,3 @@
 {
-  "**/*.py": "# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI\n# SPDX - License - Identifier: GPL-3.0-or-later"
+  "**/*.py": "# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI\n# SPDX - License - Identifier: GPL-3.0-or-later"
 }

--- a/AddLicensesToFiles.py
+++ b/AddLicensesToFiles.py
@@ -1,19 +1,63 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+#!/usr/bin/env python
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-import fileinput
-import os
-import sys
+# Update license comment block at the top files
+#
+# Reads the license and file glob pattern from .licenserc.json. It will
+# update any file that does not match. It will remove any old license lines,
+# identified by being leading comments containing "Copyright" or "License".
 
-for root, dirs, files in os.walk('.'):
-    for line in fileinput.input(
-        (os.path.join(root, name) for name in files if name.endswith('.py')),
-            inplace=True,
-            # backup='.bak' # uncomment this if you want backups
-    ):
-        if fileinput.isfirstline() and line != "# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI\n":
-            sys.stdout.write('# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI\n# SPDX - License - '
-                             'Identifier: GPL-3.0-or-later\n\n')
-            sys.stdout.write(line)
+import glob
+import json
+
+update_count = 0
+
+
+def update_copyrights_glob(globpattern, copyright_string):
+    for filepath in glob.iglob(globpattern, recursive=True):
+        update_copyright_file(filepath, copyright_string)
+
+
+def update_copyright_file(filepath, copyright_string):
+    global update_count
+    copyright_lines = copyright_string.split("\n")
+    lines = open(filepath).readlines()
+    if lines[0].startswith("#!"):
+        shebang_line = lines.pop(0)
+    else:
+        shebang_line = ""
+
+    # Check if the copyright is already correct
+    is_good = True
+    for i in range(len(copyright_lines)):
+        if lines[i].strip() != copyright_lines[i].strip():
+            is_good = False
+    if is_good:
+        return
+
+    # Remove any existing copyright lines
+    while len(lines):
+        if ((lines[0].startswith("#") and "Copyright" in lines[0])
+                or (lines[0].startswith("#") and "License" in lines[0])):
+            lines.pop(0)
         else:
-            sys.stdout.write(line)
+            break
+
+    # Output modified file
+    update_count += 1
+    with open(filepath, "w") as outfile:
+        if shebang_line:
+            outfile.write(shebang_line)
+        outfile.write("\n".join(copyright_lines) + "\n")
+
+        outfile.write("".join(lines))
+
+
+if __name__ == "__main__":
+    copyright_strings = json.load(open(".licenserc.json"))
+
+    for globpattern, copyright_string in copyright_strings.items():
+        update_copyrights_glob(globpattern, copyright_string)
+
+    print("Updated", update_count, "files")

--- a/Makefile
+++ b/Makefile
@@ -60,4 +60,4 @@ yapf_apply:
 flake8:
 	python -m flake8
 
-check: yapf_apply flake8 mypy test
+check: yapf flake8 mypy test

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 # -*- coding: utf-8 -*-

--- a/mantidimaging/__init__.py
+++ b/mantidimaging/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 __version__ = '2.0.0'

--- a/mantidimaging/__main__.py
+++ b/mantidimaging/__main__.py
@@ -1,7 +1,6 @@
+#!/usr/bin/env python
 # Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-
-# !/usr/bin/env python
 
 if __name__ == '__main__':
     from mantidimaging import main

--- a/mantidimaging/__main__.py
+++ b/mantidimaging/__main__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 if __name__ == '__main__':

--- a/mantidimaging/core/__init__.py
+++ b/mantidimaging/core/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from . import operations, io, parallel, tools, utility  # noqa: F401

--- a/mantidimaging/core/data/__init__.py
+++ b/mantidimaging/core/data/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .images import Images  # noqa: F401

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from dataclasses import dataclass

--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import datetime

--- a/mantidimaging/core/data/test/__init__.py
+++ b/mantidimaging/core/data/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/data/test/fake_logfile.py
+++ b/mantidimaging/core/data/test/fake_logfile.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from mantidimaging.core.utility.imat_log_file_parser import CSVLogParser, IMATLogFile, TextLogParser

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import io

--- a/mantidimaging/core/data/utility.py
+++ b/mantidimaging/core/data/utility.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import TYPE_CHECKING

--- a/mantidimaging/core/gpu/__init__.py
+++ b/mantidimaging/core/gpu/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/gpu/test/__init__.py
+++ b/mantidimaging/core/gpu/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/gpu/test/gpu_test.py
+++ b/mantidimaging/core/gpu/test/gpu_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/gpu/test/import_test.py
+++ b/mantidimaging/core/gpu/test/import_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/gpu/utility.py
+++ b/mantidimaging/core/gpu/utility.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import os

--- a/mantidimaging/core/io/__init__.py
+++ b/mantidimaging/core/io/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from . import (  # noqa: F401

--- a/mantidimaging/core/io/loader/__init__.py
+++ b/mantidimaging/core/io/loader/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .loader import (  # noqa: F401

--- a/mantidimaging/core/io/loader/img_loader.py
+++ b/mantidimaging/core/io/loader/img_loader.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 """
 This module handles the loading of FIT, FITS, TIF, TIFF

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 import os
 from dataclasses import dataclass

--- a/mantidimaging/core/io/loader/stack_loader.py
+++ b/mantidimaging/core/io/loader/stack_loader.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from mantidimaging.core.data import Images

--- a/mantidimaging/core/io/loader/test/__init__.py
+++ b/mantidimaging/core/io/loader/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/io/loader/test/loader_test.py
+++ b/mantidimaging/core/io/loader/test/loader_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 import os
 from unittest import mock

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import os

--- a/mantidimaging/core/io/test/__init__.py
+++ b/mantidimaging/core/io/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import os

--- a/mantidimaging/core/io/test/utility_test.py
+++ b/mantidimaging/core/io/test/utility_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import os

--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import glob

--- a/mantidimaging/core/net/__init__.py
+++ b/mantidimaging/core/net/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/net/help_pages.py
+++ b/mantidimaging/core/net/help_pages.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from PyQt5.QtCore import QUrl

--- a/mantidimaging/core/operation_history/__init__.py
+++ b/mantidimaging/core/operation_history/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operation_history/const.py
+++ b/mantidimaging/core/operation_history/const.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 OPERATION_HISTORY = 'operation_history'

--- a/mantidimaging/core/operation_history/operations.py
+++ b/mantidimaging/core/operation_history/operations.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operation_history/test/__init__.py
+++ b/mantidimaging/core/operation_history/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operation_history/test/operation_history_test.py
+++ b/mantidimaging/core/operation_history/test/operation_history_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/operations/__init__.py
+++ b/mantidimaging/core/operations/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/base_filter.py
+++ b/mantidimaging/core/operations/base_filter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/circular_mask/__init__.py
+++ b/mantidimaging/core/operations/circular_mask/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .circular_mask import CircularMaskFilter  # noqa:F401

--- a/mantidimaging/core/operations/circular_mask/circular_mask.py
+++ b/mantidimaging/core/operations/circular_mask/circular_mask.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/circular_mask/test/__init__.py
+++ b/mantidimaging/core/operations/circular_mask/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/circular_mask/test/circular_mask_test.py
+++ b/mantidimaging/core/operations/circular_mask/test/circular_mask_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/operations/clip_values/__init__.py
+++ b/mantidimaging/core/operations/clip_values/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .clip_values import ClipValuesFilter  # noqa:F401

--- a/mantidimaging/core/operations/clip_values/clip_values.py
+++ b/mantidimaging/core/operations/clip_values/clip_values.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/clip_values/test/__init__.py
+++ b/mantidimaging/core/operations/clip_values/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/clip_values/test/clip_values_test.py
+++ b/mantidimaging/core/operations/clip_values/test/clip_values_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/operations/crop_coords/__init__.py
+++ b/mantidimaging/core/operations/crop_coords/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .crop_coords import CropCoordinatesFilter, execute_single  # noqa:F401

--- a/mantidimaging/core/operations/crop_coords/crop_coords.py
+++ b/mantidimaging/core/operations/crop_coords/crop_coords.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/crop_coords/test/__init__.py
+++ b/mantidimaging/core/operations/crop_coords/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
+++ b/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/operations/divide/__init__.py
+++ b/mantidimaging/core/operations/divide/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .divide import DivideFilter  # noqa:F401

--- a/mantidimaging/core/operations/divide/divide.py
+++ b/mantidimaging/core/operations/divide/divide.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/divide/test/__init__.py
+++ b/mantidimaging/core/operations/divide/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/divide/test/divide_test.py
+++ b/mantidimaging/core/operations/divide/test/divide_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/operations/flat_fielding/__init__.py
+++ b/mantidimaging/core/operations/flat_fielding/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .flat_fielding import FlatFieldFilter  # noqa:F401

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/flat_fielding/test/__init__.py
+++ b/mantidimaging/core/operations/flat_fielding/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
+++ b/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/operations/gaussian/__init__.py
+++ b/mantidimaging/core/operations/gaussian/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .gaussian import GaussianFilter, modes  # noqa:F401

--- a/mantidimaging/core/operations/gaussian/gaussian.py
+++ b/mantidimaging/core/operations/gaussian/gaussian.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/gaussian/test/__init__.py
+++ b/mantidimaging/core/operations/gaussian/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/gaussian/test/gaussian_test.py
+++ b/mantidimaging/core/operations/gaussian/test/gaussian_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/operations/loader.py
+++ b/mantidimaging/core/operations/loader.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import List

--- a/mantidimaging/core/operations/median_filter/__init__.py
+++ b/mantidimaging/core/operations/median_filter/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .median_filter import MedianFilter, modes  # noqa:F401

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/median_filter/test/__init__.py
+++ b/mantidimaging/core/operations/median_filter/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/median_filter/test/median_filter_test.py
+++ b/mantidimaging/core/operations/median_filter/test/median_filter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/operations/monitor_normalisation/__init__.py
+++ b/mantidimaging/core/operations/monitor_normalisation/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .monitor_normalisation import MonitorNormalisation  # noqa:F401

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from functools import partial
 from typing import Callable, Dict, Any

--- a/mantidimaging/core/operations/monitor_normalisation/test/__init__.py
+++ b/mantidimaging/core/operations/monitor_normalisation/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/monitor_normalisation/test/monitor_normalisation_test.py
+++ b/mantidimaging/core/operations/monitor_normalisation/test/monitor_normalisation_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from functools import partial
 

--- a/mantidimaging/core/operations/outliers/__init__.py
+++ b/mantidimaging/core/operations/outliers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .outliers import OutliersFilter, modes  # noqa:F401

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import operator

--- a/mantidimaging/core/operations/outliers/test/__init__.py
+++ b/mantidimaging/core/operations/outliers/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/outliers/test/outliers_test.py
+++ b/mantidimaging/core/operations/outliers/test/outliers_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/operations/rebin/__init__.py
+++ b/mantidimaging/core/operations/rebin/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .rebin import RebinFilter, modes  # noqa:F401

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/rebin/test/__init__.py
+++ b/mantidimaging/core/operations/rebin/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/rebin/test/rebin_test.py
+++ b/mantidimaging/core/operations/rebin/test/rebin_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/operations/remove_all_stripe/__init__.py
+++ b/mantidimaging/core/operations/remove_all_stripe/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .remove_all_stripe import RemoveAllStripesFilter  # noqa:F401

--- a/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
+++ b/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/remove_all_stripe/test/__init__.py
+++ b/mantidimaging/core/operations/remove_all_stripe/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/remove_all_stripe/test/remove_all_stripe_test.py
+++ b/mantidimaging/core/operations/remove_all_stripe/test/remove_all_stripe_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/operations/remove_dead_stripe/__init__.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .remove_dead_stripe import RemoveDeadStripesFilter  # noqa:F401

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/remove_dead_stripe/test/__init__.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/remove_dead_stripe/test/remove_dead_stripe_test.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/test/remove_dead_stripe_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/operations/remove_large_stripe/__init__.py
+++ b/mantidimaging/core/operations/remove_large_stripe/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .remove_large_stripe import RemoveLargeStripesFilter  # noqa:F401

--- a/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
+++ b/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/remove_large_stripe/test/__init__.py
+++ b/mantidimaging/core/operations/remove_large_stripe/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/remove_large_stripe/test/remove_large_stripe_test.py
+++ b/mantidimaging/core/operations/remove_large_stripe/test/remove_large_stripe_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/operations/remove_stripe/__init__.py
+++ b/mantidimaging/core/operations/remove_stripe/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .stripe_removal import StripeRemovalFilter, wavelet_names  # noqa:F401

--- a/mantidimaging/core/operations/remove_stripe/stripe_removal.py
+++ b/mantidimaging/core/operations/remove_stripe/stripe_removal.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/remove_stripe/test/__init__.py
+++ b/mantidimaging/core/operations/remove_stripe/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/remove_stripe/test/stripe_removal_test.py
+++ b/mantidimaging/core/operations/remove_stripe/test/stripe_removal_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/operations/remove_stripe_filtering/__init__.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .remove_stripe_filtering import RemoveStripeFilteringFilter  # noqa:F401

--- a/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/remove_stripe_filtering/test/__init__.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/remove_stripe_filtering/test/remove_stripe_filtering_test.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/test/remove_stripe_filtering_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/__init__.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .remove_stripe_sorting_fitting import RemoveStripeSortingFittingFilter  # noqa:F401

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/test/__init__.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/test/remove_stripe_sorting_fitting_test.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/test/remove_stripe_sorting_fitting_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/operations/rescale/__init__.py
+++ b/mantidimaging/core/operations/rescale/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .rescale import RescaleFilter  # noqa:F401

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/rescale/rescale_test.py
+++ b/mantidimaging/core/operations/rescale/rescale_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import math

--- a/mantidimaging/core/operations/ring_removal/__init__.py
+++ b/mantidimaging/core/operations/ring_removal/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .ring_removal import RingRemovalFilter  # noqa:F401

--- a/mantidimaging/core/operations/ring_removal/ring_removal.py
+++ b/mantidimaging/core/operations/ring_removal/ring_removal.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/ring_removal/test/__init__.py
+++ b/mantidimaging/core/operations/ring_removal/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/ring_removal/test/ring_removal_test.py
+++ b/mantidimaging/core/operations/ring_removal/test/ring_removal_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/operations/roi_normalisation/__init__.py
+++ b/mantidimaging/core/operations/roi_normalisation/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .roi_normalisation import RoiNormalisationFilter  # noqa:F401

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/roi_normalisation/test/__init__.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/operations/rotate_stack/__init__.py
+++ b/mantidimaging/core/operations/rotate_stack/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .rotate_stack import RotateFilter  # noqa:F401

--- a/mantidimaging/core/operations/rotate_stack/rotate_stack.py
+++ b/mantidimaging/core/operations/rotate_stack/rotate_stack.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/operations/rotate_stack/test/__init__.py
+++ b/mantidimaging/core/operations/rotate_stack/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/rotate_stack/test/rotate_stack_test.py
+++ b/mantidimaging/core/operations/rotate_stack/test/rotate_stack_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/parallel/__init__.py
+++ b/mantidimaging/core/parallel/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/parallel/shared.py
+++ b/mantidimaging/core/parallel/shared.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/parallel/test/__init__.py
+++ b/mantidimaging/core/parallel/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/parallel/test/utility_test.py
+++ b/mantidimaging/core/parallel/test/utility_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import numpy as np

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import ctypes

--- a/mantidimaging/core/reconstruct/__init__.py
+++ b/mantidimaging/core/reconstruct/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import Union

--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from contextlib import contextmanager

--- a/mantidimaging/core/reconstruct/base_recon.py
+++ b/mantidimaging/core/reconstruct/base_recon.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import List, Optional

--- a/mantidimaging/core/reconstruct/tomopy_recon.py
+++ b/mantidimaging/core/reconstruct/tomopy_recon.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from logging import getLogger

--- a/mantidimaging/core/rotation/__init__.py
+++ b/mantidimaging/core/rotation/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .data_model import CorTiltDataModel  # noqa: F401

--- a/mantidimaging/core/rotation/data_model.py
+++ b/mantidimaging/core/rotation/data_model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from collections import namedtuple

--- a/mantidimaging/core/rotation/polyfit_correlation.py
+++ b/mantidimaging/core/rotation/polyfit_correlation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from logging import getLogger

--- a/mantidimaging/core/rotation/test/__init__.py
+++ b/mantidimaging/core/rotation/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/rotation/test/data_model_test.py
+++ b/mantidimaging/core/rotation/test/data_model_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from unittest import TestCase

--- a/mantidimaging/core/rotation/test/polyfit_correlation_test.py
+++ b/mantidimaging/core/rotation/test/polyfit_correlation_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from unittest import mock

--- a/mantidimaging/core/tools/__init__.py
+++ b/mantidimaging/core/tools/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from . import (  # noqa: F401

--- a/mantidimaging/core/tools/abstract_tool.py
+++ b/mantidimaging/core/tools/abstract_tool.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 

--- a/mantidimaging/core/tools/importer.py
+++ b/mantidimaging/core/tools/importer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 

--- a/mantidimaging/core/tools/test/__init__.py
+++ b/mantidimaging/core/tools/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/tools/tomopy_tool.py
+++ b/mantidimaging/core/tools/tomopy_tool.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from logging import getLogger

--- a/mantidimaging/core/utility/__init__.py
+++ b/mantidimaging/core/utility/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from . import (  # noqa: F401

--- a/mantidimaging/core/utility/close_enough_point.py
+++ b/mantidimaging/core/utility/close_enough_point.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import List, Union

--- a/mantidimaging/core/utility/cor_interpolate.py
+++ b/mantidimaging/core/utility/cor_interpolate.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import numpy as np

--- a/mantidimaging/core/utility/cuda_check.py
+++ b/mantidimaging/core/utility/cuda_check.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 import subprocess
 from logging import getLogger

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 """
 Containers for data. They don't do much apart from storing the data,

--- a/mantidimaging/core/utility/execution_timer.py
+++ b/mantidimaging/core/utility/execution_timer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import time

--- a/mantidimaging/core/utility/finder.py
+++ b/mantidimaging/core/utility/finder.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import os

--- a/mantidimaging/core/utility/func_call.py
+++ b/mantidimaging/core/utility/func_call.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import inspect

--- a/mantidimaging/core/utility/histogram.py
+++ b/mantidimaging/core/utility/histogram.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import numpy as np

--- a/mantidimaging/core/utility/imat_log_file_parser.py
+++ b/mantidimaging/core/utility/imat_log_file_parser.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import csv

--- a/mantidimaging/core/utility/memory_usage.py
+++ b/mantidimaging/core/utility/memory_usage.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from logging import getLogger

--- a/mantidimaging/core/utility/optional_imports.py
+++ b/mantidimaging/core/utility/optional_imports.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 """
 A place for availability checking and import logic for optional dependencies to

--- a/mantidimaging/core/utility/progress_reporting/__init__.py
+++ b/mantidimaging/core/utility/progress_reporting/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .progress import Progress, ProgressHandler  # noqa: F401

--- a/mantidimaging/core/utility/progress_reporting/console_progress_bar.py
+++ b/mantidimaging/core/utility/progress_reporting/console_progress_bar.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import sys

--- a/mantidimaging/core/utility/progress_reporting/progress.py
+++ b/mantidimaging/core/utility/progress_reporting/progress.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import threading

--- a/mantidimaging/core/utility/progress_reporting/test/__init__.py
+++ b/mantidimaging/core/utility/progress_reporting/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/utility/progress_reporting/test/progress_test.py
+++ b/mantidimaging/core/utility/progress_reporting/test/progress_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/utility/projection_angle_parser.py
+++ b/mantidimaging/core/utility/projection_angle_parser.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import numpy as np

--- a/mantidimaging/core/utility/projection_angles.py
+++ b/mantidimaging/core/utility/projection_angles.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import math

--- a/mantidimaging/core/utility/registrator.py
+++ b/mantidimaging/core/utility/registrator.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import importlib

--- a/mantidimaging/core/utility/sensible_roi.py
+++ b/mantidimaging/core/utility/sensible_roi.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from collections.abc import Iterable

--- a/mantidimaging/core/utility/shape_splitter.py
+++ b/mantidimaging/core/utility/shape_splitter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/core/utility/size_calculator.py
+++ b/mantidimaging/core/utility/size_calculator.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 

--- a/mantidimaging/core/utility/special_imports.py
+++ b/mantidimaging/core/utility/special_imports.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 """
 A place for special import logic to live.

--- a/mantidimaging/core/utility/test/__init__.py
+++ b/mantidimaging/core/utility/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/utility/test/cuda_checker_test.py
+++ b/mantidimaging/core/utility/test/cuda_checker_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 import unittest
 from unittest import mock

--- a/mantidimaging/core/utility/test/execution_timer_test.py
+++ b/mantidimaging/core/utility/test/execution_timer_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/utility/test/imat_log_file_parser_test.py
+++ b/mantidimaging/core/utility/test/imat_log_file_parser_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import numpy as np

--- a/mantidimaging/core/utility/test/projection_angle_parser_test.py
+++ b/mantidimaging/core/utility/test/projection_angle_parser_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import os

--- a/mantidimaging/core/utility/test/shape_splitter_test.py
+++ b/mantidimaging/core/utility/test/shape_splitter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/utility/test/size_calculator_test.py
+++ b/mantidimaging/core/utility/test/size_calculator_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import numpy as np

--- a/mantidimaging/core/utility/test/version_check_test.py
+++ b/mantidimaging/core/utility/test/version_check_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/core/utility/version_check.py
+++ b/mantidimaging/core/utility/version_check.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import json

--- a/mantidimaging/gui/__init__.py
+++ b/mantidimaging/gui/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .gui import execute  # noqa: F401  # noqa:F821

--- a/mantidimaging/gui/dialogs/__init__.py
+++ b/mantidimaging/gui/dialogs/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/dialogs/async_task/__init__.py
+++ b/mantidimaging/gui/dialogs/async_task/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .model import AsyncTaskDialogModel, TaskWorkerThread  # noqa: F401

--- a/mantidimaging/gui/dialogs/async_task/model.py
+++ b/mantidimaging/gui/dialogs/async_task/model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from logging import getLogger

--- a/mantidimaging/gui/dialogs/async_task/presenter.py
+++ b/mantidimaging/gui/dialogs/async_task/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import traceback

--- a/mantidimaging/gui/dialogs/async_task/task.py
+++ b/mantidimaging/gui/dialogs/async_task/task.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from logging import getLogger

--- a/mantidimaging/gui/dialogs/async_task/test/__init__.py
+++ b/mantidimaging/gui/dialogs/async_task/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/dialogs/async_task/test/model_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/model_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import time

--- a/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import time

--- a/mantidimaging/gui/dialogs/async_task/test/task_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/task_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import Callable

--- a/mantidimaging/gui/dialogs/cor_inspection/__init__.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .model import CORInspectionDialogModel  # noqa: F401

--- a/mantidimaging/gui/dialogs/cor_inspection/model.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from dataclasses import replace
 from logging import getLogger

--- a/mantidimaging/gui/dialogs/cor_inspection/presenter.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import traceback

--- a/mantidimaging/gui/dialogs/cor_inspection/recon_slice_view.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/recon_slice_view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import Tuple, TYPE_CHECKING

--- a/mantidimaging/gui/dialogs/cor_inspection/test/__init__.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/dialogs/cor_inspection/test/model_test.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/test/model_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/dialogs/cor_inspection/test/presenter_test.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/dialogs/cor_inspection/types.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/types.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from enum import Enum

--- a/mantidimaging/gui/dialogs/cor_inspection/view.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import List, Union

--- a/mantidimaging/gui/dialogs/multiple_stack_select/__init__.py
+++ b/mantidimaging/gui/dialogs/multiple_stack_select/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/dialogs/multiple_stack_select/view.py
+++ b/mantidimaging/gui/dialogs/multiple_stack_select/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import TYPE_CHECKING

--- a/mantidimaging/gui/dialogs/op_history_copy/__init__.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .view import OpHistoryCopyDialogView  # noqa:F401

--- a/mantidimaging/gui/dialogs/op_history_copy/model.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import Iterable

--- a/mantidimaging/gui/dialogs/op_history_copy/presenter.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import List, TYPE_CHECKING, Iterable, Any, Dict

--- a/mantidimaging/gui/dialogs/op_history_copy/test/__init__.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/dialogs/op_history_copy/test/model_test.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/test/model_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/dialogs/op_history_copy/view.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import Iterable, Tuple

--- a/mantidimaging/gui/gui.py
+++ b/mantidimaging/gui/gui.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import logging

--- a/mantidimaging/gui/mvp_base/__init__.py
+++ b/mantidimaging/gui/mvp_base/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .view import (BaseDialogView, BaseMainWindowView)  # noqa: F401

--- a/mantidimaging/gui/mvp_base/presenter.py
+++ b/mantidimaging/gui/mvp_base/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from logging import getLogger

--- a/mantidimaging/gui/mvp_base/test/__init__.py
+++ b/mantidimaging/gui/mvp_base/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/mvp_base/test/presenter_test.py
+++ b/mantidimaging/gui/mvp_base/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/mvp_base/view.py
+++ b/mantidimaging/gui/mvp_base/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from logging import getLogger

--- a/mantidimaging/gui/utility/__init__.py
+++ b/mantidimaging/gui/utility/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from mantidimaging.gui.utility.get_parameters_from_stack import (  # noqa: F401

--- a/mantidimaging/gui/utility/common.py
+++ b/mantidimaging/gui/utility/common.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from contextlib import contextmanager

--- a/mantidimaging/gui/utility/get_parameters_from_stack.py
+++ b/mantidimaging/gui/utility/get_parameters_from_stack.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 

--- a/mantidimaging/gui/utility/qt_helpers.py
+++ b/mantidimaging/gui/utility/qt_helpers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 """
 Module containing helper functions relating to PyQt.

--- a/mantidimaging/gui/widgets/__init__.py
+++ b/mantidimaging/gui/widgets/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .mpl_navigation_toolbar_simple import (  # noqa: F401

--- a/mantidimaging/gui/widgets/mi_image_view/__init__.py
+++ b/mantidimaging/gui/widgets/mi_image_view/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/widgets/mi_image_view/presenter.py
+++ b/mantidimaging/gui/widgets/mi_image_view/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from logging import getLogger

--- a/mantidimaging/gui/widgets/mi_image_view/test/__init__.py
+++ b/mantidimaging/gui/widgets/mi_image_view/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/widgets/mi_image_view/test/test_presenter.py
+++ b/mantidimaging/gui/widgets/mi_image_view/test/test_presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import List

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from time import sleep

--- a/mantidimaging/gui/widgets/mpl_navigation_toolbar_simple.py
+++ b/mantidimaging/gui/widgets/mpl_navigation_toolbar_simple.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT

--- a/mantidimaging/gui/widgets/removable_row_table_view.py
+++ b/mantidimaging/gui/widgets/removable_row_table_view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from PyQt5.QtCore import Qt, QModelIndex

--- a/mantidimaging/gui/widgets/stack_selector/__init__.py
+++ b/mantidimaging/gui/widgets/stack_selector/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .view import StackSelectorWidgetView  # noqa: F401

--- a/mantidimaging/gui/widgets/stack_selector/presenter.py
+++ b/mantidimaging/gui/widgets/stack_selector/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import traceback

--- a/mantidimaging/gui/widgets/stack_selector/view.py
+++ b/mantidimaging/gui/widgets/stack_selector/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import TYPE_CHECKING

--- a/mantidimaging/gui/widgets/stack_selector_dialog/__init__.py
+++ b/mantidimaging/gui/widgets/stack_selector_dialog/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/widgets/stack_selector_dialog/stack_selector_dialog.py
+++ b/mantidimaging/gui/widgets/stack_selector_dialog/stack_selector_dialog.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from typing import TYPE_CHECKING, Optional
 

--- a/mantidimaging/gui/widgets/stack_selector_dialog/test/__init__.py
+++ b/mantidimaging/gui/widgets/stack_selector_dialog/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/widgets/stack_selector_dialog/test/test_stack_selector_dialog.py
+++ b/mantidimaging/gui/widgets/stack_selector_dialog/test/test_stack_selector_dialog.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 import unittest
 from unittest import mock

--- a/mantidimaging/gui/windows/__init__.py
+++ b/mantidimaging/gui/windows/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/windows/load_dialog/__init__.py
+++ b/mantidimaging/gui/windows/load_dialog/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .view import MWLoadDialog  # noqa: F401

--- a/mantidimaging/gui/windows/load_dialog/field.py
+++ b/mantidimaging/gui/windows/load_dialog/field.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import os

--- a/mantidimaging/gui/windows/load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/load_dialog/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import os

--- a/mantidimaging/gui/windows/load_dialog/test/__init__.py
+++ b/mantidimaging/gui/windows/load_dialog/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/windows/load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/load_dialog/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/windows/load_dialog/view.py
+++ b/mantidimaging/gui/windows/load_dialog/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import Optional, Tuple

--- a/mantidimaging/gui/windows/main/__init__.py
+++ b/mantidimaging/gui/windows/main/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .model import MainWindowModel  # noqa: F401

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 import os
 import uuid

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 import os
 import traceback

--- a/mantidimaging/gui/windows/main/save_dialog.py
+++ b/mantidimaging/gui/windows/main/save_dialog.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from PyQt5 import Qt

--- a/mantidimaging/gui/windows/main/test/__init__.py
+++ b/mantidimaging/gui/windows/main/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/windows/main/test/save_test.py
+++ b/mantidimaging/gui/windows/main/test/save_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import os

--- a/mantidimaging/gui/windows/operations/__init__.py
+++ b/mantidimaging/gui/windows/operations/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .model import FiltersWindowModel  # noqa: F401

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from collections import namedtuple

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import traceback

--- a/mantidimaging/gui/windows/operations/test/__init__.py
+++ b/mantidimaging/gui/windows/operations/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/windows/operations/test/test_model.py
+++ b/mantidimaging/gui/windows/operations/test/test_model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/windows/operations/test/test_view.py
+++ b/mantidimaging/gui/windows/operations/test/test_view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import TYPE_CHECKING

--- a/mantidimaging/gui/windows/recon/__init__.py
+++ b/mantidimaging/gui/windows/recon/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .model import ReconstructWindowModel  # noqa: F401

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from math import isnan
 from typing import Tuple, Optional

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from logging import getLogger

--- a/mantidimaging/gui/windows/recon/point_table_model.py
+++ b/mantidimaging/gui/windows/recon/point_table_model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from enum import Enum

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import traceback

--- a/mantidimaging/gui/windows/recon/test/__init__.py
+++ b/mantidimaging/gui/windows/recon/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/windows/recon/test/model_test.py
+++ b/mantidimaging/gui/windows/recon/test/model_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import TYPE_CHECKING, List, Optional

--- a/mantidimaging/gui/windows/stack_choice/__init__.py
+++ b/mantidimaging/gui/windows/stack_choice/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/windows/stack_choice/compare_presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/compare_presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import traceback

--- a/mantidimaging/gui/windows/stack_choice/presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import traceback

--- a/mantidimaging/gui/windows/stack_choice/presenter_base.py
+++ b/mantidimaging/gui/windows/stack_choice/presenter_base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from mantidimaging.gui.mvp_base.presenter import BasePresenter

--- a/mantidimaging/gui/windows/stack_choice/tests/__init__.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/windows/stack_choice/tests/test_compare_presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/test_compare_presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/windows/stack_choice/tests/test_presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/test_presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/windows/stack_choice/tests/test_view.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/test_view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 import unittest
 from unittest import mock

--- a/mantidimaging/gui/windows/stack_choice/view.py
+++ b/mantidimaging/gui/windows/stack_choice/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from enum import Enum, auto

--- a/mantidimaging/gui/windows/stack_visualiser/__init__.py
+++ b/mantidimaging/gui/windows/stack_visualiser/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from mantidimaging.gui.windows.stack_visualiser.presenter import (  # noqa: F401

--- a/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
+++ b/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from PyQt5 import Qt

--- a/mantidimaging/gui/windows/stack_visualiser/model.py
+++ b/mantidimaging/gui/windows/stack_visualiser/model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import numpy as np

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import numpy as np

--- a/mantidimaging/gui/windows/stack_visualiser/test/__init__.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 import unittest
 from typing import Tuple

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import TYPE_CHECKING

--- a/mantidimaging/gui/windows/welcome_screen/__init__.py
+++ b/mantidimaging/gui/windows/welcome_screen/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/windows/welcome_screen/presenter.py
+++ b/mantidimaging/gui/windows/welcome_screen/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from PyQt5.QtCore import QSettings

--- a/mantidimaging/gui/windows/welcome_screen/tests/test_presenter.py
+++ b/mantidimaging/gui/windows/welcome_screen/tests/test_presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/windows/welcome_screen/tests/test_view.py
+++ b/mantidimaging/gui/windows/welcome_screen/tests/test_view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest

--- a/mantidimaging/gui/windows/welcome_screen/view.py
+++ b/mantidimaging/gui/windows/welcome_screen/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from mantidimaging.core.utility import finder

--- a/mantidimaging/helper.py
+++ b/mantidimaging/helper.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 """
 Module for commonly used functions across the modules.

--- a/mantidimaging/ipython.py
+++ b/mantidimaging/ipython.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 

--- a/mantidimaging/ipython.py
+++ b/mantidimaging/ipython.py
@@ -1,7 +1,6 @@
+#!/usr/bin/env python
 # Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-
-# !/usr/bin/env python
 
 
 def main():

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import argparse

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -1,7 +1,7 @@
+#!/usr/bin/env python
 # Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-# !/usr/bin/env python
 import argparse
 import logging
 import warnings

--- a/mantidimaging/test_helpers/__init__.py
+++ b/mantidimaging/test_helpers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 """
 This package contains testing helpers for unit tests across the application

--- a/mantidimaging/test_helpers/file_outputting_test_case.py
+++ b/mantidimaging/test_helpers/file_outputting_test_case.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import shutil

--- a/mantidimaging/test_helpers/qt_mocks.py
+++ b/mantidimaging/test_helpers/qt_mocks.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from unittest.mock import Mock

--- a/mantidimaging/test_helpers/start_qapplication.py
+++ b/mantidimaging/test_helpers/start_qapplication.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 # Mantid Repository : https://github.com/mantidproject/mantid

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import os

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
+#!/usr/bin/env python
 # Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-
-# !/usr/bin/env python
 
 import fnmatch
 import os

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2020 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import fnmatch


### PR DESCRIPTION
### Issue

closes #833 

### Description

Update licenses and licenses update script.

Note: I'll push the  `.licenserc.json` change first, so I can see the failure. Then another patch to make it pass.

### Testing 

Check that the licenses now have a date of 2021

### Acceptance Criteria 

Licenses updated. license_checker stage in tests passes.

Running `python AddLicensesToFiles.py` should not make any further file modifications

### Documentation

Not needed.
