### PR TITLE
Rollback tomopy version to 1.9

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - scipy=1.5.3
     - scikit-image=0.18.*
     - numpy=1.19.4
-    - tomopy=1.10.*=cuda*
+    - tomopy=1.9.*=cuda*
     - cudatoolkit=9.2*
     - cupy
     - astra-toolbox=1.9.9.dev4

--- a/docs/developer_guide/developer_conventions.rst
+++ b/docs/developer_guide/developer_conventions.rst
@@ -21,3 +21,9 @@ Conda runtime dependencies can be specified in `conda/meta.yaml`. These will be 
 Pip runtime dependencies can't be tracked automatically and so must be installed as part of the environment. These should be listed in `environment.yml`. Due to technical limitations they must also be duplicated in the pip section of `environment-dev.yml`.
 
 Development dependencies should be listed in `environment-dev.yml`, with conda and pip dependencies placed in the correct place.
+
+When updating dependencies or modifying `conda/meta.yaml`, it is important to test that there are no conflicts that will prevent the package being built. This can be done by running
+
+.. code::
+
+    make build-conda-package

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -30,4 +30,4 @@ Developer Changes
 Dependency updates
 ------------------
 
-- pyqtgraph 0.12, scikit-image 0.18, tomopy 1.10
+- pyqtgraph 0.12, scikit-image 0.18, tomopy 1.9


### PR DESCRIPTION
Last version compatible with Cuda toolkit 9.2

### Issue

Un-fixes the tomopy part of #970 but allows everything to work on IDAaaS

### Description

Rollback tomopy version to 1.9

### Testing & Acceptance Criteria 

Confirm that a package is built with

`make build-conda-package`

### Documentation

Updated release notes.
