### PR TITLE
1001: Exception when trying to load log file

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -21,7 +21,8 @@ Fixes
 - #961 : Test failure: ImportError: libcuda.so.1
 - #953 : NaNs in result when reconstructing with FBP_CUDA
 - #959 : Median GPU does not work with even values
-- #990 : Remove combine historgram checkbox
+- #990 : Remove combine histogram checkbox
+- #1001 : Exception when selecting Log in Load Dataset dialog
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/windows/load_dialog/view.py
+++ b/mantidimaging/gui/windows/load_dialog/view.py
@@ -73,11 +73,11 @@ class MWLoadDialog(QDialog):
 
         self.flat_before_log, self.select_flat_before_log = self.create_file_input(7)
         self.select_flat_before_log.clicked.connect(lambda: self.presenter.notify(
-            Notification.UPDATE_SINGLE_FILE, field=self.flat_before_log, name="Flat Before Log", image_file=False))
+            Notification.UPDATE_SINGLE_FILE, field=self.flat_before_log, name="Flat Before Log", is_image_file=False))
 
         self.flat_after_log, self.select_flat_after_log = self.create_file_input(8)
         self.select_flat_after_log.clicked.connect(lambda: self.presenter.notify(
-            Notification.UPDATE_SINGLE_FILE, field=self.flat_after_log, name="Flat After Log", image_file=False))
+            Notification.UPDATE_SINGLE_FILE, field=self.flat_after_log, name="Flat After Log", is_image_file=False))
 
         self.step_all.clicked.connect(self._set_all_step)
         self.step_preview.clicked.connect(self._set_preview_step)


### PR DESCRIPTION
### Issue

Closes #1001

### Description

Fixes the wrong argument name being entered for the `is_image_file` bool.

### Acceptance Criteria 

Check that clicking on the flat before/after log buttons brings up a file dialog rather than leading to an exception.

### Documentation

Updated the release notes.
