### PR TITLE
Use integer division

### DIFF
--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -47,7 +47,7 @@ class FilterPreviews(GraphicsLayoutWidget):
     def __init__(self, parent=None, **kwargs):
         super(FilterPreviews, self).__init__(parent, **kwargs)
 
-        widget_location = self.mapToGlobal(QPoint(self.width() / 2, 0))
+        widget_location = self.mapToGlobal(QPoint(self.width() // 2, 0))
         # allow the widget to take up to 80% of the desktop's height
         if QGuiApplication.screenAt(widget_location) is not None:
             screen_height = QGuiApplication.screenAt(widget_location).availableGeometry().height()


### PR DESCRIPTION


### Issue

Closes #971 

### Description
Avoid passing a float as a pixel location

### Testing & Acceptance Criteria 

`pytest -vs mantidimaging/gui/windows/operations/test/test_view.py`

should not show warning at filter_previews.py:50

### Documentation

Just a warning fix
