### PR TITLE
Applitools tests: call processEvents before screenshot 

### DIFF
--- a/docs/developer_guide/index.rst
+++ b/docs/developer_guide/index.rst
@@ -38,3 +38,4 @@ To check that the set up was successful, try running the tests from the source d
    developer_conventions
    conda_packaging_and_docker_image
    release
+   testing

--- a/docs/developer_guide/testing.rst
+++ b/docs/developer_guide/testing.rst
@@ -1,0 +1,50 @@
+Testing
+=======
+
+Mantid imaging uses unit tests, static analysis and GUI approval testing
+
+The full test suite can be run using:
+
+.. code ::
+
+    make check
+
+Tests are run automatically on pull requests on GitHub using actions, but should also be run during development.
+
+Unit testing
+------------
+
+Unit tests can be run using `pytest <https://docs.pytest.org/>`_, e.g.
+
+.. code::
+
+    python -m pytest
+
+For options such as running a subset of tests, see `PyTest Docs <https://docs.pytest.org/en/stable/usage.html>`_
+
+
+Static analysis
+---------------
+
+Mantid Imaging uses `mypy <http://mypy-lang.org/>`_, `flake8 <https://flake8.pycqa.org/>`_ and `yapf <https://github.com/google/yapf>`_ for static analysis and formatting. They are run by :code:`make check`, or can be run individually, e.g. :code:`make mypy`.
+
+
+GUI Testing
+-----------
+
+Mantid Imaging uses `Applitools Eyes <https://applitools.com/products-eyes/>`_ for GUI approval testing. Screenshots of windows are uploaded and compared to known good baseline images. This is run in the github action on pull requests.
+
+Appplitools requires an API key to use, which can be found on via a Applitools web interface. On a developer machine this can be passed as an environment variable. E.g.
+
+.. code::
+
+    APPLITOOLS_API_KEY=XXXXXXXXXX xvfb-run --auto-servernum pytest -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests
+
+Differences between uploaded and baseline images can be examined and approved or rejected from the Applitools web interface.
+
+To run without a key or to prevent uploads, set ``APPLITOOLS_API_KEY`` to ``local`` and choose a directory to save the screenshots. Note that this does not check for changes, and will always pass. e.g.
+
+.. code::
+
+    mkdir /tmp/gui_test
+    APPLITOOLS_API_KEY=local APPLITOOLS_IMAGE_DIR=/tmp/gui_test xvfb-run --auto-servernum pytest -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests

--- a/docs/release_notes/2.1.rst
+++ b/docs/release_notes/2.1.rst
@@ -39,3 +39,4 @@ Developer Changes
 
 - #770 : Use multiprocessing.Array
 - #709 : Applitools GUI tests
+- #908 : Fix GUI test failure

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -37,6 +37,13 @@ if not os.path.exists(LOAD_SAMPLE):
         "Data not present, please clone to your home directory e.g. git clone https://github.com/mantidproject/mantidim"
         "aging-data.git ~/mantidimaging-data")
 
+APPLITOOLS_IMAGE_DIR = os.getenv("APPLITOOLS_IMAGE_DIR")
+if APPLITOOLS_IMAGE_DIR is None:
+    APPLITOOLS_IMAGE_DIR = mkdtemp(prefix="mantid_image_eyes_")
+else:
+    if not os.path.isdir(APPLITOOLS_IMAGE_DIR):
+        raise ValueError(f"Directory does not exist: APPLITOOLS_IMAGE_DIR = {APPLITOOLS_IMAGE_DIR}")
+
 QApplication.setFont(QFont("Sans Serif", 10))
 
 
@@ -53,7 +60,7 @@ class BaseEyesTest(unittest.TestCase):
         self.eyes_manager.set_match_level(MatchLevel.LAYOUT)
 
         self.imaging = None
-        self.eyes_manager.image_directory = mkdtemp()
+        self.eyes_manager.image_directory = APPLITOOLS_IMAGE_DIR
 
         self.stacks = []
 

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -76,8 +76,8 @@ class BaseEyesTest(unittest.TestCase):
     def imaging(self, imaging):
         self.eyes_manager.imaging = imaging
 
-    def check_target(self, image=None, widget: QWidget = None):
-        self.eyes_manager.check_target(image, widget)
+    def check_target(self, widget: QWidget = None):
+        self.eyes_manager.check_target(widget)
 
     @staticmethod
     def show_menu(widget: QMainWindow, menu: QMenu):

--- a/mantidimaging/eyes_tests/eyes_manager.py
+++ b/mantidimaging/eyes_tests/eyes_manager.py
@@ -53,16 +53,14 @@ class EyesManager:
         self.imaging.show()
         QApplication.processEvents()
 
-    def _take_screenshot(self, widget: QWidget = None, directory=None):
+    def _take_screenshot(self, widget: QWidget = None):
         """
-        :param directory: The directory to save the screenshot to, should be a temporary directory. If None is given it
-        will generate a temporary directory.
-
+        :param widget: Widget to take screen shot of or main window if None.
         :return: Will return the path to the saved image, or None if failed.
         """
-        if directory is None and self.image_directory is None:
+        if self.image_directory is None:
             directory = mkdtemp()
-        elif directory is None:
+        else:
             directory = self.image_directory
 
         if widget is None and self.imaging is not None:

--- a/mantidimaging/eyes_tests/eyes_manager.py
+++ b/mantidimaging/eyes_tests/eyes_manager.py
@@ -43,6 +43,9 @@ class EyesManager:
 
         image = self._take_screenshot(widget=widget, image_name=test_image_name)
 
+        if self.eyes.api_key == "local":
+            return
+
         if not self.eyes.is_open:
             self.eyes.open(self.application_name, test_file_name)
         self.eyes.check_image(image, test_method_name)

--- a/mantidimaging/eyes_tests/eyes_manager.py
+++ b/mantidimaging/eyes_tests/eyes_manager.py
@@ -73,6 +73,7 @@ class EyesManager:
             widget = self.imaging
 
         if isinstance(widget, QWidget):
+            QApplication.processEvents()
             image = widget.grab()
         else:
             image = None

--- a/mantidimaging/eyes_tests/eyes_manager.py
+++ b/mantidimaging/eyes_tests/eyes_manager.py
@@ -36,9 +36,8 @@ class EyesManager:
     def abort(self):
         self.eyes.abort_if_not_closed()
 
-    def check_target(self, image=None, widget: QWidget = None):
-        if image is None:
-            image = self._take_screenshot(widget=widget)
+    def check_target(self, widget: QWidget = None):
+        image = self._take_screenshot(widget=widget)
         test_method_name = inspect.stack()[2][3]
         if not self.eyes.is_open:
             test_file_name = os.path.basename(inspect.stack()[2][1])

--- a/mantidimaging/eyes_tests/eyes_manager.py
+++ b/mantidimaging/eyes_tests/eyes_manager.py
@@ -37,10 +37,13 @@ class EyesManager:
         self.eyes.abort_if_not_closed()
 
     def check_target(self, widget: QWidget = None):
-        image = self._take_screenshot(widget=widget)
+        test_file_name = os.path.basename(inspect.stack()[2][1])
         test_method_name = inspect.stack()[2][3]
+        test_image_name = test_file_name.rpartition(".")[0] + "_" + test_method_name
+
+        image = self._take_screenshot(widget=widget, image_name=test_image_name)
+
         if not self.eyes.is_open:
-            test_file_name = os.path.basename(inspect.stack()[2][1])
             self.eyes.open(self.application_name, test_file_name)
         self.eyes.check_image(image, test_method_name)
 
@@ -52,9 +55,10 @@ class EyesManager:
         self.imaging.show()
         QApplication.processEvents()
 
-    def _take_screenshot(self, widget: QWidget = None):
+    def _take_screenshot(self, widget: QWidget = None, image_name=None):
         """
         :param widget: Widget to take screen shot of or main window if None.
+        :param image_name: File name for screenshot
         :return: Will return the path to the saved image, or None if failed.
         """
         if self.image_directory is None:
@@ -70,9 +74,15 @@ class EyesManager:
         else:
             image = None
 
-        file_path = os.path.join(directory, str(uuid4()))
+        if image_name is None:
+            image_name = str(uuid4())
+
+        file_path = os.path.join(directory, image_name) + ".png"
+
         if image.save(file_path, "PNG"):
             return file_path
+        else:
+            raise IOError("Failed to save", file_path)
 
     def close_eyes(self):
         if self.eyes.is_open:


### PR DESCRIPTION
### Issue

Fixes #908 

### Description

The fix is to call processEvents before taking the screenshot. Along the way I made some improvements to make it easier to run the GUI tests without uploading to applitools.

Give screenshots friendly names and store in a single directory.

Add APPLITOOLS_IMAGE_DIR enviroment varaible, to specifiy where
screenshots are stored.

If APPLITOOLS_API_KEY=local skip upload step. (Tests will pass, screen
shots can be examined locally).

Remove unused image argument of check_target()

Remove unused directory argment of _take_screenshot()

### Testing & Acceptance Criteria 

GUI tests should pass now.

Also it is now possible to run the tests locally without an API key, and see the screenshots in a directory.

```
    mkdir /tmp/gui_test
    APPLITOOLS_API_KEY=local APPLITOOLS_IMAGE_DIR=/tmp/gui_test xvfb-run --auto-servernum pytest -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests
```

### Documentation

Wrote up some documents on testing.
