### PR TITLE
886: Don't reset zoom when filter parameters are changed

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -25,3 +25,4 @@ Fixes
 - #878 : Update update instructions in version check
 - #885 : RuntimeError after closing wizard
 - #805, #875 : Fix segmentation fault due to object lifetime
+- #886 : Don't reset zoom when changing operation parameters

--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -34,7 +34,16 @@
         <property name="sizeConstraint">
          <enum>QLayout::SetDefaultConstraint</enum>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>9</number>
+        </property>
+        <property name="topMargin">
+         <number>9</number>
+        </property>
+        <property name="rightMargin">
+         <number>9</number>
+        </property>
+        <property name="bottomMargin">
          <number>9</number>
         </property>
         <item>
@@ -440,6 +449,20 @@
             </property>
             <property name="text">
              <string>Invert diff image</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="lockScaleCheckBox">
+            <property name="text">
+             <string>Lock scale</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="lockZoomCheckBox">
+            <property name="text">
+             <string>Lock zoom</string>
             </property>
            </widget>
           </item>

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -233,3 +233,13 @@ class FilterPreviews(GraphicsLayoutWidget):
     def auto_range(self):
         # This will cause the previews to all show by just causing autorange on self.image_before_vb
         self.image_before_vb.autoRange()
+
+    def record_histogram_regions(self):
+        self.before_region = self.image_before_hist.region.getRegion()
+        self.diff_region = self.image_difference_hist.region.getRegion()
+        self.after_region = self.image_after_hist.region.getRegion()
+
+    def restore_histogram_regions(self):
+        self.image_before_hist.region.setRegion(self.before_region)
+        self.image_difference_hist.region.setRegion(self.diff_region)
+        self.image_after_hist.region.setRegion(self.after_region)

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -242,6 +242,10 @@ class FiltersWindowPresenter(BasePresenter):
     def do_update_previews(self):
         self.view.clear_previews()
         if self.stack is not None:
+            lock_scale = self.view.lockScaleCheckBox.isChecked()
+            if lock_scale:
+                self.view.previews.record_histogram_regions()
+
             stack_presenter = self.stack.presenter
             subset: Images = stack_presenter.get_image(self.model.preview_image_idx)
             before_image = np.copy(subset.data[0])
@@ -271,9 +275,12 @@ class FiltersWindowPresenter(BasePresenter):
                     diff = np.negative(diff, out=diff)
                 self._update_preview_image(diff, self.view.preview_image_difference)
 
-            # Ensure all of it is visible
+            # Ensure all of it is visible if the lock zoom isn't checked
             if not self.view.lockZoomCheckBox.isChecked():
                 self.view.previews.auto_range()
+
+            if lock_scale:
+                self.view.previews.restore_histogram_regions()
 
     @staticmethod
     def _update_preview_image(image_data: Optional[np.ndarray], image: ImageItem):

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -73,7 +73,7 @@ class FiltersWindowPresenter(BasePresenter):
             elif signal == Notification.APPLY_FILTER_TO_ALL:
                 self.do_apply_filter_to_all()
             elif signal == Notification.UPDATE_PREVIEWS:
-                self.do_update_previews(auto_range=False)
+                self.do_update_previews()
             elif signal == Notification.SCROLL_PREVIEW_UP:
                 self.do_scroll_preview(1)
             elif signal == Notification.SCROLL_PREVIEW_DOWN:
@@ -239,7 +239,7 @@ class FiltersWindowPresenter(BasePresenter):
     def _do_apply_filter_sync(self, apply_to):
         self.model.do_apply_filter_sync(apply_to, partial(self._post_filter, apply_to))
 
-    def do_update_previews(self, auto_range: bool = True):
+    def do_update_previews(self):
         self.view.clear_previews()
         if self.stack is not None:
             stack_presenter = self.stack.presenter
@@ -272,7 +272,7 @@ class FiltersWindowPresenter(BasePresenter):
                 self._update_preview_image(diff, self.view.preview_image_difference)
 
             # Ensure all of it is visible
-            if auto_range:
+            if not self.view.lockZoomCheckBox.isChecked():
                 self.view.previews.auto_range()
 
     @staticmethod

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -73,7 +73,7 @@ class FiltersWindowPresenter(BasePresenter):
             elif signal == Notification.APPLY_FILTER_TO_ALL:
                 self.do_apply_filter_to_all()
             elif signal == Notification.UPDATE_PREVIEWS:
-                self.do_update_previews()
+                self.do_update_previews(auto_range=False)
             elif signal == Notification.SCROLL_PREVIEW_UP:
                 self.do_scroll_preview(1)
             elif signal == Notification.SCROLL_PREVIEW_DOWN:
@@ -239,7 +239,7 @@ class FiltersWindowPresenter(BasePresenter):
     def _do_apply_filter_sync(self, apply_to):
         self.model.do_apply_filter_sync(apply_to, partial(self._post_filter, apply_to))
 
-    def do_update_previews(self):
+    def do_update_previews(self, auto_range: bool = True):
         self.view.clear_previews()
         if self.stack is not None:
             stack_presenter = self.stack.presenter
@@ -272,7 +272,8 @@ class FiltersWindowPresenter(BasePresenter):
                 self._update_preview_image(diff, self.view.preview_image_difference)
 
             # Ensure all of it is visible
-            self.view.previews.auto_range()
+            if auto_range:
+                self.view.previews.auto_range()
 
     @staticmethod
     def _update_preview_image(image_data: Optional[np.ndarray], image: ImageItem):

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -172,7 +172,21 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.view.clear_previews.assert_called_once()
         self.view.previews.auto_range.assert_called_once()
         self.assertEqual(3, update_preview_image_mock.call_count)
+
+    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter._update_preview_image')
+    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.apply_to_images')
+    def test_auto_range_called_when_auto_range_is_checked(self, apply_mock: mock.Mock, update_preview_image_mock: mock.Mock):
+        stack = mock.Mock()
+        presenter = mock.Mock()
+        stack.presenter = presenter
+        images = generate_images()
+        presenter.get_image.return_value = images
+        self.presenter.stack = stack
+        self.presenter.do_update_previews()
+        self.view.lockZoomCheckBox.isChecked.return_value = True
+
         apply_mock.assert_called_once()
+
 
     def test_get_filter_module_name(self):
         self.presenter.model.filters = mock.MagicMock()

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -159,34 +159,42 @@ class FiltersWindowPresenterTest(unittest.TestCase):
 
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter._update_preview_image')
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.apply_to_images')
-    def test_update_previews(self, apply_mock: mock.Mock, update_preview_image_mock: mock.Mock):
+    def test_update_previews_with_no_lock_checked(self, apply_mock: mock.Mock, update_preview_image_mock: mock.Mock):
         stack = mock.Mock()
         presenter = mock.Mock()
         stack.presenter = presenter
         images = generate_images()
         presenter.get_image.return_value = images
         self.presenter.stack = stack
+        self.view.lockZoomCheckBox.isChecked.return_value = False
+        self.view.lockScaleCheckBox.isChecked.return_value = False
         self.presenter.do_update_previews()
 
         presenter.get_image.assert_called_once_with(self.presenter.model.preview_image_idx)
         self.view.clear_previews.assert_called_once()
-        self.view.previews.auto_range.assert_called_once()
         self.assertEqual(3, update_preview_image_mock.call_count)
+        apply_mock.assert_called_once()
+        self.view.previews.auto_range.assert_called_once()
+        self.view.previews.record_histogram_regions.assert_not_called()
+        self.view.previews.restore_histogram_regions.assert_not_called()
 
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter._update_preview_image')
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.apply_to_images')
-    def test_auto_range_called_when_auto_range_is_checked(self, apply_mock: mock.Mock, update_preview_image_mock: mock.Mock):
+    def test_auto_range_called_when_locks_are_checked(self, apply_mock: mock.Mock,
+                                                      update_preview_image_mock: mock.Mock):
         stack = mock.Mock()
         presenter = mock.Mock()
         stack.presenter = presenter
         images = generate_images()
         presenter.get_image.return_value = images
         self.presenter.stack = stack
-        self.presenter.do_update_previews()
         self.view.lockZoomCheckBox.isChecked.return_value = True
+        self.view.lockScaleCheckBox.isChecked.return_value = True
+        self.presenter.do_update_previews()
 
-        apply_mock.assert_called_once()
-
+        self.view.previews.auto_range.assert_not_called()
+        self.view.previews.record_histogram_regions.assert_called_once()
+        self.view.previews.restore_histogram_regions.assert_called_once()
 
     def test_get_filter_module_name(self):
         self.presenter.model.filters = mock.MagicMock()

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -35,6 +35,8 @@ class FiltersWindowView(BaseMainWindowView):
     combinedHistograms: QCheckBox
     invertDifference: QCheckBox
     overlayDifference: QCheckBox
+    lockScaleCheckBox: QCheckBox
+    lockZoomCheckBox: QCheckBox
 
     previewsLayout: QVBoxLayout
     previews: FilterPreviews


### PR DESCRIPTION
### Issue

Closes #886

### Description

Adds checkboxes for locking the zoom and histogram scales.

### Testing 

Updated one test and added another for checking what happens when the boxes are checked.

### Acceptance Criteria 

Check the boxes and change the operation parameters. Check that the zoom/histogram scale remains the same.

### Documentation

Updated the release notes.
