### PR TITLE
Remove combine histogram checkbox

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -20,6 +20,7 @@ Fixes
 - #961 : Test failure: ImportError: libcuda.so.1
 - #953 : NaNs in result when reconstructing with FBP_CUDA
 - #959 : Median GPU does not work with even values
+- #990 : Remove combine historgram checkbox
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1393</width>
+    <width>1465</width>
     <height>733</height>
    </rect>
   </property>
@@ -401,28 +401,6 @@
             </property>
             <property name="text">
              <string>Link Images</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="combinedHistograms">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>Combine histograms</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
             </property>
            </widget>
           </item>

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -32,7 +32,6 @@ class FiltersWindowView(BaseMainWindowView):
 
     linkImages: QCheckBox
     showHistogramLegend: QCheckBox
-    combinedHistograms: QCheckBox
     invertDifference: QCheckBox
     overlayDifference: QCheckBox
     lockScaleCheckBox: QCheckBox
@@ -79,7 +78,6 @@ class FiltersWindowView(BaseMainWindowView):
         self.previewsLayout.addWidget(self.previews)
         self.clear_previews()
 
-        self.combinedHistograms.stateChanged.connect(self.histogram_mode_changed)
         self.showHistogramLegend.stateChanged.connect(self.histogram_legend_is_changed)
         # set here to trigger the changed event
         self.showHistogramLegend.setChecked(True)
@@ -160,21 +158,6 @@ class FiltersWindowView(BaseMainWindowView):
 
     def clear_previews(self):
         self.previews.clear_items()
-
-    def histogram_mode_changed(self):
-        combined_histograms = self.combinedHistograms.isChecked()
-        self.previews.combined_histograms = combined_histograms
-
-        # Clear old histogram bits
-        self.previews.delete_histograms()
-        self.previews.delete_histogram_labels()
-
-        # Init the correct histograms
-        if combined_histograms:
-            self.previews.init_histogram()
-        else:
-            self.previews.init_separate_histograms()
-        self.previews.update_histogram_data()
 
     def histogram_legend_is_changed(self):
         self.previews.histogram_legend_visible = self.showHistogramLegend.isChecked()


### PR DESCRIPTION
### Issue
Closes #990 

### Description
Make the histograms in the operation window always combined.

### Testing & Acceptance Criteria 

Check that operations window functions normally. Check combine histogram checkbox is gone.

This should effect the applitools tests. I'll make some A/Bs

### Documentation

Release notes
