### PR TITLE
Revert "Prevent recon and ops window both opening at same time"

### DIFF
--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -255,9 +255,6 @@ class MainWindowView(BaseMainWindowView):
         self.save_dialogue.show()
 
     def show_recon_window(self):
-        if self.filters is not None and self.filters.isVisible():
-            QMessageBox.warning(self, "", "Close Operations window before opening Reconstruction")
-            return
         if not self.recon:
             self.recon = ReconstructWindowView(self)
             self.recon.recon_applied.connect(self.recon_applied.emit)
@@ -267,9 +264,6 @@ class MainWindowView(BaseMainWindowView):
             self.recon.raise_()
 
     def show_filters_window(self):
-        if self.recon is not None and self.recon.isVisible():
-            QMessageBox.warning(self, "", "Close Reconstruction window before opening Operations")
-            return
         if not self.filters:
             self.filters = FiltersWindowView(self)
             self.filters.filter_applied.connect(self.filter_applied.emit)


### PR DESCRIPTION
This reverts commit 09b43d962d9923b9c8c550655bf86a31b0b5db49.

### Issue

Closes #928 

### Description

From discussions it was decided that it is useful to be able to have both windows open simultaneously, as it can be useful to look at values in used other when setting parameters.

### Testing & Acceptance Criteria 
Check that both operations and recon windows can be opened simutainiously

### Documentation


