### PR TITLE
845: Low Contrast Image Warning

### DIFF
--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -204,7 +204,7 @@ class IOTest(FileOutputtingTestCase):
 
     def test_metadata_round_trip(self):
         # Create dummy image stack
-        sample = th.gen_img_shared_array_with_val(42.)
+        sample = th.gen_img_numpy_rand()
         images = Images(sample)
         images.metadata['message'] = 'hello, world!'
 

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -58,14 +58,6 @@ def _set_random_data(data, shape):
     return images
 
 
-def gen_img_shared_array_with_val(val=1., shape=g_shape):
-    d = pu.create_array(shape)
-    n = np.full(shape, val)
-    # move the data in the shared array
-    d[:] = n[:]
-    return d
-
-
 def assert_not_equals(one: np.ndarray, two: np.ndarray):
     """
     Assert equality for numpy ndarrays using the numpy testing library.


### PR DESCRIPTION
### Issue

Closes #845

### Description

Replaces the constant array in `test_metadata_round_trip` with a random array, which appears to fix the low contrast problem. Also removed the helper method responsible for creating a constant array as this was only being used in the one test.

### Testing 

n/a

### Acceptance Criteria 

Check that the warning no longer appears.

### Documentation

n/a
