### PR TITLE
Update scikit-image and tomopy

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - pip
     - astropy=4.2
     - scipy=1.5.3
-    - scikit-image=0.17.2
+    - scikit-image=0.18.*
     - numpy=1.19.4
     - tomopy=1.7.1=cuda*
     - cudatoolkit=9.2*

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - scipy=1.5.3
     - scikit-image=0.18.*
     - numpy=1.19.4
-    - tomopy=1.7.1=cuda*
+    - tomopy=1.10.*=cuda*
     - cudatoolkit=9.2*
     - cupy
     - astra-toolbox=1.9.9.dev4

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -28,4 +28,4 @@ Developer Changes
 Dependency updates
 ------------------
 
-- pyqtgraph 0.12, scikit-image 0.18
+- pyqtgraph 0.12, scikit-image 0.18, tomopy 1.10

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -28,4 +28,4 @@ Developer Changes
 Dependency updates
 ------------------
 
-- pyqtgraph 0.12
+- pyqtgraph 0.12, scikit-image 0.18


### PR DESCRIPTION
### Issue

Fixes #970 

### Description


Deprecation warning was in scikit-image, and fixed upstream in 0.18, and in Tomopy fixed in 1.10

### Testing & Acceptance Criteria 

`pytest -vs mantidimaging/core/operations/rebin/test/rebin_test.py`

should not have a warnings

### Documentation

release notes
