### PR TITLE
959: Prevent even values for median filter kernel

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -18,6 +18,7 @@ Fixes
 - #957 : Crop Coordinates ROI not changing
 - #961 : Test failure: ImportError: libcuda.so.1
 - #953 : NaNs in result when reconstructing with FBP_CUDA
+- #959 : Median GPU does not work with even values
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -25,7 +25,7 @@ KERNEL_SIZE_TOOLTIP = "Size of the median filter kernel"
 
 
 class KernelSpinBox(QSpinBox):
-    def __init__(self):
+    def __init__(self, on_change: Callable):
         super().__init__()
         self.setMinimum(3)
         self.setMaximum(999)
@@ -33,6 +33,7 @@ class KernelSpinBox(QSpinBox):
         self.setKeyboardTracking(False)
         self.setToolTip(KERNEL_SIZE_TOOLTIP)
         self.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
+        self.valueChanged.connect(lambda: on_change_and_disable(self, on_change))
 
     def validate(self, input: str, pos: int) -> Tuple[QValidator.State, str, int]:
         if not input:
@@ -83,8 +84,7 @@ class MedianFilter(BaseFilter):
 
     @staticmethod
     def register_gui(form: 'QFormLayout', on_change: Callable, view) -> Dict[str, Any]:
-        size_field = KernelSpinBox()
-        size_field.valueChanged.connect(lambda: on_change_and_disable(size_field, on_change))
+        size_field = KernelSpinBox(on_change)
         size_field_label = QLabel("Kernel Size")
         size_field_label.setToolTip(KERNEL_SIZE_TOOLTIP)
         form.addRow(size_field_label, size_field)

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -26,6 +26,10 @@ KERNEL_SIZE_TOOLTIP = "Size of the median filter kernel"
 
 class KernelSpinBox(QSpinBox):
     def __init__(self, on_change: Callable):
+        """
+        Spin box for entering kernel sizes that only accepts odd numbers.
+        :param on_change: The function to be called when the value changes.
+        """
         super().__init__()
         self.setMinimum(3)
         self.setMaximum(999)
@@ -36,6 +40,10 @@ class KernelSpinBox(QSpinBox):
         self.valueChanged.connect(lambda: on_change_and_disable(self, on_change))
 
     def validate(self, input: str, pos: int) -> Tuple[QValidator.State, str, int]:
+        """
+        Validate the spin box input. Returns as Intermediate state if the input is empty or contains an even number,
+        otherwise it returns Acceptable.
+        """
         if not input:
             return QValidator.Intermediate, input, pos
         kernel_size = int(input)
@@ -84,6 +92,8 @@ class MedianFilter(BaseFilter):
 
     @staticmethod
     def register_gui(form: 'QFormLayout', on_change: Callable, view) -> Dict[str, Any]:
+
+        # Create a spin box without add property to form in order to allow a custom validate method
         size_field = KernelSpinBox(on_change)
         size_field_label = QLabel("Kernel Size")
         size_field_label.setToolTip(KERNEL_SIZE_TOOLTIP)

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -62,7 +62,7 @@ class MedianFilter(BaseFilter):
     def register_gui(form: 'QFormLayout', on_change: Callable, view) -> Dict[str, Any]:
         _, size_field = add_property_to_form('Kernel Size',
                                              Type.INT,
-                                             3, (2, 1000),
+                                             3, (3, 1000),
                                              form=form,
                                              on_change=on_change,
                                              tooltip="Size of the median filter kernel")
@@ -80,6 +80,8 @@ class MedianFilter(BaseFilter):
                                             tooltip='Run the median filter on the GPU',
                                             form=form,
                                             on_change=on_change)
+
+        size_field.setSingleStep(2)
 
         return {'size_field': size_field, 'mode_field': mode_field, 'use_gpu_field': gpu_field}
 

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -7,7 +7,7 @@ from typing import Callable, Dict, Any, TYPE_CHECKING, Tuple
 
 import scipy.ndimage as scipy_ndimage
 from PyQt5.QtGui import QValidator
-from PyQt5.QtWidgets import QSpinBox
+from PyQt5.QtWidgets import QSpinBox, QLabel, QSizePolicy
 
 from mantidimaging import helper as h
 from mantidimaging.core.data import Images
@@ -16,10 +16,12 @@ from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.utility import add_property_to_form
-from mantidimaging.gui.utility.qt_helpers import Type, _on_change_and_disable
+from mantidimaging.gui.utility.qt_helpers import Type, on_change_and_disable
 
 if TYPE_CHECKING:
     from PyQt5.QtWidgets import QFormLayout  # pragma: no cover
+
+KERNEL_SIZE_TOOLTIP = "Size of the median filter kernel"
 
 
 class KernelSpinBox(QSpinBox):
@@ -28,6 +30,9 @@ class KernelSpinBox(QSpinBox):
         self.setMinimum(3)
         self.setMaximum(999)
         self.setSingleStep(2)
+        self.setKeyboardTracking(False)
+        self.setToolTip(KERNEL_SIZE_TOOLTIP)
+        self.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
 
     def validate(self, input: str, pos: int) -> Tuple[QValidator.State, str, int]:
         if not input:
@@ -79,9 +84,10 @@ class MedianFilter(BaseFilter):
     @staticmethod
     def register_gui(form: 'QFormLayout', on_change: Callable, view) -> Dict[str, Any]:
         size_field = KernelSpinBox()
-        size_field.valueChanged.connect(lambda: _on_change_and_disable(size_field, on_change))
-        size_field.setToolTip("Size of the median filter kernel")
-        form.addRow("Kernel Size", size_field)
+        size_field.valueChanged.connect(lambda: on_change_and_disable(size_field, on_change))
+        size_field_label = QLabel("Kernel Size")
+        size_field_label.setToolTip(KERNEL_SIZE_TOOLTIP)
+        form.addRow(size_field_label, size_field)
 
         _, mode_field = add_property_to_form('Edge Mode',
                                              Type.CHOICE,

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -93,7 +93,7 @@ class MedianFilter(BaseFilter):
     @staticmethod
     def register_gui(form: 'QFormLayout', on_change: Callable, view) -> Dict[str, Any]:
 
-        # Create a spin box without add property to form in order to allow a custom validate method
+        # Create a spin box for kernel size without add_property_to_form in order to allow a custom validate method
         size_field = KernelSpinBox(on_change)
         size_field_label = QLabel("Kernel Size")
         size_field_label.setToolTip(KERNEL_SIZE_TOOLTIP)

--- a/mantidimaging/core/operations/median_filter/test/median_kernel_test.py
+++ b/mantidimaging/core/operations/median_filter/test/median_kernel_test.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+import unittest
+from unittest import mock
+
+from mantidimaging.core.operations.median_filter.median_filter import KernelSpinBox
+from mantidimaging.test_helpers import start_qapplication
+
+
+@start_qapplication
+class MedianKernelTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.size_kernel = KernelSpinBox(on_change=mock.Mock())
+
+    def test_default_kernel_size(self):
+        self.assertEqual(self.size_kernel.value(), 3)

--- a/mantidimaging/core/operations/median_filter/test/median_kernel_test.py
+++ b/mantidimaging/core/operations/median_filter/test/median_kernel_test.py
@@ -24,6 +24,11 @@ class MedianKernelTest(unittest.TestCase):
         self.size_kernel.stepDown()
         self.assertEqual(self.size_kernel.value(), 3)
 
+    def test_maximum_value_of_nine_nine_nine(self):
+        self.size_kernel.setValue(999)
+        self.size_kernel.stepUp()
+        self.assertEqual(self.size_kernel.value(), 999)
+
     def test_even_numbers_rejected(self):
         for even_num_str in [str(i) for i in range(2, 10, 2)]:
             self.size_kernel.lineEdit().setText(even_num_str)

--- a/mantidimaging/core/operations/median_filter/test/median_kernel_test.py
+++ b/mantidimaging/core/operations/median_filter/test/median_kernel_test.py
@@ -4,6 +4,9 @@
 import unittest
 from unittest import mock
 
+from PyQt5.QtCore import Qt
+from PyQt5.QtTest import QTest
+
 from mantidimaging.core.operations.median_filter.median_filter import KernelSpinBox
 from mantidimaging.test_helpers import start_qapplication
 
@@ -16,7 +19,7 @@ class MedianKernelTest(unittest.TestCase):
     def test_default_kernel_size(self):
         self.assertEqual(self.size_kernel.value(), 3)
 
-    def test_increase_jumps_by_two(self):
+    def test_step_up_increases_size_by_two(self):
         self.size_kernel.stepUp()
         self.assertEqual(self.size_kernel.value(), 5)
 
@@ -33,3 +36,9 @@ class MedianKernelTest(unittest.TestCase):
         for even_num_str in [str(i) for i in range(2, 10, 2)]:
             self.size_kernel.lineEdit().setText(even_num_str)
             self.assertEqual(self.size_kernel.value(), 3)
+
+    def test_odd_kernel_size_with_even_first_digit_is_accepted(self):
+        QTest.keyClick(self.size_kernel.lineEdit(), Qt.Key_Delete)  # Clear the line edit
+        QTest.keyClicks(self.size_kernel.lineEdit(), "21")
+        QTest.keyClick(self.size_kernel.lineEdit(), Qt.Key_Enter)
+        self.assertEqual(self.size_kernel.value(), 21)

--- a/mantidimaging/core/operations/median_filter/test/median_kernel_test.py
+++ b/mantidimaging/core/operations/median_filter/test/median_kernel_test.py
@@ -10,9 +10,21 @@ from mantidimaging.test_helpers import start_qapplication
 
 @start_qapplication
 class MedianKernelTest(unittest.TestCase):
-
     def setUp(self) -> None:
         self.size_kernel = KernelSpinBox(on_change=mock.Mock())
 
     def test_default_kernel_size(self):
         self.assertEqual(self.size_kernel.value(), 3)
+
+    def test_increase_jumps_by_two(self):
+        self.size_kernel.stepUp()
+        self.assertEqual(self.size_kernel.value(), 5)
+
+    def test_minimum_value_of_three(self):
+        self.size_kernel.stepDown()
+        self.assertEqual(self.size_kernel.value(), 3)
+
+    def test_even_numbers_rejected(self):
+        for even_num_str in [str(i) for i in range(2, 10, 2)]:
+            self.size_kernel.lineEdit().setText(even_num_str)
+            self.assertEqual(self.size_kernel.value(), 3)

--- a/mantidimaging/gui/utility/qt_helpers.py
+++ b/mantidimaging/gui/utility/qt_helpers.py
@@ -78,7 +78,7 @@ class Type(IntEnum):
     BUTTON = auto()
 
 
-def _on_change_and_disable(widget: QWidget, on_change: Callable):
+def on_change_and_disable(widget: QWidget, on_change: Callable):
     """
     Makes sure the widget is disabled while running the on_update method. This is required for spin boxes that
     continue increasing when generating a preview image is computationally intensive.
@@ -151,14 +151,14 @@ def add_property_to_form(label: str,
         right_widget.setKeyboardTracking(False)
         set_spin_box(right_widget, int)
         if on_change is not None:
-            right_widget.valueChanged.connect(lambda: _on_change_and_disable(right_widget, on_change))
+            right_widget.valueChanged.connect(lambda: on_change_and_disable(right_widget, on_change))
 
     elif dtype == 'float' or dtype == Type.FLOAT:
         right_widget = Qt.QDoubleSpinBox()
         set_spin_box(right_widget, float)
         right_widget.setKeyboardTracking(False)
         if on_change is not None:
-            right_widget.valueChanged.connect(lambda: _on_change_and_disable(right_widget, on_change))
+            right_widget.valueChanged.connect(lambda: on_change_and_disable(right_widget, on_change))
 
     elif dtype == 'bool' or dtype == Type.BOOL:
         right_widget = Qt.QCheckBox()


### PR DESCRIPTION
### Issue

Closes #959 

### Description

Prevents the user from using even numbers as the kernel size in the medial filter.

### Testing 

Wrote some tests for the `KernelSpinBox` and one of them uses `QTest`. It might be worth using it in other places.

### Acceptance Criteria 

Check that only odd numbers from 3 to 999 work with the kernel size.

### Documentation

Updated the release notes.
