### PR TITLE
Fix conda build

### DIFF
--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -26,7 +26,7 @@ runs:
     shell: bash -l {0}
     run: |
       conda config --set always_yes yes --set changeps1 no
-      conda create -n build-env anaconda python=3.8
+      conda create -n build-env anaconda-client python=3.8
       conda activate build-env
       conda install conda-build conda-verify
 

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v2.0.1
         with:
+          environment-file: environment-dev.yml
           activate-environment: mantidimaging-dev
           auto-activate-base: false
 


### PR DESCRIPTION
### Issue

Closes #1000 

### Description

There were 2 issues.
* The `anaconda-client` package is much quicker to install than `anaconda` (especially with extra channnels)
* We still need to use the environment file, so that channel are enabled

### Testing & Acceptance Criteria 

I have been testing in #1002 . There is a successful publish in

https://github.com/mantidproject/mantidimaging/pull/1002/checks?check_run_id=2712831580


### Documentation

Not needed
