### PR TITLE
920: Don't forget parameters when closing and reopening recon window

### DIFF
--- a/docs/release_notes/2.1.rst
+++ b/docs/release_notes/2.1.rst
@@ -15,6 +15,7 @@ New features
 - #873 : Link histogram scales in operations window
 - #914 : Modes for ROI normalisation
 - #872 : Histogram improvement
+- #920 : Don't forget parameters when closing and reopening recon window
 
 Fixes
 -----

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -262,6 +262,7 @@ class MainWindowView(BaseMainWindowView):
         else:
             self.recon.activateWindow()
             self.recon.raise_()
+            self.recon.show()
 
     def show_filters_window(self):
         if not self.filters:

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -179,7 +179,7 @@ class ReconstructWindowView(BaseMainWindowView):
         if self.presenter.recon_is_running:
             e.ignore()
         else:
-            super().closeEvent(e)
+            self.hide()
 
     def check_stack_for_invalid_180_deg_proj(self, uuid: UUID):
         selected_images = self.main_window.get_images_from_stack_uuid(uuid)


### PR DESCRIPTION
### Issue

Closes #920

### Description

Makes the reconstruction window hide rather than close.

### Acceptance Criteria 

Change some of the parameters on the reconstruction window and close it. Reopen and check that the parameters are still there.

### Documentation

Updated release notes.
