### PR TITLE
Set viewport size

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -31,6 +31,6 @@ dependencies:
       - pytest-repeat==0.9.1
       - psutil==5.7.3
       - isort==5.6.4
-      - eyes-images==4.15.0
+      - eyes-images==4.20.*
       - parameterized==0.8.1
       - pre-commit

--- a/mantidimaging/eyes_tests/eyes_manager.py
+++ b/mantidimaging/eyes_tests/eyes_manager.py
@@ -12,6 +12,10 @@ from applitools.images import Eyes
 
 from mantidimaging.gui.windows.main import MainWindowView
 
+# Used to disabiguate tests on the Applitools platform. set explicitly to avoid depending on the window size
+VIEWPORT_WIDTH = 1920
+VIEWPORT_HEIGHT = 1080
+
 
 class EyesManager:
     def __init__(self, application_name="Mantid Imaging", test_name=None):
@@ -47,7 +51,12 @@ class EyesManager:
             return
 
         if not self.eyes.is_open:
-            self.eyes.open(self.application_name, test_file_name)
+            self.eyes.open(self.application_name,
+                           test_file_name,
+                           dimension={
+                               'width': VIEWPORT_WIDTH,
+                               'height': VIEWPORT_HEIGHT
+                           })
         self.eyes.check_image(image, test_method_name)
 
     def close_imaging(self):


### PR DESCRIPTION
### Issue
Closes #996 

### Description

Set an explicit viewport size. This prevents changes in window size triggering create of a new baseline, rather than being compared to the existing baseline.

Thanks to Applitools support, for helping solve this.

### Testing 

This will trigger recreating all existing baselines, with a viewport of 1920x1080.

### Acceptance Criteria 

New baselines with a viewport of 1920x1080

### Documentation
Just a test fix. Comments in code.
