### PR TITLE
Pad screenshot to the view port size for Applitools

### DIFF
--- a/mantidimaging/eyes_tests/eyes_manager.py
+++ b/mantidimaging/eyes_tests/eyes_manager.py
@@ -7,6 +7,7 @@ from tempfile import mkdtemp
 from uuid import uuid4
 
 from PyQt5.QtWidgets import QWidget, QApplication
+from PyQt5.QtGui import QImage, QPainter, QColor
 from applitools.common import BatchInfo, MatchLevel
 from applitools.images import Eyes
 
@@ -81,11 +82,17 @@ class EyesManager:
         if widget is None and self.imaging is not None:
             widget = self.imaging
 
-        if isinstance(widget, QWidget):
-            QApplication.processEvents()
-            image = widget.grab()
-        else:
-            image = None
+        if not isinstance(widget, QWidget):
+            raise ValueError("widget is not a QWidget")
+
+        QApplication.processEvents()
+        window_image = widget.grab()
+
+        image = QImage(VIEWPORT_WIDTH, VIEWPORT_HEIGHT, QImage.Format.Format_RGB32)
+        image.fill(QColor(255, 255, 255))
+        painter = QPainter(image)
+        painter.drawPixmap(0, 0, window_image)
+        painter.end()
 
         if image_name is None:
             image_name = str(uuid4())


### PR DESCRIPTION
### Issue

Fixes issue related to #997

### Description
In 412954f51d #997 a viewport size is set to avoid new baselines being
generated if the window size changes.

But the API does not allow comparing to a baseline of a different size,
so pad to the viewport size.

### Testing & Acceptance Criteria 

GUI tests should now pass

### Documentation
Not needed
