### PR TITLE
Remove deleteLater calls and WA_DeleteOnClose attributes

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -24,3 +24,4 @@ Fixes
 - #866 : Warning if running Flat-fielding again
 - #878 : Update update instructions in version check
 - #885 : RuntimeError after closing wizard
+- #805, #875 : Fix segmentation fault due to object lifetime

--- a/mantidimaging/gui/dialogs/op_history_copy/view.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/view.py
@@ -31,9 +31,7 @@ class OpHistoryCopyDialogView(BaseDialogView):
     def display_op_history(self, operations: Iterable[ImageOperation]):
         layout = self.operationsContainer.layout()
         while layout.count():
-            first_row = layout.takeAt(0)
-            if first_row.widget():
-                first_row.widget().deleteLater()
+            layout.takeAt(0)
 
         for op in operations:
             row, check = self.build_operation_row(op)

--- a/mantidimaging/gui/mvp_base/view.py
+++ b/mantidimaging/gui/mvp_base/view.py
@@ -21,7 +21,6 @@ class BaseMainWindowView(Qt.QMainWindow):
         LOG.debug('UI window closed')
         self.cleanup()
         super(BaseMainWindowView, self).closeEvent(e)
-        self.deleteLater()
 
     def cleanup(self):
         """
@@ -44,8 +43,6 @@ class BaseDialogView(Qt.QDialog):
 
         if ui_file is not None:
             compile_ui(ui_file, self)
-
-        self.setAttribute(Qt.Qt.WA_DeleteOnClose)
 
     def show_error_dialog(self, msg=""):
         """

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -67,7 +67,6 @@ class MainWindowView(BaseMainWindowView):
     def __init__(self, open_dialogs=True):
         super(MainWindowView, self).__init__(None, "gui/ui/main_window.ui")
 
-        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
         self.setWindowTitle("Mantid Imaging")
 
         self.presenter = MainWindowPresenter(self)

--- a/mantidimaging/gui/windows/stack_choice/view.py
+++ b/mantidimaging/gui/windows/stack_choice/view.py
@@ -5,7 +5,6 @@ from enum import Enum, auto
 from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 import numpy as np
-from PyQt5 import QtCore
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QCheckBox, QMainWindow, QMessageBox, QPushButton, QSizePolicy
 from pyqtgraph import ViewBox
@@ -36,7 +35,6 @@ class StackChoiceView(BaseMainWindowView):
 
         self.presenter = presenter
 
-        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
         self.setWindowTitle("Choose the stack you want to keep")
         self.setWindowModality(Qt.ApplicationModal)
 

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -54,12 +54,10 @@ class StackVisualiserViewTest(unittest.TestCase):
 
     def test_closeEvent_deletes_images(self):
         self.dock.setFloating = mock.Mock()
-        self.dock.deleteLater = mock.Mock()
 
         self.view.close()
 
         self.dock.setFloating.assert_called_once_with(False)
-        self.dock.deleteLater.assert_called_once_with()
         self.assertEqual(None, self.view.presenter.images)
         self.window.remove_stack.assert_called_once_with(self.view)
 
@@ -69,7 +67,6 @@ class StackVisualiserViewTest(unittest.TestCase):
         self.test_data.proj180deg = images
 
         p180_dock.setFloating = mock.Mock()  # type: ignore[assignment]
-        p180_dock.deleteLater = mock.Mock()  # type: ignore[assignment]
 
         p180_view.close()
 
@@ -79,7 +76,6 @@ class StackVisualiserViewTest(unittest.TestCase):
         self.assertFalse(self.test_data.has_proj180deg())
 
         p180_dock.setFloating.assert_called_once_with(False)
-        p180_dock.deleteLater.assert_called_once_with()
         self.assertIsNone(p180_view.presenter.images)
         self.window.remove_stack.assert_called_once_with(p180_view)  # type: ignore[attr-defined]
 
@@ -89,7 +85,6 @@ class StackVisualiserViewTest(unittest.TestCase):
         self.test_data.proj180deg = images
 
         p180_dock.setFloating = mock.Mock()  # type: ignore[assignment]
-        p180_dock.deleteLater = mock.Mock()  # type: ignore[assignment]
 
         p180_view.close()
 
@@ -99,7 +94,6 @@ class StackVisualiserViewTest(unittest.TestCase):
         self.assertTrue(self.test_data.has_proj180deg())
 
         p180_dock.setFloating.assert_not_called()
-        p180_dock.deleteLater.assert_not_called()
         self.assertIsNotNone(p180_view.presenter.images)
         self.window.remove_stack.assert_not_called()  # type: ignore[attr-defined]
 

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -136,9 +136,6 @@ class StackVisualiserView(BaseMainWindowView):
             # allowing it to be GC'ed
             self.presenter.delete_data()
             window.remove_stack(self)
-            self.deleteLater()
-            # refers to the QDockWidget within which the stack is contained
-            self.dock.deleteLater()
 
     def roi_changed_callback(self, roi: SensibleROI):
         self.roi_updated.emit(roi)

--- a/mantidimaging/gui/windows/wizard/view.py
+++ b/mantidimaging/gui/windows/wizard/view.py
@@ -90,7 +90,6 @@ class WizardView(BaseDialogView):
         super().__init__(parent, "gui/ui/wizard.ui")
         self.stages = {}
         self.presenter = presenter
-        self.setAttribute(Qt.WA_DeleteOnClose, False)
 
     def add_stage(self, stage_name: str):
         new_stage = WizardStage(stage_name)


### PR DESCRIPTION
These can cause the Qt objects to be deleted while python references still exist.

This should prevent hitting the segfault while running the application. There is still a common segfault in the GUI tests that needs further investigation (see  #891).

### Issue

closes #875 
closes #805 

### Description

This should be a more complete fix for #805 . We should never need to explicitly call the deleteLater() method or set WA_DeleteOnClose, as these can delete the underlying C++ object while leaving the python wrapper around.

### Testing 

Check that tests run without segfault.

Check process on #875 

### Acceptance Criteria 

No more segfaults in tests or normal usage

### Documentation
Added to release notes.
