### PR TITLE
906: Clip values

### DIFF
--- a/docs/release_notes/2.1.rst
+++ b/docs/release_notes/2.1.rst
@@ -39,6 +39,7 @@ Fixes
 - #914: Outliers acts as median in dark mode
 - #919: Median min kernel size
 - #905: Ring Removal has no effect
+- #906: Clip values
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -218,7 +218,7 @@ class FilterPreviews(GraphicsLayoutWidget):
             view.linkView(ViewBox.YAxis, None)
 
     def add_difference_overlay(self, diff):
-        diff = -diff
+        diff = np.absolute(diff)
         diff[diff > 0.0] = 1.0
         pos = np.array([0, 1])
         color = np.array([[0, 0, 0, 0], [255, 0, 0, 255]], dtype=np.ubyte)

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -22,6 +22,8 @@ before_pen = (200, 0, 0)
 after_pen = (0, 200, 0)
 diff_pen = (0, 0, 200)
 
+OVERLAY_THRESHOLD = 1e-3
+
 Coord = namedtuple('Coord', ['row', 'col'])
 histogram_coords = {"before": Coord(4, 0), "after": Coord(4, 1), "combined": Coord(4, 0)}
 
@@ -219,7 +221,7 @@ class FilterPreviews(GraphicsLayoutWidget):
 
     def add_difference_overlay(self, diff):
         diff = np.absolute(diff)
-        diff[diff > 0.0] = 1.0
+        diff[diff > OVERLAY_THRESHOLD] = 1.0
         pos = np.array([0, 1])
         color = np.array([[0, 0, 0, 0], [255, 0, 0, 255]], dtype=np.ubyte)
         map = ColorMap(pos, color)


### PR DESCRIPTION
### Issue

Closes #906

### Description

Makes the overlay colour all pixels where the absolute value of the change is > 10^-3.

### Testing 

Haven't done an, as there aren't any tests for the filter previews file.

### Acceptance Criteria 

Open the operations window and check that all red pixels in the image after overlay have a difference greater than 10^-3 while all unchanged pixels have a different smaller than this value.

### Documentation

Updated the release notes.
