### PR TITLE
Prevent image changing before user has finished typing

### DIFF
--- a/docs/release_notes/2.1.rst
+++ b/docs/release_notes/2.1.rst
@@ -33,6 +33,7 @@ Fixes
 - #716 : Prevent simultaneous operations
 - #901: Rebin Operation failed: '<' not supported between instances of 'Progress' and 'int'
 - #912: Fix ROI normalise due to rescale changes
+= #921: Ops window Image spin box looses focus after key press
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -209,6 +209,9 @@
              </item>
              <item>
               <widget class="QSpinBox" name="previewImageIndex">
+               <property name="keyboardTracking">
+                <bool>false</bool>
+               </property>
                <property name="maximum">
                 <number>9999999</number>
                </property>


### PR DESCRIPTION
### Issue

Closes #921 

### Description

Set keyboardTracking on the previewImageIndex spinbox in the ops window.
Now the user can type in an image number and press enter or tab.

### Testing & Acceptance Criteria 

Check that the image selector spinbox on the ops window works as expected. And that it is possible to type in an image number


### Documentation

Updated release notes
