### PR TITLE
Ensure mantidproject/mantidimaging:base gets pushed

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -20,3 +20,5 @@ centos7-base:
 ubuntu18-base:
 	docker build -f Ubuntu18_base.Dockerfile -t mantidproject/mantidimaging:ubuntu18-base ..
 	docker push mantidproject/mantidimaging:ubuntu18-base
+	docker tag mantidproject/mantidimaging:ubuntu18-base mantidproject/mantidimaging:base
+	docker push mantidproject/mantidimaging:base


### PR DESCRIPTION
### Issue

The mantidproject/mantidimaging:base was not getting updated. This was causing images on dockerhub to be built from and old image that lacked gcc.

### Description

Push the ubuntu18-base image is base

### Testing 

I have tested by running locally, and now the dockerhub builds are working again

![image](https://user-images.githubusercontent.com/74248560/116386144-6954af00-a811-11eb-8324-75828edc3082.png)

