### PR TITLE
Fix segfaults

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -24,5 +24,5 @@ Fixes
 - #866 : Warning if running Flat-fielding again
 - #878 : Update update instructions in version check
 - #885 : RuntimeError after closing wizard
-- #805, #875 : Fix segmentation fault due to object lifetime
+- #805, #875, #891 : Fix segmentation fault due to object lifetime
 - #886 : Don't reset zoom when changing operation parameters

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -86,8 +86,8 @@ class BaseEyesTest(unittest.TestCase):
 
     def _load_data_set(self):
         dataset = loader.load(file_names=[LOAD_SAMPLE])
-        dock, vis = self.imaging.presenter.create_new_stack(dataset, "Stack 1")
+        vis = self.imaging.presenter.create_new_stack(dataset, "Stack 1")
 
         QApplication.sendPostedEvents()
 
-        return dock, vis
+        return vis

--- a/mantidimaging/eyes_tests/test_main_window.py
+++ b/mantidimaging/eyes_tests/test_main_window.py
@@ -52,7 +52,7 @@ class MainWindowTest(BaseEyesTest):
     def test_main_window_image_menu(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
         self.show_menu(self.imaging, self.imaging.menuImage)
 
         self.check_target(widget=self.imaging.menuImage)
@@ -60,7 +60,7 @@ class MainWindowTest(BaseEyesTest):
     def test_main_window_loaded_data(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.check_target()
 
@@ -68,6 +68,6 @@ class MainWindowTest(BaseEyesTest):
         self._load_data_set()
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.check_target()

--- a/mantidimaging/eyes_tests/test_main_window.py
+++ b/mantidimaging/eyes_tests/test_main_window.py
@@ -9,7 +9,6 @@ from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
 class MainWindowTest(BaseEyesTest):
     def setUp(self):
         super(MainWindowTest, self).setUp()
-        self.docks = []
 
     def test_main_window_opens(self):
         self.check_target()
@@ -51,23 +50,17 @@ class MainWindowTest(BaseEyesTest):
 
     def test_main_window_image_menu(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
         self.show_menu(self.imaging, self.imaging.menuImage)
 
         self.check_target(widget=self.imaging.menuImage)
 
     def test_main_window_loaded_data(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.check_target()
 
     def test_main_window_loaded_2_sets_of_data(self):
         self._load_data_set()
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.check_target()

--- a/mantidimaging/eyes_tests/test_operations_window.py
+++ b/mantidimaging/eyes_tests/test_operations_window.py
@@ -9,7 +9,6 @@ from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
 class OperationsWindowTest(BaseEyesTest):
     def setUp(self):
         super(OperationsWindowTest, self).setUp()
-        self.docks = []
 
     def tearDown(self):
         self.imaging.filters.close()
@@ -21,16 +20,12 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operation_window_opens_with_data(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.check_target(widget=self.imaging.filters)
 
     def test_operation_window_after_data_was_processed(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.ask_confirmation = mock.MagicMock(return_value=True)
@@ -44,8 +39,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_crop_coordinates_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Crop Coordinates")
@@ -55,8 +48,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_flat_fielding_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Flat-fielding")
@@ -66,8 +57,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_remove_outliers_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Remove Outliers")
@@ -77,8 +66,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_ROI_normalisation_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("ROI Normalisation")
@@ -88,8 +75,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_circular_mask_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Circular Mask")
@@ -99,8 +84,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_clip_values_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Clip Values")
@@ -110,8 +93,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_divide_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Divide")
@@ -121,8 +102,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_gaussian_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Gaussian")
@@ -132,8 +111,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_median_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Median")
@@ -143,8 +120,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_monitor_normalisation_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Monitor Normalisation")
@@ -154,8 +129,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_rebin_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Rebin")
@@ -165,8 +138,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_rescale_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Rescale")
@@ -176,8 +147,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_ring_removal_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Ring Removal")
@@ -187,8 +156,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_rotate_stack_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Rotate Stack")
@@ -198,8 +165,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_remove_all_stripes_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Remove all stripes")
@@ -209,8 +174,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_remove_dead_stripes_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Remove dead stripes")
@@ -220,8 +183,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_remove_large_stripes_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Remove large stripes")
@@ -231,8 +192,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_stripe_removal_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Stripe Removal")
@@ -242,8 +201,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_remove_stripes_with_filtering_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Remove stripes with filtering")
@@ -253,8 +210,6 @@ class OperationsWindowTest(BaseEyesTest):
 
     def test_operations_remove_stripes_with_sorting_and_fitting_parameters(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Remove stripes with sorting and fitting")

--- a/mantidimaging/eyes_tests/test_operations_window.py
+++ b/mantidimaging/eyes_tests/test_operations_window.py
@@ -18,7 +18,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operation_window_opens_with_data(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.check_target(widget=self.imaging.filters)
@@ -26,7 +26,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operation_window_after_data_was_processed(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.ask_confirmation = mock.MagicMock(return_value=True)
@@ -41,7 +41,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_crop_coordinates_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Crop Coordinates")
@@ -52,7 +52,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_flat_fielding_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Flat-fielding")
@@ -63,7 +63,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_remove_outliers_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Remove Outliers")
@@ -74,7 +74,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_ROI_normalisation_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("ROI Normalisation")
@@ -85,7 +85,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_circular_mask_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Circular Mask")
@@ -96,7 +96,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_clip_values_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Clip Values")
@@ -107,7 +107,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_divide_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Divide")
@@ -118,7 +118,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_gaussian_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Gaussian")
@@ -129,7 +129,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_median_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Median")
@@ -140,7 +140,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_monitor_normalisation_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Monitor Normalisation")
@@ -151,7 +151,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_rebin_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Rebin")
@@ -162,7 +162,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_rescale_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Rescale")
@@ -173,7 +173,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_ring_removal_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Ring Removal")
@@ -184,7 +184,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_rotate_stack_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Rotate Stack")
@@ -195,7 +195,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_remove_all_stripes_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Remove all stripes")
@@ -206,7 +206,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_remove_dead_stripes_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Remove dead stripes")
@@ -217,7 +217,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_remove_large_stripes_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Remove large stripes")
@@ -228,7 +228,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_stripe_removal_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Stripe Removal")
@@ -239,7 +239,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_remove_stripes_with_filtering_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Remove stripes with filtering")
@@ -250,7 +250,7 @@ class OperationsWindowTest(BaseEyesTest):
     def test_operations_remove_stripes_with_sorting_and_fitting_parameters(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_filters_window()
         self.imaging.filters.filterSelector.setCurrentText("Remove stripes with sorting and fitting")

--- a/mantidimaging/eyes_tests/test_operations_window.py
+++ b/mantidimaging/eyes_tests/test_operations_window.py
@@ -11,6 +11,10 @@ class OperationsWindowTest(BaseEyesTest):
         super(OperationsWindowTest, self).setUp()
         self.docks = []
 
+    def tearDown(self):
+        self.imaging.filters.close()
+        super().tearDown()
+
     def test_operation_window_opens(self):
         self.imaging.show_filters_window()
         self.check_target(widget=self.imaging.filters)

--- a/mantidimaging/eyes_tests/test_reconstruct_window.py
+++ b/mantidimaging/eyes_tests/test_reconstruct_window.py
@@ -16,7 +16,7 @@ class ReconstructionWindowTest(BaseEyesTest):
     def test_reconstruction_window_opens_with_data(self):
         self._load_data_set()
         for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii.dock)
+            self.docks.append(ii)
 
         self.imaging.show_recon_window()
 

--- a/mantidimaging/eyes_tests/test_reconstruct_window.py
+++ b/mantidimaging/eyes_tests/test_reconstruct_window.py
@@ -6,7 +6,6 @@ from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
 class ReconstructionWindowTest(BaseEyesTest):
     def setUp(self):
         super(ReconstructionWindowTest, self).setUp()
-        self.docks = []
 
     def tearDown(self):
         self.imaging.recon.close()
@@ -19,8 +18,6 @@ class ReconstructionWindowTest(BaseEyesTest):
 
     def test_reconstruction_window_opens_with_data(self):
         self._load_data_set()
-        for ii in self.imaging.presenter.model.get_all_stack_visualisers():
-            self.docks.append(ii)
 
         self.imaging.show_recon_window()
 

--- a/mantidimaging/eyes_tests/test_reconstruct_window.py
+++ b/mantidimaging/eyes_tests/test_reconstruct_window.py
@@ -8,6 +8,10 @@ class ReconstructionWindowTest(BaseEyesTest):
         super(ReconstructionWindowTest, self).setUp()
         self.docks = []
 
+    def tearDown(self):
+        self.imaging.recon.close()
+        super().tearDown()
+
     def test_reconstruction_window_opens(self):
         self.imaging.show_recon_window()
 

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -23,6 +23,11 @@ class UnrotateablePlotROI(ROI):
         self.addScaleHandle([1, 1], [0, 0])
 
 
+# ImageView objects cannot always be safely garbage collected. To prevent this
+# we need keep a reference to the dead objects.
+graveyard = []
+
+
 class MIImageView(ImageView):
     details: QLabel
     roiString = None
@@ -39,6 +44,7 @@ class MIImageView(ImageView):
                  detailsSpanAllCols=False,
                  *args):
         super().__init__(parent, name, view, imageItem, levelMode, *args)
+        graveyard.append(self)
         self.presenter = MIImagePresenter()
         self.details = QLabel("", self.ui.layoutWidget)
         self.details.setStyleSheet("QLabel { color : white; background-color: black}")

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -93,9 +93,9 @@ class MainWindowModel(object):
     def _stack_names(self) -> List[str]:
         return [stack.name for stack in self.stack_list]
 
-    def add_stack(self, stack_visualiser: StackVisualiserView, dock_widget: 'QDockWidget'):
+    def add_stack(self, stack_visualiser: StackVisualiserView):
         stack_visualiser.uuid = uuid.uuid1()
-        self.active_stacks[stack_visualiser.uuid] = dock_widget
+        self.active_stacks[stack_visualiser.uuid] = stack_visualiser
         logger.debug(f"Active stacks: {self.active_stacks}")
 
     def get_stack(self, stack_uuid: uuid.UUID) -> QDockWidget:
@@ -108,9 +108,8 @@ class MainWindowModel(object):
         return self.active_stacks[stack_uuid]  # type:ignore
 
     def set_images_in_stack(self, stack_uuid: uuid.UUID, images: Images):
+
         stack = self.active_stacks[stack_uuid]
-        if isinstance(stack, QDockWidget):
-            stack: StackVisualiserView = stack.widget()  # type:ignore
 
         if not stack.presenter.images == images:
             stack.image_view.clear()
@@ -126,8 +125,7 @@ class MainWindowModel(object):
         return None
 
     def get_stack_by_images(self, images: Images) -> StackVisualiserView:
-        for _, dock_widget in self.active_stacks.items():
-            sv: StackVisualiserView = dock_widget.widget()  # type: ignore
+        for _, sv in self.active_stacks.items():
             if images is sv.presenter.images:
                 return sv
         raise RuntimeError(f"Did not find stack {images} in active stacks! "
@@ -138,15 +136,15 @@ class MainWindowModel(object):
         :param stack_uuid: The unique ID of the stack that will be retrieved.
         :return The Stack Visualiser widget that contains the data.
         """
-        return self.active_stacks[stack_uuid].widget()  # type:ignore
+        return self.active_stacks[stack_uuid]  # type:ignore
 
     def get_all_stack_visualisers(self) -> List[StackVisualiserView]:
-        return [stack.widget() for stack in self.active_stacks.values()]  # type:ignore
+        return [stack for stack in self.active_stacks.values()]  # type:ignore
 
     def get_all_stack_visualisers_with_180deg_proj(self) -> List[StackVisualiserView]:
         return [
-            stack.widget() for stack in self.active_stacks.values()  # type:ignore
-            if stack.widget().presenter.images.has_proj180deg()
+            stack for stack in self.active_stacks.values()  # type:ignore
+            if stack.presenter.images.has_proj180deg()
         ]
 
     def get_stack_history(self, stack_uuid: uuid.UUID) -> Optional[Dict[str, Any]]:

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -4,10 +4,10 @@ import os
 import traceback
 from enum import Enum, auto
 from logging import getLogger
-from typing import TYPE_CHECKING, Union, Tuple, Optional
+from typing import TYPE_CHECKING, Union, Optional
 from uuid import UUID
 
-from PyQt5.QtWidgets import QDockWidget, QTabBar, QApplication
+from PyQt5.QtWidgets import QTabBar, QApplication
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.data.dataset import Dataset
@@ -105,13 +105,9 @@ class MainWindowPresenter(BasePresenter):
         log.error(msg)
         self.show_error(msg, traceback.format_exc())
 
-    def make_stack_window(self, images: Images, title) -> Tuple[QDockWidget, StackVisualiserView]:
-        stack_visualiser = self.view.create_stack_window(images, title=title)
-        return stack_visualiser
-
     def _add_stack(self, images: Images, filename: str, sample_dock):
         name = self.model.create_name(os.path.basename(filename))
-        stack_visualiser = self.make_stack_window(images, title=f"{name}")
+        stack_visualiser = self.view.create_stack_window(images, title=f"{name}")
         self.model.add_stack(stack_visualiser)
         self.view.tabifyDockWidget(sample_dock, stack_visualiser)
 
@@ -119,7 +115,7 @@ class MainWindowPresenter(BasePresenter):
         title = self.model.create_name(title)
 
         sample = container if isinstance(container, Images) else container.sample
-        sample_stack_vis = self.make_stack_window(sample, title)
+        sample_stack_vis = self.view.create_stack_window(sample, title)
         self.model.add_stack(sample_stack_vis)
 
         current_stack_visualisers = self.get_all_stack_visualisers()

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -106,38 +106,37 @@ class MainWindowPresenter(BasePresenter):
         self.show_error(msg, traceback.format_exc())
 
     def make_stack_window(self, images: Images, title) -> Tuple[QDockWidget, StackVisualiserView]:
-        dock = self.view.create_stack_window(images, title=title)
-        stack_visualiser = dock.widget()
-        return dock, stack_visualiser
+        stack_visualiser = self.view.create_stack_window(images, title=title)
+        return stack_visualiser
 
     def _add_stack(self, images: Images, filename: str, sample_dock):
         name = self.model.create_name(os.path.basename(filename))
-        dock, stack_visualiser = self.make_stack_window(images, title=f"{name}")
-        self.model.add_stack(stack_visualiser, dock)
-        self.view.tabifyDockWidget(sample_dock, dock)
+        stack_visualiser = self.make_stack_window(images, title=f"{name}")
+        self.model.add_stack(stack_visualiser)
+        self.view.tabifyDockWidget(sample_dock, stack_visualiser)
 
     def create_new_stack(self, container: Union[Images, Dataset], title: str):
         title = self.model.create_name(title)
 
         sample = container if isinstance(container, Images) else container.sample
-        sample_dock, sample_stack_vis = self.make_stack_window(sample, title)
-        self.model.add_stack(sample_stack_vis, sample_dock)
+        sample_stack_vis = self.make_stack_window(sample, title)
+        self.model.add_stack(sample_stack_vis)
 
         current_stack_visualisers = self.get_all_stack_visualisers()
         if len(current_stack_visualisers) > 1:
-            self.view.tabifyDockWidget(current_stack_visualisers[0].dock, sample_dock)
+            self.view.tabifyDockWidget(current_stack_visualisers[0], sample_stack_vis)
 
         if isinstance(container, Dataset):
             if container.flat_before and container.flat_before.filenames:
-                self._add_stack(container.flat_before, container.flat_before.filenames[0], sample_dock)
+                self._add_stack(container.flat_before, container.flat_before.filenames[0], sample_stack_vis)
             if container.flat_after and container.flat_after.filenames:
-                self._add_stack(container.flat_after, container.flat_after.filenames[0], sample_dock)
+                self._add_stack(container.flat_after, container.flat_after.filenames[0], sample_stack_vis)
             if container.dark_before and container.dark_before.filenames:
-                self._add_stack(container.dark_before, container.dark_before.filenames[0], sample_dock)
+                self._add_stack(container.dark_before, container.dark_before.filenames[0], sample_stack_vis)
             if container.dark_after and container.dark_after.filenames:
-                self._add_stack(container.dark_after, container.dark_after.filenames[0], sample_dock)
+                self._add_stack(container.dark_after, container.dark_after.filenames[0], sample_stack_vis)
             if container.sample.has_proj180deg() and container.sample.proj180deg.filenames:
-                self._add_stack(container.sample.proj180deg, container.sample.proj180deg.filenames[0], sample_dock)
+                self._add_stack(container.sample.proj180deg, container.sample.proj180deg.filenames[0], sample_stack_vis)
 
         if len(current_stack_visualisers) > 1:
             tab_bar = self.view.findChild(QTabBar)
@@ -149,7 +148,7 @@ class MainWindowPresenter(BasePresenter):
 
         self.view.active_stacks_changed.emit()
 
-        return sample_dock, sample_stack_vis
+        return sample_stack_vis
 
     def save(self):
         kwargs = {

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -56,10 +56,9 @@ class MainWindowModelTest(unittest.TestCase):
     def test_add_stack(self):
         stack_mock = mock.Mock()
         expected_name = "stackname"
-        widget_mock = mock.Mock()
-        widget_mock.windowTitle.return_value = expected_name
+        stack_mock.windowTitle.return_value = expected_name
 
-        self.model.add_stack(stack_mock, widget_mock)
+        self.model.add_stack(stack_mock)
 
         self.assertTrue(hasattr(stack_mock, 'uuid'))
         self.assertEqual(1, len(self.model.stack_list))
@@ -91,11 +90,8 @@ class MainWindowModelTest(unittest.TestCase):
 
     def test_get_stack_visualiser(self):
         uid, widget_mock, _ = self._add_mock_widget()
-        expected_widget = mock.Mock()
-        widget_mock.widget.return_value = expected_widget
 
-        self.assertIs(expected_widget, self.model.get_stack_visualiser(uid))
-        widget_mock.widget.assert_called_once()
+        self.assertIs(widget_mock, self.model.get_stack_visualiser(uid))
 
     def test_do_remove_stack(self):
         uid, _, _ = self._add_mock_widget()

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -67,15 +67,11 @@ class MainWindowPresenterTest(unittest.TestCase):
 
     def test_make_stack_window(self):
         images = generate_images()
-        dock_mock = mock.Mock()
         stack_visualiser_mock = mock.Mock()
+        self.view.create_stack_window.return_value = stack_visualiser_mock
 
-        dock_mock.widget.return_value = stack_visualiser_mock
-        self.view.create_stack_window.return_value = dock_mock
+        sv = self.presenter.make_stack_window(images, "mytitle")
 
-        dock, sv = self.presenter.make_stack_window(images, "mytitle")
-
-        self.assertIs(dock_mock, dock)
         self.assertIs(stack_visualiser_mock, sv)
 
     def test_add_stack(self):

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -65,15 +65,6 @@ class MainWindowPresenterTest(unittest.TestCase):
         start_async_mock.assert_called_once_with(self.view, self.presenter.model.load_stack,
                                                  self.presenter._on_stack_load_done, {'file_path': file_path})
 
-    def test_make_stack_window(self):
-        images = generate_images()
-        stack_visualiser_mock = mock.Mock()
-        self.view.create_stack_window.return_value = stack_visualiser_mock
-
-        sv = self.presenter.make_stack_window(images, "mytitle")
-
-        self.assertIs(stack_visualiser_mock, sv)
-
     def test_add_stack(self):
         images = generate_images()
         dock_mock = mock.Mock()

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -165,9 +165,7 @@ class MainWindowViewTest(unittest.TestCase):
                          setCentralWidget=DEFAULT,
                          addDockWidget=DEFAULT)
     @mock.patch("mantidimaging.gui.windows.main.view.StackVisualiserView")
-    @mock.patch("mantidimaging.gui.windows.main.view.QDockWidget")
     def test_create_stack_window(self,
-                                 mock_dock: mock.Mock,
                                  mock_sv: mock.Mock,
                                  setCentralWidget: Mock = Mock(),
                                  addDockWidget: Mock = Mock()):
@@ -178,13 +176,11 @@ class MainWindowViewTest(unittest.TestCase):
 
         self.view.create_stack_window(images, title, position=position, floating=floating)
 
-        mock_dock.assert_called_once_with(title, self.view)
-        dock = mock_dock.return_value
+        mock_sv.assert_called_once_with(self.view, title, images)
+        dock = mock_sv.return_value
         setCentralWidget.assert_called_once_with(dock)
         addDockWidget.assert_called_once_with(position, dock)
 
-        mock_sv.assert_called_once_with(self.view, dock, images)
-        dock.setWidget.assert_called_once_with(mock_sv.return_value)
         dock.setFloating.assert_called_once_with(floating)
 
     @mock.patch("mantidimaging.gui.windows.main.view.QMessageBox")

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -9,7 +9,7 @@ from uuid import UUID
 from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtGui import QIcon, QDragEnterEvent, QDropEvent
-from PyQt5.QtWidgets import QAction, QDialog, QLabel, QMessageBox, QMenu, QDockWidget, QFileDialog
+from PyQt5.QtWidgets import QAction, QDialog, QLabel, QMessageBox, QMenu, QFileDialog
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.utility import finder
@@ -308,24 +308,20 @@ class MainWindowView(BaseMainWindowView):
                             stack: Images,
                             title: str,
                             position=QtCore.Qt.TopDockWidgetArea,
-                            floating=False) -> QDockWidget:
-        dock = QDockWidget(title, self)
+                            floating=False) -> StackVisualiserView:
+        stack_vis = StackVisualiserView(self, title, stack)
 
         # this puts the new stack window into the centre of the window
-        self.setCentralWidget(dock)
+        self.setCentralWidget(stack_vis)
 
         # add the dock widget into the main window
-        self.addDockWidget(position, dock)
+        self.addDockWidget(position, stack_vis)
 
-        # we can get the stack visualiser widget with dock_widget.widget
-        dock.setWidget(StackVisualiserView(self, dock, stack))
+        stack_vis.setFloating(floating)
 
-        dock.setFloating(floating)
-
-        return dock
+        return stack_vis
 
     def remove_stack(self, obj: StackVisualiserView):
-        getLogger(__name__).debug("Removing stack with uuid %s", obj.uuid)
         self.presenter.notify(PresNotification.REMOVE_STACK, uuid=obj.uuid)
 
     def rename_stack(self, current_name: str, new_name: str):

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -5,8 +5,6 @@ from typing import Tuple
 from unittest import mock
 from unittest.mock import Mock
 
-from PyQt5 import sip
-
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.data import Images
 from mantidimaging.core.utility.sensible_roi import SensibleROI
@@ -16,7 +14,6 @@ from mantidimaging.gui.windows.stack_visualiser import StackVisualiserView
 from mantidimaging.test_helpers import start_qapplication
 
 versions._use_test_values()
-docks = []
 
 
 @start_qapplication
@@ -27,18 +24,11 @@ class StackVisualiserViewTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(StackVisualiserViewTest, self).__init__(*args, **kwargs)
 
-    def tearDown(self) -> None:
-        sip.delete(self.view)  # type: ignore
-        self.view = None
-        self.window = None  # type: ignore[assignment]
-        self.dock = None
-
     def setUp(self):
         with mock.patch("mantidimaging.gui.windows.main.view.WelcomeScreenPresenter"):
             self.window = MainWindowView()
         self.window.remove_stack = mock.Mock()
         self.view, self.test_data = self._add_stack_visualiser()
-        docks.append(self.view)
 
     def _add_stack_visualiser(self) -> Tuple[StackVisualiserView, Images]:
         test_data = th.generate_images()

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -6,7 +6,6 @@ from unittest import mock
 from unittest.mock import Mock
 
 from PyQt5 import sip
-from PyQt5.QtWidgets import QDockWidget
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.data import Images
@@ -38,35 +37,35 @@ class StackVisualiserViewTest(unittest.TestCase):
         with mock.patch("mantidimaging.gui.windows.main.view.WelcomeScreenPresenter"):
             self.window = MainWindowView()
         self.window.remove_stack = mock.Mock()
-        self.dock, self.view, self.test_data = self._add_stack_visualiser()
-        docks.append(self.dock)
+        self.view, self.test_data = self._add_stack_visualiser()
+        docks.append(self.view)
 
-    def _add_stack_visualiser(self) -> Tuple[QDockWidget, StackVisualiserView, Images]:
+    def _add_stack_visualiser(self) -> Tuple[StackVisualiserView, Images]:
         test_data = th.generate_images()
         self.window.create_new_stack(test_data, "Test Data")
         view = self.window.get_stack_with_images(test_data)
-        return view.dock, view, test_data
+        return view, test_data
 
     def test_name(self):
         title = "Potatoes"
-        self.dock.setWindowTitle(title)
+        self.view.setWindowTitle(title)
         self.assertEqual(title, self.view.name)
 
     def test_closeEvent_deletes_images(self):
-        self.dock.setFloating = mock.Mock()
+        self.view.setFloating = mock.Mock()
 
         self.view.close()
 
-        self.dock.setFloating.assert_called_once_with(False)
+        self.view.setFloating.assert_called_once_with(False)
         self.assertEqual(None, self.view.presenter.images)
         self.window.remove_stack.assert_called_once_with(self.view)
 
     @mock.patch("mantidimaging.gui.windows.main.view.StackVisualiserView.ask_confirmation", return_value=True)
     def test_closeEvent_deletes_images_with_proj180_user_accepts(self, ask_confirmation_mock: Mock):
-        p180_dock, p180_view, images = self._add_stack_visualiser()
+        p180_view, images = self._add_stack_visualiser()
         self.test_data.proj180deg = images
 
-        p180_dock.setFloating = mock.Mock()  # type: ignore[assignment]
+        p180_view.setFloating = mock.Mock()  # type: ignore[assignment]
 
         p180_view.close()
 
@@ -75,16 +74,16 @@ class StackVisualiserViewTest(unittest.TestCase):
         # proj180 has been cleared from the stack referencing it
         self.assertFalse(self.test_data.has_proj180deg())
 
-        p180_dock.setFloating.assert_called_once_with(False)
+        p180_view.setFloating.assert_called_once_with(False)
         self.assertIsNone(p180_view.presenter.images)
         self.window.remove_stack.assert_called_once_with(p180_view)  # type: ignore[attr-defined]
 
     @mock.patch("mantidimaging.gui.windows.main.view.StackVisualiserView.ask_confirmation", return_value=False)
     def test_closeEvent_deletes_images_with_proj180_user_declined(self, ask_confirmation_mock: Mock):
-        p180_dock, p180_view, images = self._add_stack_visualiser()
+        p180_view, images = self._add_stack_visualiser()
         self.test_data.proj180deg = images
 
-        p180_dock.setFloating = mock.Mock()  # type: ignore[assignment]
+        p180_view.setFloating = mock.Mock()  # type: ignore[assignment]
 
         p180_view.close()
 
@@ -93,7 +92,7 @@ class StackVisualiserViewTest(unittest.TestCase):
         # proj180 has been cleared from the stack referencing it
         self.assertTrue(self.test_data.has_proj180deg())
 
-        p180_dock.setFloating.assert_not_called()
+        p180_view.setFloating.assert_not_called()
         self.assertIsNotNone(p180_view.presenter.images)
         self.window.remove_stack.assert_not_called()  # type: ignore[attr-defined]
 


### PR DESCRIPTION
### Issue

Hopefully closes #891 closes  #875

### Description

Fixes the segfaults by preventing MIImageView objects from being garbage collected.

Remove some workarounds that were previously used in the tests.

Previously StackVisualiserView was a BaseMainWindowView embedded in a
QDockWidget. This required it to hold a reference to the dock, and
modify the docks CloseEvent.

By getting rid of the dock as a separate object, a lot of code can be
simplified.

### Acceptance Criteria 

Tests including GUI tests should always pass without segfault.

Should be possible to do a complete reconstruction without a segfault.

RAM use should still fall after closing a large image stack.

### Documentation

Yes
