### PR TITLE
Update pyqtgraph to 0.12

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -23,3 +23,8 @@ Developer Changes
 -----------------
 
 - #917 : Intermittent failure of StripeRemovalTest.test_memory_executed_wf
+
+Dependency updates
+------------------
+
+- pyqtgraph 0.12

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -11,7 +11,7 @@ dependencies:
   - pip:
       # For running
       - pyqt5==5.15
-      - pyqtgraph==0.11
+      - pyqtgraph>=0.12.1,<0.13
       - jenkspy==0.2.0
       # For developement
       - pytest==6.2.1

--- a/environment.yml
+++ b/environment.yml
@@ -11,5 +11,5 @@ dependencies:
   - pip
   - pip:
       - pyqt5==5.15
-      - pyqtgraph==0.11
+      - pyqtgraph>=0.12.1,<0.13
       - jenkspy==0.2.0


### PR DESCRIPTION
### Issue

closes #975 

### Description

Update pyqtgraph to 0.12

### Testing & acceptance Criteria 
Check that the conda automated tests are using pyqtgraph 0.12.1 and that tests pass

### Documentation

update drelease_notes
