### PR TITLE
Palette changer, sample only from middle of recon output

### DIFF
--- a/mantidimaging/gui/widgets/palette_changer/test/presenter_test.py
+++ b/mantidimaging/gui/widgets/palette_changer/test/presenter_test.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import numpy as np
 
-from mantidimaging.gui.widgets.palette_changer.presenter import PaletteChangerPresenter, RANDOM_CUTOFF
+from mantidimaging.gui.widgets.palette_changer.presenter import PaletteChangerPresenter, SAMPLE_SIZE
 
 
 def _normalise_break_value(break_value, min_value, max_value):
@@ -32,7 +32,7 @@ class PaletteChangerPresenterTest(unittest.TestCase):
         return sorted([np.random.choice(self.presenter.flattened_image) for _ in range(n_vals)])
 
     def test_flattened_image_creation_for_large_image(self):
-        assert self.presenter.flattened_image.size == RANDOM_CUTOFF
+        assert self.presenter.flattened_image.size == SAMPLE_SIZE
         assert self.presenter.flattened_image.ndim == 1
 
     def test_flattened_image_creation_for_small_image(self):
@@ -130,3 +130,12 @@ class PaletteChangerPresenterTest(unittest.TestCase):
             self.assertIn(new_tick, self.recon_gradient.ticks.keys())
 
         assert n_materials + 1 == len(self.recon_gradient.ticks.keys())
+
+    def test_get_sample_pixels(self):
+        COUNT = 50
+        recon_image = np.random.random((50, 50))
+        sampled = self.presenter._get_sample_pixels(recon_image, COUNT, 0.9)
+
+        self.assertEqual(len(sampled), COUNT)
+        for sample in sampled:
+            self.assertIn(sample, recon_image)


### PR DESCRIPTION
Select a random sample of pixels from a circle in the center of the
recon output to avoid artefacts on edges and corners.

### Issue

closes #859 

### Description

The recon output has artefacts in the edges and corners which through off the jenks algorithm. Sample only from the good region to get a better distribution of colour.

### Testing 

On a reconstruction right click on the colour bar and select auto.

### Acceptance Criteria 

Somewhat better choice of colours than the standard linear one.

### Documentation

No doc change needed. Not in release notes because tweak to new feature. 