### PR TITLE
864: Ops window, image selector in preview section skips by 2

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -17,3 +17,4 @@ Fixes
 - #846 : Fixing AstropyDeprecationWarning
 - #843 : Error loading stack
 - #856 : Move shared array allocation to `multiprocessing.Array` when on Python 3.8
+- #854 : Ops window, image selector in preview section skips by 2

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -220,6 +220,8 @@ class FiltersWindowPresenter(BasePresenter):
 
     def do_update_previews(self):
         self.view.clear_previews()
+        # Disable preview image index scrollbox to prevent double-increase
+        self.view.previewImageIndex.setEnabled(False)
         if self.stack is not None:
             stack_presenter = self.stack.presenter
             subset: Images = stack_presenter.get_image(self.model.preview_image_idx)
@@ -252,6 +254,9 @@ class FiltersWindowPresenter(BasePresenter):
 
             # Ensure all of it is visible
             self.view.previews.auto_range()
+
+        # Enable preview image index box when preview has been created
+        self.view.previewImageIndex.setEnabled(True)
 
     @staticmethod
     def _update_preview_image(image_data: Optional[np.ndarray], image: ImageItem):

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -226,3 +226,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
 
         stack.presenter.images.copy.assert_called_once()
         self.assertEqual(stack_data, self.presenter.original_images_stack)
+
+    def test_preview_image_spin_box_disabled_while_updating_preview(self):
+        self.presenter.do_update_previews()
+        self.view.previewImageIndex.setEnabled.assert_has_calls([mock.call(False), mock.call(True)])


### PR DESCRIPTION
### Issue

Closes #864

### Description

Disables then enables the spin box while the operation preview is being generated.

### Testing 

Added a test to check that `setEnabled` is called twice when the preview is generated.

### Acceptance Criteria 

Change the preview index value with the left-mouse button and check that the value only increases once for the operations mentioned in #864

### Documentation

Updated the release notes.
