### PR TITLE
874: Operation window widgets resize

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -19,3 +19,4 @@ Fixes
 - #856 : Move shared array allocation to `multiprocessing.Array` when on Python 3.8
 - #854 : Ops window, image selector in preview section skips by 2
 - #856 : Operations auto update not triggered on spinbox changes
+- #874 : Widgets in Operations window need minimum sizes

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -112,7 +112,8 @@ class FilterPreviews(GraphicsLayoutWidget):
     def resizeEvent(self, ev: QResizeEvent):
         if ev is not None:
             size = ev.size()
-            self.image_layout.setFixedHeight(min(size.height() * 0.7, self.ALLOWED_HEIGHT))
+            # self.image_layout.setFixedHeight(min(size.height() * 0.7, self.ALLOWED_HEIGHT))
+            LOG.info("Size change")
         super().resizeEvent(ev)
 
     def image_in_vb(self, name=None):

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -112,8 +112,11 @@ class FilterPreviews(GraphicsLayoutWidget):
     def resizeEvent(self, ev: QResizeEvent):
         if ev is not None:
             size = ev.size()
-            # self.image_layout.setFixedHeight(min(size.height() * 0.7, self.ALLOWED_HEIGHT))
-            LOG.info("Size change")
+            image_layout_height = min(size.height() * 0.7, self.ALLOWED_HEIGHT)
+            # self.image_layout.setFixedHeight(image_layout_height)
+            self.histogram.setFixedHeight(image_layout_height * 0.25)
+        else:
+            LOG.info("ev is None")
         super().resizeEvent(ev)
 
     def image_in_vb(self, name=None):

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -110,7 +110,7 @@ class FilterPreviews(GraphicsLayoutWidget):
             scene.contextMenu = [item for item in scene.contextMenu if "export" not in item.text().lower()]
 
     def resizeEvent(self, ev: QResizeEvent):
-        if ev is not None:
+        if ev is not None and isinstance(self.histogram, PlotItem):
             size = ev.size()
             self.histogram.setFixedHeight(min(size.height() * 0.7, self.ALLOWED_HEIGHT) * 0.25)
         super().resizeEvent(ev)

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -112,8 +112,7 @@ class FilterPreviews(GraphicsLayoutWidget):
     def resizeEvent(self, ev: QResizeEvent):
         if ev is not None:
             size = ev.size()
-            image_layout_height = min(size.height() * 0.7, self.ALLOWED_HEIGHT)
-            self.histogram.setFixedHeight(image_layout_height * 0.25)
+            self.histogram.setFixedHeight(min(size.height() * 0.7, self.ALLOWED_HEIGHT) * 0.25)
         super().resizeEvent(ev)
 
     def image_in_vb(self, name=None):

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -113,10 +113,7 @@ class FilterPreviews(GraphicsLayoutWidget):
         if ev is not None:
             size = ev.size()
             image_layout_height = min(size.height() * 0.7, self.ALLOWED_HEIGHT)
-            # self.image_layout.setFixedHeight(image_layout_height)
             self.histogram.setFixedHeight(image_layout_height * 0.25)
-        else:
-            LOG.info("ev is None")
         super().resizeEvent(ev)
 
     def image_in_vb(self, name=None):


### PR DESCRIPTION
### Issue

Closes #874

### Description

Sets a fixed height for the pixel values histogram rather than the image layout.

### Testing 

Tested it out on my own machine and IDAaaS. 

### Acceptance Criteria 

Reduce the size of the operations window and check that everything remains visible.

### Documentation

Updated the release notes.
