### PR TITLE
Update doc versions and api command

### DIFF
--- a/docs/_templates/versioning.html
+++ b/docs/_templates/versioning.html
@@ -13,7 +13,7 @@
 <h3>{{ _('Versions') }}</h3>
 <ul>
   <li><a href="{{ pathto("",1)}}index.html">Latest</a></li>
-  {%- for item in ['0.9.0', '1.0.0', '1.1.0', '2.0.0'] %}
+  {%- for item in ['0.9.0', '1.0.0', '1.1.0', '2.0.0', '2.1.0'] %}
   <li><a href="{{ pathto("",1)}}{{ item }}/index.html">{{ item }}</a></li>
   {%- endfor %}
 </ul>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -166,4 +166,4 @@ html_use_smartypants = False
 smv_tag_whitelist = r'^\d+\.\d+\.\d+$'  # tags that look like versions
 smv_branch_whitelist = None  # No branches
 smv_released_pattern = r''
-smv_prebuild_command = "python setup.py docs_api"
+smv_prebuild_command = "python setup.py docs_api || python setup.py internal_docs_api"


### PR DESCRIPTION
Add 2.1.0 to the nav bar

Update command to build api docs for recent versions

### Issue

Between 2.0 and 2.1 the command to build the api docs changed. Update the multiversion configuration to match


### Testing 

The doc stage in the automated tests should now pass

