### PR TITLE
969: Nexus loader mypy coverage

### DIFF
--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -78,7 +78,7 @@ class Images:
         self.metadata = json.load(f)
         self._is_sinograms = self.metadata.get(const.SINOGRAMS, False)
 
-    def save_metadata(self, f, rescale_params=None):
+    def save_metadata(self, f: TextIO, rescale_params: Optional[Dict[str, Union[str, float]]] = None):
         self.metadata[const.SINOGRAMS] = self.is_sinograms
 
         if rescale_params is not None:

--- a/mantidimaging/core/io/loader/nexus_loader.py
+++ b/mantidimaging/core/io/loader/nexus_loader.py
@@ -56,8 +56,8 @@ class NexusLoader:
         self.tomo_entry = None
         self.data = None
         self.image_key_dataset = None
-        self.issues = None
-        self.title = None
+        self.issues: List[str] = []
+        self.title: str = ""
 
     def load_nexus_data(self, file_path: str) -> Tuple[Optional[Dataset], str, List[str]]:
         """

--- a/mantidimaging/core/io/loader/stack_loader.py
+++ b/mantidimaging/core/io/loader/stack_loader.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-from typing import Optional, Callable, Union, List
+from typing import Optional, Callable, Union, List, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -11,18 +11,8 @@ from mantidimaging.core.utility.data_containers import Indices
 from mantidimaging.core.utility.progress_reporting import Progress
 
 
-def parallel_move_data(input_data, output_data):
-    """
-    Forwarded function for parallel loading of data
-    :param input_data: shared_data
-
-    :param output_data: second_shared_data
-
-    """
-    output_data[:] = input_data[:]
-
-
-def do_stack_load_seq(data, new_data, img_shape, name, progress):
+def do_stack_load_seq(data: np.ndarray, new_data: np.ndarray, img_shape: Tuple[int, ...], name: str,
+                      progress: Optional[Progress]) -> np.ndarray:
     """
     Sequential version of loading the data.
     This performs faster locally, but parallel performs faster on SCARF

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -10,6 +10,7 @@ import numpy as np
 from .utility import DEFAULT_IO_FILE_FORMAT
 from ..data.images import Images
 from ..operations.rescale import RescaleFilter
+from ..utility.data_containers import Indices
 from ..utility.progress_reporting import Progress
 
 LOG = getLogger(__name__)
@@ -53,16 +54,16 @@ def write_nxs(data: np.ndarray, filename: str, projection_angles: Optional[np.nd
 
 
 def save(images: Images,
-         output_dir,
+         output_dir: str,
          name_prefix: str = DEFAULT_NAME_PREFIX,
          swap_axes: bool = False,
          out_format: str = DEFAULT_IO_FILE_FORMAT,
          overwrite_all: bool = False,
-         custom_idx=None,
+         custom_idx: Optional[int] = None,
          zfill_len: int = DEFAULT_ZFILL_LENGTH,
          name_postfix: str = DEFAULT_NAME_POSTFIX,
-         indices=None,
-         pixel_depth=None,
+         indices: Union[List[int], Indices, None] = None,
+         pixel_depth: Optional[str] = None,
          progress: Optional[Progress] = None) -> Union[str, List[str]]:
     """
     Save image volume (3d) into a series of slices along the Z axis.

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -3,7 +3,7 @@
 
 import os
 from logging import getLogger
-from typing import List, Union
+from typing import List, Union, Optional
 
 import numpy as np
 
@@ -20,20 +20,20 @@ DEFAULT_NAME_POSTFIX = ''
 INT16_SIZE = 65536
 
 
-def write_fits(data, filename, overwrite=False):
+def write_fits(data: np.ndarray, filename: str, overwrite: bool = False):
     import astropy.io.fits as fits
     hdu = fits.PrimaryHDU(data)
     hdulist = fits.HDUList([hdu])
     hdulist.writeto(filename, overwrite=overwrite)
 
 
-def write_img(data, filename, overwrite=False):
+def write_img(data: np.ndarray, filename: str, overwrite: bool = False):
     from mantidimaging.core.utility.special_imports import import_skimage_io
     skio = import_skimage_io()
     skio.imsave(filename, data)
 
 
-def write_nxs(data, filename, projection_angles=None, overwrite=False):
+def write_nxs(data: np.ndarray, filename: str, projection_angles: Optional[np.ndarray] = None, overwrite: bool = False):
     import h5py
     nxs = h5py.File(filename, 'w')
 
@@ -54,16 +54,16 @@ def write_nxs(data, filename, projection_angles=None, overwrite=False):
 
 def save(images: Images,
          output_dir,
-         name_prefix=DEFAULT_NAME_PREFIX,
-         swap_axes=False,
-         out_format=DEFAULT_IO_FILE_FORMAT,
-         overwrite_all=False,
+         name_prefix: str = DEFAULT_NAME_PREFIX,
+         swap_axes: bool = False,
+         out_format: str = DEFAULT_IO_FILE_FORMAT,
+         overwrite_all: bool = False,
          custom_idx=None,
-         zfill_len=DEFAULT_ZFILL_LENGTH,
-         name_postfix=DEFAULT_NAME_POSTFIX,
+         zfill_len: int = DEFAULT_ZFILL_LENGTH,
+         name_postfix: str = DEFAULT_NAME_POSTFIX,
          indices=None,
          pixel_depth=None,
-         progress=None) -> Union[str, List[str]]:
+         progress: Optional[Progress] = None) -> Union[str, List[str]]:
     """
     Save image volume (3d) into a series of slices along the Z axis.
     The Z axis in the script is the ndarray.shape[0].

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -3,7 +3,7 @@
 
 import os
 from logging import getLogger
-from typing import List, Union, Optional
+from typing import List, Union, Optional, Dict, Callable
 
 import numpy as np
 
@@ -103,13 +103,13 @@ def save(images: Images,
     make_dirs_if_needed(output_dir, overwrite_all)
 
     # Define current parameters
-    min_value = np.nanmin(images.data)
-    max_value = np.nanmax(images.data)
+    min_value: float = np.nanmin(images.data)
+    max_value: float = np.nanmax(images.data)
     int_16_slope = max_value / INT16_SIZE
 
     # Do rescale if needed.
     if pixel_depth is None or pixel_depth == "float32":
-        rescale_params = None
+        rescale_params: Optional[Dict[str, Union[str, float]]] = None
     elif pixel_depth == "int16":
         # turn the offset to string otherwise json throws a TypeError when trying to save float32
         rescale_params = {"offset": str(min_value), "slope": int_16_slope}
@@ -133,7 +133,7 @@ def save(images: Images,
         return filename
     else:
         if out_format in ['fit', 'fits']:
-            write_func = write_fits
+            write_func: Callable[[np.ndarray, str, bool], None] = write_fits
         else:
             # pass all other formats to skimage
             write_func = write_img
@@ -164,17 +164,17 @@ def save(images: Images,
         return names
 
 
-def rescale_single_image(image: np.ndarray, min_input: float, max_input: float, max_output: float):
+def rescale_single_image(image: np.ndarray, min_input: float, max_input: float, max_output: float) -> np.ndarray:
     return RescaleFilter.filter_single_image(image, min_input, max_input, max_output, data_type=np.uint16)
 
 
-def generate_names(name_prefix,
-                   indices,
-                   num_images,
-                   custom_idx=None,
-                   zfill_len=DEFAULT_ZFILL_LENGTH,
-                   name_postfix=DEFAULT_NAME_POSTFIX,
-                   out_format=DEFAULT_IO_FILE_FORMAT):
+def generate_names(name_prefix: str,
+                   indices: Union[List[int], Indices, None],
+                   num_images: int,
+                   custom_idx: Optional[int] = None,
+                   zfill_len: int = DEFAULT_ZFILL_LENGTH,
+                   name_postfix: str = DEFAULT_NAME_POSTFIX,
+                   out_format: str = DEFAULT_IO_FILE_FORMAT) -> List[str]:
     start_index = indices[0] if indices else 0
     if custom_idx:
         index = custom_idx
@@ -191,7 +191,7 @@ def generate_names(name_prefix,
     return names
 
 
-def make_dirs_if_needed(dirname=None, overwrite_all=False):
+def make_dirs_if_needed(dirname: Optional[str] = None, overwrite_all: bool = False):
     """
     Makes sure that the directory needed (for example to save a file)
     exists, otherwise creates it.
@@ -208,184 +208,3 @@ def make_dirs_if_needed(dirname=None, overwrite_all=False):
     elif os.listdir(path) and not overwrite_all:
         raise RuntimeError("The output directory is NOT empty:{0}\nThis can be "
                            "overridden by specifying 'Overwrite on name conflict'.".format(path))
-
-
-class Saver(object):
-    """
-    This class doesn't have any try: ... except: ... because when called
-    it's usually at an end point, where there would be no point in recovering.
-
-    However if the directory in which the output should be written out does
-    not exist, it will be created on the first call of make_dirs_if_needed.
-
-    This class should always fail early before any
-    expensive operations have been attempted.
-    """
-    @staticmethod
-    def supported_formats():
-        # reuse supported formats, they currently share them
-        from mantidimaging.core.io.loader import supported_formats
-        return supported_formats()
-
-    def __init__(self, config):
-        self._output_path = config.func.output_path
-        if self._output_path is not None:
-            self._output_path = os.path.abspath(os.path.expanduser(self._output_path))
-
-        self._out_format = config.func.out_format
-        self._overwrite_all = config.func.overwrite_all
-        self._swap_axes = config.func.swap_axes
-        self._indices = config.func.indices
-
-        self._preproc_dir = config.func.preproc_subdir
-        self._save_preproc = config.func.save_preproc
-
-        self._out_slices_prefix = config.func.out_slices_prefix
-        self._out_horiz_slices_prefix = config.func.out_horiz_slices_prefix
-        self._out_horiz_slices_subdir = config.func.out_horiz_slices_subdir
-        self._save_horiz_slices = config.func.save_horiz_slices
-
-        # assign package functions for ease of access
-        self.save = save
-        self.make_dirs_if_needed = make_dirs_if_needed
-
-    def should_save_output(self):
-        return self._output_path is not None
-
-    def get_output_path(self):
-        return self._output_path
-
-    def save_single_image(self,
-                          data,
-                          subdir=None,
-                          name='saved_image',
-                          swap_axes=False,
-                          custom_index=None,
-                          zfill_len=0,
-                          name_postfix='',
-                          use_preproc_folder=True,
-                          progress=None):
-        """
-        Save a single image to a single image file.
-        THIS SHOULD NOT BE USED WITH A 3D STACK OF IMAGES.
-
-        :param subdir: Specify an additional subdirectory
-               inside the output directory
-        :param data: Data volume with pre-processed images
-        :param name: Image name to be appended
-        :param custom_index: Index that will be appended at the end of the image filename
-        :param zfill_len: Prepend zeros to the output file names to have a
-               constant file name length. Example:
-               - saving out an image with zfill_len = 6:
-               saved_image000001,...saved_image000201 and so on
-               - saving out an image with zfill_len = 3:
-               saved_image001,...saved_image201 and so on
-        :param name_postfix: String to be appended after the zero fill.
-               This is not recommended and might confuse
-               imaging programs (including this script) as to
-               the order of the images, and they could
-               end up not loading all of the images.
-        """
-        assert data.ndim == 2, \
-            "This should not be used with a 3D stack of images!"
-
-        progress = Progress.ensure_instance(progress, task_name='Save Image')
-
-        # reshape so that it works with the internals
-        data = data.reshape(1, data.shape[0], data.shape[1])
-        if self._output_path is None:
-            LOG.info("Not saving a single image, " "because no output path is specified.")
-            return
-
-        # using the config's output dir
-        if use_preproc_folder:
-            output_dir = os.path.join(self._output_path, self._preproc_dir)
-        else:
-            output_dir = self._output_path
-
-        if subdir is not None:
-            # using the provided subdir
-            output_dir = os.path.join(output_dir, subdir)
-            output_dir = os.path.abspath(output_dir)
-
-        with progress:
-            progress.update(msg="Saving single image {0} dtype: {1}".format(output_dir, data.dtype))
-
-            save(data,
-                 output_dir,
-                 name,
-                 swap_axes,
-                 out_format=self._out_format,
-                 overwrite_all=self._overwrite_all,
-                 zfill_len=zfill_len,
-                 name_postfix=name_postfix,
-                 custom_idx=custom_index,
-                 indices=self._indices)
-
-    def save_preproc_images(self, data, progress=None):
-        """
-        Specialised save function to save out the pre-processed images.
-
-        This will save the images out in a subdir /pre-processed/.
-
-        :param data: The pre-processed data that will be saved
-        """
-        progress = Progress.ensure_instance(progress, task_name='Save Preprocessed')
-
-        if self._save_preproc and self._output_path is not None:
-            preproc_dir = os.path.join(self._output_path, self._preproc_dir)
-
-            with progress:
-                progress.update(msg="Saving all pre-processed images into {0} "
-                                "dtype: {1}".format(preproc_dir, data.dtype))
-
-                save(data,
-                     preproc_dir,
-                     'out_preproc_image',
-                     self._swap_axes,
-                     self._out_format,
-                     self._overwrite_all,
-                     indices=self._indices)
-
-    def save_recon_output(self, data, progress=None):
-        """
-        Specialised method to save out the reconstructed data
-        depending on the configuration options.
-
-        This will save out the data in a subdirectory /reconstructed/.
-        If --save-horiz-slices is specified, the axis will be flipped and
-        the result will be saved out in /reconstructed/horiz.
-        ^ This means that the data usage will double as
-        numpy.swapaxes WILL COPY AND DOUBLE the data!
-
-        :param data: Reconstructed data volume that will be saved out.
-        """
-        progress = Progress.ensure_instance(progress, task_name='Save Reconstruction')
-
-        if self._output_path is None:
-            LOG.warning("Not saving reconstruction output, " "because no output path is specified.")
-            return
-
-        out_recon_dir = os.path.join(self._output_path, 'reconstructed')
-
-        with progress:
-            progress.update(msg="Starting saving slices of the reconstructed "
-                            "volume in: {0}...".format(out_recon_dir))
-
-            save(data,
-                 out_recon_dir,
-                 self._out_slices_prefix,
-                 self._swap_axes,
-                 self._out_format,
-                 self._overwrite_all,
-                 indices=self._indices)
-
-            # Sideways slices:
-            if self._save_horiz_slices:
-                out_horiz_dir = os.path.join(out_recon_dir, self._out_horiz_slices_subdir)
-
-                LOG.info("Saving horizontal slices in: {0}".format(out_horiz_dir))
-
-                # save out the horizontal slices by flipping the axes
-                save(data, out_horiz_dir, self._out_horiz_slices_prefix, not self._swap_axes, self._out_format,
-                     self._overwrite_all)

--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -31,7 +31,7 @@ def get_file_extension(file: str) -> Optional[str]:
     return os.path.splitext(file)[1][1:]
 
 
-def get_candidate_file_extensions(ext):
+def get_candidate_file_extensions(ext: str) -> List[str]:
     """
     Gets a list of file extensions which can be used to load files.
     :param ext: User provided file extension
@@ -39,10 +39,10 @@ def get_candidate_file_extensions(ext):
     """
     # Get all tuples of similar extensions that the provided extension appears
     # in
-    candidates = [e for e in SIMILAR_FILE_EXTENSIONS if ext in e]
+    similar_extensions = [e for e in SIMILAR_FILE_EXTENSIONS if ext in e]
 
     # Concatenate them all into a single list
-    candidates = list(itertools.chain(*candidates))
+    candidates = list(itertools.chain(*similar_extensions))
 
     # Remove the provided extension from the list
     if ext in candidates:
@@ -110,7 +110,7 @@ def find_images_in_same_directory(sample_dirname: Path, type: str, suffix: str,
     return None
 
 
-def get_folder_names(path):
+def get_folder_names(path: str) -> List[str]:
     """
     Get all folder names in a specific path.
 
@@ -136,7 +136,7 @@ def get_folder_names(path):
     return folders
 
 
-def _alphanum_key_split(path_str):
+def _alphanum_key_split(path_str: str) -> List[Union[int, str]]:
     """
     From a string to a list of alphabetic and numeric elements. Intended to
     be used for sequence number/natural sorting. In list.sort() the

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -48,7 +48,11 @@ class RescaleFilter(BaseFilter):
         return images
 
     @staticmethod
-    def filter_single_image(image: ndarray, min_input: float, max_input: float, max_output: float, data_type=float32):
+    def filter_single_image(image: ndarray,
+                            min_input: float,
+                            max_input: float,
+                            max_output: float,
+                            data_type=float32) -> np.ndarray:
         np.clip(image, min_input, max_input, out=image)
         image -= min_input
         data_max = nanmax(image)

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -44,7 +44,7 @@ def create_array(shape: Tuple[Any, ...], dtype: npt.DTypeLike = np.float32) -> n
     return _create_shared_array(shape, dtype)
 
 
-def _create_shared_array(shape, dtype: npt.DTypeLike = np.float32):
+def _create_shared_array(shape, dtype: npt.DTypeLike = np.float32) -> np.ndarray:
     ctype: SimpleCType = ctypes.c_float  # default to numpy float32 / C type float
     if dtype == np.uint8 or dtype == 'uint8':
         ctype = ctypes.c_uint8

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -8,7 +8,7 @@ from functools import partial
 from logging import getLogger
 from multiprocessing import Array
 from multiprocessing.pool import Pool
-from typing import Any, List, Tuple, Type, Union
+from typing import List, Tuple, Type, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -27,7 +27,7 @@ def enough_memory(shape, dtype):
     return full_size_KB(shape=shape, axis=0, dtype=dtype) < system_free_memory().kb()
 
 
-def create_array(shape: Tuple[Any, ...], dtype: npt.DTypeLike = np.float32) -> np.ndarray:
+def create_array(shape: Tuple[int, ...], dtype: npt.DTypeLike = np.float32) -> np.ndarray:
     """
     Create an array, either in a memory file (if name provided), or purely in memory (if name is None)
 

--- a/mantidimaging/core/utility/progress_reporting/progress.py
+++ b/mantidimaging/core/utility/progress_reporting/progress.py
@@ -140,7 +140,7 @@ class Progress(object):
         else:
             return 0.0
 
-    def set_estimated_steps(self, num_steps):
+    def set_estimated_steps(self, num_steps: int):
         """
         Sets the number of steps this task is expected to take to complete.
         """


### PR DESCRIPTION
### Issue

Closes #969

### Description

Improves mypy check coverage for nexus_loader, stack_loader, saver, and utility. Removed unused `Saver` class.

File | Imprecision Before | Imprecision After
-- | -- | --
mantidimaging.core.io.loader.nexus_loader | 20.30% | 16.34%
mantidimaging.core.io.loader.stack_loader | 24.00% | 8.00%
mantidimaging.core.io.saver | 41.54% | 16.19%
mantidimaging.core.io.utility | 18.75% | 2.20%
**Total** | 37.87% | 26.63%

### Acceptance Criteria 

Check that the tests pass. Check the mypy report.

### Documentation

Release notes were updated in a previous PR.
