### PR TITLE
Roll back cudatoolkit to 9.2, add cupy

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -28,7 +28,8 @@ requirements:
     - scikit-image=0.17.2
     - numpy=1.19.4
     - tomopy=1.7.1=cuda*
-    - cudatoolkit=10.2*
+    - cudatoolkit=9.2*
+    - cupy
     - astra-toolbox=1.9.9.dev4
     - requests=2.25.1
     - h5py=3.1.0

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -13,6 +13,7 @@ New features
 Fixes
 -----
 
+- #939 : median: NameError: name 'cp' is not defined
 
 Developer Changes
 -----------------


### PR DESCRIPTION
### Issue

Fixes #939

### Description

This allows cupy to work on IDAaaS with a CUDA 9.2 install. Also still
runs on systems with newer CUDA drivers installed.

### Testing 

I'll attach an environment file to test with

### Acceptance Criteria 

Check that an environment with `cudatoolkit=9.2*` with work for median filter in GPU mode and reconstruction with astra.

(wont really know if this works until the nightly reaches IDAaaS)

### Documentation
Updated release notes
