### PR TITLE
Add 5 minute timeout to the pytest step in actions

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: mypy
         shell: bash -l {0}
+        # COMPAT: applitools has some bad signatures, so use --no-site-packages
         run: |
           mypy --ignore-missing-imports --no-site-packages mantidimaging
 

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -44,6 +44,7 @@ jobs:
           mypy --ignore-missing-imports --no-site-packages mantidimaging
 
       - name: pytest
+        timeout-minutes: 5
         shell: bash -l {0}
         run: |
           xvfb-run --auto-servernum python -m pytest --cov --cov-report=xml -n auto --count 10 --ignore=mantidimaging/eyes_tests

--- a/.github/workflows/cos7_testing.yml
+++ b/.github/workflows/cos7_testing.yml
@@ -40,7 +40,8 @@ jobs:
     - name: mypy
       uses: ./.github/actions/test
       with:
-        command: mypy --ignore-missing-imports mantidimaging
+        # COMPAT: applitools has some bad signatures, so use --no-site-packages
+        command: mypy --ignore-missing-imports --no-site-packages mantidimaging
         label: centos7
 
     - name: pytest

--- a/.github/workflows/cos7_testing.yml
+++ b/.github/workflows/cos7_testing.yml
@@ -44,6 +44,7 @@ jobs:
         label: centos7
 
     - name: pytest
+      timeout-minutes: 5
       uses: ./.github/actions/test
       with:
         command: xvfb-run pytest -n auto --count 10 --ignore=mantidimaging/eyes_tests

--- a/.github/workflows/u18_testing.yml
+++ b/.github/workflows/u18_testing.yml
@@ -37,7 +37,8 @@ jobs:
     - name: mypy
       uses: ./.github/actions/test
       with:
-        command: mypy --ignore-missing-imports mantidimaging
+        # COMPAT: applitools has some bad signatures, so use --no-site-packages
+        command: mypy --ignore-missing-imports --no-site-packages mantidimaging
 
     - name: pytest
       timeout-minutes: 5

--- a/.github/workflows/u18_testing.yml
+++ b/.github/workflows/u18_testing.yml
@@ -40,6 +40,7 @@ jobs:
         command: mypy --ignore-missing-imports mantidimaging
 
     - name: pytest
+      timeout-minutes: 5
       uses: ./.github/actions/test
       with:
         command: xvfb-run pytest -n auto --count 10 --ignore=mantidimaging/eyes_tests


### PR DESCRIPTION
Some failures in pytest cause it to hang. Better to fail fast than wait.

### Issue

No issue

### Description

Add `timeout-minutes` option

### Testing 

Automated testing on github actions

### Acceptance Criteria 

Actions tests run

### Documentation

NA