### PR TITLE
1011: Pixel size should allow setting decimal places

### DIFF
--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -444,7 +444,11 @@
                </widget>
               </item>
               <item row="4" column="1">
-               <widget class="QDoubleSpinBox" name="pixelSize"/>
+               <widget class="QDoubleSpinBox" name="pixelSize">
+                <property name="maximum">
+                 <double>99999.000000000000000</double>
+                </property>
+               </widget>
               </item>
              </layout>
             </item>

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -444,11 +444,7 @@
                </widget>
               </item>
               <item row="4" column="1">
-               <widget class="QSpinBox" name="pixelSize">
-                <property name="maximum">
-                 <number>99999</number>
-                </property>
-               </widget>
+               <widget class="QDoubleSpinBox" name="pixelSize"/>
               </item>
              </layout>
             </item>


### PR DESCRIPTION
### Issue

Closes #1011 

### Description

The pixel size in the recon window is now set with a double spin box.

### Acceptance Criteria 

Check that setting the pixel size to a value with two decimal places works.

### Documentation

Updated release notes.
