### PR TITLE
Prevent runtime errors after closing wizard

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -23,3 +23,4 @@ Fixes
 - #874 : Widgets in Operations window need minimum sizes
 - #866 : Warning if running Flat-fielding again
 - #878 : Update update instructions in version check
+- #885 : RuntimeError after closing wizard

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -97,6 +97,8 @@ class MainWindowView(BaseMainWindowView):
         if self.open_dialogs and WelcomeScreenPresenter.show_today():
             self.show_about()
 
+        self.wizard = None
+
     def setup_shortcuts(self):
         self.actionLoadDataset.triggered.connect(self.show_load_dialogue)
         self.actionLoadImages.triggered.connect(self.load_image_stack)
@@ -156,7 +158,8 @@ class MainWindowView(BaseMainWindowView):
         self.load_dialogue.show()
 
     def show_wizard(self):
-        self.wizard = WizardPresenter(self)
+        if self.wizard is None:
+            self.wizard = WizardPresenter(self)
         self.wizard.show()
 
     @staticmethod

--- a/mantidimaging/gui/windows/wizard/view.py
+++ b/mantidimaging/gui/windows/wizard/view.py
@@ -90,6 +90,7 @@ class WizardView(BaseDialogView):
         super().__init__(parent, "gui/ui/wizard.ui")
         self.stages = {}
         self.presenter = presenter
+        self.setAttribute(Qt.WA_DeleteOnClose, False)
 
     def add_stage(self, stage_name: str):
         new_stage = WizardStage(stage_name)


### PR DESCRIPTION
No need to delete wizard when its closed. Let it just hide so it can keep being updated by stack changes.

### Issue

Closes #885 

### Description
Turn off WA_DeleteOnClose
Make main window reuse existing wizard view

### Testing 

Instructions on  #885

### Acceptance Criteria 

No errors when following instructions from #885 

### Documentation

Updated release notes
