### PR TITLE
873: Link histogram scales

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -8,6 +8,8 @@ New features
 
 - #823: Automatically transpose colour palette
 - #567: Add new user wizard
+- #886 : Don't reset zoom when changing operation parameters
+- #873 : Link histogram scales in operations window
 
 Fixes
 -----
@@ -25,5 +27,3 @@ Fixes
 - #878 : Update update instructions in version check
 - #885 : RuntimeError after closing wizard
 - #805, #875, #891 : Fix segmentation fault due to object lifetime
-- #886 : Don't reset zoom when changing operation parameters
-- #873 : Link histogram scales in operations window

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -26,3 +26,4 @@ Fixes
 - #885 : RuntimeError after closing wizard
 - #805, #875 : Fix segmentation fault due to object lifetime
 - #886 : Don't reset zoom when changing operation parameters
+- #873 : Link histogram scales in operations window

--- a/mantidimaging/core/operations/base_filter.py
+++ b/mantidimaging/core/operations/base_filter.py
@@ -22,6 +22,7 @@ class FilterGroup(Enum):
 
 class BaseFilter:
     filter_name = "Unnamed Filter"
+    link_histograms = False
     __name__ = "BaseFilter"
     """
     The base class for filter algorithms, which should extend this class.

--- a/mantidimaging/core/operations/circular_mask/circular_mask.py
+++ b/mantidimaging/core/operations/circular_mask/circular_mask.py
@@ -21,6 +21,7 @@ class CircularMaskFilter(BaseFilter):
     Caution: Ensure that the radius does not mask data from the sample.
     """
     filter_name = "Circular Mask"
+    link_histograms = True
 
     @staticmethod
     def filter_func(data: Images,

--- a/mantidimaging/core/operations/clip_values/clip_values.py
+++ b/mantidimaging/core/operations/clip_values/clip_values.py
@@ -19,6 +19,7 @@ class ClipValuesFilter(BaseFilter):
     Caution: Make sure the value range does not clip information from the sample.
     """
     filter_name = "Clip Values"
+    link_histograms = True
 
     @staticmethod
     def filter_func(data,

--- a/mantidimaging/core/operations/crop_coords/crop_coords.py
+++ b/mantidimaging/core/operations/crop_coords/crop_coords.py
@@ -27,6 +27,7 @@ class CropCoordinatesFilter(BaseFilter):
     during the rotation of the sample in the dataset.
     """
     filter_name = "Crop Coordinates"
+    link_histograms = True
 
     @staticmethod
     def filter_func(images: Images,

--- a/mantidimaging/core/operations/divide/divide.py
+++ b/mantidimaging/core/operations/divide/divide.py
@@ -23,6 +23,7 @@ class DivideFilter(BaseFilter):
     Caution: Check preview values before applying divide
     """
     filter_name = "Divide"
+    link_histograms = True
 
     @staticmethod
     def filter_func(images: Images, value: Union[int, float] = 0e7, unit="micron", progress=None) -> Images:

--- a/mantidimaging/core/operations/gaussian/gaussian.py
+++ b/mantidimaging/core/operations/gaussian/gaussian.py
@@ -24,6 +24,7 @@ class GaussianFilter(BaseFilter):
     When: As a pre-processing step to reduce noise.
     """
     filter_name = "Gaussian"
+    link_histograms = True
 
     @staticmethod
     def filter_func(data: Images, size=None, mode=None, order=None, cores=None, chunksize=None, progress=None):

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -28,6 +28,7 @@ class MedianFilter(BaseFilter):
     When: As a pre-processing step to reduce noise.
     """
     filter_name = "Median"
+    link_histograms = True
 
     @staticmethod
     def filter_func(data: Images, size=None, mode="reflect", cores=None, chunksize=None, progress=None, force_cpu=True):

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -24,6 +24,7 @@ class MonitorNormalisation(BaseFilter):
     When: As a pre-processing step to normalise the value ranges of the data.
     """
     filter_name = "Monitor Normalisation"
+    link_histograms = True
 
     @staticmethod
     def filter_func(images: Images, cores=None, chunksize=None, progress=None) -> Images:

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -33,6 +33,7 @@ class OutliersFilter(BaseFilter):
     images, to remove pixels with very large values that will cause issues in the flat-fielding.
     """
     filter_name = "Remove Outliers"
+    link_histograms = True
 
     @staticmethod
     def _execute(data, diff, radius, mode):

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -24,6 +24,7 @@ class RebinFilter(BaseFilter):
     When: If you want to reduce the data size by losing information.
     """
     filter_name = "Rebin"
+    link_histograms = True
 
     @staticmethod
     def filter_func(images: Images, rebin_param=0.5, mode=None, cores=None, chunksize=None, progress=None) -> Images:

--- a/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
+++ b/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
@@ -27,6 +27,7 @@ class RemoveAllStripesFilter(BaseFilter):
     and should be fixed by ROI Normalisation instead!
     """
     filter_name = "Remove all stripes"
+    link_histograms = True
 
     @staticmethod
     def filter_func(images: Images, snr=3, la_size=61, sm_size=21, dim=1, cores=None, chunksize=None, progress=None):

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -27,6 +27,7 @@ class RemoveDeadStripesFilter(BaseFilter):
     and should be fixed by ROI Normalisation instead!
     """
     filter_name = "Remove dead stripes"
+    link_histograms = True
 
     @staticmethod
     def filter_func(images: Images, snr=3, size=61, cores=None, chunksize=None, progress=None):

--- a/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
+++ b/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
@@ -26,6 +26,7 @@ class RemoveLargeStripesFilter(BaseFilter):
     and should be fixed by ROI Normalisation instead!
     """
     filter_name = "Remove large stripes"
+    link_histograms = True
 
     @staticmethod
     def filter_func(images, snr=3, la_size=61, cores=None, chunksize=None, progress=None):

--- a/mantidimaging/core/operations/remove_stripe/stripe_removal.py
+++ b/mantidimaging/core/operations/remove_stripe/stripe_removal.py
@@ -23,6 +23,7 @@ class StripeRemovalFilter(BaseFilter):
     and should be fixed by ROI Normalisation instead!
     """
     filter_name = "Stripe Removal"
+    link_histograms = True
 
     @staticmethod
     def filter_func(images, wf=None, ti=None, sf=None, cores=None, chunksize=None, progress=None):

--- a/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
@@ -29,6 +29,7 @@ class RemoveStripeFilteringFilter(BaseFilter):
     and should be fixed by ROI Normalisation instead!
     """
     filter_name = "Remove stripes with filtering"
+    link_histograms = True
 
     @staticmethod
     def filter_func(images: Images,

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
@@ -27,6 +27,7 @@ class RemoveStripeSortingFittingFilter(BaseFilter):
     and should be fixed by ROI Normalisation instead!
     """
     filter_name = "Remove stripes with sorting and fitting"
+    link_histograms = True
 
     @staticmethod
     def filter_func(images: Images, order=1, sigmax=3, sigmay=3, cores=None, chunksize=None, progress=None):

--- a/mantidimaging/core/operations/ring_removal/ring_removal.py
+++ b/mantidimaging/core/operations/ring_removal/ring_removal.py
@@ -19,6 +19,7 @@ class RingRemovalFilter(BaseFilter):
     When: To remove ring-filters that have not been removed by the pre-processing
     """
     filter_name = "Ring Removal"
+    link_histograms = True
 
     @staticmethod
     def filter_func(images: Images,

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -29,6 +29,7 @@ class RoiNormalisationFilter(BaseFilter):
     are brighter/darker than the rest. This can be fixed with this operation.
     """
     filter_name = "ROI Normalisation"
+    link_histograms = True
 
     @staticmethod
     def filter_func(images: Images, region_of_interest: SensibleROI = None, cores=None, chunksize=None, progress=None):

--- a/mantidimaging/core/operations/rotate_stack/rotate_stack.py
+++ b/mantidimaging/core/operations/rotate_stack/rotate_stack.py
@@ -26,6 +26,7 @@ class RotateFilter(BaseFilter):
     vector geometry will correct for the tilt without manual rotation.
     """
     filter_name = "Rotate Stack"
+    link_histograms = True
 
     @staticmethod
     def filter_func(data: Images, angle=None, dark=None, cores=None, chunksize=None, progress=None):

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -260,14 +260,10 @@ class FilterPreviews(GraphicsLayoutWidget):
         """
         Makes the histogram scale of the before image match the histogram scale of the after image.
         """
-        self.image_after_hist.sigLevelChangeFinished.disconnect()
         self.image_after_hist.region.setRegion(self.image_before_hist.region.getRegion())
-        self.image_after_hist.sigLevelChangeFinished.connect(self.link_image_before_to_after_hist_range)
 
     def link_image_before_to_after_hist_range(self):
         """
         Makes the histogram scale of the after image match the histogram scale of the before image.
         """
-        self.image_before_hist.region.sigRegionChangeFinished.disconnect()
         self.image_before_hist.region.setRegion(self.image_after_hist.region.getRegion())
-        self.image_before_hist.region.sigRegionChangeFinished.connect(self.link_image_after_to_before_hist_range)

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -252,7 +252,6 @@ class FilterPreviews(GraphicsLayoutWidget):
         if create_link:
             self.image_after_hist.sigLevelChangeFinished.connect(self.link_image_before_to_after_hist_range)
             self.image_before_hist.sigLevelChangeFinished.connect(self.link_image_after_to_before_hist_range)
-            self.link_image_after_to_before_hist_range()
         else:
             self.image_before_hist.sigLevelChangeFinished.disconnect()
             self.image_after_hist.sigLevelChangeFinished.disconnect()

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -251,6 +251,7 @@ class FilterPreviews(GraphicsLayoutWidget):
         """
         if create_link:
             self.image_before_hist.sigLevelChangeFinished.connect(self.link_image_after_hist_range)
+            self.image_after_hist.sigLevelChangeFinished.connect(self.link_image_before_hist_range)
             self.link_image_after_hist_range()
         else:
             self.image_before_hist.sigLevelChangeFinished.disconnect()
@@ -260,3 +261,9 @@ class FilterPreviews(GraphicsLayoutWidget):
         Makes the histogram scale of the before image match the histogram scale of the after image.
         """
         self.image_after_hist.region.setRegion(self.image_before_hist.region.getRegion())
+
+    def link_image_before_hist_range(self):
+        """
+        Makes the histogram scale of the after image match the histogram scale of the before image.
+        """
+        self.image_before_hist.region.setRegion(self.image_after_hist.region.getRegion())

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -69,6 +69,8 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.image_difference, self.image_difference_vb, self.image_difference_hist = self.image_in_vb(
             name="difference")
 
+        self.image_before_hist.sigLevelChangeFinished.connect(self.link_image_after_hist_range)
+
         self.image_after_overlay = ImageItem()
         self.image_after_overlay.setZValue(10)
         self.image_after_vb.addItem(self.image_after_overlay)
@@ -233,3 +235,7 @@ class FilterPreviews(GraphicsLayoutWidget):
     def auto_range(self):
         # This will cause the previews to all show by just causing autorange on self.image_before_vb
         self.image_before_vb.autoRange()
+
+    def link_image_after_hist_range(self):
+        self.image_after_hist.region.setRegion(self.image_before_hist.region.getRegion())
+

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -69,8 +69,6 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.image_difference, self.image_difference_vb, self.image_difference_hist = self.image_in_vb(
             name="difference")
 
-        self.image_before_hist.sigLevelChangeFinished.connect(self.link_image_after_hist_range)
-
         self.image_after_overlay = ImageItem()
         self.image_after_overlay.setZValue(10)
         self.image_after_vb.addItem(self.image_after_overlay)
@@ -236,6 +234,18 @@ class FilterPreviews(GraphicsLayoutWidget):
         # This will cause the previews to all show by just causing autorange on self.image_before_vb
         self.image_before_vb.autoRange()
 
-    def link_image_after_hist_range(self):
-        self.image_after_hist.region.setRegion(self.image_before_hist.region.getRegion())
+    def link_before_after_histogram_scales(self, create_link: bool):
+        """
+        Connects or disconnects the scales of the before/after histograms.
+        :param create_link: Whether the link should be created or removed.
+        """
+        if create_link:
+            self.image_before_hist.sigLevelChangeFinished.connect(self.link_image_after_hist_range)
+        else:
+            self.image_after_hist.sigLevelChangeFinished.disconnect()
 
+    def link_image_after_hist_range(self):
+        """
+        Makes the histogram scale of the before image match the histogram scale of the after image.
+        """
+        self.image_after_hist.region.setRegion(self.image_before_hist.region.getRegion())

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -261,10 +261,14 @@ class FilterPreviews(GraphicsLayoutWidget):
         """
         Makes the histogram scale of the before image match the histogram scale of the after image.
         """
+        self.image_after_hist.sigLevelChangeFinished.disconnect()
         self.image_after_hist.region.setRegion(self.image_before_hist.region.getRegion())
+        self.image_after_hist.sigLevelChangeFinished.connect(self.link_image_before_to_after_hist_range)
 
     def link_image_before_to_after_hist_range(self):
         """
         Makes the histogram scale of the after image match the histogram scale of the before image.
         """
+        self.image_before_hist.region.sigRegionChangeFinished.disconnect()
         self.image_before_hist.region.setRegion(self.image_after_hist.region.getRegion())
+        self.image_before_hist.region.sigRegionChangeFinished.connect(self.link_image_after_to_before_hist_range)

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -251,6 +251,7 @@ class FilterPreviews(GraphicsLayoutWidget):
         """
         if create_link:
             self.image_before_hist.sigLevelChangeFinished.connect(self.link_image_after_hist_range)
+            self.link_image_after_hist_range()
         else:
             self.image_before_hist.sigLevelChangeFinished.disconnect()
 

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -242,7 +242,7 @@ class FilterPreviews(GraphicsLayoutWidget):
         if create_link:
             self.image_before_hist.sigLevelChangeFinished.connect(self.link_image_after_hist_range)
         else:
-            self.image_after_hist.sigLevelChangeFinished.disconnect()
+            self.image_before_hist.sigLevelChangeFinished.disconnect()
 
     def link_image_after_hist_range(self):
         """

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -250,19 +250,20 @@ class FilterPreviews(GraphicsLayoutWidget):
         :param create_link: Whether the link should be created or removed.
         """
         if create_link:
-            self.image_before_hist.sigLevelChangeFinished.connect(self.link_image_after_hist_range)
-            self.image_after_hist.sigLevelChangeFinished.connect(self.link_image_before_hist_range)
-            self.link_image_after_hist_range()
+            self.image_after_hist.sigLevelChangeFinished.connect(self.link_image_before_to_after_hist_range)
+            self.image_before_hist.sigLevelChangeFinished.connect(self.link_image_after_to_before_hist_range)
+            self.link_image_after_to_before_hist_range()
         else:
             self.image_before_hist.sigLevelChangeFinished.disconnect()
+            self.image_after_hist.sigLevelChangeFinished.disconnect()
 
-    def link_image_after_hist_range(self):
+    def link_image_after_to_before_hist_range(self):
         """
         Makes the histogram scale of the before image match the histogram scale of the after image.
         """
         self.image_after_hist.region.setRegion(self.image_before_hist.region.getRegion())
 
-    def link_image_before_hist_range(self):
+    def link_image_before_to_after_hist_range(self):
         """
         Makes the histogram scale of the after image match the histogram scale of the before image.
         """

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -75,6 +75,13 @@ class FiltersWindowModel(object):
         filter_idx = self._find_filter_index_from_filter_name(filter_name)
         return self.filters[filter_idx].register_gui
 
+    def link_histograms(self) -> bool:
+        """
+        Gets the link histogram status of a filter.
+        :return: True if the histograms should be linked, False otherwise.
+        """
+        return self.selected_filter.link_histograms
+
     @property
     def params_needed_from_stack(self):
         return self.selected_filter.sv_params()

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -31,11 +31,6 @@ if TYPE_CHECKING:
 
 REPEAT_FLAT_FIELDING_MSG = "Do you want to run flat-fielding again? This could cause you to lose data."
 
-LINKED_HISTOGRAMS = [
-    "Crop Coordinates", "Remove Outliers", "ROI Normalisation", "Circular Mask", "Divide", "Monitor Normalisation",
-    "Rebin", "Ring Removal", "Rotate Stack", "Clip Values", "Median", "Gaussian",
-]
-
 
 class Notification(Enum):
     REGISTER_ACTIVE_FILTER = auto()
@@ -131,7 +126,7 @@ class FiltersWindowPresenter(BasePresenter):
                                              self.view)
         self.model.setup_filter(filter_name, filter_widget_kwargs)
         self.view.clear_notification_dialog()
-        self.view.previews.link_before_after_histogram_scales(filter_name in LINKED_HISTOGRAMS or "tripe" in filter_name)
+        self.view.previews.link_before_after_histogram_scales(self.model.link_histograms())
 
     def filter_uses_parameter(self, parameter):
         return parameter in self.model.params_needed_from_stack.values() if \

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -33,7 +33,7 @@ REPEAT_FLAT_FIELDING_MSG = "Do you want to run flat-fielding again? This could c
 
 LINKED_HISTOGRAMS = [
     "Crop Coordinates", "Remove Outliers", "ROI Normalisation", "Circular Mask", "Divide", "Monitor Normalisation",
-    "Rebin", "Ring Removal", "Rotate Stack", "Remove dead stripes", "Clip Values"
+    "Rebin", "Ring Removal", "Rotate Stack", "Clip Values", "Median", "Gaussian",
 ]
 
 
@@ -131,7 +131,7 @@ class FiltersWindowPresenter(BasePresenter):
                                              self.view)
         self.model.setup_filter(filter_name, filter_widget_kwargs)
         self.view.clear_notification_dialog()
-        self.view.previews.link_before_after_histogram_scales(filter_name in LINKED_HISTOGRAMS)
+        self.view.previews.link_before_after_histogram_scales(filter_name in LINKED_HISTOGRAMS or "tripe" in filter_name)
 
     def filter_uses_parameter(self, parameter):
         return parameter in self.model.params_needed_from_stack.values() if \

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -258,6 +258,7 @@ class FiltersWindowPresenter(BasePresenter):
                 self.show_error(msg, traceback.format_exc())
                 return
 
+            # Update image after first in order to prevent wrong histogram ranges being shared
             filtered_image_data = subset.data[0]
             self._update_preview_image(filtered_image_data, self.view.preview_image_after)
 

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -250,8 +250,6 @@ class FiltersWindowPresenter(BasePresenter):
             stack_presenter = self.stack.presenter
             subset: Images = stack_presenter.get_image(self.model.preview_image_idx)
             before_image = np.copy(subset.data[0])
-            # Update image before
-            self._update_preview_image(before_image, self.view.preview_image_before)
 
             try:
                 self.model.apply_to_images(subset)
@@ -261,8 +259,10 @@ class FiltersWindowPresenter(BasePresenter):
                 return
 
             filtered_image_data = subset.data[0]
-
             self._update_preview_image(filtered_image_data, self.view.preview_image_after)
+
+            # Update image before
+            self._update_preview_image(before_image, self.view.preview_image_before)
 
             self.view.previews.update_histogram_data()
 

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -32,8 +32,8 @@ if TYPE_CHECKING:
 REPEAT_FLAT_FIELDING_MSG = "Do you want to run flat-fielding again? This could cause you to lose data."
 
 LINKED_HISTOGRAMS = [
-    "Crop coordinates", "Remove outliers", "ROI Normalisation", "Circular mask", "Divide", "Monitor Normalisation",
-    "Rebin", "Ring Removal", "Rotate Stack", "Remove dead stripes", "Clip values"
+    "Crop Coordinates", "Remove Outliers", "ROI Normalisation", "Circular Mask", "Divide", "Monitor Normalisation",
+    "Rebin", "Ring Removal", "Rotate Stack", "Remove dead stripes", "Clip Values"
 ]
 
 

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -31,6 +31,11 @@ if TYPE_CHECKING:
 
 REPEAT_FLAT_FIELDING_MSG = "Do you want to run flat-fielding again? This could cause you to lose data."
 
+LINKED_HISTOGRAMS = [
+    "Crop coordinates", "Remove outliers", "ROI Normalisation", "Circular mask", "Divide", "Monitor Normalisation",
+    "Rebin", "Ring Removal", "Rotate Stack", "Remove dead stripes", "Clip values"
+]
+
 
 class Notification(Enum):
     REGISTER_ACTIVE_FILTER = auto()
@@ -126,6 +131,7 @@ class FiltersWindowPresenter(BasePresenter):
                                              self.view)
         self.model.setup_filter(filter_name, filter_widget_kwargs)
         self.view.clear_notification_dialog()
+        self.view.previews.link_before_after_histogram_scales(filter_name in LINKED_HISTOGRAMS)
 
     def filter_uses_parameter(self, parameter):
         return parameter in self.model.params_needed_from_stack.values() if \

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -31,6 +31,21 @@ class FiltersWindowPresenterTest(unittest.TestCase):
 
         reg_fun_mock.assert_called_once()
         filter_reg_mock.assert_called_once()
+        self.view.previews.link_before_after_histogram_scales.assert_called_once()
+
+    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.filter_registration_func')
+    def test_link_before_after_histograms(self, _):
+        self.view.filterSelector.currentText.return_value = "Clip Values"
+        self.presenter.do_register_active_filter()
+
+        self.view.previews.link_before_after_histogram_scales.assert_called_once_with(True)
+
+    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.filter_registration_func')
+    def test_disconnect_before_after_histograms(self, _):
+        self.view.filterSelector.currentText.return_value = "Gaussian"
+        self.presenter.do_register_active_filter()
+
+        self.view.previews.link_before_after_histogram_scales.assert_called_once_with(False)
 
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.do_apply_filter')
     def test_apply_filter(self, apply_filter_mock: mock.Mock):

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -154,9 +154,8 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.presenter.do_update_previews()
         self.view.clear_previews.assert_called_once()
 
-    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter._update_preview_image')
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.apply_to_images')
-    def test_update_previews_apply_throws_exception(self, apply_mock: mock.Mock, update_preview_image_mock: mock.Mock):
+    def test_update_previews_apply_throws_exception(self, apply_mock: mock.Mock):
         apply_mock.side_effect = Exception
         stack = mock.Mock()
         presenter = mock.Mock()
@@ -169,7 +168,6 @@ class FiltersWindowPresenterTest(unittest.TestCase):
 
         presenter.get_image.assert_called_once_with(self.presenter.model.preview_image_idx)
         self.view.clear_previews.assert_called_once()
-        update_preview_image_mock.assert_called_once()
         apply_mock.assert_called_once()
 
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter._update_preview_image')

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -75,7 +75,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
                                  _wait_for_stack_choice: Mock = Mock(),
                                  _do_apply_filter_sync: Mock = Mock()):
         """
-        Tests when the operation has applied successfuly.
+        Tests when the operation has applied successfully.
         """
         self.presenter.view.safeApply.isChecked.return_value = False
         mock_stack_visualisers = [mock.Mock(), mock.Mock()]

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -42,7 +42,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
 
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.filter_registration_func')
     def test_disconnect_before_after_histograms(self, _):
-        self.view.filterSelector.currentText.return_value = "Gaussian"
+        self.view.filterSelector.currentText.return_value = "Rescale"
         self.presenter.do_register_active_filter()
 
         self.view.previews.link_before_after_histogram_scales.assert_called_once_with(False)

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -65,7 +65,6 @@ class FiltersWindowView(BaseMainWindowView):
         self.filterSelector.addItems(self.presenter.model.filter_names)
         self.filterSelector.currentTextChanged.connect(self.handle_filter_selection)
         self.filterSelector.currentTextChanged.connect(self._update_apply_all_button)
-        self.handle_filter_selection("")
 
         # Handle stack selection
         self.stackSelector.stack_selected_uuid.connect(self.presenter.set_stack_uuid)
@@ -79,6 +78,8 @@ class FiltersWindowView(BaseMainWindowView):
         self.previews.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.previewsLayout.addWidget(self.previews)
         self.clear_previews()
+
+        self.handle_filter_selection("")
 
         self.combinedHistograms.stateChanged.connect(self.histogram_mode_changed)
         self.showHistogramLegend.stateChanged.connect(self.histogram_legend_is_changed)


### PR DESCRIPTION
### Issue

Closes #873

### Description

Links the histogram scales of the before and after images for some of the filters.

### Testing 

Added a test for checking if the argument passed to the histogram linking function is True or False. Haven't actually tested what takes place in the filter_previews file as it doesn't have any tests.

### Acceptance Criteria 

Check that the following filters have linked histograms:

- Crop coordinates
- Remove outliers
- ROI Norm
- Circular mask
- Divide
- Monitor Normalisation
- Rebin
- Ring Removal
- Clip values
- Median
- Gaussian
- all Stripe operations

Check that changing to a non-linked operation (such as flat-fielding) breaks the connection, and then switching back to one of the above operations restores it.

### Documentation

Updated release notes.
