### PR TITLE
957: Crop Coordinates ROI not changing

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -13,6 +13,7 @@ New features
 Fixes
 -----
 
+- #957 : Crop Coordinates ROI not changing
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -143,6 +143,9 @@ class MIImageView(ImageView):
         # if the data isn't 3D the following code can't handle it correctly
         # so defer back to the original implementation which can handle 2D (any maybe ND)
         # more sensibly, albeit slower
+        if self.image.ndim != 3:
+            return super().roiChanged()
+
         roi = self._update_roi_region_avg()
         if self.roi_changed_callback and roi is not None:
             self.roi_changed_callback(roi)
@@ -162,18 +165,13 @@ class MIImageView(ImageView):
         self.sigTimeChanged.emit(ind, time)
 
     def _update_roi_region_avg(self) -> Optional[SensibleROI]:
+        if self.image.ndim != 3:
+            return None
         roi_pos, roi_size = self.get_roi()
         # image indices are in order [Z, X, Y]
         left, right = roi_pos.x, roi_pos.x + roi_size.x
         top, bottom = roi_pos.y, roi_pos.y + roi_size.y
-
-        if self.image.ndim == 3:
-            data = self.image[:, top:bottom, left:right]
-        elif self.image.ndim == 2:
-            data = self.image[top:bottom, left:right].reshape((1, ) + (roi_size.x, roi_size.y))
-        else:
-            data = self.image
-
+        data = self.image[:, top:bottom, left:right]
         if data is not None:
             while data.ndim > 1:
                 data = data.mean(axis=1)

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -276,7 +276,10 @@ class FiltersWindowView(BaseMainWindowView):
         menu.addSeparator()
         self.roi_view.imageItem.menu = menu
 
-        set_averaged_image()
+        if self.filterSelector.currentText() == "ROI Normalisation":
+            set_averaged_image()
+        else:
+            self.roi_view.setImage(self.presenter.stack.presenter.images.data)
 
         def roi_changed_callback(callback):
             roi_field.setText(callback.to_list_string())

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -256,7 +256,7 @@ class FiltersWindowView(BaseMainWindowView):
 
         def set_averaged_image():
             averaged_images = np.sum(self.presenter.stack.presenter.images.data, axis=0)
-            self.roi_view.setImage(averaged_images)
+            self.roi_view.setImage(averaged_images.reshape((1, averaged_images.shape[0], averaged_images.shape[1])))
             self.roi_view_averaged = True
 
         def toggle_average_images(images_):


### PR DESCRIPTION
### Issue

Closes #957

### Description

Fixes the ROI not changing in Crop Coordinates. 
Fixes the averaged view being default for operations other than ROI norm. 
Fixes the ROI not updating when in the averaged view.

### Testing 

Changes are only in the view files, so I haven't made any tests.

### Acceptance Criteria 

Check that moving the ROI box around changes the ROI values with and without set averaged view enabled.

### Documentation

Updated the release notes.
