### PR TITLE
Ring Removal: extract values from widgets

### DIFF
--- a/docs/release_notes/2.1.rst
+++ b/docs/release_notes/2.1.rst
@@ -36,6 +36,7 @@ Fixes
 - #912: Fix ROI normalise due to rescale changes
 - #921: Ops window Image spin box looses focus after key press
 - #914: Outliers acts as median in dark mode
+- #905: Ring Removal has no effect
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/operations/ring_removal/ring_removal.py
+++ b/mantidimaging/core/operations/ring_removal/ring_removal.py
@@ -153,10 +153,10 @@ class RingRemovalFilter(BaseFilter):
                         rwidth=None):
         return partial(RingRemovalFilter.filter_func,
                        run_ring_removal=True,
-                       center_x=x_field,
-                       center_y=y_field,
-                       thresh=thresh,
-                       thresh_max=thresh_max,
-                       thresh_min=thresh_min,
-                       theta_min=theta,
-                       rwidth=rwidth)
+                       center_x=x_field.value(),
+                       center_y=y_field.value(),
+                       thresh=thresh.value(),
+                       thresh_max=thresh_max.value(),
+                       thresh_min=thresh_min.value(),
+                       theta_min=theta.value(),
+                       rwidth=rwidth.value())

--- a/mantidimaging/core/operations/ring_removal/test/ring_removal_test.py
+++ b/mantidimaging/core/operations/ring_removal/test/ring_removal_test.py
@@ -2,6 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest
+from unittest.mock import Mock
 
 import numpy as np
 import numpy.testing as npt
@@ -46,7 +47,8 @@ class RingRemovalTest(unittest.TestCase):
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
         """
         images = th.generate_images()
-        RingRemovalFilter.execute_wrapper()(images)
+        mocks = [Mock() for _ in range(7)]
+        RingRemovalFilter.execute_wrapper(*mocks)(images)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Issue

closes #905 

### Description
filter_func needs the values, not the actual widgets.

Pass mocks in test

### Testing &  Acceptance Criteria 

Open a reconstructed image
Put in parameters from screen shot
check that some rings are removed

![Screenshot at 2021-04-15 16-15-03](https://user-images.githubusercontent.com/74248560/114896469-45a06a80-9e08-11eb-82ae-1f442e2989e3.png)


### Documentation
Added to release notes
