### PR TITLE
Remove legend checkbox

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -22,6 +22,7 @@ Fixes
 - #953 : NaNs in result when reconstructing with FBP_CUDA
 - #959 : Median GPU does not work with even values
 - #990 : Remove combine historgram checkbox
+- #989 : Remove legend checkbox
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -370,25 +370,6 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="showHistogramLegend">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>Show/hide legend of combined histogram</string>
-            </property>
-            <property name="text">
-             <string>Legend</string>
-            </property>
-            <property name="checked">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
            <widget class="QCheckBox" name="linkImages">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Maximum">

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -54,7 +54,6 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.ALLOWED_HEIGHT: QRect = screen_height * 0.8
 
         self.histogram = None
-        self.histogram_legend_visible = True
 
         self.addLabel("Image before")
         self.addLabel("Image after")

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -141,6 +141,7 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.addLabel("Pixel values", row=label_coords.row, col=label_coords.col)
 
         self.legend = self.histogram.addLegend()
+        self.legend.setOffset((0, 1))
 
     def update_histogram_data(self):
         # Plot any histogram that has data, and add a legend if both exist

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -31,7 +31,6 @@ class FiltersWindowView(BaseMainWindowView):
     collapseToggleButton: QPushButton
 
     linkImages: QCheckBox
-    showHistogramLegend: QCheckBox
     invertDifference: QCheckBox
     overlayDifference: QCheckBox
     lockScaleCheckBox: QCheckBox
@@ -77,10 +76,6 @@ class FiltersWindowView(BaseMainWindowView):
         self.previews.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.previewsLayout.addWidget(self.previews)
         self.clear_previews()
-
-        self.showHistogramLegend.stateChanged.connect(self.histogram_legend_is_changed)
-        # set here to trigger the changed event
-        self.showHistogramLegend.setChecked(True)
 
         self.linkImages.stateChanged.connect(self.link_images_changed)
         # set here to trigger the changed event
@@ -158,15 +153,6 @@ class FiltersWindowView(BaseMainWindowView):
 
     def clear_previews(self):
         self.previews.clear_items()
-
-    def histogram_legend_is_changed(self):
-        self.previews.histogram_legend_visible = self.showHistogramLegend.isChecked()
-        legend = self.previews.histogram_legend
-        if legend:
-            if self.showHistogramLegend.isChecked():
-                legend.show()
-            else:
-                legend.hide()
 
     def link_images_changed(self):
         if self.linkImages.isChecked():


### PR DESCRIPTION
### Issue
Closes #989 

### Description

Make the legend in the ops window histogram always on. Remove the checkbox.

Also move the legend to the right to reduce overlap with the plot.

### Testing & Acceptance Criteria 

Ops window should no longer have a "Legend" checkbox.

### Documentation

release_notes
