### PR TITLE
988: Show averaged view for Crop Coordinates ROI Selector

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -10,6 +10,7 @@ New features
 - #927 : ROI norm: use averaged view in ROI selector
 - #925 : Jenks / Otsu everywhere
 - #926 : Manual arithmetic filter
+- #988 : Use averaged view in ROI selector for crop
 
 Fixes
 -----

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -276,10 +276,7 @@ class FiltersWindowView(BaseMainWindowView):
         menu.addSeparator()
         self.roi_view.imageItem.menu = menu
 
-        if self.filterSelector.currentText() == "ROI Normalisation":
-            set_averaged_image()
-        else:
-            self.roi_view.setImage(self.presenter.stack.presenter.images.data)
+        set_averaged_image()
 
         def roi_changed_callback(callback):
             roi_field.setText(callback.to_list_string())


### PR DESCRIPTION
### Issue

Closes #988 

### Description

Makes the averaged view appear by default for the Crop Coordinates ROI Selector.

### Testing 

No tests as the changes affect a view.

### Acceptance Criteria 

Check that the averaged view is default.

### Documentation

Updated release notes.
