### PR TITLE
makefile: add anaconda-client conda-verify to conda build env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install-run-requirements:
 install-build-requirements:
 	@echo "Installing packages required for starting the build process"
 	conda create -n build-env
-	$(CONDA_ACTIVATE) build-env ; conda install --yes conda-build
+	$(CONDA_ACTIVATE) build-env ; conda install --yes conda-build anaconda-client conda-verify
 
 install-dev-requirements:
 	conda env create -f environment-dev.yml


### PR DESCRIPTION
anaconda-client needed to upload packages

conda-verify good to have

### Issue
Fixes issues hit making release packages

### Testing

Can be tested with
```
make build-conda-package
```

