### PR TITLE
Prevent negative numbers being passed into the logarithm function

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -15,7 +15,8 @@ Fixes
 
 - #939 : median: NameError: name 'cp' is not defined
 - #957 : Crop Coordinates ROI not changing
-- #961 :  Test failure: ImportError: libcuda.so.1
+- #961 : Test failure: ImportError: libcuda.so.1
+- #953 : NaNs in result when reconstructing with FBP_CUDA
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/reconstruct/base_recon.py
+++ b/mantidimaging/core/reconstruct/base_recon.py
@@ -9,11 +9,15 @@ from mantidimaging.core.data import Images
 from mantidimaging.core.utility.data_containers import ScalarCoR, ProjectionAngles, ReconstructionParameters
 from mantidimaging.core.utility.progress_reporting import Progress
 
+# Prevents undefined and infinite values due to negative or zero pixels in
+# projection being passed into the negative log
+MIN_PIXEL_VALUE: float = 1e-6
+
 
 class BaseRecon:
     @staticmethod
     def sino_recon_prep(sino: np.ndarray):
-        return -np.log(sino)
+        return -np.log(np.maximum(sino, MIN_PIXEL_VALUE))
 
     @staticmethod
     def single_sino(sino: np.ndarray, cor: ScalarCoR, proj_angles: ProjectionAngles,


### PR DESCRIPTION

### Issue

Closes #953 

### Description

Noise may lead to negative pixels after background subtraction. Clip the
minimum values to 1e-6 before passing into the negative log.

### Testing  & Acceptance Criteria 

Do a recon with the flower dataset. Ensure there are negative values in the projections after flat-fielding. Check that Reconstruction does not give NaNs

### Documentation

release_notes updated
