### PR TITLE
770: Move shared array allocation to `multiprocessing.Array` when on Python 3.8

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -15,3 +15,4 @@ Fixes
 - #820 : Help links go to wrong page
 - #836 : Median filter returning data from wrong images
 - #843 : Error loading stack
+- #856 : Move shared array allocation to `multiprocessing.Array` when on Python 3.8

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -8,7 +8,8 @@ from functools import partial
 from logging import getLogger
 # COMPAT python 3.7 : Using heap instead of Array,
 # see https://github.com/mantidproject/mantidimaging/pull/762#issuecomment-741663482
-from multiprocessing import heap  # type: ignore
+# from multiprocessing import heap  # type: ignore
+from multiprocessing import Array
 from multiprocessing.pool import Pool
 from typing import Any, List, Tuple, Type, Union
 
@@ -76,13 +77,15 @@ def _create_shared_array(shape, dtype: Union[str, np.dtype] = np.float32):
 
     LOG.info('Requested shared array with shape={}, length={}, size={}, ' 'dtype={}'.format(shape, length, size, dtype))
 
-    arena = heap.Arena(size)
-    mem = memoryview(arena.buffer)
-
-    array_type = ctype * length
-    array = array_type.from_buffer(mem)
-
-    data = np.frombuffer(array, dtype=dtype)
+    # arena = heap.Arena(size)
+    # mem = memoryview(arena.buffer)
+    #
+    # array_type = ctype * length
+    # array = array_type.from_buffer(mem)
+    #
+    # data = np.frombuffer(array, dtype=dtype)
+    array = Array(ctype, length)
+    data = np.frombuffer(array.get_obj(), dtype=dtype)
 
     return data.reshape(shape)
 

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -6,9 +6,6 @@ import multiprocessing
 import os
 from functools import partial
 from logging import getLogger
-# COMPAT python 3.7 : Using heap instead of Array,
-# see https://github.com/mantidproject/mantidimaging/pull/762#issuecomment-741663482
-# from multiprocessing import heap  # type: ignore
 from multiprocessing import Array
 from multiprocessing.pool import Pool
 from typing import Any, List, Tuple, Type, Union
@@ -77,13 +74,6 @@ def _create_shared_array(shape, dtype: Union[str, np.dtype] = np.float32):
 
     LOG.info('Requested shared array with shape={}, length={}, size={}, ' 'dtype={}'.format(shape, length, size, dtype))
 
-    # arena = heap.Arena(size)
-    # mem = memoryview(arena.buffer)
-    #
-    # array_type = ctype * length
-    # array = array_type.from_buffer(mem)
-    #
-    # data = np.frombuffer(array, dtype=dtype)
     array = Array(ctype, length)
     data = np.frombuffer(array.get_obj(), dtype=dtype)
 


### PR DESCRIPTION
### Issue

Closes #770 

### Description

Replaces `multiprocessing.heap` with `multiprocessing.Array`

### Testing 

n/a

### Acceptance Criteria 

Check that the existing tests still pass.
Go through the test described in https://github.com/mantidproject/mantidimaging/pull/762#issue-534291163

### Documentation

Updated the release notes.