### PR TITLE
Add cuda source file to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,10 @@ setup(
     name="mantidimaging",
     version="2.0.0",
     packages=find_packages(),
-    package_data={"mantidimaging.gui": ["ui/*.ui", "ui/images/*.png"]},
+    package_data={
+        "mantidimaging.gui": ["ui/*.ui", "ui/images/*.png"],
+        "mantidimaging.core": ["gpu/*.cu"]
+    },
     entry_points={
         "console_scripts": ["mantidimaging-ipython = mantidimaging.ipython:main"],
         "gui_scripts": ["mantidimaging = mantidimaging.main:main"],


### PR DESCRIPTION
### Issue

Closes #871 

### Description

Add .cu files to setup.py

### Testing 

Checkout branch, run
`make build-conda-package`

### Acceptance Criteria 

Check that the .cu file gets included:
`tar -tvf /home/user/miniconda/envs/build-env/conda-bld/linux-64/mantidimaging-2.0.0rc_647-py38_1.tar.bz2 | grep "core/gpu"`

### Documentation

Not needed
