### PR TITLE
Prevent simultaneous Astra calls

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -27,6 +27,7 @@ Fixes
 - #989 : Remove legend checkbox
 - #1001 : Exception when selecting Log in Load Dataset dialog
 - #991 : Handle longer running previews better
+- #1021 : Prevent simultaneous Astra calls
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -123,7 +123,8 @@ class ReconstructWindowViewTest(unittest.TestCase):
         self.view.preview_image_on_button_press(event_mock)
         self.presenter.set_preview_slice_idx.assert_not_called()
 
-    def test_update_projection(self):
+    @mock.patch("mantidimaging.gui.windows.recon.view.QSignalBlocker")
+    def test_update_projection(self, _):
         image_data = mock.Mock()
         preview_slice_idx = 13
         tilt_angle = Degrees(30)
@@ -211,7 +212,8 @@ class ReconstructWindowViewTest(unittest.TestCase):
     def test_pixel_size_property(self):
         assert self.view.pixel_size == self.pixelSize.value.return_value
 
-    def test_pixel_size_setter(self):
+    @mock.patch("mantidimaging.gui.windows.recon.view.QSignalBlocker")
+    def test_pixel_size_setter(self, _):
         value = 123
         self.view.pixel_size = value
         self.pixelSize.setValue.assert_called_once_with(value)

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -6,7 +6,7 @@ from uuid import UUID
 import numpy
 from PyQt5.QtWidgets import (QAbstractItemView, QComboBox, QDoubleSpinBox, QInputDialog, QPushButton, QSpinBox,
                              QVBoxLayout, QWidget, QMessageBox, QAction)
-from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtCore import pyqtSignal, QSignalBlocker
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.net.help_pages import SECTION_USER_GUIDE, open_help_webpage
@@ -243,7 +243,8 @@ class ReconstructWindowView(BaseMainWindowView):
         :param tilt_angle: Angle of the tilt line
         """
 
-        self.previewSliceIndex.setValue(preview_slice_index)
+        with QSignalBlocker(self.previewSliceIndex):
+            self.previewSliceIndex.setValue(preview_slice_index)
 
         self.image_view.update_projection(image_data, preview_slice_index, tilt_angle)
 
@@ -339,7 +340,8 @@ class ReconstructWindowView(BaseMainWindowView):
 
     @pixel_size.setter
     def pixel_size(self, value: int):
-        self.pixelSize.setValue(value)
+        with QSignalBlocker(self.pixelSize):
+            self.pixelSize.setValue(value)
 
     def recon_params(self) -> ReconstructionParameters:
         return ReconstructionParameters(algorithm=self.algorithm_name,


### PR DESCRIPTION
### Issue

Closes #1021 . The crash due to simultaneous calls to astra.

### Description

Add a threading.Lock . Also use QSignalBlocker to prevent some unnecessary redraws.

### Testing  & Acceptance Criteria 

Tests should pass

The specific test is (note needs to be run on a machine with cuda working):

`APPLITOOLS_API_KEY=local APPLITOOLS_IMAGE_DIR=/tmp/gui_test xvfb-run --auto-servernum pytest -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests/ -vs -k test_reconstruction_window_opens_with`

### Documentation

release notes
