### PR TITLE
Catch cupy ImportError error

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -15,6 +15,7 @@ Fixes
 
 - #939 : median: NameError: name 'cp' is not defined
 - #957 : Crop Coordinates ROI not changing
+- #961 :  Test failure: ImportError: libcuda.so.1
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/gpu/utility.py
+++ b/mantidimaging/core/gpu/utility.py
@@ -12,6 +12,10 @@ try:
     import cupy as cp
     mempool = cp.get_default_memory_pool()
 except ModuleNotFoundError:
+    # cupy not installed
+    CUPY_NOT_IMPORTED = True
+except ImportError:
+    # cupy installed, but unable to load CUDA
     CUPY_NOT_IMPORTED = True
 
 MAX_CUPY_MEMORY_FRACTION = 0.8


### PR DESCRIPTION
Occurs when cupy is installed, but there is a problem with CUDA

### Issue
Closes #961 

### Description

Catch cupy ImportError error

### Testing & Acceptance Criteria 
Test on github actions should now pass


### Documentation
release notes done
