### PR TITLE
Prevent simultaneous operations

### DIFF
--- a/docs/release_notes/2.1.rst
+++ b/docs/release_notes/2.1.rst
@@ -30,6 +30,7 @@ Fixes
 - #878 : Update update instructions in version check
 - #885 : RuntimeError after closing wizard
 - #805, #875, #891 : Fix segmentation fault due to object lifetime
+- #716 : Prevent simultaneous operations
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -255,6 +255,9 @@ class MainWindowView(BaseMainWindowView):
         self.save_dialogue.show()
 
     def show_recon_window(self):
+        if self.filters is not None and self.filters.isVisible():
+            QMessageBox.warning(self, "", "Close Operations window before opening Reconstruction")
+            return
         if not self.recon:
             self.recon = ReconstructWindowView(self)
             self.recon.recon_applied.connect(self.recon_applied.emit)
@@ -264,6 +267,9 @@ class MainWindowView(BaseMainWindowView):
             self.recon.raise_()
 
     def show_filters_window(self):
+        if self.recon is not None and self.recon.isVisible():
+            QMessageBox.warning(self, "", "Close Reconstruction window before opening Operations")
+            return
         if not self.filters:
             self.filters = FiltersWindowView(self)
             self.filters.filter_applied.connect(self.filter_applied.emit)

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -54,6 +54,7 @@ class FiltersWindowPresenter(BasePresenter):
 
         self.original_images_stack: Union[List[Tuple[Images, UUID]]] = []
         self.applying_to_all = False
+        self.filter_is_running = False
 
         self.prev_apply_single_state = True
         self.prev_apply_all_state = True
@@ -228,8 +229,10 @@ class FiltersWindowPresenter(BasePresenter):
             self.view.show_operation_completed(self.model.selected_filter.filter_name)
 
         self.view.filter_applied.emit()
+        self.filter_is_running = False
 
     def _do_apply_filter(self, apply_to):
+        self.filter_is_running = True
         # Record the previous button states
         self.prev_apply_single_state = self.view.applyButton.isEnabled()
         self.prev_apply_all_state = self.view.applyToAllButton.isEnabled()

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -106,6 +106,12 @@ class FiltersWindowView(BaseMainWindowView):
         self.filterHelpButton.pressed.connect(self.open_help_webpage)
         self.collapseToggleButton.pressed.connect(self.toggle_filters_section)
 
+    def closeEvent(self, e):
+        if self.presenter.filter_is_running:
+            e.ignore()
+        else:
+            super().closeEvent(e)
+
     def cleanup(self):
         self.stackSelector.unsubscribe_from_main_window()
         if self.roi_view is not None:

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -175,6 +175,12 @@ class ReconstructWindowView(BaseMainWindowView):
         self.image_view.recon_hist.gradient.menu.insertAction(action, self.auto_colour_action)
         self.image_view.recon_hist.gradient.menu.insertSeparator(self.auto_colour_action)
 
+    def closeEvent(self, e):
+        if self.presenter.recon_is_running:
+            e.ignore()
+        else:
+            super().closeEvent(e)
+
     def check_stack_for_invalid_180_deg_proj(self, uuid: UUID):
         selected_images = self.main_window.get_images_from_stack_uuid(uuid)
         if selected_images.has_proj180deg() and \


### PR DESCRIPTION
### Issue

closes #716 

### Description

Some GUI changes so that a user can't start an operation and reconstruction at the same time.

Prevent ops and recon windows closing while something is in progress. Prevent both windows being open at the same time.

### Testing & Acceptance Criteria 

Check that ops and recon windows can't be closed with an action is progress.

Check that they cant both be opened at the same time

### Documentation


