### PR TITLE
866: Flat fielding warning

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -1,4 +1,3 @@
-
 Mantid Imaging next release
 ===========================
 

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -1,3 +1,4 @@
+
 Mantid Imaging next release
 ===========================
 
@@ -20,3 +21,4 @@ Fixes
 - #854 : Ops window, image selector in preview section skips by 2
 - #856 : Operations auto update not triggered on spinbox changes
 - #874 : Widgets in Operations window need minimum sizes
+- #866 : Warning if running Flat-fielding again

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -55,6 +55,11 @@ class FiltersWindowPresenter(BasePresenter):
         self.original_images_stack: Union[List[Tuple[Images, UUID]]] = []
         self.applying_to_all = False
 
+        self.prev_apply_single_state = True
+        self.prev_apply_stack_state = True
+        self.main_window.filter_applied.connect(
+            lambda: self._set_apply_buttons_enabled(self.prev_apply_single_state, self.prev_apply_stack_state))
+
     @property
     def main_window(self) -> 'MainWindowView':
         return self._main_window
@@ -224,11 +229,12 @@ class FiltersWindowPresenter(BasePresenter):
         self.view.filter_applied.emit()
 
     def _do_apply_filter(self, apply_to):
-        prev_apply_single_enabled = self.view.applyButton.isEnabled()
-        prev_apply_all_enabled = self.view.applyToAllButton.isEnabled()
+        # Record the previous button states
+        self.prev_apply_single_state = self.view.applyButton.isEnabled()
+        self.prev_apply_stack_state = self.view.applyToAllButton.isEnabled()
+        # Disable the apply buttons
         self._set_apply_buttons_enabled(False, False)
         self.model.do_apply_filter(apply_to, partial(self._post_filter, apply_to))
-        self._set_apply_buttons_enabled(prev_apply_single_enabled, prev_apply_all_enabled)
 
     def _do_apply_filter_sync(self, apply_to):
         self.model.do_apply_filter_sync(apply_to, partial(self._post_filter, apply_to))
@@ -297,5 +303,10 @@ class FiltersWindowPresenter(BasePresenter):
                    for operation in self.stack.presenter.images.metadata[OPERATION_HISTORY])
 
     def _set_apply_buttons_enabled(self, apply_single_enabled: bool, apply_all_enabled: bool):
+        """
+        Changes the state of the apply buttons before/after an operation is being run.
+        :param apply_single_enabled: The desired state for the apply (to single image) button.
+        :param apply_all_enabled: The desired state for the apply to stack button.
+        """
         self.view.applyButton.setEnabled(apply_single_enabled)
         self.view.applyToAllButton.setEnabled(apply_all_enabled)

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -14,6 +14,7 @@ from PyQt5.QtWidgets import QApplication
 from pyqtgraph import ImageItem
 
 from mantidimaging.core.data import Images
+from mantidimaging.core.operation_history.const import OPERATION_HISTORY, OPERATION_DISPLAY_NAME
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.utility import BlockQtSignals
 from mantidimaging.gui.utility.common import operation_in_progress
@@ -283,9 +284,9 @@ class FiltersWindowPresenter(BasePresenter):
         """
         if self.view.filterSelector.currentText() != FLAT_FIELDING:
             return False
-        if "operation_history" not in self.stack.presenter.images.metadata:
+        if OPERATION_HISTORY not in self.stack.presenter.images.metadata:
             return False
-        for operation in self.stack.presenter.images.metadata["operation_history"]:
-            if operation["display_name"] == FLAT_FIELDING:
+        for operation in self.stack.presenter.images.metadata[OPERATION_HISTORY]:
+            if operation[OPERATION_DISPLAY_NAME] == FLAT_FIELDING:
                 return True
         return False

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -56,9 +56,9 @@ class FiltersWindowPresenter(BasePresenter):
         self.applying_to_all = False
 
         self.prev_apply_single_state = True
-        self.prev_apply_stack_state = True
+        self.prev_apply_all_state = True
         self.main_window.filter_applied.connect(
-            lambda: self._set_apply_buttons_enabled(self.prev_apply_single_state, self.prev_apply_stack_state))
+            lambda: self._set_apply_buttons_enabled(self.prev_apply_single_state, self.prev_apply_all_state))
 
     @property
     def main_window(self) -> 'MainWindowView':
@@ -231,7 +231,7 @@ class FiltersWindowPresenter(BasePresenter):
     def _do_apply_filter(self, apply_to):
         # Record the previous button states
         self.prev_apply_single_state = self.view.applyButton.isEnabled()
-        self.prev_apply_stack_state = self.view.applyToAllButton.isEnabled()
+        self.prev_apply_all_state = self.view.applyToAllButton.isEnabled()
         # Disable the apply buttons
         self._set_apply_buttons_enabled(False, False)
         self.model.do_apply_filter(apply_to, partial(self._post_filter, apply_to))
@@ -304,9 +304,9 @@ class FiltersWindowPresenter(BasePresenter):
 
     def _set_apply_buttons_enabled(self, apply_single_enabled: bool, apply_all_enabled: bool):
         """
-        Changes the state of the apply buttons before/after an operation is being run.
-        :param apply_single_enabled: The desired state for the apply (to single image) button.
-        :param apply_all_enabled: The desired state for the apply to stack button.
+        Changes the state of the apply buttons before/after an operation is run.
+        :param apply_single_enabled: The desired state for the apply button.
+        :param apply_all_enabled: The desired state for the apply to all button.
         """
         self.view.applyButton.setEnabled(apply_single_enabled)
         self.view.applyToAllButton.setEnabled(apply_all_enabled)

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -222,7 +222,11 @@ class FiltersWindowPresenter(BasePresenter):
             self.view.show_operation_completed(self.model.selected_filter.filter_name)
 
     def _do_apply_filter(self, apply_to):
+        prev_apply_single_enabled = self.view.applyButton.isEnabled()
+        prev_apply_all_enabled = self.view.applyToAllButton.isEnabled()
+        self._set_apply_buttons_enabled(False, False)
         self.model.do_apply_filter(apply_to, partial(self._post_filter, apply_to))
+        self._set_apply_buttons_enabled(prev_apply_single_enabled, prev_apply_all_enabled)
 
     def _do_apply_filter_sync(self, apply_to):
         self.model.do_apply_filter_sync(apply_to, partial(self._post_filter, apply_to))
@@ -285,3 +289,7 @@ class FiltersWindowPresenter(BasePresenter):
             return False
         return any(operation[OPERATION_DISPLAY_NAME] == FLAT_FIELDING
                    for operation in self.stack.presenter.images.metadata[OPERATION_HISTORY])
+
+    def _set_apply_buttons_enabled(self, apply_single_enabled: bool, apply_all_enabled: bool):
+        self.view.applyButton.setEnabled(apply_single_enabled)
+        self.view.applyToAllButton.setEnabled(apply_all_enabled)

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -151,9 +151,6 @@ class FiltersWindowPresenter(BasePresenter):
         confirmed = self.view.ask_confirmation("Are you sure you want to apply this filter to \n\nALL OPEN STACKS?")
         if not confirmed:
             return
-        if self._already_run_flat_fielding():
-            if not self.view.ask_confirmation(REPEAT_FLAT_FIELDING_MSG):
-                return
         stacks = self.main_window.get_all_stack_visualisers()
         if self.view.safeApply.isChecked():
             with operation_in_progress("Safe Apply: Copying Data", "-------------------------------------", self.view):

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -276,6 +276,9 @@ class FiltersWindowPresenter(BasePresenter):
         return self.model.get_filter_module_name(filter_idx)
 
     def _already_run_flat_fielding(self):
+        """
+        Checks if flat-fielding is being run for a second time.
+        """
         if self.view.filterSelector.currentText() != "Flat-fielding":
             return False
         if "operation_history" not in self.stack.presenter.images.metadata:

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -283,7 +283,5 @@ class FiltersWindowPresenter(BasePresenter):
             return False
         if OPERATION_HISTORY not in self.stack.presenter.images.metadata:
             return False
-        for operation in self.stack.presenter.images.metadata[OPERATION_HISTORY]:
-            if operation[OPERATION_DISPLAY_NAME] == FLAT_FIELDING:
-                return True
-        return False
+        return any(operation[OPERATION_DISPLAY_NAME] == FLAT_FIELDING
+                   for operation in self.stack.presenter.images.metadata[OPERATION_HISTORY])

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -22,6 +22,8 @@ from mantidimaging.gui.windows.stack_visualiser.view import StackVisualiserView
 
 from .model import FiltersWindowModel
 
+FLAT_FIELDING = "Flat-fielding"
+
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # pragma: no cover
     from mantidimaging.gui.windows.operations import FiltersWindowView  # pragma: no cover
@@ -279,11 +281,11 @@ class FiltersWindowPresenter(BasePresenter):
         """
         Checks if flat-fielding is being run for a second time.
         """
-        if self.view.filterSelector.currentText() != "Flat-fielding":
+        if self.view.filterSelector.currentText() != FLAT_FIELDING:
             return False
         if "operation_history" not in self.stack.presenter.images.metadata:
             return False
         for operation in self.stack.presenter.images.metadata["operation_history"]:
-            if operation["display_name"] == "Flat-fielding":
+            if operation["display_name"] == FLAT_FIELDING:
                 return True
         return False

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -125,9 +125,8 @@ class FiltersWindowPresenter(BasePresenter):
             self.model.params_needed_from_stack is not None else False
 
     def do_apply_filter(self):
-
         if self._already_run_flat_fielding():
-            if not self.view.ask_confirmation(REPEAT_FLAT_FIELDING_MSG)
+            if not self.view.ask_confirmation(REPEAT_FLAT_FIELDING_MSG):
                 return
 
         if self.view.safeApply.isChecked():
@@ -147,11 +146,11 @@ class FiltersWindowPresenter(BasePresenter):
         self._do_apply_filter(apply_to)
 
     def do_apply_filter_to_all(self):
-        confirmed = self.view.ask_confirmation(REPEAT_FLAT_FIELDING_MSG)
+        confirmed = self.view.ask_confirmation("Are you sure you want to apply this filter to \n\nALL OPEN STACKS?")
         if not confirmed:
             return
         if self._already_run_flat_fielding():
-            if not self.view.ask_confirmation("Do you want to run flat-fielding again? This could cause you to lose data.")
+            if not self.view.ask_confirmation(REPEAT_FLAT_FIELDING_MSG)
                 return
         stacks = self.main_window.get_all_stack_visualisers()
         if self.view.safeApply.isChecked():

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -277,7 +277,7 @@ class FiltersWindowPresenter(BasePresenter):
 
     def _already_run_flat_fielding(self):
         """
-        Checks if flat-fielding is being run for a second time.
+        :return: True if this is not the first time flat-fielding is being run, False otherwise.
         """
         if self.view.filterSelector.currentText() != FLAT_FIELDING:
             return False

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # pragma: no cover
     from mantidimaging.gui.windows.operations import FiltersWindowView  # pragma: no cover
 
-
 REPEAT_FLAT_FIELDING_MSG = "Do you want to run flat-fielding again? This could cause you to lose data."
 
 
@@ -150,7 +149,7 @@ class FiltersWindowPresenter(BasePresenter):
         if not confirmed:
             return
         if self._already_run_flat_fielding():
-            if not self.view.ask_confirmation(REPEAT_FLAT_FIELDING_MSG)
+            if not self.view.ask_confirmation(REPEAT_FLAT_FIELDING_MSG):
                 return
         stacks = self.main_window.get_all_stack_visualisers()
         if self.view.safeApply.isChecked():
@@ -277,7 +276,11 @@ class FiltersWindowPresenter(BasePresenter):
         return self.model.get_filter_module_name(filter_idx)
 
     def _already_run_flat_fielding(self):
-        if self.view.filterSelector.currentText() is not "Flat-fielding":
+        if self.view.filterSelector.currentText() != "Flat-fielding":
             return False
-
-        # return flat-fielding in operation history
+        if "operation_history" not in self.stack.presenter.images.metadata:
+            return False
+        for operation in self.stack.presenter.images.metadata["operation_history"]:
+            if operation["display_name"] == "Flat-fielding":
+                return True
+        return False

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -231,6 +231,9 @@ class FiltersWindowPresenterTest(unittest.TestCase):
 
     @mock.patch("mantidimaging.gui.windows.operations.presenter.operation_in_progress")
     def test_warning_when_flat_fielding_is_run_twice(self, _):
+        """
+        Test that a warning is displayed if the user is trying to run flat-fielding again.
+        """
         self.view.filterSelector.currentText.return_value = FLAT_FIELDING
         self.presenter.stack = mock.MagicMock()
         self.presenter.stack.presenter.images.metadata = {
@@ -244,6 +247,9 @@ class FiltersWindowPresenterTest(unittest.TestCase):
 
     @mock.patch("mantidimaging.gui.windows.operations.presenter.operation_in_progress")
     def test_no_warning_when_flat_fielding_isnt_run(self, _):
+        """
+        Test no warning is created if the user isn't running flat fielding.
+        """
         self.view.filterSelector.currentText.return_value = "Median"
         self.presenter.stack = mock.MagicMock()
         self.presenter._do_apply_filter = mock.MagicMock()
@@ -252,6 +258,10 @@ class FiltersWindowPresenterTest(unittest.TestCase):
 
     @mock.patch("mantidimaging.gui.windows.operations.presenter.operation_in_progress")
     def test_no_warning_when_flat_fielding_is_first_operation(self, _):
+        """
+        Test that no warning is created when flat fielding is the first operation the user runs, and no operation
+        history exists.
+        """
         self.view.filterSelector.currentText.return_value = FLAT_FIELDING
         self.presenter.stack = mock.MagicMock()
         self.presenter._do_apply_filter = mock.MagicMock()
@@ -260,6 +270,9 @@ class FiltersWindowPresenterTest(unittest.TestCase):
 
     @mock.patch("mantidimaging.gui.windows.operations.presenter.operation_in_progress")
     def test_no_warning_when_flat_fielding_is_run_for_first_time(self, _):
+        """
+        Test that no warning is created if an operation history exists but flat fielding isn't in it.
+        """
         self.view.filterSelector.currentText.return_value = FLAT_FIELDING
         self.presenter.stack = mock.MagicMock()
         self.presenter.stack.presenter.images.metadata = {

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -283,3 +283,20 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.presenter._do_apply_filter = mock.MagicMock()
         self.presenter.do_apply_filter()
         self.view.ask_confirmation.assert_not_called()
+
+    @mock.patch("mantidimaging.gui.windows.operations.presenter.operation_in_progress")
+    def test_no_operation_run_when_user_cancels_flat_fielding(self, _):
+        """
+        Test that pressing "Cancel" when the flat-fielding warning is displayed means that no operation is run.
+        """
+        self.view.filterSelector.currentText.return_value = FLAT_FIELDING
+        self.presenter.stack = mock.MagicMock()
+        self.presenter.stack.presenter.images.metadata = {
+            OPERATION_HISTORY: [{
+                OPERATION_DISPLAY_NAME: "Flat-fielding"
+            }]
+        }
+        self.presenter._do_apply_filter = mock.MagicMock()
+        self.view.ask_confirmation.return_value = False
+        self.presenter.do_apply_filter()
+        self.presenter._do_apply_filter.assert_not_called()

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -226,3 +226,11 @@ class FiltersWindowPresenterTest(unittest.TestCase):
 
         stack.presenter.images.copy.assert_called_once()
         self.assertEqual(stack_data, self.presenter.original_images_stack)
+
+    @mock.patch("mantidimaging.gui.windows.operations.presenter.operation_in_progress")
+    def test_warning_when_flat_fielding_is_run_twice(self, _):
+        self.view.filterSelector.currentText.return_value = "Flat-fielding"
+        self.presenter.stack = mock.MagicMock()
+        self.presenter.stack.images.metadata = {"operation_history": [{"display_name": "Flat-fielding"}]}
+        self.presenter._do_apply_filter = mock.MagicMock()
+        self.presenter.do_apply_filter()

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -9,6 +9,7 @@ from unittest.mock import DEFAULT, Mock
 
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.operations import FiltersWindowPresenter
+from mantidimaging.gui.windows.operations.presenter import REPEAT_FLAT_FIELDING_MSG
 from mantidimaging.test_helpers.unit_test_helper import assert_called_once_with, generate_images
 
 
@@ -231,6 +232,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     def test_warning_when_flat_fielding_is_run_twice(self, _):
         self.view.filterSelector.currentText.return_value = "Flat-fielding"
         self.presenter.stack = mock.MagicMock()
-        self.presenter.stack.images.metadata = {"operation_history": [{"display_name": "Flat-fielding"}]}
+        self.presenter.stack.presenter.images.metadata = {"operation_history": [{"display_name": "Flat-fielding"}]}
         self.presenter._do_apply_filter = mock.MagicMock()
         self.presenter.do_apply_filter()
+        self.view.ask_confirmation.assert_called_once_with(REPEAT_FLAT_FIELDING_MSG)

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -7,6 +7,7 @@ from functools import partial
 from unittest import mock
 from unittest.mock import DEFAULT, Mock
 
+from mantidimaging.core.operation_history.const import OPERATION_HISTORY, OPERATION_DISPLAY_NAME
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.operations import FiltersWindowPresenter
 from mantidimaging.gui.windows.operations.presenter import REPEAT_FLAT_FIELDING_MSG, FLAT_FIELDING
@@ -232,7 +233,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     def test_warning_when_flat_fielding_is_run_twice(self, _):
         self.view.filterSelector.currentText.return_value = FLAT_FIELDING
         self.presenter.stack = mock.MagicMock()
-        self.presenter.stack.presenter.images.metadata = {"operation_history": [{"display_name": "Flat-fielding"}]}
+        self.presenter.stack.presenter.images.metadata = {OPERATION_HISTORY: [{OPERATION_DISPLAY_NAME: "Flat-fielding"}]}
         self.presenter._do_apply_filter = mock.MagicMock()
         self.presenter.do_apply_filter()
         self.view.ask_confirmation.assert_called_once_with(REPEAT_FLAT_FIELDING_MSG)
@@ -241,6 +242,23 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     def test_no_warning_when_flat_fielding_isnt_run(self, _):
         self.view.filterSelector.currentText.return_value = "Median"
         self.presenter.stack = mock.MagicMock()
+        self.presenter._do_apply_filter = mock.MagicMock()
+        self.presenter.do_apply_filter()
+        self.view.ask_confirmation.assert_not_called()
+
+    @mock.patch("mantidimaging.gui.windows.operations.presenter.operation_in_progress")
+    def test_no_warning_when_flat_fielding_is_first_operation(self, _):
+        self.view.filterSelector.currentText.return_value = FLAT_FIELDING
+        self.presenter.stack = mock.MagicMock()
+        self.presenter._do_apply_filter = mock.MagicMock()
+        self.presenter.do_apply_filter()
+        self.view.ask_confirmation.assert_not_called()
+
+    @mock.patch("mantidimaging.gui.windows.operations.presenter.operation_in_progress")
+    def test_no_warning_when_flat_fielding_is_run_for_first_time(self, _):
+        self.view.filterSelector.currentText.return_value = FLAT_FIELDING
+        self.presenter.stack = mock.MagicMock()
+        self.presenter.stack.presenter.images.metadata = {OPERATION_HISTORY: [{OPERATION_DISPLAY_NAME: "Remove Outliers"}]}
         self.presenter._do_apply_filter = mock.MagicMock()
         self.presenter.do_apply_filter()
         self.view.ask_confirmation.assert_not_called()

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -233,7 +233,11 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     def test_warning_when_flat_fielding_is_run_twice(self, _):
         self.view.filterSelector.currentText.return_value = FLAT_FIELDING
         self.presenter.stack = mock.MagicMock()
-        self.presenter.stack.presenter.images.metadata = {OPERATION_HISTORY: [{OPERATION_DISPLAY_NAME: "Flat-fielding"}]}
+        self.presenter.stack.presenter.images.metadata = {
+            OPERATION_HISTORY: [{
+                OPERATION_DISPLAY_NAME: "Flat-fielding"
+            }]
+        }
         self.presenter._do_apply_filter = mock.MagicMock()
         self.presenter.do_apply_filter()
         self.view.ask_confirmation.assert_called_once_with(REPEAT_FLAT_FIELDING_MSG)
@@ -258,7 +262,11 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     def test_no_warning_when_flat_fielding_is_run_for_first_time(self, _):
         self.view.filterSelector.currentText.return_value = FLAT_FIELDING
         self.presenter.stack = mock.MagicMock()
-        self.presenter.stack.presenter.images.metadata = {OPERATION_HISTORY: [{OPERATION_DISPLAY_NAME: "Remove Outliers"}]}
+        self.presenter.stack.presenter.images.metadata = {
+            OPERATION_HISTORY: [{
+                OPERATION_DISPLAY_NAME: "Remove Outliers"
+            }]
+        }
         self.presenter._do_apply_filter = mock.MagicMock()
         self.presenter.do_apply_filter()
         self.view.ask_confirmation.assert_not_called()

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -9,7 +9,7 @@ from unittest.mock import DEFAULT, Mock
 
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.operations import FiltersWindowPresenter
-from mantidimaging.gui.windows.operations.presenter import REPEAT_FLAT_FIELDING_MSG
+from mantidimaging.gui.windows.operations.presenter import REPEAT_FLAT_FIELDING_MSG, FLAT_FIELDING
 from mantidimaging.test_helpers.unit_test_helper import assert_called_once_with, generate_images
 
 
@@ -230,9 +230,17 @@ class FiltersWindowPresenterTest(unittest.TestCase):
 
     @mock.patch("mantidimaging.gui.windows.operations.presenter.operation_in_progress")
     def test_warning_when_flat_fielding_is_run_twice(self, _):
-        self.view.filterSelector.currentText.return_value = "Flat-fielding"
+        self.view.filterSelector.currentText.return_value = FLAT_FIELDING
         self.presenter.stack = mock.MagicMock()
         self.presenter.stack.presenter.images.metadata = {"operation_history": [{"display_name": "Flat-fielding"}]}
         self.presenter._do_apply_filter = mock.MagicMock()
         self.presenter.do_apply_filter()
         self.view.ask_confirmation.assert_called_once_with(REPEAT_FLAT_FIELDING_MSG)
+
+    @mock.patch("mantidimaging.gui.windows.operations.presenter.operation_in_progress")
+    def test_no_warning_when_flat_fielding_isnt_run(self, _):
+        self.view.filterSelector.currentText.return_value = "Median"
+        self.presenter.stack = mock.MagicMock()
+        self.presenter._do_apply_filter = mock.MagicMock()
+        self.presenter.do_apply_filter()
+        self.view.ask_confirmation.assert_not_called()


### PR DESCRIPTION
### Issue

Closes #866

### Description

Displays a warning message if the user runs flat-fielding more than once.

### Testing 

Wrote tests to go through the different cases:
- running flat fielding a second time -> message displayed
- not running flat fielding at all -> no message displayed
- running flat fielding for the first time w/ non-empty operation history -> no message displayed
- running flat fielding for the first time w/ empty operation history -> no message displayed
- running flat fielding a second time and press cancel -> filter isn't run

Also made tests for the changes to the apply buttons.

### Acceptance Criteria 

Check that the tests pass and cover appropriate test cases. Check that a message appears when you try to run flat-fielding twice. Check that pressing cancel when the message appears causes the operation to be cancelled. Check that the apply buttons become disabled until the operation is complete.

### Documentation

Updated the release notes.
