### PR TITLE
Applitools: use stricter MatchLevel.CONTENT

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -39,6 +39,7 @@ Developer Changes
 - #978 : Update Qt API usage
 - #998 : setup.py command to install current developer requirements
 - #969 : Improve mypy coverage in core.io
+- #1007 : Change applitools check level to content
 
 Dependency updates
 ------------------

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -59,7 +59,7 @@ class BaseEyesTest(unittest.TestCase):
         cls.eyes_manager.set_batch(APPLITOOLS_BATCH_ID)
 
     def setUp(self):
-        self.eyes_manager.set_match_level(MatchLevel.LAYOUT)
+        self.eyes_manager.set_match_level(MatchLevel.CONTENT)
 
         self.imaging = None
         self.eyes_manager.image_directory = APPLITOOLS_IMAGE_DIR

--- a/mantidimaging/eyes_tests/eyes_manager.py
+++ b/mantidimaging/eyes_tests/eyes_manager.py
@@ -23,7 +23,7 @@ class EyesManager:
     def __init__(self, application_name="Mantid Imaging", test_name=None):
         self.application_name = application_name
         self.eyes = Eyes()
-        self.eyes.match_level = MatchLevel.LAYOUT
+        self.eyes.match_level = MatchLevel.CONTENT
         self.image_directory = None
         self.imaging = None
         if test_name is None:

--- a/mantidimaging/eyes_tests/test_welcome_window.py
+++ b/mantidimaging/eyes_tests/test_welcome_window.py
@@ -2,18 +2,12 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from unittest import mock
 
-from applitools.common import MatchLevel
-
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
 
 
 class WelcomeWindowTest(BaseEyesTest):
     def setUp(self):
         super(WelcomeWindowTest, self).setUp()
-
-        # We use content to ensure that the message delivery doesn't change this has a higher likelihood of causing
-        # spurious failures hence it only being used when necessary.
-        self.eyes_manager.set_match_level(MatchLevel.CONTENT)
 
     @mock.patch("mantidimaging.gui.windows.welcome_screen.presenter.versions")
     @mock.patch("mantidimaging.gui.windows.welcome_screen.presenter.cuda_check")


### PR DESCRIPTION
### Issue

Closes #1007 

### Description

Applitools: use stricter MatchLevel.CONTENT

This should help pick up smaller changes that were being missed.

https://applitools.com/docs/common/cmn-eyes-match-levels.html

### Testing & Acceptance Criteria 

Should pass tests

### Documentation

release_notes
