### PR TITLE
931: Crop Coordinates Error

### DIFF
--- a/docs/release_notes/2.1.rst
+++ b/docs/release_notes/2.1.rst
@@ -40,6 +40,7 @@ Fixes
 - #919: Median min kernel size
 - #905: Ring Removal has no effect
 - #906: Clip values
+- #931: Crop Coordinates error if image is smaller than 200x200
 
 Developer Changes
 -----------------

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -32,3 +32,4 @@ dependencies:
       - psutil==5.7.3
       - isort==5.6.4
       - eyes-images==4.15.0
+      - parameterized==0.8.1

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -110,9 +110,6 @@ class FiltersWindowModel(object):
     def apply_to_images(self, images, progress=None):
         input_kwarg_widgets = self.filter_widget_kwargs.copy()
 
-        if not input_kwarg_widgets:
-            return
-
         # Validate required kwargs are supplied so pre-processing does not happen unnecessarily
         if not self.selected_filter.validate_execute_kwargs(input_kwarg_widgets):
             raise ValueError("Not all required parameters specified")

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -110,6 +110,9 @@ class FiltersWindowModel(object):
     def apply_to_images(self, images, progress=None):
         input_kwarg_widgets = self.filter_widget_kwargs.copy()
 
+        if not input_kwarg_widgets:
+            return
+
         # Validate required kwargs are supplied so pre-processing does not happen unnecessarily
         if not self.selected_filter.validate_execute_kwargs(input_kwarg_widgets):
             raise ValueError("Not all required parameters specified")

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -331,15 +331,21 @@ class FiltersWindowPresenter(BasePresenter):
         self.view.applyToAllButton.setEnabled(apply_all_enabled)
 
     def init_crop_coords(self, roi_field: QLineEdit):
-        if self.stack is not None:
-            larger = np.greater(self.stack.presenter.images.data[0].shape, (200, 200))
-            if all(larger):
-                return
-            x = 200
-            y = 200
-            if not larger[0]:
-                x = self.stack.presenter.images.data[0].shape[0] // 2
-            if not larger[1]:
-                y = self.stack.presenter.images.data[0].shape[1] // 2
-            crop_string = ", ".join(["0", "0", str(y), str(x)])
-            roi_field.setText(crop_string)
+        """
+        Sets the initial value of the crop coordinates line edit widget so that it doesn't contain values that are
+        larger than the image.
+        :param roi_field: The ROI field line edit widget.
+        """
+        if self.stack is None:
+            return
+
+        larger = np.greater(self.stack.presenter.images.data[0].shape, (200, 200))
+        if all(larger):
+            return
+        x = y = 200
+        if not larger[0]:
+            x = self.stack.presenter.images.data[0].shape[0] // 2
+        if not larger[1]:
+            y = self.stack.presenter.images.data[0].shape[1] // 2
+        crop_string = ", ".join(["0", "0", str(y), str(x)])
+        roi_field.setText(crop_string)

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -133,7 +133,6 @@ class FiltersWindowPresenter(BasePresenter):
         self.view.clear_notification_dialog()
         self.view.previews.link_before_after_histogram_scales(self.model.link_histograms())
 
-
     def filter_uses_parameter(self, parameter):
         return parameter in self.model.params_needed_from_stack.values() if \
             self.model.params_needed_from_stack is not None else False
@@ -331,11 +330,15 @@ class FiltersWindowPresenter(BasePresenter):
         self.view.applyToAllButton.setEnabled(apply_all_enabled)
 
     def init_crop_coords(self, roi_field: QLineEdit):
-        larger = np.greater(self.stack.presenter.images.data[0].shape, (200, 200))
-        if larger[0] and larger[1]:
-            return
-        if not larger[0]:
-            pass
-        if not larger[1]:
-            pass
-
+        if self.stack is not None:
+            larger = np.greater(self.stack.presenter.images.data[0].shape, (200, 200))
+            if all(larger):
+                return
+            x = 200
+            y = 200
+            if not larger[0]:
+                x = self.stack.presenter.images.data[0].shape[0] // 2
+            if not larger[1]:
+                y = self.stack.presenter.images.data[0].shape[1] // 2
+            crop_string = ", ".join(["0", "0", str(y), str(x)])
+            roi_field.setText(crop_string)

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -259,7 +259,8 @@ class FiltersWindowPresenter(BasePresenter):
             before_image = np.copy(subset.data[0])
 
             try:
-                self.model.apply_to_images(subset)
+                if self.model.filter_widget_kwargs is not None:
+                    self.model.apply_to_images(subset)
             except Exception as e:
                 msg = f"Error applying filter for preview: {e}"
                 self.show_error(msg, traceback.format_exc())

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -10,7 +10,7 @@ from typing import List, TYPE_CHECKING, Optional, Tuple, Union
 from uuid import UUID
 
 import numpy as np
-from PyQt5.QtWidgets import QApplication
+from PyQt5.QtWidgets import QApplication, QLineEdit
 from pyqtgraph import ImageItem
 
 from mantidimaging.core.data import Images
@@ -125,9 +125,14 @@ class FiltersWindowPresenter(BasePresenter):
         # Register new filter (adding it's property widgets to the properties layout)
         filter_widget_kwargs = register_func(self.view.filterPropertiesLayout, self.view.auto_update_triggered.emit,
                                              self.view)
+
+        if filter_name == "Crop Coordinates":
+            self.init_crop_coords(filter_widget_kwargs["roi_field"])
+
         self.model.setup_filter(filter_name, filter_widget_kwargs)
         self.view.clear_notification_dialog()
         self.view.previews.link_before_after_histogram_scales(self.model.link_histograms())
+
 
     def filter_uses_parameter(self, parameter):
         return parameter in self.model.params_needed_from_stack.values() if \
@@ -324,3 +329,13 @@ class FiltersWindowPresenter(BasePresenter):
         """
         self.view.applyButton.setEnabled(apply_single_enabled)
         self.view.applyToAllButton.setEnabled(apply_all_enabled)
+
+    def init_crop_coords(self, roi_field: QLineEdit):
+        larger = np.greater(self.stack.presenter.images.data[0].shape, (200, 200))
+        if larger[0] and larger[1]:
+            return
+        if not larger[0]:
+            pass
+        if not larger[1]:
+            pass
+

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -259,7 +259,7 @@ class FiltersWindowPresenter(BasePresenter):
             before_image = np.copy(subset.data[0])
 
             try:
-                if self.model.filter_widget_kwargs is not None:
+                if self.model.filter_widget_kwargs:
                     self.model.apply_to_images(subset)
             except Exception as e:
                 msg = f"Error applying filter for preview: {e}"

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -342,10 +342,7 @@ class FiltersWindowPresenter(BasePresenter):
         larger = np.greater(self.stack.presenter.images.data[0].shape, (200, 200))
         if all(larger):
             return
-        x = y = 200
-        if not larger[0]:
-            x = self.stack.presenter.images.data[0].shape[0] // 2
-        if not larger[1]:
-            y = self.stack.presenter.images.data[0].shape[1] // 2
+        x = min(self.stack.presenter.images.data[0].shape[0], 200)
+        y = min(self.stack.presenter.images.data[0].shape[1], 200)
         crop_string = ", ".join(["0", "0", str(y), str(x)])
         roi_field.setText(crop_string)

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -378,7 +378,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.presenter.init_crop_coords(mock_roi_field)
         mock_roi_field.setText.assert_not_called()
 
-    @parameterized.expand([(190, 201, "0, 0, 200, 95"), (201, 80, "0, 0, 40, 200"), (200, 200, "0, 0, 100, 100")])
+    @parameterized.expand([(190, 201, "0, 0, 200, 190"), (201, 80, "0, 0, 80, 200"), (200, 200, "0, 0, 200, 200")])
     def test_set_text_called_when_image_not_greater_than_200_by_200(self, shape_x, shape_y, expected):
         mock_roi_field = mock.Mock()
         self.presenter.stack = mock.Mock()

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -20,6 +20,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.main_window.filter_applied.connect = mock.Mock()
         self.view = mock.MagicMock()
         self.presenter = FiltersWindowPresenter(self.view, self.main_window)
+        self.presenter.model.filter_widget_kwargs = {"roi_field": None}
         self.view.presenter = self.presenter
 
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.filter_registration_func')

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -8,7 +8,6 @@ from functools import partial
 from unittest import mock
 from unittest.mock import DEFAULT, Mock
 
-import pytest
 from parameterized import parameterized
 
 from mantidimaging.core.operation_history.const import OPERATION_HISTORY, OPERATION_DISPLAY_NAME
@@ -375,14 +374,14 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     def test_init_crop_coords_does_nothing_when_image_is_greater_than_200_by_200(self):
         mock_roi_field = mock.Mock()
         self.presenter.stack = mock.Mock()
-        self.presenter.stack.presenter.images.data = np.ones((2,201,201))
+        self.presenter.stack.presenter.images.data = np.ones((2, 201, 201))
         self.presenter.init_crop_coords(mock_roi_field)
         mock_roi_field.setText.assert_not_called()
 
-    @parameterized.expand([(200,201), (201,200), (200,200)])
-    def test_set_text_called_when_image_not_greater_than_200_by_200(self, shape_x, shape_y):
+    @parameterized.expand([(190, 201, "0, 0, 200, 95"), (201, 80, "0, 0, 40, 200"), (200, 200, "0, 0, 100, 100")])
+    def test_set_text_called_when_image_not_greater_than_200_by_200(self, shape_x, shape_y, expected):
         mock_roi_field = mock.Mock()
         self.presenter.stack = mock.Mock()
-        self.presenter.stack.presenter.images.data = np.ones((2,shape_x, shape_y))
+        self.presenter.stack.presenter.images.data = np.ones((2, shape_x, shape_y))
         self.presenter.init_crop_coords(mock_roi_field)
-        mock_roi_field.setText.assert_called_once()
+        mock_roi_field.setText.assert_called_once_with(expected)

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -8,6 +8,9 @@ from functools import partial
 from unittest import mock
 from unittest.mock import DEFAULT, Mock
 
+import pytest
+from parameterized import parameterized
+
 from mantidimaging.core.operation_history.const import OPERATION_HISTORY, OPERATION_DISPLAY_NAME
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.operations import FiltersWindowPresenter
@@ -372,6 +375,14 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     def test_init_crop_coords_does_nothing_when_image_is_greater_than_200_by_200(self):
         mock_roi_field = mock.Mock()
         self.presenter.stack = mock.Mock()
-        self.presenter.stack.presenter.images.data = np.ones((3,201,201))
+        self.presenter.stack.presenter.images.data = np.ones((2,201,201))
         self.presenter.init_crop_coords(mock_roi_field)
         mock_roi_field.setText.assert_not_called()
+
+    @parameterized.expand([(200,201), (201,200), (200,200)])
+    def test_set_text_called_when_image_not_greater_than_200_by_200(self, shape_x, shape_y):
+        mock_roi_field = mock.Mock()
+        self.presenter.stack = mock.Mock()
+        self.presenter.stack.presenter.images.data = np.ones((2,shape_x, shape_y))
+        self.presenter.init_crop_coords(mock_roi_field)
+        mock_roi_field.setText.assert_called_once()

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -2,6 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import unittest
+import numpy as np
 from functools import partial
 
 from unittest import mock
@@ -362,3 +363,15 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.presenter._do_apply_filter(None)
         assert self.presenter.prev_apply_single_state == prev_apply_single_state
         assert self.presenter.prev_apply_all_state == prev_apply_all_state
+
+    def test_init_crop_coords_does_nothing_when_stack_is_none(self):
+        mock_roi_field = mock.Mock()
+        self.presenter.init_crop_coords(mock_roi_field)
+        mock_roi_field.setText.assert_not_called()
+
+    def test_init_crop_coords_does_nothing_when_image_is_greater_than_200_by_200(self):
+        mock_roi_field = mock.Mock()
+        self.presenter.stack = mock.Mock()
+        self.presenter.stack.presenter.images.data = np.ones((3,201,201))
+        self.presenter.init_crop_coords(mock_roi_field)
+        mock_roi_field.setText.assert_not_called()

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -79,8 +79,6 @@ class FiltersWindowView(BaseMainWindowView):
         self.previewsLayout.addWidget(self.previews)
         self.clear_previews()
 
-        self.handle_filter_selection("")
-
         self.combinedHistograms.stateChanged.connect(self.histogram_mode_changed)
         self.showHistogramLegend.stateChanged.connect(self.histogram_legend_is_changed)
         # set here to trigger the changed event
@@ -105,6 +103,8 @@ class FiltersWindowView(BaseMainWindowView):
         # Handle help button pressed
         self.filterHelpButton.pressed.connect(self.open_help_webpage)
         self.collapseToggleButton.pressed.connect(self.toggle_filters_section)
+
+        self.handle_filter_selection("")
 
     def closeEvent(self, e):
         if self.presenter.filter_is_running:


### PR DESCRIPTION
### Issue

Closes #931 

### Description

Sets the initial crop coordinates value to something smaller than the current image.

### Testing 

Added tests for the `init_cop_coords` function.

### Acceptance Criteria 

Load the  "tilt1_ready2" dataset and open the operations window. Check that no error message appears.

### Documentation

Updated the release notes.
