### PR TITLE
901: Rebin operation failed

### DIFF
--- a/docs/release_notes/2.1.rst
+++ b/docs/release_notes/2.1.rst
@@ -31,6 +31,7 @@ Fixes
 - #885 : RuntimeError after closing wizard
 - #805, #875, #891 : Fix segmentation fault due to object lifetime
 - #716 : Prevent simultaneous operations
+- #901: Rebin Operation failed: '<' not supported between instances of 'Progress' and 'int'
 
 Developer Changes
 -----------------

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -11,6 +11,7 @@ New features
 Fixes
 -----
 
+#901: Rebin Operation failed: '<' not supported between instances of 'Progress' and 'int'
 
 Developer Changes
 -----------------

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -11,7 +11,6 @@ New features
 Fixes
 -----
 
-#901: Rebin Operation failed: '<' not supported between instances of 'Progress' and 'int'
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -57,7 +57,11 @@ class RebinFilter(BaseFilter):
                                   mode=mode,
                                   output_shape=empty_resized_data.shape[1:])
             ps.shared_list = [sample, empty_resized_data]
-            ps.execute(f, sample.shape[0], cores, "Applying Rebin", progress)
+            ps.execute(partial_func=f,
+                       num_operations=sample.shape[0],
+                       cores=cores,
+                       msg="Applying Rebin",
+                       progress=progress)
             images.data = empty_resized_data
 
         return images

--- a/mantidimaging/core/operations/rebin/test/rebin_test.py
+++ b/mantidimaging/core/operations/rebin/test/rebin_test.py
@@ -165,6 +165,21 @@ class RebinTest(unittest.TestCase):
         self.assertEqual(factor.value.call_count, 1)
         self.assertEqual(mode_field.currentText.call_count, 1)
 
+    @mock.patch("mantidimaging.core.operations.rebin.rebin.ps")
+    def test_execute_argument_order(self, ps_mock):
+
+        images = th.generate_images()
+        mode = 'reflect'
+        cores = 4
+        progress_mock = mock.Mock()
+        RebinFilter.filter_func(images=images, mode=mode, cores=cores, progress=progress_mock)
+
+        ps_mock.execute.assert_called_once_with(partial_func=ps_mock.create_partial.return_value,
+                                                num_operations=images.data.shape[0],
+                                                cores=cores,
+                                                msg="Applying Rebin",
+                                                progress=progress_mock)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Issue

Closes #901

### Description

Makes the `execute` method use named arguments so the progress object isn't confused for the number of cores.

### Testing 

Added an operation order test.

### Acceptance Criteria 

Run the Rebin operation and check the error doesn't appear.

### Documentation

Updated the release notes.
