### PR TITLE
Recon preview in AsyncTaskDialogView

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -24,6 +24,7 @@ Fixes
 - #990 : Remove combine histogram checkbox
 - #989 : Remove legend checkbox
 - #1001 : Exception when selecting Log in Load Dataset dialog
+- #991 : Handle longer running previews better
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/utility/func_call.py
+++ b/mantidimaging/core/utility/func_call.py
@@ -4,7 +4,7 @@
 import inspect
 
 
-def call_with_known_parameters(func, *args, **kwargs):
+def call_with_known_parameters(func, **kwargs):
     sig = inspect.signature(func)
     params = sig.parameters.keys()
     ka = dict((k, v) for k, v in kwargs.items() if k in params)

--- a/mantidimaging/eyes_tests/eyes_manager.py
+++ b/mantidimaging/eyes_tests/eyes_manager.py
@@ -4,6 +4,7 @@
 import inspect
 import os
 from tempfile import mkdtemp
+import time
 from uuid import uuid4
 
 from PyQt5.QtWidgets import QWidget, QApplication
@@ -85,6 +86,7 @@ class EyesManager:
         if not isinstance(widget, QWidget):
             raise ValueError("widget is not a QWidget")
 
+        time.sleep(0.2)
         QApplication.processEvents()
         window_image = widget.grab()
 

--- a/mantidimaging/gui/dialogs/async_task/model.py
+++ b/mantidimaging/gui/dialogs/async_task/model.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from logging import getLogger
-from typing import Callable
+from typing import Callable, Optional
 
 from PyQt5.QtCore import QObject, pyqtSignal
 
@@ -20,7 +20,7 @@ class AsyncTaskDialogModel(QObject):
         self.task = TaskWorkerThread()
         self.task.finished.connect(self._on_task_exit)
 
-        self.on_complete_function: Callable = lambda: None
+        self.on_complete_function: Optional[Callable] = None
 
     def do_execute_async(self):
         """
@@ -29,7 +29,7 @@ class AsyncTaskDialogModel(QObject):
         self.task.start()
 
     @property
-    def task_is_running(self):
+    def task_is_running(self) -> bool:
         return self.task.isRunning()
 
     def _on_task_exit(self):

--- a/mantidimaging/gui/dialogs/async_task/presenter.py
+++ b/mantidimaging/gui/dialogs/async_task/presenter.py
@@ -39,8 +39,7 @@ class AsyncTaskDialogPresenter(QObject, ProgressHandler):
     def set_task(self, f):
         self.model.task.task_function = f
 
-    def set_parameters(self, *args, **kwargs):
-        self.model.task.args = args
+    def set_parameters(self, **kwargs):
         self.model.task.kwargs = kwargs
 
     def set_on_complete(self, f):

--- a/mantidimaging/gui/dialogs/async_task/presenter.py
+++ b/mantidimaging/gui/dialogs/async_task/presenter.py
@@ -50,7 +50,7 @@ class AsyncTaskDialogPresenter(QObject, ProgressHandler):
         Starts async task execution and shows GUI.
         """
         self.model.do_execute_async()
-        self.view.show()
+        self.view.show_delayed(1000)
 
     @property
     def task_is_running(self):

--- a/mantidimaging/gui/dialogs/async_task/presenter.py
+++ b/mantidimaging/gui/dialogs/async_task/presenter.py
@@ -4,10 +4,12 @@
 import traceback
 from logging import getLogger
 from enum import Enum
+
+from typing import Callable
+
 from PyQt5.QtCore import QObject, pyqtSignal
 
 from mantidimaging.core.utility.progress_reporting import ProgressHandler
-
 from .model import AsyncTaskDialogModel
 
 
@@ -36,13 +38,13 @@ class AsyncTaskDialogPresenter(QObject, ProgressHandler):
             self.show_error(e, traceback.format_exc())
             getLogger(__name__).exception("Notification handler failed")
 
-    def set_task(self, f):
+    def set_task(self, f: Callable):
         self.model.task.task_function = f
 
     def set_parameters(self, **kwargs):
         self.model.task.kwargs = kwargs
 
-    def set_on_complete(self, f):
+    def set_on_complete(self, f: Callable):
         self.model.on_complete_function = f
 
     def do_start_processing(self):

--- a/mantidimaging/gui/dialogs/async_task/task.py
+++ b/mantidimaging/gui/dialogs/async_task/task.py
@@ -29,7 +29,6 @@ class TaskWorkerThread(QThread):
 
         self.task_function = None
 
-        self.args = []
         self.kwargs = {}
 
         self.result = None
@@ -42,7 +41,7 @@ class TaskWorkerThread(QThread):
             if self.task_function is None:
                 raise ValueError("No task function provided")
 
-            self.result = call_with_known_parameters(self.task_function, *self.args, **self.kwargs)
+            self.result = call_with_known_parameters(self.task_function, **self.kwargs)
 
         except Exception as e:
             log.exception("Failed to execute task")

--- a/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
@@ -24,7 +24,7 @@ class AsyncTaskDialogPresenterTest(unittest.TestCase):
         self.assertFalse(p.task_is_running)
 
         p.notify(Notification.START)
-        v.show.assert_called_once()
+        v.show_delayed.assert_called_once()
         self.assertTrue(p.task_is_running)
 
         p.model.task.wait()

--- a/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
@@ -20,7 +20,7 @@ class AsyncTaskDialogPresenterTest(unittest.TestCase):
 
         p = AsyncTaskDialogPresenter(v)
         p.set_task(f)
-        p.set_parameters([5], {'b': 4})
+        p.set_parameters(b=4)
         self.assertFalse(p.task_is_running)
 
         p.notify(Notification.START)

--- a/mantidimaging/gui/dialogs/async_task/test/view_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/view_test.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+import unittest
+
+from unittest import mock
+
+from mantidimaging.gui.dialogs.async_task import (AsyncTaskDialogView)
+from mantidimaging.test_helpers import start_qapplication
+
+
+@start_qapplication
+class AsyncTaskDialogViewTest(unittest.TestCase):
+    @mock.patch('mantidimaging.gui.dialogs.async_task.view.AsyncTaskDialogPresenter')
+    def setUp(self, mock_atd) -> None:
+        self.view = AsyncTaskDialogView(None, True)
+        self.view.infoText = mock.Mock()
+        self.mock_qtimer = mock.Mock()
+        self.view.show_timer = self.mock_qtimer
+        self.mock_atd = mock_atd
+
+    def test_handle_completion_success(self):
+        self.view.handle_completion(True)
+        self.view.infoText.setText.assert_called_once_with("Complete")
+
+    def test_handle_completion_fail(self):
+        self.view.handle_completion(False)
+        self.view.infoText.setText.assert_called_once_with("Task failed.")
+
+    def test_show_delayed(self):
+        self.view.show_delayed(10)
+
+        self.mock_qtimer.singleShot.assert_called_once_with(10, self.view.show_from_timer)
+        self.mock_qtimer.start.assert_called_once()

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -22,14 +22,8 @@ class AsyncTaskDialogView(BaseDialogView):
         self.progressBar.setMinimum(0)
         self.progressBar.setMaximum(1000)
 
-        self.progress_text = self.infoText.text()
         self.show_timer = QTimer(self)
         self.hide()
-
-    def reject(self):
-        # Do not close the dialog when processing is still ongoing
-        if not self.presenter.task_is_running:
-            super(AsyncTaskDialogView, self).reject()
 
     def handle_completion(self, successful):
         """

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-from typing import Callable
+from typing import Callable, Dict, Optional
 
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.mvp_base import BaseDialogView
@@ -12,7 +12,7 @@ from PyQt5.QtCore import QTimer
 
 
 class AsyncTaskDialogView(BaseDialogView):
-    def __init__(self, parent: QMainWindow, auto_close=False):
+    def __init__(self, parent: QMainWindow, auto_close: bool = False):
         super(AsyncTaskDialogView, self).__init__(parent, 'gui/ui/async_task_dialog.ui')
 
         self.parent_view = parent
@@ -25,7 +25,7 @@ class AsyncTaskDialogView(BaseDialogView):
         self.show_timer = QTimer(self)
         self.hide()
 
-    def handle_completion(self, successful):
+    def handle_completion(self, successful: bool):
         """
         Updates the UI after the task has been completed.
 
@@ -42,7 +42,7 @@ class AsyncTaskDialogView(BaseDialogView):
         if self.auto_close:
             self.hide()
 
-    def set_progress(self, progress, message):
+    def set_progress(self, progress: float, message: str):
         # Set status message
         if message:
             self.infoText.setText(message)
@@ -59,7 +59,7 @@ class AsyncTaskDialogView(BaseDialogView):
             self.show()
 
 
-def start_async_task_view(parent: QMainWindow, task: Callable, on_complete: Callable, kwargs=None):
+def start_async_task_view(parent: QMainWindow, task: Callable, on_complete: Callable, kwargs: Optional[Dict] = None):
     atd = AsyncTaskDialogView(parent, auto_close=True)
     if not kwargs:
         kwargs = {'progress': Progress()}

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -8,6 +8,7 @@ from mantidimaging.gui.mvp_base import BaseDialogView
 from .presenter import AsyncTaskDialogPresenter
 
 from PyQt5.QtWidgets import QMainWindow
+from PyQt5.QtCore import QTimer
 
 
 class AsyncTaskDialogView(BaseDialogView):
@@ -22,6 +23,8 @@ class AsyncTaskDialogView(BaseDialogView):
         self.progressBar.setMaximum(1000)
 
         self.progress_text = self.infoText.text()
+        self.show_timer = QTimer(self)
+        self.hide()
 
     def reject(self):
         # Do not close the dialog when processing is still ongoing
@@ -34,6 +37,7 @@ class AsyncTaskDialogView(BaseDialogView):
 
         :param successful: If the task was successful
         """
+        self.show_timer.stop()
         if successful:
             # Set info text to "Complete"
             self.infoText.setText("Complete")
@@ -51,6 +55,14 @@ class AsyncTaskDialogView(BaseDialogView):
 
         # Update progress bar
         self.progressBar.setValue(progress * 1000)
+
+    def show_delayed(self, timeout):
+        self.show_timer.singleShot(timeout, self.show_from_timer)
+        self.show_timer.start()
+
+    def show_from_timer(self):
+        if self.presenter.task_is_running:
+            self.show()
 
 
 def start_async_task_view(parent: QMainWindow, task: Callable, on_complete: Callable, kwargs=None):

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -93,12 +93,13 @@ class ReconImagesView(GraphicsLayoutWidget):
         self.sinogram_hist.imageChanged(autoLevel=True, autoRange=True)
         set_histogram_log_scale(self.sinogram_hist)
 
-    def update_recon(self, image_data, refresh_recon_slice_histogram):
+    def update_recon(self, image_data):
         self.recon.clear()
-        self.recon.setImage(image_data, autoLevels=refresh_recon_slice_histogram)
-        if refresh_recon_slice_histogram:
-            self.recon_hist.imageChanged(autoLevel=True, autoRange=True)
+        self.recon.setImage(image_data, autoLevels=False)
         set_histogram_log_scale(self.recon_hist)
+
+    def update_recon_hist(self):
+        self.recon_hist.imageChanged(autoLevel=True, autoRange=True)
 
     def mouse_over(self, ev, img):
         # Ignore events triggered by leaving window or right clicking
@@ -114,10 +115,7 @@ class ReconImagesView(GraphicsLayoutWidget):
         self.slice_changed(CloseEnoughPoint(ev.pos()).y)
 
     def slice_changed(self, slice_index):
-        # don't refresh the histogram on click to stop the contrast for re-adjusting for each slice
-        # it's much easier to see what's happening to the reconstruction if the slice doesn't
-        # reset after every click
-        self.parent.presenter.do_preview_reconstruct_slice(slice_idx=slice_index, refresh_recon_slice_histogram=False)
+        self.parent.presenter.do_preview_reconstruct_slice(slice_idx=slice_index)
         self.sigSliceIndexChanged.emit(slice_index)
 
     def clear_recon(self):

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -4,7 +4,7 @@
 import traceback
 from enum import Enum, auto
 from logging import getLogger
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Callable
 
 from PyQt5.QtWidgets import QWidget
 
@@ -179,11 +179,16 @@ class ReconstructWindowPresenter(BasePresenter):
         start_async_task_view(self.view, self.model.run_full_recon, self._on_volume_recon_done,
                               {'recon_params': self.view.recon_params()})
 
-    def _get_reconstruct_slice(self, cor, slice_idx: Optional[int]) -> Optional[Images]:
+    def _get_reconstruct_slice(self, cor, slice_idx: Optional[int], call_back: Callable[[TaskWorkerThread],
+                                                                                        None]) -> None:
         # If no COR is provided and there are regression results then calculate
         # the COR for the selected preview slice
         cor = self.model.get_me_a_cor(cor)
-        return self.model.run_preview_recon(slice_idx, cor, self.view.recon_params())
+        start_async_task_view(self.view, self.model.run_preview_recon, call_back, {
+            'slice_idx': slice_idx,
+            'cor': cor,
+            'recon_params': self.view.recon_params()
+        })
 
     def _get_slice_index(self, slice_idx: Optional[int]):
         if slice_idx is None:
@@ -198,24 +203,28 @@ class ReconstructWindowPresenter(BasePresenter):
 
         slice_idx = self._get_slice_index(slice_idx)
         self.view.update_sinogram(self.model.images.sino(slice_idx))
-        images = None
-        try:
-            images = self._get_reconstruct_slice(cor, slice_idx)
-        except Exception as err:
-            self.view.show_error_dialog(f"Encountered error while trying to reconstruct: {str(err)}. "
-                                        f"Check your COR table values for invalid values!")
+        self._get_reconstruct_slice(cor, slice_idx, self._on_preview_reconstruct_slice_done)
 
+    def _on_preview_reconstruct_slice_done(self, task: TaskWorkerThread):
+        if task.error is not None:
+            self.view.show_error_dialog(f"Encountered error while trying to reconstruct: {str(task.error)}")
+            return
+
+        images: Images = task.result
         if images is not None:
             self.view.update_recon_preview(images.data[0])
 
     def do_stack_reconstruct_slice(self, cor=None, slice_idx: Optional[int] = None):
         slice_idx = self._get_slice_index(slice_idx)
-        images = None
-        try:
-            images = self._get_reconstruct_slice(cor, slice_idx)
-        except ValueError as err:
-            self.view.show_error_dialog(f"Encountered error while trying to reconstruct: {str(err)}")
+        self._get_reconstruct_slice(cor, slice_idx, self._on_stack_reconstruct_slice_done)
 
+    def _on_stack_reconstruct_slice_done(self, task: TaskWorkerThread):
+        if task.error is not None:
+            self.view.show_error_dialog(f"Encountered error while trying to reconstruct: {str(task.error)}")
+            return
+
+        images: Images = task.result
+        slice_idx = self._get_slice_index(None)
         if images is not None:
             self.view.show_recon_volume(images)
             images.record_operation('AstraRecon.single_sino',

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -123,7 +123,8 @@ class ReconstructWindowPresenter(BasePresenter):
         self.view.rotation_centre = self.model.last_cor.value
         self.view.pixel_size = self.get_pixel_size_from_images()
         self.do_update_projection()
-        self.do_preview_reconstruct_slice(refresh_recon_slice_histogram=True)
+        self.view.update_recon_hist_needed = True
+        self.do_preview_reconstruct_slice()
 
     def set_preview_projection_idx(self, idx):
         self.model.preview_projection_idx = idx
@@ -191,10 +192,7 @@ class ReconstructWindowPresenter(BasePresenter):
             self.model.preview_slice_idx = slice_idx
         return slice_idx
 
-    def do_preview_reconstruct_slice(self,
-                                     cor=None,
-                                     slice_idx: Optional[int] = None,
-                                     refresh_recon_slice_histogram: bool = False):
+    def do_preview_reconstruct_slice(self, cor=None, slice_idx: Optional[int] = None):
         if self.model.images is None:
             return
 
@@ -208,7 +206,7 @@ class ReconstructWindowPresenter(BasePresenter):
                                         f"Check your COR table values for invalid values!")
 
         if images is not None:
-            self.view.update_recon_preview(images.data[0], refresh_recon_slice_histogram)
+            self.view.update_recon_preview(images.data[0])
 
     def do_stack_reconstruct_slice(self, cor=None, slice_idx: Optional[int] = None):
         slice_idx = self._get_slice_index(slice_idx)

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -42,6 +42,7 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.view.filterNameLabel = mock.Mock()
         self.view.numIter = mock.Mock()
         self.view.numIterLabel = mock.Mock()
+        self.view.image_view = mock.Mock()
 
     @mock.patch('mantidimaging.gui.windows.recon.model.get_reconstructor_for')
     def test_set_stack_uuid(self, mock_get_reconstructor_for):

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -139,15 +139,20 @@ class ReconstructWindowViewTest(unittest.TestCase):
         self.view.update_sinogram(image_data)
         self.image_view.update_sinogram.assert_called_once_with(image_data)
 
-    def test_update_recon_preview(self):
+    def test_update_recon_preview_no_hist(self):
         image_data = mock.Mock()
+        self.view.update_recon_hist_needed = False
 
-        for refresh_recon_slice_histogram in [True, False]:
-            with self.subTest(refresh_recon_slice_histogram=refresh_recon_slice_histogram):
-                self.view.update_recon_preview(image_data, refresh_recon_slice_histogram)
-                self.image_view.update_recon.assert_called_once_with(image_data, refresh_recon_slice_histogram)
-            if refresh_recon_slice_histogram:
-                self.image_view.update_recon.reset_mock()
+        self.view.update_recon_preview(image_data)
+        self.image_view.update_recon.assert_called_once_with(image_data)
+
+    def test_update_recon_preview_and_hist(self):
+        image_data = mock.Mock()
+        self.view.update_recon_hist_needed = True
+
+        self.view.update_recon_preview(image_data)
+        self.image_view.update_recon.assert_called_once_with(image_data)
+        self.image_view.update_recon_hist.assert_called_once_with()
 
     def test_reset_image_recon_preview(self):
         self.view.reset_image_recon_preview()

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -77,6 +77,7 @@ class ReconstructWindowView(BaseMainWindowView):
             self.algorithmName.setCurrentIndex(0)
             self.algorithmName.setEnabled(True)
 
+        self.update_recon_hist_needed = False
         self.stackSelector.stack_selected_uuid.connect(self.presenter.set_stack_uuid)
 
         # Handle preview image selection
@@ -249,12 +250,15 @@ class ReconstructWindowView(BaseMainWindowView):
     def update_sinogram(self, image_data):
         self.image_view.update_sinogram(image_data)
 
-    def update_recon_preview(self, image_data: numpy.ndarray, refresh_recon_slice_histogram: bool):
+    def update_recon_preview(self, image_data: numpy.ndarray):
         """
         Updates the reconstruction preview image with new data.
         """
         # Plot image
-        self.image_view.update_recon(image_data, refresh_recon_slice_histogram)
+        self.image_view.update_recon(image_data)
+        if self.update_recon_hist_needed:
+            self.image_view.update_recon_hist()
+            self.update_recon_hist_needed = False
 
     def reset_image_recon_preview(self):
         """


### PR DESCRIPTION
### Issue
Closes #991 

### Description

Prevent slow recon previews locking the GUI. Run the task in thread with AsyncTaskDialogView.

Make AsyncTaskDialogView not show for the first second, to avoid the pop when a task is quick.

### Testing 

Cam test with SIRT and setting the number of iterations high enough for preview to be slow.

### Acceptance Criteria 

Progress bar should show when a preview takes more than a second.

### Documentation

release notes
