### PR TITLE
Fix ROI normalisation scaling

### DIFF
--- a/docs/release_notes/2.1.rst
+++ b/docs/release_notes/2.1.rst
@@ -32,6 +32,7 @@ Fixes
 - #805, #875, #891 : Fix segmentation fault due to object lifetime
 - #716 : Prevent simultaneous operations
 - #901: Rebin Operation failed: '<' not supported between instances of 'Progress' and 'int'
+- #912: Fix ROI normalise due to rescale changes
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -96,7 +96,7 @@ def _calc_max(data):
     return data.max()
 
 
-def _divide_by_air_sum(data=None, air_sums=None):
+def _divide_by_air(data=None, air_sums=None):
     data[:] = np.true_divide(data, air_sums)
 
 
@@ -133,7 +133,7 @@ def _execute(data: np.ndarray, air_region: SensibleROI, cores=None, chunksize=No
         post_max = (air_maxs / air_means).max()
         air_means *= post_max / init_max
 
-        do_divide = ps.create_partial(_divide_by_air_sum, fwd_function=ps.inplace2)
+        do_divide = ps.create_partial(_divide_by_air, fwd_function=ps.inplace2)
         ps.shared_list = [data, air_means]
         ps.execute(do_divide, data.shape[0], progress, cores=cores)
 


### PR DESCRIPTION
### Issue

Closes #912 

### Description

Instead of calling RescaleFilter, move the rescale step into RoiNormalisationFilter

Restore pre 2.0 behaviour so that offset is not applied

### Testing & Acceptance Criteria 

In the comparison window after running ROI normalise, ensure that there is no offset of small value introduced.

### Documentation

Added to release notes


