### PR TITLE
Add center mode to ring removal

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -16,6 +16,7 @@ New features
 - #987 : Allow Flat-fielding without dark subtraction
 - #1011 : Pixel size should allow setting decimal places
 - #1013 : NeXus Loading Window
+- #904 : Default to using image center for ring removal COR
 
 Fixes
 -----

--- a/mantidimaging/core/operations/ring_removal/ring_removal.py
+++ b/mantidimaging/core/operations/ring_removal/ring_removal.py
@@ -42,6 +42,7 @@ class RingRemovalFilter(BaseFilter):
 
         :param images: Sample data which is to be processed. Expected in radiograms
         :param run_ring_removal: Uses Wavelet-Fourier based ring removal
+        :param center_mode: Whether to use the center of the image or a user-defined value
         :param center_x: (float, optional) abscissa location of center of rotation
         :param center_y: (float, optional) ordinate location of center of rotation
         :param thresh: (float, optional)

--- a/mantidimaging/core/operations/ring_removal/ring_removal.py
+++ b/mantidimaging/core/operations/ring_removal/ring_removal.py
@@ -3,6 +3,8 @@
 
 from functools import partial
 
+from PyQt5.QtWidgets import QComboBox
+
 from mantidimaging import helper as h
 from mantidimaging.core.data import Images
 from mantidimaging.core.operations.base_filter import BaseFilter
@@ -24,6 +26,7 @@ class RingRemovalFilter(BaseFilter):
     @staticmethod
     def filter_func(images: Images,
                     run_ring_removal=False,
+                    center_mode="manual",
                     center_x=None,
                     center_y=None,
                     thresh=300.0,
@@ -57,6 +60,9 @@ class RingRemovalFilter(BaseFilter):
 
         tp = safe_import('tomopy.misc.corr')
 
+        if center_mode != "manual":
+            center_x = center_y = None
+
         if run_ring_removal:
             h.check_data_stack(images)
 
@@ -83,6 +89,13 @@ class RingRemovalFilter(BaseFilter):
 
         range1 = (0, 1000000)
         range2 = (-1000000, 1000000)
+
+        _, center_mode = add_property_to_form('Center of rotation',
+                                              Type.CHOICE,
+                                              valid_values=["image center", "manual"],
+                                              form=form,
+                                              on_change=on_change,
+                                              tooltip="Use image center or enter manually")
 
         _, x_field = add_property_to_form('Center of rotation X position',
                                           Type.INT,
@@ -133,7 +146,20 @@ class RingRemovalFilter(BaseFilter):
                                          on_change=on_change,
                                          tooltip="Maximum width of the rings to be filtered in pixels")
 
+        def enable_center():
+            if center_mode.currentText() == "manual":
+                x_field.setEnabled(True)
+                y_field.setEnabled(True)
+            else:
+                x_field.setEnabled(False)
+                y_field.setEnabled(False)
+
+        assert (isinstance(center_mode, QComboBox))
+        center_mode.currentIndexChanged.connect(enable_center)
+        enable_center()
+
         return {
+            "center_mode": center_mode,
             "x_field": x_field,
             "y_field": y_field,
             "thresh": thresh,
@@ -144,7 +170,8 @@ class RingRemovalFilter(BaseFilter):
         }
 
     @staticmethod
-    def execute_wrapper(x_field=None,
+    def execute_wrapper(center_mode=None,
+                        x_field=None,
                         y_field=None,
                         thresh=None,
                         thresh_max=None,
@@ -153,6 +180,7 @@ class RingRemovalFilter(BaseFilter):
                         rwidth=None):
         return partial(RingRemovalFilter.filter_func,
                        run_ring_removal=True,
+                       center_mode=center_mode.currentText(),
                        center_x=x_field.value(),
                        center_y=y_field.value(),
                        thresh=thresh.value(),

--- a/mantidimaging/core/operations/ring_removal/test/ring_removal_test.py
+++ b/mantidimaging/core/operations/ring_removal/test/ring_removal_test.py
@@ -35,7 +35,7 @@ class RingRemovalTest(unittest.TestCase):
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
         """
         images = th.generate_images()
-        mocks = [Mock() for _ in range(7)]
+        mocks = [Mock() for _ in range(8)]
         RingRemovalFilter.execute_wrapper(*mocks)(images)
 
 


### PR DESCRIPTION
When set to "image center", then pass None through to tomopy. This
causes it to default to the image center. This is right value unless the
image has been cropped after reconstruction.

### Issue

Closes #904 

### Description

When set to "image center", then pass None through to tomopy. This
causes it to default to the image center. This is right value unless the
image has been cropped after reconstruction.

### Testing & Acceptance Criteria

Check that selecting "image center" disables the coordinate boxes.

For the tilt1_ready2 data, after a reconstruction I get this. Note that that corrections are centered on the image center.

![Screenshot at 2021-06-30 18-35-29](https://user-images.githubusercontent.com/74248560/124006374-1397b100-d9d2-11eb-8278-411f7577b18a.png)

with the same settings, but COR x and y set to 100, the corrections are offset 

### Documentation
release_notes
