### PR TITLE
Set min value of difference in remove outliers to zero

### DIFF
--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -74,7 +74,7 @@ class OutliersFilter(BaseFilter):
         _, diff_field = add_property_to_form('Difference',
                                              'float',
                                              1000,
-                                             valid_values=(2, 1000),
+                                             valid_values=(0, 1000),
                                              form=form,
                                              on_change=on_change,
                                              tooltip="Difference between pixels that will be used to spot outliers.\n"

--- a/mantidimaging/core/operations/outliers/test/outliers_test.py
+++ b/mantidimaging/core/operations/outliers/test/outliers_test.py
@@ -62,10 +62,10 @@ class OutliersTest(unittest.TestCase):
         # use sets because dictionary order isn't guaranteed in Python 3
         self.assertEqual({'diff_field', 'size_field', 'mode_field'}, set(gui_dict.keys()))
 
-    def test_gui_diff_spin_box_min_is_2(self):
+    def test_gui_diff_spin_box_min_is_0(self):
         gui_dict = OutliersFilter.register_gui(mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
 
-        self.assertEqual(2, gui_dict["diff_field"].minimum())
+        self.assertEqual(0, gui_dict["diff_field"].minimum())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Issue

Closes #949 

### Description

Set minimum value for difference field back to zero

### Testing & Acceptance Criteria 

In operations window, Remove Outliers. Try setting a difference of 0.1

### Documentation

Just a quick fix
