### PR TITLE
919: Minimum kernel size of 2

### DIFF
--- a/docs/release_notes/2.1.rst
+++ b/docs/release_notes/2.1.rst
@@ -36,6 +36,7 @@ Fixes
 - #912: Fix ROI normalise due to rescale changes
 - #921: Ops window Image spin box looses focus after key press
 - #914: Outliers acts as median in dark mode
+- #919: Median min kernel size
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/operations/gaussian/gaussian.py
+++ b/mantidimaging/core/operations/gaussian/gaussian.py
@@ -58,7 +58,7 @@ class GaussianFilter(BaseFilter):
     def register_gui(form, on_change, view):
         _, size_field = add_property_to_form('Kernel Size',
                                              Type.INT,
-                                             3, (0, 1000),
+                                             3, (2, 1000),
                                              form=form,
                                              on_change=on_change,
                                              tooltip="Size of the median filter kernel")

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -62,7 +62,7 @@ class MedianFilter(BaseFilter):
     def register_gui(form: 'QFormLayout', on_change: Callable, view) -> Dict[str, Any]:
         _, size_field = add_property_to_form('Kernel Size',
                                              Type.INT,
-                                             3, (0, 1000),
+                                             3, (2, 1000),
                                              form=form,
                                              on_change=on_change,
                                              tooltip="Size of the median filter kernel")

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -74,7 +74,7 @@ class OutliersFilter(BaseFilter):
         _, diff_field = add_property_to_form('Difference',
                                              'float',
                                              1000,
-                                             valid_values=(0, 1000000),
+                                             valid_values=(2, 1000000),
                                              form=form,
                                              on_change=on_change,
                                              tooltip="Difference between pixels that will be used to spot outliers.\n"

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -74,7 +74,7 @@ class OutliersFilter(BaseFilter):
         _, diff_field = add_property_to_form('Difference',
                                              'float',
                                              1000,
-                                             valid_values=(2, 1000000),
+                                             valid_values=(2, 1000),
                                              form=form,
                                              on_change=on_change,
                                              tooltip="Difference between pixels that will be used to spot outliers.\n"

--- a/mantidimaging/core/operations/outliers/test/outliers_test.py
+++ b/mantidimaging/core/operations/outliers/test/outliers_test.py
@@ -62,10 +62,10 @@ class OutliersTest(unittest.TestCase):
         # use sets because dictionary order isn't guaranteed in Python 3
         self.assertEqual({'diff_field', 'size_field', 'mode_field'}, set(gui_dict.keys()))
 
-    def test_gui_diff_spin_box_min_is_0(self):
+    def test_gui_diff_spin_box_min_is_2(self):
         gui_dict = OutliersFilter.register_gui(mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
 
-        self.assertEqual(0, gui_dict["diff_field"].minimum())
+        self.assertEqual(2, gui_dict["diff_field"].minimum())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Issue

Closes #919 

### Description

Makes the median, remove outliers, and gaussian filters have a minimum kernel size of 2. Also changed the max kernel size of outliers from 1000000 to 1000 to match the other filters.

### Acceptance Criteria 

Check that the spin boxes can't have a value lower than 2.

### Documentation

Updated the release notes.
