### PR TITLE
Add ROI normalisation modes

### DIFF
--- a/docs/release_notes/2.1.rst
+++ b/docs/release_notes/2.1.rst
@@ -13,6 +13,7 @@ New features
 - #567: Add new user wizard
 - #886 : Don't reset zoom when changing operation parameters
 - #873 : Link histogram scales in operations window
+- #914 : Modes for ROI normalisation
 
 Fixes
 -----

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -118,21 +118,6 @@ class FlatFieldFilter(BaseFilter):
     def register_gui(form, on_change, view: FiltersWindowView) -> Dict[str, Any]:
         from mantidimaging.gui.utility import add_property_to_form
 
-        def string_contains_all_parts(string: str, parts: list) -> bool:
-            for part in parts:
-                if part.lower() not in string:
-                    return False
-            return True
-
-        def try_to_select_relevant_stack(name: str, widget: StackSelectorWidgetView) -> None:
-            # Split based on whitespace
-            name_parts = name.split()
-            for i in range(widget.count()):
-                # If widget text contains all name parts
-                if string_contains_all_parts(widget.itemText(i).lower(), name_parts):
-                    widget.setCurrentIndex(i)
-                    break
-
         _, selected_flat_fielding_widget = add_property_to_form(
             "Flat Fielding Method",
             Type.CHOICE,
@@ -172,25 +157,25 @@ class FlatFieldFilter(BaseFilter):
         assert isinstance(flat_before_widget, StackSelectorWidgetView)
         flat_before_widget.setMaximumWidth(375)
         flat_before_widget.subscribe_to_main_window(view.main_window)
-        try_to_select_relevant_stack("Flat", flat_before_widget)
-        try_to_select_relevant_stack("Flat Before", flat_before_widget)
+        flat_before_widget.try_to_select_relevant_stack("Flat")
+        flat_before_widget.try_to_select_relevant_stack("Flat Before")
 
         assert isinstance(flat_after_widget, StackSelectorWidgetView)
         flat_after_widget.setMaximumWidth(375)
         flat_after_widget.subscribe_to_main_window(view.main_window)
-        try_to_select_relevant_stack("Flat After", flat_after_widget)
+        flat_after_widget.try_to_select_relevant_stack("Flat After")
         flat_after_widget.setEnabled(False)
 
         assert isinstance(dark_before_widget, StackSelectorWidgetView)
         dark_before_widget.setMaximumWidth(375)
         dark_before_widget.subscribe_to_main_window(view.main_window)
-        try_to_select_relevant_stack("Dark", dark_before_widget)
-        try_to_select_relevant_stack("Dark Before", dark_before_widget)
+        dark_before_widget.try_to_select_relevant_stack("Dark")
+        dark_before_widget.try_to_select_relevant_stack("Dark Before")
 
         assert isinstance(dark_after_widget, StackSelectorWidgetView)
         dark_after_widget.setMaximumWidth(375)
         dark_after_widget.subscribe_to_main_window(view.main_window)
-        try_to_select_relevant_stack("Dark After", dark_after_widget)
+        dark_after_widget.try_to_select_relevant_stack("Dark After")
         dark_after_widget.setEnabled(False)
 
         # Ensure that fields that are not currently used are disabled

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -3,6 +3,7 @@
 
 from functools import partial
 from logging import getLogger
+from typing import List, Optional
 
 import numpy as np
 
@@ -15,6 +16,11 @@ from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.utility import add_property_to_form
 from mantidimaging.gui.utility.qt_helpers import Type
+from mantidimaging.gui.widgets.stack_selector import StackSelectorWidgetView
+
+
+def modes() -> List[str]:
+    return ['Preserve Max', 'Stack Average', 'Flat Field']
 
 
 class RoiNormalisationFilter(BaseFilter):
@@ -31,7 +37,13 @@ class RoiNormalisationFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images: Images, region_of_interest: SensibleROI = None, cores=None, chunksize=None, progress=None):
+    def filter_func(images: Images,
+                    region_of_interest: SensibleROI = None,
+                    normalisation_mode: str = modes()[0],
+                    flat_field: Optional[Images] = None,
+                    cores=None,
+                    chunksize=None,
+                    progress=None):
         """Normalise by beam intensity.
 
         This does NOT do any checks if the Air Region is out of bounds!
@@ -45,6 +57,15 @@ class RoiNormalisationFilter(BaseFilter):
                            from which sums will be calculated and all images will
                            be normalised.
 
+        :param normalisation_mode: Controls what the air regions are normalised to.
+            'Preserve Max' : Normalisation is scaled such that the the maximum pixel value of the stack is equal before
+                             and after the operation.
+            'Stack Average' : The mean value of the air region across all projections is preserved.
+            'Flat Field' : The mean value of the air regions in the projections is made equal to the mean value of the
+                           air region in the flat field.
+
+        :param flat_field: If 'Flat Field' mode is used, pass in the flat field images.
+
         :param cores: The number of cores that will be used to process the data.
 
         :param chunksize: The number of chunks that each worker will receive.
@@ -52,12 +73,23 @@ class RoiNormalisationFilter(BaseFilter):
 
         :returns: Filtered data (stack of images)
         """
+        if normalisation_mode not in modes():
+            raise ValueError(f"Unknown normalisation_mode: {normalisation_mode}, should be one of {modes()}")
+
+        if normalisation_mode == "Flat Field" and flat_field is None:
+            raise ValueError('flat_field must provided if using normalisation_mode of "Flat Field"')
+
+        if flat_field is not None:
+            flat_field_data = flat_field.data
+        else:
+            flat_field_data = None
+
         h.check_data_stack(images)
 
         # just get data reference
         if region_of_interest:
             progress = Progress.ensure_instance(progress, task_name='ROI Normalisation')
-            _execute(images.data, region_of_interest, cores, chunksize, progress)
+            _execute(images.data, region_of_interest, normalisation_mode, flat_field_data, cores, chunksize, progress)
         h.check_data_stack(images)
         return images
 
@@ -73,13 +105,43 @@ class RoiNormalisationFilter(BaseFilter):
                              form=form,
                              on_change=on_change,
                              run_on_press=lambda: view.roi_visualiser(roi_field))
-        return {'roi_field': roi_field}
+
+        _, mode_field = add_property_to_form('Normalise Mode',
+                                             Type.CHOICE,
+                                             valid_values=modes(),
+                                             form=form,
+                                             on_change=on_change,
+                                             tooltip="Method to normalise output values")
+
+        _, flat_field_widget = add_property_to_form("Flat file",
+                                                    Type.STACK,
+                                                    form=form,
+                                                    filters_view=view,
+                                                    on_change=on_change,
+                                                    tooltip="Flat images to be used for normalising.")
+
+        assert isinstance(flat_field_widget, StackSelectorWidgetView)
+        flat_field_widget.setMaximumWidth(375)
+        flat_field_widget.subscribe_to_main_window(view.main_window)
+        flat_field_widget.try_to_select_relevant_stack("Flat")
+        flat_field_widget.try_to_select_relevant_stack("Flat Before")
+
+        flat_field_widget.setEnabled(False)
+        mode_field.currentTextChanged.connect(lambda text: enable_correct_fields_only(text, flat_field_widget))
+
+        return {'roi_field': roi_field, 'norm_mode': mode_field, 'flat_field': flat_field_widget}
 
     @staticmethod
-    def execute_wrapper(roi_field):
+    def execute_wrapper(roi_field, norm_mode, flat_field):
         try:
             roi = SensibleROI.from_list([int(number) for number in roi_field.text().strip("[").strip("]").split(",")])
-            return partial(RoiNormalisationFilter.filter_func, region_of_interest=roi)
+            mode = norm_mode.currentText()
+            flat = flat_field.main_window.get_stack_visualiser(flat_field.current())
+            flat_images = flat.presenter.images
+            return partial(RoiNormalisationFilter.filter_func,
+                           region_of_interest=roi,
+                           normalisation_mode=mode,
+                           flat_field=flat_images)
         except Exception as e:
             raise ValueError(f"The provided ROI string is invalid! Error: {e}")
 
@@ -100,7 +162,13 @@ def _divide_by_air(data=None, air_sums=None):
     data[:] = np.true_divide(data, air_sums)
 
 
-def _execute(data: np.ndarray, air_region: SensibleROI, cores=None, chunksize=None, progress=None):
+def _execute(data: np.ndarray,
+             air_region: SensibleROI,
+             normalisation_mode: str,
+             flat_field: Optional[np.ndarray],
+             cores=None,
+             chunksize=None,
+             progress=None):
     log = getLogger(__name__)
 
     with progress:
@@ -122,16 +190,26 @@ def _execute(data: np.ndarray, air_region: SensibleROI, cores=None, chunksize=No
         ps.shared_list = [data, air_means]
         ps.execute(do_calculate_air_means, data.shape[0], progress, cores=cores)
 
-        air_maxs = pu.create_array((img_num, ), data.dtype)
-        do_calculate_air_max = ps.create_partial(_calc_max, ps.return_to_second_at_i)
+        if normalisation_mode == 'Preserve Max':
+            air_maxs = pu.create_array((img_num, ), data.dtype)
+            do_calculate_air_max = ps.create_partial(_calc_max, ps.return_to_second_at_i)
 
-        ps.shared_list = [data, air_maxs]
-        ps.execute(do_calculate_air_max, data.shape[0], progress, cores=cores)
+            ps.shared_list = [data, air_maxs]
+            ps.execute(do_calculate_air_max, data.shape[0], progress, cores=cores)
 
-        # calculate the before and after maximum
-        init_max = air_maxs.max()
-        post_max = (air_maxs / air_means).max()
-        air_means *= post_max / init_max
+            # calculate the before and after maximum
+            init_max = air_maxs.max()
+            post_max = (air_maxs / air_means).max()
+            air_means *= post_max / init_max
+
+        elif normalisation_mode == 'Stack Average':
+            air_means /= air_means.mean()
+
+        elif normalisation_mode == 'Flat Field' and flat_field is not None:
+            flat_mean = pu.create_array((flat_field.shape[0], ), flat_field.dtype)
+            ps.shared_list = [flat_field, flat_mean]
+            ps.execute(do_calculate_air_means, flat_field.shape[0], progress, cores=cores)
+            air_means /= flat_mean.mean()
 
         do_divide = ps.create_partial(_divide_by_air, fwd_function=ps.inplace2)
         ps.shared_list = [data, air_means]
@@ -142,3 +220,10 @@ def _execute(data: np.ndarray, air_region: SensibleROI, cores=None, chunksize=No
         min_avg = np.min(air_means) / avg
 
         log.info(f"Normalization by air region. " f"Average: {avg}, max ratio: {max_avg}, min ratio: {min_avg}.")
+
+
+def enable_correct_fields_only(text, flat_file_widget):
+    if text == "Flat Field":
+        flat_file_widget.setEnabled(True)
+    else:
+        flat_file_widget.setEnabled(False)

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -95,12 +95,12 @@ class RoiNormalisationFilter(BaseFilter):
 
     @staticmethod
     def register_gui(form, on_change, view):
-        label, roi_field = add_property_to_form("ROI",
+        label, roi_field = add_property_to_form("Air Region",
                                                 Type.STR,
                                                 form=form,
                                                 on_change=on_change,
                                                 default_value="0, 0, 200, 200")
-        add_property_to_form("Select ROI",
+        add_property_to_form("Select Air Region",
                              "button",
                              form=form,
                              on_change=on_change,

--- a/mantidimaging/gui/widgets/stack_selector/test/__init__.py
+++ b/mantidimaging/gui/widgets/stack_selector/test/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/widgets/stack_selector/test/test_view.py
+++ b/mantidimaging/gui/widgets/stack_selector/test/test_view.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+import unittest
+import pytest
+
+from mantidimaging.gui.widgets.stack_selector.view import _string_contains_all_parts, StackSelectorWidgetView
+from mantidimaging.test_helpers import start_qapplication
+
+
+@pytest.mark.parametrize("in_string,in_parts,expected", [
+    ("flat_0001", ["Flat"], True),
+    ("flat_0001", ["flat"], True),
+    ("dark_0001", ["flat"], False),
+    ("flat_0001", ["flat", "before"], False),
+    ("flat_before_0001", ["flat", "before"], True),
+])
+def test_string_contains_all_parts(in_string, in_parts, expected):
+    assert _string_contains_all_parts(in_string, in_parts) == expected
+
+
+@start_qapplication
+class StackSelectorWidgetViewTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.view = StackSelectorWidgetView(None)
+
+    def _add_items(self):
+        self.view.addItems(["flat_0001", "dark_0001", "tomo_0001"])
+
+    def test_try_to_select_relevant_stack(self):
+        print(self.view)
+        self._add_items()
+        self.view.try_to_select_relevant_stack("dark")
+        self.assertEqual(self.view.currentIndex(), 1)
+        self.assertEqual(self.view.currentText(), "dark_0001")
+
+        self.view.try_to_select_relevant_stack("flat")
+        self.assertEqual(self.view.currentIndex(), 0)
+        self.assertEqual(self.view.currentText(), "flat_0001")

--- a/mantidimaging/gui/widgets/stack_selector/view.py
+++ b/mantidimaging/gui/widgets/stack_selector/view.py
@@ -11,6 +11,13 @@ if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # pragma: no cover
 
 
+def _string_contains_all_parts(string: str, parts: list) -> bool:
+    for part in parts:
+        if part.lower() not in string:
+            return False
+    return True
+
+
 class StackSelectorWidgetView(Qt.QComboBox):
     stacks_updated = Qt.pyqtSignal()
 
@@ -56,3 +63,12 @@ class StackSelectorWidgetView(Qt.QComboBox):
 
     def select_eligible_stack(self):
         self.presenter.notify(Notification.SELECT_ELIGIBLE_STACK)
+
+    def try_to_select_relevant_stack(self, name: str) -> None:
+        # Split based on whitespace
+        name_parts = name.split()
+        for i in range(self.count()):
+            # If widget text contains all name parts
+            if _string_contains_all_parts(self.itemText(i).lower(), name_parts):
+                self.setCurrentIndex(i)
+                break


### PR DESCRIPTION
### Issue

Closes #914 

### Description
Add ROI normalisation modes

'Preserve Max' : Normalisation is scaled such that the the maximum pixel value of the stack is equal before
	     and after the operation.
'Stack Average' : The mean value of the air region across all projections is preserved.
'Flat Field' : The mean value of the air regions in the projects is made equal to the mean value of the air
	   region in the flat field.

'Preserve Max' is equivilent to the old behaviour.

### Testing 

Tests are updated, and check for sensible behaviour of the 3 modes

### Acceptance Criteria 

Each mode works

### Documentation

Release notes and doc strings updated
