### PR TITLE
Qt API changes

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -24,6 +24,7 @@ Developer Changes
 -----------------
 
 - #917 : Intermittent failure of StripeRemovalTest.test_memory_executed_wf
+- #978 : Update Qt API usage
 
 Dependency updates
 ------------------

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -36,7 +36,7 @@ class KernelSpinBox(QSpinBox):
         self.setSingleStep(2)
         self.setKeyboardTracking(False)
         self.setToolTip(KERNEL_SIZE_TOOLTIP)
-        self.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
+        self.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Fixed)
         self.valueChanged.connect(lambda: on_change_and_disable(self, on_change))
 
     def validate(self, input: str, pos: int) -> Tuple[QValidator.State, str, int]:
@@ -45,11 +45,11 @@ class KernelSpinBox(QSpinBox):
         otherwise it returns Acceptable.
         """
         if not input:
-            return QValidator.Intermediate, input, pos
+            return QValidator.State.Intermediate, input, pos
         kernel_size = int(input)
         if kernel_size % 2 != 0:
-            return QValidator.Acceptable, input, pos
-        return QValidator.Intermediate, input, pos
+            return QValidator.State.Acceptable, input, pos
+        return QValidator.State.Intermediate, input, pos
 
 
 class MedianFilter(BaseFilter):

--- a/mantidimaging/core/operations/median_filter/test/median_kernel_test.py
+++ b/mantidimaging/core/operations/median_filter/test/median_kernel_test.py
@@ -38,7 +38,7 @@ class MedianKernelTest(unittest.TestCase):
             self.assertEqual(self.size_kernel.value(), 3)
 
     def test_odd_kernel_size_with_even_first_digit_is_accepted(self):
-        QTest.keyClick(self.size_kernel.lineEdit(), Qt.Key_Delete)  # Clear the line edit
+        QTest.keyClick(self.size_kernel.lineEdit(), Qt.Key.Key_Delete)  # Clear the line edit
         QTest.keyClicks(self.size_kernel.lineEdit(), "21")
-        QTest.keyClick(self.size_kernel.lineEdit(), Qt.Key_Enter)
+        QTest.keyClick(self.size_kernel.lineEdit(), Qt.Key.Key_Enter)
         self.assertEqual(self.size_kernel.value(), 21)

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -83,13 +83,13 @@ class RebinFilter(BaseFilter):
         _, shape_x = add_property_to_form('X', Type.INT, valid_values=shape_range, on_change=on_change)
         _, shape_y = add_property_to_form('Y', Type.INT, valid_values=shape_range, on_change=on_change)
 
-        from PyQt5 import Qt
-        shape_fields = Qt.QHBoxLayout()
+        from PyQt5.QtWidgets import QHBoxLayout, QRadioButton, QLabel, QComboBox
+        shape_fields = QHBoxLayout()
         shape_fields.addWidget(shape_x)
         shape_fields.addWidget(shape_y)
 
         # Rebin dimension selection options
-        rebin_by_factor_radio = Qt.QRadioButton("Rebin by Factor")
+        rebin_by_factor_radio = QRadioButton("Rebin by Factor")
 
         def size_by_factor_toggled(enabled):
             factor.setEnabled(enabled)
@@ -97,7 +97,7 @@ class RebinFilter(BaseFilter):
 
         rebin_by_factor_radio.toggled.connect(size_by_factor_toggled)
 
-        rebin_to_dimensions_radio = Qt.QRadioButton("Rebin to Dimensions")
+        rebin_to_dimensions_radio = QRadioButton("Rebin to Dimensions")
 
         def size_by_dimensions_toggled(enabled):
             shape_x.setEnabled(enabled)
@@ -107,8 +107,8 @@ class RebinFilter(BaseFilter):
         rebin_to_dimensions_radio.toggled.connect(size_by_dimensions_toggled)
 
         # Rebin mode options
-        label_mode = Qt.QLabel("Mode")
-        mode_field = Qt.QComboBox()
+        label_mode = QLabel("Mode")
+        mode_field = QComboBox()
         mode_field.addItems(modes())
 
         form.addRow(rebin_to_dimensions_radio, shape_fields)

--- a/mantidimaging/gui/dialogs/async_task/model.py
+++ b/mantidimaging/gui/dialogs/async_task/model.py
@@ -4,15 +4,15 @@
 from logging import getLogger
 from typing import Callable
 
-from PyQt5 import Qt, QtCore
+from PyQt5.QtCore import QObject, pyqtSignal
 
 from .task import TaskWorkerThread
 
 
-class AsyncTaskDialogModel(Qt.QObject):
+class AsyncTaskDialogModel(QObject):
 
     # Signal emitted when task processing has terminated
-    task_done = QtCore.pyqtSignal(bool)
+    task_done = pyqtSignal(bool)
 
     def __init__(self):
         super(AsyncTaskDialogModel, self).__init__()

--- a/mantidimaging/gui/dialogs/async_task/presenter.py
+++ b/mantidimaging/gui/dialogs/async_task/presenter.py
@@ -4,7 +4,7 @@
 import traceback
 from logging import getLogger
 from enum import Enum
-from PyQt5 import Qt
+from PyQt5.QtCore import QObject, pyqtSignal
 
 from mantidimaging.core.utility.progress_reporting import ProgressHandler
 
@@ -15,8 +15,8 @@ class Notification(Enum):
     START = 1
 
 
-class AsyncTaskDialogPresenter(Qt.QObject, ProgressHandler):
-    progress_updated = Qt.pyqtSignal(float, str)
+class AsyncTaskDialogPresenter(QObject, ProgressHandler):
+    progress_updated = pyqtSignal(float, str)
 
     def __init__(self, view):
         super(AsyncTaskDialogPresenter, self).__init__()

--- a/mantidimaging/gui/dialogs/async_task/task.py
+++ b/mantidimaging/gui/dialogs/async_task/task.py
@@ -3,12 +3,12 @@
 
 from logging import getLogger
 
-from PyQt5 import Qt
+from PyQt5.QtCore import QThread
 
 from mantidimaging.core.utility.func_call import call_with_known_parameters
 
 
-class TaskWorkerThread(Qt.QThread):
+class TaskWorkerThread(QThread):
     """
     Thread for running tasks asynchronously to the GUI.
 

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -7,11 +7,11 @@ from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.mvp_base import BaseDialogView
 from .presenter import AsyncTaskDialogPresenter
 
-from PyQt5 import Qt
+from PyQt5.QtWidgets import QMainWindow
 
 
 class AsyncTaskDialogView(BaseDialogView):
-    def __init__(self, parent: 'Qt.QMainWindow', auto_close=False):
+    def __init__(self, parent: QMainWindow, auto_close=False):
         super(AsyncTaskDialogView, self).__init__(parent, 'gui/ui/async_task_dialog.ui')
 
         self.parent_view = parent
@@ -53,7 +53,7 @@ class AsyncTaskDialogView(BaseDialogView):
         self.progressBar.setValue(progress * 1000)
 
 
-def start_async_task_view(parent: 'Qt.QMainWindow', task: Callable, on_complete: Callable, kwargs=None):
+def start_async_task_view(parent: QMainWindow, task: Callable, on_complete: Callable, kwargs=None):
     atd = AsyncTaskDialogView(parent, auto_close=True)
     if not kwargs:
         kwargs = {'progress': Progress()}

--- a/mantidimaging/gui/dialogs/cor_inspection/presenter.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/presenter.py
@@ -6,7 +6,7 @@ from enum import Enum
 from logging import getLogger
 from typing import TYPE_CHECKING
 
-from PyQt5 import Qt
+from PyQt5.QtCore import pyqtSignal
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.utility.data_containers import ScalarCoR, ReconstructionParameters
@@ -30,7 +30,7 @@ class Notification(Enum):
 
 
 class CORInspectionDialogPresenter(BasePresenter):
-    progress_updated = Qt.pyqtSignal(float, str)
+    progress_updated = pyqtSignal(float, str)
 
     view: 'CORInspectionDialogView'
 

--- a/mantidimaging/gui/dialogs/op_history_copy/view.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/view.py
@@ -49,7 +49,7 @@ class OpHistoryCopyDialogView(BaseDialogView):
         check.setText(operation.display_name)
         check.setStyleSheet('font-weight: bold')
         check.setChecked(True)
-        check.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Preferred)
+        check.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Preferred)
         parent_layout.addWidget(check)
 
         row_num = 1

--- a/mantidimaging/gui/gui.py
+++ b/mantidimaging/gui/gui.py
@@ -7,7 +7,7 @@ import sys
 import traceback
 
 import pyqtgraph
-from PyQt5.Qt import QApplication
+from PyQt5.QtWidgets import QApplication
 
 from mantidimaging.gui.windows.main import MainWindowView
 

--- a/mantidimaging/gui/mvp_base/view.py
+++ b/mantidimaging/gui/mvp_base/view.py
@@ -3,14 +3,14 @@
 
 from logging import getLogger
 
-from PyQt5 import Qt, QtWidgets
+from PyQt5.QtWidgets import QMainWindow, QMessageBox, QDialog
 
 from mantidimaging.gui.utility import compile_ui
 
 LOG = getLogger(__name__)
 
 
-class BaseMainWindowView(Qt.QMainWindow):
+class BaseMainWindowView(QMainWindow):
     def __init__(self, parent, ui_file=None):
         super(BaseMainWindowView, self).__init__(parent)
 
@@ -34,10 +34,10 @@ class BaseMainWindowView(Qt.QMainWindow):
 
         :param msg: Error message string
         """
-        QtWidgets.QMessageBox.critical(self, "Error", str(msg))
+        QMessageBox.critical(self, "Error", str(msg))
 
 
-class BaseDialogView(Qt.QDialog):
+class BaseDialogView(QDialog):
     def __init__(self, parent, ui_file=None):
         super(BaseDialogView, self).__init__(parent)
 
@@ -50,4 +50,4 @@ class BaseDialogView(Qt.QDialog):
 
         :param msg: Error message string
         """
-        QtWidgets.QMessageBox.critical(self, "Error", str(msg))
+        QMessageBox.critical(self, "Error", str(msg))

--- a/mantidimaging/gui/utility/qt_helpers.py
+++ b/mantidimaging/gui/utility/qt_helpers.py
@@ -9,10 +9,10 @@ from enum import IntEnum, auto
 from logging import getLogger
 from typing import Any, Tuple, Union, List, Callable
 
-from PyQt5 import Qt
 from PyQt5 import uic  # type: ignore
 from PyQt5.QtCore import QObject
-from PyQt5.QtWidgets import QLabel, QLineEdit, QSpinBox, QDoubleSpinBox, QCheckBox, QWidget, QSizePolicy, QAction, QMenu
+from PyQt5.QtWidgets import (QLabel, QLineEdit, QSpinBox, QDoubleSpinBox, QCheckBox, QWidget, QSizePolicy, QAction,
+                             QMenu, QPushButton, QLayout, QFileDialog, QComboBox)
 
 from mantidimaging.core.utility import finder
 
@@ -27,7 +27,7 @@ class BlockQtSignals(object):
         if not isinstance(q_objects, list):
             q_objects = [q_objects]
         for obj in q_objects:
-            assert isinstance(obj, Qt.QObject), \
+            assert isinstance(obj, QObject), \
                 "This class must be used with QObjects"
 
         self.q_objects = q_objects
@@ -48,11 +48,11 @@ def compile_ui(ui_file, qt_obj=None):
 
 
 def select_directory(field, caption):
-    assert isinstance(field, Qt.QLineEdit), ("The passed object is of type {0}. This function only works with "
-                                             "QLineEdit".format(type(field)))
+    assert isinstance(field, QLineEdit), ("The passed object is of type {0}. This function only works with "
+                                          "QLineEdit".format(type(field)))
 
     # open file dialogue and set the text if file is selected
-    field.setText(Qt.QFileDialog.getExistingDirectory(caption=caption))
+    field.setText(QFileDialog.getExistingDirectory(caption=caption))
 
 
 def get_value_from_qwidget(widget: QWidget):
@@ -139,7 +139,7 @@ def add_property_to_form(label: str,
 
     if dtype in ['str', Type.STR, 'tuple', Type.TUPLE, 'NoneType', Type.NONETYPE, 'list', Type.LIST]:
         # TODO for tuple with numbers add N combo boxes, N = number of tuple members
-        right_widget = Qt.QLineEdit()
+        right_widget = QLineEdit()
         right_widget.setToolTip(tooltip)
         right_widget.setText(default_value)
 
@@ -147,21 +147,21 @@ def add_property_to_form(label: str,
             right_widget.editingFinished.connect(lambda: on_change())
 
     elif dtype == 'int' or dtype == Type.INT:
-        right_widget = Qt.QSpinBox()
+        right_widget = QSpinBox()
         right_widget.setKeyboardTracking(False)
         set_spin_box(right_widget, int)
         if on_change is not None:
             right_widget.valueChanged.connect(lambda: on_change_and_disable(right_widget, on_change))
 
     elif dtype == 'float' or dtype == Type.FLOAT:
-        right_widget = Qt.QDoubleSpinBox()
+        right_widget = QDoubleSpinBox()
         set_spin_box(right_widget, float)
         right_widget.setKeyboardTracking(False)
         if on_change is not None:
             right_widget.valueChanged.connect(lambda: on_change_and_disable(right_widget, on_change))
 
     elif dtype == 'bool' or dtype == Type.BOOL:
-        right_widget = Qt.QCheckBox()
+        right_widget = QCheckBox()
         if isinstance(default_value, bool):
             right_widget.setChecked(default_value)
         elif isinstance(default_value, str):
@@ -176,8 +176,8 @@ def add_property_to_form(label: str,
             right_widget.stateChanged[int].connect(lambda: on_change())
 
     elif dtype == "choice" or dtype == Type.CHOICE:
-        right_widget = Qt.QComboBox()
-        right_widget.setSizeAdjustPolicy(Qt.QComboBox.AdjustToContents)
+        right_widget = QComboBox()
+        right_widget.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
         if valid_values:
             right_widget.addItems(valid_values)
         if on_change is not None:
@@ -190,7 +190,7 @@ def add_property_to_form(label: str,
             right_widget.currentIndexChanged[int].connect(lambda: on_change())
 
     elif dtype == 'button' or dtype == Type.BUTTON:
-        left_widget = Qt.QPushButton(label)
+        left_widget = QPushButton(label)
         if run_on_press is not None:
             left_widget.clicked.connect(lambda: run_on_press())
 
@@ -214,10 +214,10 @@ def add_property_to_form(label: str,
         log.debug("Missing tooltip for %s", label)
 
     if left_widget:
-        left_widget.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
+        left_widget.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Fixed)
 
     if right_widget:
-        right_widget.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
+        right_widget.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Fixed)
     # Add to form layout
     if form is not None:
         form.addRow(left_widget, right_widget)
@@ -236,7 +236,7 @@ def delete_all_widgets_from_layout(lo):
         item = lo.takeAt(0)
 
         # Recurse for child layouts
-        if isinstance(item, Qt.QLayout):
+        if isinstance(item, QLayout):
             delete_all_widgets_from_layout(item)
 
         # Orphan child widgets (seting a None parent removes them from the

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -4,7 +4,7 @@
 from time import sleep
 from typing import Callable, Optional, Tuple
 
-from PyQt5 import QtCore
+from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QApplication, QHBoxLayout, QLabel, QPushButton, QSizePolicy, QAction
 from pyqtgraph import ROI, ImageItem, ImageView
 from pyqtgraph.GraphicsScene.mouseEvents import HoverEvent
@@ -186,7 +186,7 @@ class MIImageView(ImageView):
         original_handler = self.ui.roiPlot.mousePressEvent
 
         def extended_handler(ev):
-            if ev.button() == QtCore.Qt.LeftButton:
+            if ev.button() == Qt.MouseButton.LeftButton:
                 self.set_timeline_to_tick_nearest(ev.x())
             original_handler(ev)
 

--- a/mantidimaging/gui/widgets/removable_row_table_view.py
+++ b/mantidimaging/gui/widgets/removable_row_table_view.py
@@ -10,7 +10,7 @@ class RemovableRowTableView(QTableView):
         super(RemovableRowTableView, self).keyPressEvent(e)
 
         # Handle deletion of a row from the table by pressing the [Delete] key
-        if e.key() == Qt.Key_Delete:
+        if e.key() == Qt.Key.Key_Delete:
             self.removeSelectedRows()
 
     def removeSelectedRows(self):

--- a/mantidimaging/gui/widgets/stack_selector/view.py
+++ b/mantidimaging/gui/widgets/stack_selector/view.py
@@ -3,7 +3,8 @@
 
 from typing import TYPE_CHECKING
 
-from PyQt5 import Qt
+from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtWidgets import QComboBox
 
 from .presenter import (StackSelectorWidgetPresenter, Notification)
 
@@ -18,11 +19,11 @@ def _string_contains_all_parts(string: str, parts: list) -> bool:
     return True
 
 
-class StackSelectorWidgetView(Qt.QComboBox):
-    stacks_updated = Qt.pyqtSignal()
+class StackSelectorWidgetView(QComboBox):
+    stacks_updated = pyqtSignal()
 
-    stack_selected_int = Qt.pyqtSignal(int)
-    stack_selected_uuid = Qt.pyqtSignal('PyQt_PyObject')
+    stack_selected_int = pyqtSignal(int)
+    stack_selected_uuid = pyqtSignal('PyQt_PyObject')
 
     main_window: 'MainWindowView'
 

--- a/mantidimaging/gui/windows/load_dialog/view.py
+++ b/mantidimaging/gui/windows/load_dialog/view.py
@@ -3,9 +3,8 @@
 
 from typing import Optional, Tuple
 
-from PyQt5 import Qt
 from PyQt5.QtWidgets import QComboBox, QCheckBox, QTreeWidget, QTreeWidgetItem, QPushButton, QSizePolicy, \
-    QHeaderView, QSpinBox
+    QHeaderView, QSpinBox, QDialog, QFileDialog
 
 from mantidimaging.core.io.loader.loader import DEFAULT_PIXEL_SIZE, DEFAULT_IS_SINOGRAM, DEFAULT_PIXEL_DEPTH
 from mantidimaging.core.utility.data_containers import LoadingParameters
@@ -14,7 +13,7 @@ from mantidimaging.gui.windows.load_dialog.field import Field
 from .presenter import LoadPresenter, Notification
 
 
-class MWLoadDialog(Qt.QDialog):
+class MWLoadDialog(QDialog):
     tree: QTreeWidget
     pixel_bit_depth: QComboBox
     images_are_sinograms: QCheckBox
@@ -103,7 +102,7 @@ class MWLoadDialog(Qt.QDialog):
 
         select_button = QPushButton("Select", self)
         select_button.setMaximumWidth(100)
-        select_button.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Maximum)
+        select_button.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Maximum)
 
         self.tree.setItemWidget(section, 3, select_button)
         field = Field(self, self.tree, section, use)
@@ -122,9 +121,9 @@ class MWLoadDialog(Qt.QDialog):
         else:
             # Assume text file
             file_filter = "Log File (*.txt *.log *.csv)"
-        selected_file, _ = Qt.QFileDialog.getOpenFileName(caption=caption,
-                                                          filter=f"{file_filter};;All (*.*)",
-                                                          initialFilter=file_filter)
+        selected_file, _ = QFileDialog.getOpenFileName(caption=caption,
+                                                       filter=f"{file_filter};;All (*.*)",
+                                                       initialFilter=file_filter)
 
         if len(selected_file) > 0:
             return selected_file

--- a/mantidimaging/gui/windows/main/save_dialog.py
+++ b/mantidimaging/gui/windows/main/save_dialog.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-from PyQt5 import Qt
+from PyQt5.QtWidgets import QDialog, QDialogButtonBox
 
 from mantidimaging.core.io.loader import supported_formats
 from mantidimaging.core.io.utility import DEFAULT_IO_FILE_FORMAT
@@ -18,14 +18,14 @@ def sort_by_tomo_and_recon(stack_id: StackId):
         return 3
 
 
-class MWSaveDialog(Qt.QDialog):
+class MWSaveDialog(QDialog):
     def __init__(self, parent, stack_list):
         super(MWSaveDialog, self).__init__(parent)
         compile_ui('gui/ui/save_dialog.ui', self)
 
         self.browseButton.clicked.connect(lambda: select_directory(self.savePath, "Browse"))
 
-        self.buttonBox.button(Qt.QDialogButtonBox.SaveAll).clicked.connect(self.save_all)
+        self.buttonBox.button(QDialogButtonBox.StandardButton.SaveAll).clicked.connect(self.save_all)
 
         # dynamically add all the supported formats
         formats = supported_formats()

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -143,12 +143,11 @@ class MainWindowViewTest(unittest.TestCase):
                                                       new_name="oranges")
 
     @mock.patch("mantidimaging.gui.windows.main.view.getLogger")
-    @mock.patch("mantidimaging.gui.windows.main.view.QtWidgets")
-    def test_uncaught_exception(self, mock_qtwidgets, mock_getlogger):
+    @mock.patch("mantidimaging.gui.windows.main.view.QMessageBox")
+    def test_uncaught_exception(self, mock_qtmessagebox, mock_getlogger):
         self.view.uncaught_exception("user-error", "log-error")
 
-        mock_qtwidgets.QMessageBox.critical.assert_called_once_with(self.view, self.view.UNCAUGHT_EXCEPTION,
-                                                                    "user-error")
+        mock_qtmessagebox.critical.assert_called_once_with(self.view, self.view.UNCAUGHT_EXCEPTION, "user-error")
         mock_getlogger.return_value.error.assert_called_once_with("log-error")
 
     @mock.patch("mantidimaging.gui.windows.main.view.WelcomeScreenPresenter")
@@ -156,10 +155,10 @@ class MainWindowViewTest(unittest.TestCase):
         self.view.show_about()
         mock_welcomescreen.assert_called_once_with(self.view)
 
-    @mock.patch("mantidimaging.gui.windows.main.view.QtGui")
-    def test_open_online_documentation(self, mock_qtgui: mock.Mock):
+    @mock.patch("mantidimaging.gui.windows.main.view.QDesktopServices")
+    def test_open_online_documentation(self, mock_qtdeskserv: mock.Mock):
         self.view.open_online_documentation()
-        mock_qtgui.QDesktopServices.openUrl.assert_called_once()
+        mock_qtdeskserv.openUrl.assert_called_once()
 
     @mock.patch.multiple("mantidimaging.gui.windows.main.view.MainWindowView",
                          setCentralWidget=DEFAULT,

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -6,9 +6,8 @@ from logging import getLogger
 from typing import Optional
 from uuid import UUID
 
-from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtGui import QIcon, QDragEnterEvent, QDropEvent
+from PyQt5.QtCore import Qt, pyqtSignal, QUrl
+from PyQt5.QtGui import QIcon, QDragEnterEvent, QDropEvent, QDesktopServices
 from PyQt5.QtWidgets import QAction, QDialog, QLabel, QMessageBox, QMenu, QFileDialog
 
 from mantidimaging.core.data import Images
@@ -145,8 +144,8 @@ class MainWindowView(BaseMainWindowView):
 
     @staticmethod
     def open_online_documentation():
-        url = QtCore.QUrl("https://mantidproject.github.io/mantidimaging/")
-        QtGui.QDesktopServices.openUrl(url)
+        url = QUrl("https://mantidproject.github.io/mantidimaging/")
+        QDesktopServices.openUrl(url)
 
     def show_about(self):
         self.welcome_window = WelcomeScreenPresenter(self)
@@ -308,7 +307,7 @@ class MainWindowView(BaseMainWindowView):
     def create_stack_window(self,
                             stack: Images,
                             title: str,
-                            position=QtCore.Qt.TopDockWidgetArea,
+                            position=Qt.DockWidgetArea.TopDockWidgetArea,
                             floating=False) -> StackVisualiserView:
         stack_vis = StackVisualiserView(self, title, stack)
 
@@ -337,11 +336,11 @@ class MainWindowView(BaseMainWindowView):
         if self.presenter.have_active_stacks and self.open_dialogs:
             # Show confirmation box asking if the user really wants to quit if
             # they have data loaded
-            msg_box = QtWidgets.QMessageBox.question(self,
-                                                     "Quit",
-                                                     "Are you sure you want to quit with loaded data?",
-                                                     defaultButton=QtWidgets.QMessageBox.No)
-            should_close = msg_box == QtWidgets.QMessageBox.Yes
+            msg_box = QMessageBox.question(self,
+                                           "Quit",
+                                           "Are you sure you want to quit with loaded data?",
+                                           defaultButton=QMessageBox.No)
+            should_close = msg_box == QMessageBox.Yes
 
         if should_close:
             # Pass close event to parent
@@ -352,7 +351,7 @@ class MainWindowView(BaseMainWindowView):
             event.ignore()
 
     def uncaught_exception(self, user_error_msg, log_error_msg):
-        QtWidgets.QMessageBox.critical(self, self.UNCAUGHT_EXCEPTION, f"{user_error_msg}")
+        QMessageBox.critical(self, self.UNCAUGHT_EXCEPTION, f"{user_error_msg}")
         getLogger(__name__).error(log_error_msg)
 
     def show_stack_select_dialog(self):

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -4,7 +4,7 @@
 from typing import TYPE_CHECKING
 
 import numpy as np
-from PyQt5 import Qt
+from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import (QAction, QApplication, QCheckBox, QComboBox, QLabel, QMainWindow, QMenu, QMessageBox,
                              QPushButton, QSizePolicy, QSplitter, QStyle, QVBoxLayout)
 from pyqtgraph import ImageItem
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
 
 
 class FiltersWindowView(BaseMainWindowView):
-    auto_update_triggered = Qt.pyqtSignal()
-    filter_applied = Qt.pyqtSignal()
+    auto_update_triggered = pyqtSignal()
+    filter_applied = pyqtSignal()
 
     splitter: QSplitter
     collapseToggleButton: QPushButton

--- a/mantidimaging/gui/windows/recon/point_table_model.py
+++ b/mantidimaging/gui/windows/recon/point_table_model.py
@@ -52,23 +52,23 @@ class CorTiltPointQtModel(QAbstractTableModel, CorTiltDataModel):
 
     def flags(self, index):
         flags = super(CorTiltPointQtModel, self).flags(index)
-        flags |= Qt.ItemIsEditable
+        flags |= Qt.ItemFlag.ItemIsEditable
         return flags
 
-    def data(self, index, role=Qt.DisplayRole):
+    def data(self, index, role=Qt.ItemDataRole.DisplayRole):
         if not index.isValid():
             return None
 
         col = index.column()
         col_field = Column(col)
 
-        if role == Qt.DisplayRole:
+        if role == Qt.ItemDataRole.DisplayRole:
             if col_field == Column.SLICE_INDEX:
                 return self._points[index.row()].slice_index
             if col_field == Column.CENTRE_OF_ROTATION:
                 return self._points[index.row()].cor
 
-        elif role == Qt.ToolTipRole:
+        elif role == Qt.ItemDataRole.ToolTipRole:
             if col_field == Column.SLICE_INDEX:
                 return 'Slice index (y coordinate of projection)'
             elif col_field == Column.CENTRE_OF_ROTATION:
@@ -84,8 +84,8 @@ class CorTiltPointQtModel(QAbstractTableModel, CorTiltDataModel):
                 column.append(point.slice_index)
             return column
 
-    def setData(self, index, val, role=Qt.EditRole):
-        if role != Qt.EditRole:
+    def setData(self, index, val, role=Qt.ItemDataRole.EditRole):
+        if role != Qt.ItemDataRole.EditRole:
             return False
 
         self.clear_results()
@@ -139,10 +139,10 @@ class CorTiltPointQtModel(QAbstractTableModel, CorTiltDataModel):
         self.sort_points()
 
     def headerData(self, section, orientation, role):
-        if orientation != Qt.Horizontal:
+        if orientation != Qt.Orientation.Horizontal:
             return None
 
-        if role != Qt.DisplayRole:
+        if role != Qt.ItemDataRole.DisplayRole:
             return None
 
         return COLUMN_NAMES[Column(section)]

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -6,7 +6,7 @@ from uuid import UUID
 import numpy
 from PyQt5.QtWidgets import (QAbstractItemView, QComboBox, QDoubleSpinBox, QInputDialog, QPushButton, QSpinBox,
                              QVBoxLayout, QWidget, QMessageBox, QAction)
-from PyQt5 import Qt
+from PyQt5.QtCore import pyqtSignal
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.net.help_pages import SECTION_USER_GUIDE, open_help_webpage
@@ -63,7 +63,7 @@ class ReconstructWindowView(BaseMainWindowView):
 
     stackSelector: StackSelectorWidgetView
 
-    recon_applied = Qt.pyqtSignal()
+    recon_applied = pyqtSignal()
 
     def __init__(self, main_window: 'MainWindowView'):
         super().__init__(main_window, 'gui/ui/recon_window.ui')

--- a/mantidimaging/gui/windows/stack_choice/view.py
+++ b/mantidimaging/gui/windows/stack_choice/view.py
@@ -36,7 +36,7 @@ class StackChoiceView(BaseMainWindowView):
         self.presenter = presenter
 
         self.setWindowTitle("Choose the stack you want to keep")
-        self.setWindowModality(Qt.ApplicationModal)
+        self.setWindowModality(Qt.WindowModality.ApplicationModal)
 
         # Create stacks and place them in the choice window
         self.original_stack = MIImageView(detailsSpanAllCols=True)

--- a/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
+++ b/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
@@ -1,14 +1,13 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-from PyQt5 import Qt
-from PyQt5.QtWidgets import QWidget, QTreeWidget, QTreeWidgetItem
+from PyQt5.QtWidgets import QWidget, QTreeWidget, QTreeWidgetItem, QDialog, QDialogButtonBox, QVBoxLayout
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.operation_history import const
 
 
-class MetadataDialog(Qt.QDialog):
+class MetadataDialog(QDialog):
     """
     Dialog used to show a pretty formatted version of the image metadata.
     """
@@ -21,10 +20,10 @@ class MetadataDialog(Qt.QDialog):
 
         main_widget = MetadataDialog.build_metadata_tree(images.metadata)
 
-        buttons = Qt.QDialogButtonBox(Qt.QDialogButtonBox.Ok)
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok)
         buttons.accepted.connect(self.accept)
 
-        layout = Qt.QVBoxLayout()
+        layout = QVBoxLayout()
         layout.addWidget(main_widget)
         layout.addWidget(buttons)
         self.setLayout(layout)

--- a/mantidimaging/gui/windows/welcome_screen/tests/test_presenter.py
+++ b/mantidimaging/gui/windows/welcome_screen/tests/test_presenter.py
@@ -18,8 +18,8 @@ class WelcomeScreenPresenterTest(unittest.TestCase):
         QCoreApplication.setApplicationName("test1")
         QCoreApplication.setOrganizationName("org1")
         cls.settings_dir = tempfile.TemporaryDirectory()
-        QSettings.setDefaultFormat(QSettings.IniFormat)
-        QSettings.setPath(QSettings.IniFormat, QSettings.UserScope, cls.settings_dir.name)
+        QSettings.setDefaultFormat(QSettings.Format.IniFormat)
+        QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope, cls.settings_dir.name)
 
     def setUp(self):
         self.v = mock.MagicMock()

--- a/mantidimaging/gui/windows/wizard/view.py
+++ b/mantidimaging/gui/windows/wizard/view.py
@@ -4,8 +4,7 @@
 from __future__ import annotations
 from PyQt5.QtWidgets import QLabel, QWidget, QVBoxLayout, QGroupBox, QPushButton, QStyle
 from PyQt5.QtGui import QIcon
-from PyQt5.QtCore import Qt
-from PyQt5.Qt import pyqtSignal
+from PyQt5.QtCore import pyqtSignal, Qt
 from typing import List
 
 from mantidimaging.gui.mvp_base import BaseDialogView
@@ -39,7 +38,7 @@ class WizardStep(QWidget):
         self.name = step["name"]
         self.layout = QVBoxLayout(self)
         self.title_label = QPushButton("Step: " + self.name)
-        self.title_label.setLayoutDirection(Qt.RightToLeft)
+        self.title_label.setLayoutDirection(Qt.LayoutDirection.RightToLeft)
 
         self.layout.addWidget(self.title_label)
 
@@ -78,7 +77,7 @@ class WizardStep(QWidget):
         self.title_label.setEnabled(enabled)
 
         if self.done_predicate(stack_history):
-            self.title_label.setIcon(self.style().standardIcon(QStyle.SP_DialogApplyButton))
+            self.title_label.setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_DialogApplyButton))
         else:
             self.title_label.setIcon(QIcon())
 


### PR DESCRIPTION
### Issue
Fixes #978 

### Description

Make the changes that are still compatible with Qt5, but will make Qt6 migration easier.

Changes are in 2 main categories:
- Objects in PyQt5.QtWidgets and PyQt5.QtCore are no longer accessible through PyQt5.Qt
e.g.
```diff
-        from PyQt5 import Qt
-        shape_fields = Qt.QHBoxLayout()
+        from PyQt5.QtWidgets import QHBoxLayout
+        shape_fields = QHBoxLayout()
```
Most of these can be found by hunting for any imports of PyQt5.Qt,
`ack --python "import" | grep PyQt5 | egrep "\WQt($|\W)"`
But there are still some things like enums in PyQt5.QtCore.Qt.


- Enums must be used from their namespace
```diff
-        if role == Qt.DisplayRole:
+        if role == Qt.ItemDataRole.DisplayRole:
```
Some of these can be tracked down in https://doc.qt.io/qt-5/qt.html

Others are inside widgets
```diff
-        right_widget.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        right_widget.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
```
The best way to find these is looking through
`ack --python "Qt\."`



### Testing & Acceptance Criteria 

Tests should pass. Should be no visible GUI changes

### Documentation
release notes
