### PR TITLE
846: AstropyDeprecationWarning

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -14,3 +14,4 @@ Fixes
 - #816 : Error finding screen size in some dual screen set ups
 - #820 : Help links go to wrong page
 - #836 : Median filter returning data from wrong images
+- #846 : Fixing AstropyDeprecationWarning

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -24,7 +24,7 @@ def write_fits(data, filename, overwrite=False):
     import astropy.io.fits as fits
     hdu = fits.PrimaryHDU(data)
     hdulist = fits.HDUList([hdu])
-    hdulist.writeto(filename, clobber=overwrite)
+    hdulist.writeto(filename, overwrite=overwrite)
 
 
 def write_img(data, filename, overwrite=False):


### PR DESCRIPTION
### Issue

Closes #846 

### Description

Changes the parameter name in `hdulist.writeto` from `clobber` to `overwrite`.

### Testing 

n/a

### Acceptance Criteria 

Check that the error no longer appears.

### Documentation

Updated the release notes.