### PR TITLE
925: Jenks/Otsu everywhere

### DIFF
--- a/docs/release_notes/2.1.rst
+++ b/docs/release_notes/2.1.rst
@@ -16,7 +16,6 @@ New features
 - #914 : Modes for ROI normalisation
 - #872 : Histogram improvement
 - #920 : Don't forget parameters when closing and reopening recon window
-- #925 : Jenks / Otsu everywhere
 
 Fixes
 -----

--- a/docs/release_notes/2.1.rst
+++ b/docs/release_notes/2.1.rst
@@ -15,6 +15,7 @@ New features
 - #873 : Link histogram scales in operations window
 - #914 : Modes for ROI normalisation
 - #872 : Histogram improvement
+- #925 : Jenks / Otsu everywhere
 
 Fixes
 -----

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -8,6 +8,7 @@ New features
 ------------
 
 - #927 : ROI norm: use averaged view in ROI selector
+- #925 : Jenks / Otsu everywhere
 
 Fixes
 -----

--- a/docs/user_guide/gui/image_view.rst
+++ b/docs/user_guide/gui/image_view.rst
@@ -58,8 +58,9 @@ the different materials in the image. In some cases, this may make the different
 distinguish from one another. Be aware that the success of the algorithm greatly depends on how much the histogram
 cooperates.
 
-This feature can be accessed by right clicking the projection histogram in the recon window and selecting "Auto", or
-by clicking on the "Auto Change Colour Palette" button in the bottom-left corner. This is shown below:
+This feature can be accessed by right clicking the projection histogram in the recon window and selecting "Auto". In the
+Reconstruction window, there is also the option to access the auto colour feature by clicking on the "Auto Change Colour
+Palette" button in the bottom-left corner. This is shown below:
 
 .. image:: ../../_static/access_auto_colour_palette.png
     :alt: Accessing the auto colour palette

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -230,5 +230,5 @@ class MIImageView(ImageView):
         set_histogram_log_scale(self.getHistogramWidget().item)
 
     def on_colour_change_palette(self):
-        change_colour_palette = PaletteChangerView(parent=None, hists=[self.ui.histogram.item], image=self.image)
+        change_colour_palette = PaletteChangerView(parent=None, main_hist=self.ui.histogram.item, image=self.image)
         change_colour_palette.show()

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -230,5 +230,8 @@ class MIImageView(ImageView):
         set_histogram_log_scale(self.getHistogramWidget().item)
 
     def on_colour_change_palette(self):
+        """
+        Opens the Palette Changer window when the "Auto" option has been clicked.
+        """
         change_colour_palette = PaletteChangerView(parent=None, main_hist=self.ui.histogram.item, image=self.image)
         change_colour_palette.show()

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -5,7 +5,7 @@ from time import sleep
 from typing import Callable, Optional, Tuple
 
 from PyQt5 import QtCore
-from PyQt5.QtWidgets import QApplication, QHBoxLayout, QLabel, QPushButton, QSizePolicy
+from PyQt5.QtWidgets import QApplication, QHBoxLayout, QLabel, QPushButton, QSizePolicy, QAction
 from pyqtgraph import ROI, ImageItem, ImageView
 from pyqtgraph.GraphicsScene.mouseEvents import HoverEvent
 
@@ -13,6 +13,7 @@ from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint
 from mantidimaging.core.utility.histogram import set_histogram_log_scale
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.widgets.mi_image_view.presenter import MIImagePresenter
+from mantidimaging.gui.widgets.palette_changer.view import PaletteChangerView
 
 
 class UnrotateablePlotROI(ROI):
@@ -101,6 +102,13 @@ class MIImageView(ImageView):
 
         self.imageItem.sigImageChanged.connect(self._refresh_message)
         self.imageItem.sigImageChanged.connect(self.set_log_scale)
+
+        self.auto_colour_action = QAction("Auto")
+        self.auto_colour_action.triggered.connect(self.on_colour_change_palette)
+
+        action = self.ui.histogram.item.gradient.menu.actions()[12]
+        self.ui.histogram.item.gradient.menu.insertAction(action, self.auto_colour_action)
+        self.ui.histogram.item.gradient.menu.insertSeparator(self.auto_colour_action)
 
         # Work around for https://github.com/mantidproject/mantidimaging/issues/565
         for scene in [self.scene, self.ui.roiPlot.sceneObj, self.ui.histogram.sceneObj]:
@@ -220,3 +228,7 @@ class MIImageView(ImageView):
 
     def set_log_scale(self):
         set_histogram_log_scale(self.getHistogramWidget().item)
+
+    def on_colour_change_palette(self):
+        change_colour_palette = PaletteChangerView(parent=None, hists=[self.ui.histogram.item], recon_image=self.image)
+        change_colour_palette.show()

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -230,5 +230,5 @@ class MIImageView(ImageView):
         set_histogram_log_scale(self.getHistogramWidget().item)
 
     def on_colour_change_palette(self):
-        change_colour_palette = PaletteChangerView(parent=None, hists=[self.ui.histogram.item], recon_image=self.image)
+        change_colour_palette = PaletteChangerView(parent=None, hists=[self.ui.histogram.item], image=self.image)
         change_colour_palette.show()

--- a/mantidimaging/gui/widgets/palette_changer/presenter.py
+++ b/mantidimaging/gui/widgets/palette_changer/presenter.py
@@ -14,15 +14,18 @@ SAMPLE_SIZE = 15000  # Chosen to avoid Jenks becoming slow
 
 
 class PaletteChangerPresenter(BasePresenter):
-    def __init__(self, view, hists: List[HistogramLUTItem], recon_image: np.ndarray):
+    def __init__(self, view, hists: List[HistogramLUTItem], image: np.ndarray, recon_mode):
         super(PaletteChangerPresenter, self).__init__(view)
         self.rng = np.random.default_rng()
         self.hists = hists
-        self.recon_image = recon_image
-        self.recon_histogram = hists[0]
+        self.image = image
+        self.main_histogram = hists[0]
 
         # Sample a subset of the histogram image to send to Jenks or Otsu
-        self.flattened_image = self._get_sample_pixels(self.recon_image, min(SAMPLE_SIZE, recon_image.size))
+        if recon_mode:
+            self.flattened_image = self._get_sample_pixels(self.image, min(SAMPLE_SIZE, image.size))
+        else:
+            self.flattened_image = np.random.choice(image.flatten(), min(SAMPLE_SIZE, image.size))
 
     def notify(self, signal):
         pass
@@ -48,7 +51,7 @@ class PaletteChangerPresenter(BasePresenter):
         carried out because the method for determining a new tick's colour fails if there are no ticks present. Hence,
         these are only removed after the new Otsu/Jenks ticks have already been placed in the histogram.
         """
-        self.old_ticks = list(self.recon_histogram.gradient.ticks.keys())
+        self.old_ticks = list(self.main_histogram.gradient.ticks.keys())
 
     def _insert_new_ticks(self, tick_points: List[float]):
         """
@@ -57,7 +60,7 @@ class PaletteChangerPresenter(BasePresenter):
         n_tick_points = len(tick_points)
         colours = self._get_colours(n_tick_points)
         for i in range(n_tick_points):
-            self.recon_histogram.gradient.addTick(tick_points[i], color=colours[i], finish=False)
+            self.main_histogram.gradient.addTick(tick_points[i], color=colours[i], finish=False)
 
     def _change_colour_map(self):
         """
@@ -71,7 +74,7 @@ class PaletteChangerPresenter(BasePresenter):
         """
         Determine the Otsu threshold tick point.
         """
-        vals = filters.threshold_multiotsu(self.recon_image, classes=self.view.num_materials)
+        vals = filters.threshold_multiotsu(self.image, classes=self.view.num_materials)
         return self._normalise_tick_values(vals.tolist())
 
     def _generate_jenks_tick_points(self) -> List[float]:
@@ -86,9 +89,9 @@ class PaletteChangerPresenter(BasePresenter):
         Scale the collection of break values so that they range from 0 to 1. This is done because addTick expects an
         x value in this range.
         """
-        min_val = self.recon_image.min()
-        max_val = self.recon_image.max()
-        val_range = np.ptp(self.recon_image)
+        min_val = self.image.min()
+        max_val = self.image.max()
+        val_range = np.ptp(self.image)
         breaks = [min_val] + breaks + [max_val]
         return [(break_x - min_val) / val_range for break_x in breaks]
 
@@ -97,15 +100,15 @@ class PaletteChangerPresenter(BasePresenter):
         Remove the default recon histogram ticks from the image.
         """
         for t in self.old_ticks:
-            self.recon_histogram.gradient.removeTick(t, finish=False)
+            self.main_histogram.gradient.removeTick(t, finish=False)
 
     def _update_ticks(self):
         """
         Tell the recon histogram ticks to update at the end of a change.
         """
-        self.recon_histogram.gradient.showTicks()
-        self.recon_histogram.gradient.updateGradient()
-        self.recon_histogram.gradient.sigGradientChangeFinished.emit(self.recon_histogram.gradient)
+        self.main_histogram.gradient.showTicks()
+        self.main_histogram.gradient.updateGradient()
+        self.main_histogram.gradient.sigGradientChangeFinished.emit(self.main_histogram.gradient)
 
     def _get_colours(self, num_ticks: int) -> List[float]:
         """
@@ -114,7 +117,7 @@ class PaletteChangerPresenter(BasePresenter):
         the histogram.
         """
         norms = np.linspace(0, 1, num_ticks)
-        return [self.recon_histogram.gradient.getColor(norm) for norm in norms]
+        return [self.main_histogram.gradient.getColor(norm) for norm in norms]
 
     def _get_sample_pixels(self, image: np.ndarray, count: int, width: float = 0.9):
         """

--- a/mantidimaging/gui/widgets/palette_changer/test/presenter_test.py
+++ b/mantidimaging/gui/widgets/palette_changer/test/presenter_test.py
@@ -22,11 +22,12 @@ def _normalise_break_values(break_vals, min_value, max_value):
 class PaletteChangerPresenterTest(unittest.TestCase):
     def setUp(self) -> None:
         self.view = mock.MagicMock()
-        self.histograms = [mock.Mock() for _ in range(3)]
-        self.recon_histogram = self.histograms[0]
+        self.histograms = [mock.Mock() for _ in range(2)]
+        self.recon_histogram = mock.Mock()
         self.recon_image = np.random.random((200, 200))
         self.recon_gradient = self.recon_histogram.gradient
-        self.presenter = PaletteChangerPresenter(self.view, self.histograms, self.recon_image, True)
+        self.presenter = PaletteChangerPresenter(self.view, self.histograms, self.recon_histogram, self.recon_image,
+                                                 True)
 
     def get_sorted_random_elements_from_projection_image(self, n_vals: int):
         return sorted([np.random.choice(self.presenter.flattened_image) for _ in range(n_vals)])
@@ -36,7 +37,8 @@ class PaletteChangerPresenterTest(unittest.TestCase):
         assert self.presenter.flattened_image.ndim == 1
 
     def test_flattened_image_creation_for_small_image(self):
-        presenter = PaletteChangerPresenter(self.view, self.histograms, np.random.random((20, 20)), False)
+        presenter = PaletteChangerPresenter(self.view, self.histograms, self.recon_histogram, np.random.random(
+            (20, 20)), True)
         assert presenter.flattened_image.size == 400
         assert presenter.flattened_image.ndim == 1
 

--- a/mantidimaging/gui/widgets/palette_changer/test/presenter_test.py
+++ b/mantidimaging/gui/widgets/palette_changer/test/presenter_test.py
@@ -144,12 +144,10 @@ class PaletteChangerPresenterTest(unittest.TestCase):
 
     @mock.patch("mantidimaging.gui.widgets.palette_changer.presenter.np.random.choice")
     def test_not_recon_mode_calls_choice(self, choice_mock):
-        PaletteChangerPresenter(self.view, self.histograms, self.recon_histogram, np.random.random(
-            (20, 20)), False)
+        PaletteChangerPresenter(self.view, self.histograms, self.recon_histogram, np.random.random((20, 20)), False)
         choice_mock.assert_called_once()
 
     @mock.patch("mantidimaging.gui.widgets.palette_changer.presenter.np.random.choice")
     def test_recon_mode_doesnt_call_choice(self, choice_mock):
-        PaletteChangerPresenter(self.view, self.histograms, self.recon_histogram, np.random.random(
-            (20, 20)), True)
+        PaletteChangerPresenter(self.view, self.histograms, self.recon_histogram, np.random.random((20, 20)), True)
         choice_mock.assert_not_called()

--- a/mantidimaging/gui/widgets/palette_changer/test/presenter_test.py
+++ b/mantidimaging/gui/widgets/palette_changer/test/presenter_test.py
@@ -141,3 +141,15 @@ class PaletteChangerPresenterTest(unittest.TestCase):
         self.assertEqual(len(sampled), COUNT)
         for sample in sampled:
             self.assertIn(sample, recon_image)
+
+    @mock.patch("mantidimaging.gui.widgets.palette_changer.presenter.np.random.choice")
+    def test_not_recon_mode_calls_choice(self, choice_mock):
+        PaletteChangerPresenter(self.view, self.histograms, self.recon_histogram, np.random.random(
+            (20, 20)), False)
+        choice_mock.assert_called_once()
+
+    @mock.patch("mantidimaging.gui.widgets.palette_changer.presenter.np.random.choice")
+    def test_recon_mode_doesnt_call_choice(self, choice_mock):
+        PaletteChangerPresenter(self.view, self.histograms, self.recon_histogram, np.random.random(
+            (20, 20)), True)
+        choice_mock.assert_not_called()

--- a/mantidimaging/gui/widgets/palette_changer/test/presenter_test.py
+++ b/mantidimaging/gui/widgets/palette_changer/test/presenter_test.py
@@ -26,7 +26,7 @@ class PaletteChangerPresenterTest(unittest.TestCase):
         self.recon_histogram = self.histograms[0]
         self.recon_image = np.random.random((200, 200))
         self.recon_gradient = self.recon_histogram.gradient
-        self.presenter = PaletteChangerPresenter(self.view, self.histograms, self.recon_image)
+        self.presenter = PaletteChangerPresenter(self.view, self.histograms, self.recon_image, True)
 
     def get_sorted_random_elements_from_projection_image(self, n_vals: int):
         return sorted([np.random.choice(self.presenter.flattened_image) for _ in range(n_vals)])
@@ -36,7 +36,7 @@ class PaletteChangerPresenterTest(unittest.TestCase):
         assert self.presenter.flattened_image.ndim == 1
 
     def test_flattened_image_creation_for_small_image(self):
-        presenter = PaletteChangerPresenter(self.view, self.histograms, np.random.random((20, 20)))
+        presenter = PaletteChangerPresenter(self.view, self.histograms, np.random.random((20, 20)), False)
         assert presenter.flattened_image.size == 400
         assert presenter.flattened_image.ndim == 1
 

--- a/mantidimaging/gui/widgets/palette_changer/view.py
+++ b/mantidimaging/gui/widgets/palette_changer/view.py
@@ -13,9 +13,9 @@ class PaletteChangerView(BaseDialogView):
     algorithmComboBox: QComboBox
     colourMapComboBox: QComboBox
 
-    def __init__(self, parent, hists, recon_image):
+    def __init__(self, parent, hists, image, recon_mode=False):
         super(PaletteChangerView, self).__init__(parent, "gui/ui/palette_changer.ui")
-        self.presenter = PaletteChangerPresenter(self, hists, recon_image)
+        self.presenter = PaletteChangerPresenter(self, hists, image, recon_mode)
         self.accepted.connect(self.presenter.change_colour_palette)
         self.colourMapComboBox.setCurrentText("spectrum")
 

--- a/mantidimaging/gui/widgets/palette_changer/view.py
+++ b/mantidimaging/gui/widgets/palette_changer/view.py
@@ -13,9 +13,9 @@ class PaletteChangerView(BaseDialogView):
     algorithmComboBox: QComboBox
     colourMapComboBox: QComboBox
 
-    def __init__(self, parent, hists, image, recon_mode=False):
+    def __init__(self, parent, main_hist, image, other_hists=[], recon_mode=False):
         super(PaletteChangerView, self).__init__(parent, "gui/ui/palette_changer.ui")
-        self.presenter = PaletteChangerPresenter(self, hists, image, recon_mode)
+        self.presenter = PaletteChangerPresenter(self, other_hists, main_hist, image, recon_mode)
         self.accepted.connect(self.presenter.change_colour_palette)
         self.colourMapComboBox.setCurrentText("spectrum")
 

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -302,7 +302,7 @@ class FilterPreviews(GraphicsLayoutWidget):
 
     def _on_change_colour_palette(self, main_histogram: HistogramLUTItem, image: ImageItem):
         """
-        Creates a Pallete Changer window when the "Auto" option has been selected.
+        Creates a Palette Changer window when the "Auto" option has been selected.
         :param main_histogram: The HistogramLUTItem.
         :param image: The ImageItem.
         """

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -288,14 +288,24 @@ class FilterPreviews(GraphicsLayoutWidget):
         set_histogram_log_scale(self.image_after_hist)
 
     def _add_auto_colour_action(self, histogram: HistogramLUTItem, image: ImageItem):
+        """
+        Adds an "Auto" action to the histogram right-click menu.
+        :param histogram: The HistogramLUTItem
+        :param image: The ImageItem to have the Jenks/Otsu algorithm performed on it.
+        """
         self.auto_colour_actions.append(QAction("Auto"))
-        self.auto_colour_actions[-1].triggered.connect(lambda: self.on_change_colour_palette(histogram, image))
+        self.auto_colour_actions[-1].triggered.connect(lambda: self._on_change_colour_palette(histogram, image))
 
         action = histogram.gradient.menu.actions()[12]
         histogram.gradient.menu.insertAction(action, self.auto_colour_actions[-1])
         histogram.gradient.menu.insertSeparator(self.auto_colour_actions[-1])
 
-    def on_change_colour_palette(self, main_histogram: HistogramLUTItem, image: ImageItem):
+    def _on_change_colour_palette(self, main_histogram: HistogramLUTItem, image: ImageItem):
+        """
+        Creates a Pallete Changer window when the "Auto" option has been selected.
+        :param main_histogram: The HistogramLUTItem.
+        :param image: The ImageItem.
+        """
         other_histograms = self.all_histograms[:]
         other_histograms.remove(main_histogram)
         change_colour_palette = PaletteChangerView(self, main_histogram, image.image, other_histograms)

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -8,12 +8,14 @@ from typing import Optional
 import numpy as np
 from PyQt5.QtCore import QPoint, QRect
 from PyQt5.QtGui import QGuiApplication, QResizeEvent
+from PyQt5.QtWidgets import QAction
 from pyqtgraph import ColorMap, GraphicsLayoutWidget, ImageItem, LegendItem, PlotItem, ViewBox
 from pyqtgraph.graphicsItems.GraphicsLayout import GraphicsLayout
 from pyqtgraph.graphicsItems.HistogramLUTItem import HistogramLUTItem
 
 from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint
 from mantidimaging.core.utility.histogram import set_histogram_log_scale
+from mantidimaging.gui.widgets.palette_changer.view import PaletteChangerView
 
 LOG = getLogger(__name__)
 
@@ -71,6 +73,8 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.image_after, self.image_after_vb, self.image_after_hist = self.image_in_vb(name="after")
         self.image_difference, self.image_difference_vb, self.image_difference_hist = self.image_in_vb(
             name="difference")
+
+        self.all_histogram = [self.image_before_hist, self.image_after, self.image_difference_hist]
 
         self.image_after_overlay = ImageItem()
         self.image_after_overlay.setZValue(10)
@@ -277,3 +281,12 @@ class FilterPreviews(GraphicsLayoutWidget):
         """
         set_histogram_log_scale(self.image_before_hist)
         set_histogram_log_scale(self.image_after_hist)
+
+    def _add_auto_colour_action(self):
+        self.auto_colour_actions.append(QAction("Auto"))
+        self.auto_colour_actions[-1].triggered.connect(lambda: self.on_change_colour_pallete())
+
+    def on_change_colour_palette(self, main_histogram: HistogramLUTItem, image: np.ndarray):
+        other_histograms = self.all_histograms[:].remove(main_histogram)
+        change_colour_palette = PaletteChangerView(self, main_histogram, image, other_histograms)
+        change_colour_palette.show()

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -404,6 +404,9 @@ class ReconstructWindowView(BaseMainWindowView):
         self.refineIterationsBtn.setEnabled(self.algorithm_name == "SIRT_CUDA")
 
     def on_change_colour_palette(self):
+        """
+        Opens the Palette Changer window when the "Auto" option has been clicked.
+        """
         change_colour_palette = PaletteChangerView(self, self.image_view.recon_hist, self.image_view.recon.image,
                                                    [self.image_view.sinogram_hist, self.image_view.projection_hist],
                                                    True)

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -167,7 +167,6 @@ class ReconstructWindowView(BaseMainWindowView):
         self.corHelpButton.clicked.connect(lambda: self.open_help_webpage("reconstructions/center_of_rotation"))
 
         # Preparing the auto change colour map UI
-        self.hists = [self.image_view.recon_hist, self.image_view.sinogram_hist, self.image_view.projection_hist]
         self.auto_colour_action = QAction("Auto")
         self.auto_colour_action.triggered.connect(self.on_change_colour_palette)
 
@@ -405,5 +404,7 @@ class ReconstructWindowView(BaseMainWindowView):
         self.refineIterationsBtn.setEnabled(self.algorithm_name == "SIRT_CUDA")
 
     def on_change_colour_palette(self):
-        change_colour_palette = PaletteChangerView(self, self.hists, self.image_view.recon.image, True)
+        change_colour_palette = PaletteChangerView(self, self.image_view.recon_hist, self.image_view.recon.image,
+                                                   [self.image_view.sinogram_hist, self.image_view.projection_hist],
+                                                   True)
         change_colour_palette.show()

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -405,5 +405,5 @@ class ReconstructWindowView(BaseMainWindowView):
         self.refineIterationsBtn.setEnabled(self.algorithm_name == "SIRT_CUDA")
 
     def on_change_colour_palette(self):
-        change_colour_palette = PaletteChangerView(self, self.hists, self.image_view.recon.image)
+        change_colour_palette = PaletteChangerView(self, self.hists, self.image_view.recon.image, True)
         change_colour_palette.show()


### PR DESCRIPTION
### Issue

Closes #925

### Description

Adds the Jenks and Otsu filters to the main, the image comparison, and operation windows.

### Testing 

Added tests for the different Palette Changer modes.

### Acceptance Criteria 

Check that the Auto option works in the different image views.

### Documentation

Updated the release notes and updated the "Automatic Gradient Tweaking" section in the docs.