### PR TITLE
Merge CIL recon

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -19,14 +19,14 @@ requirements:
     - pip
     - setuptools=49.6.0
     - sphinx=3.3.1
-    - numpy=1.20.*
+    - numpy=1.18.*
   run:
     - python=3.8.*
     - pip
     - astropy=4.2
     - scipy=1.5.3
     - scikit-image=0.18.*
-    - numpy=1.20.*
+    - numpy=1.18.*
     - tomopy=1.9.*=cuda*
     - cudatoolkit=9.2*
     - cupy
@@ -35,6 +35,10 @@ requirements:
     - h5py=3.1.0
     - sarepy=2020.07
     - psutil=5.8.*
+    - cil=21.2.*
+    - cil-astra=21.2.*
+    - ccpi-regulariser=20.9
+    - tomophantom=1.4.*
 
 build:
   number: 1

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -17,6 +17,7 @@ New features
 - #1011 : Pixel size should allow setting decimal places
 - #1013 : NeXus Loading Window
 - #904 : Default to using image center for ring removal COR
+- #1025 : Add the Total Variation (TV) with Primal-Dual Hybrid Gradient (PDHG) from CIL
 
 Fixes
 -----
@@ -46,4 +47,4 @@ Developer Changes
 Dependency updates
 ------------------
 
-- pyqtgraph 0.12, scikit-image 0.18, tomopy 1.9, numpy 1.20
+- pyqtgraph 0.12, scikit-image 0.18, tomopy 1.9, numpy 1.18

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -4,6 +4,7 @@ channels:
   - dtasev
   - astra-toolbox/label/dev
   - conda-forge
+  - ccpi
   - defaults
 dependencies:
   - mantidimaging

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
   - dtasev
   - astra-toolbox/label/dev
   - conda-forge
+  - ccpi
   - defaults
 # Dependencies that can be installed with conda should be in conda/meta.yaml
 dependencies:

--- a/mantidimaging/core/io/loader/img_loader.py
+++ b/mantidimaging/core/io/loader/img_loader.py
@@ -4,10 +4,11 @@
 This module handles the loading of FIT, FITS, TIF, TIFF
 """
 import os
-from typing import Tuple, Optional, List, Callable, Union
+from typing import Tuple, Optional, List, Callable, Union, TYPE_CHECKING
 
 import numpy as np
-import numpy.typing as npt
+if TYPE_CHECKING:
+    import numpy.typing as npt
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.io.utility import get_file_names, get_prefix
@@ -25,7 +26,7 @@ def execute(load_func: Callable[[str], np.ndarray],
             dark_before_path: Optional[str],
             dark_after_path: Optional[str],
             img_format: str,
-            dtype: npt.DTypeLike,
+            dtype: 'npt.DTypeLike',
             indices: Union[List[int], Indices, None],
             progress: Optional[Progress] = None) -> Dataset:
     """
@@ -88,7 +89,7 @@ class ImageLoader(object):
                  load_func: Callable[[str], np.ndarray],
                  img_format: str,
                  img_shape: Tuple[int, ...],
-                 data_dtype: npt.DTypeLike,
+                 data_dtype: 'npt.DTypeLike',
                  indices: Union[List[int], Indices, None],
                  progress: Optional[Progress] = None):
         self.load_func = load_func

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -4,10 +4,11 @@ import os
 from dataclasses import dataclass
 from logging import getLogger, Logger
 from pathlib import Path
-from typing import Tuple, List, Optional, Union
+from typing import Tuple, List, Optional, Union, TYPE_CHECKING
 
 import numpy as np
-import numpy.typing as npt
+if TYPE_CHECKING:
+    import numpy.typing as npt
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.data.dataset import Dataset
@@ -88,7 +89,7 @@ class FileInformation:
 def read_in_file_information(input_path: str,
                              in_prefix: str = '',
                              in_format: str = DEFAULT_IO_FILE_FORMAT,
-                             data_dtype: npt.DTypeLike = np.float32) -> FileInformation:
+                             data_dtype: 'npt.DTypeLike' = np.float32) -> FileInformation:
     input_file_names = get_file_names(input_path, in_format, in_prefix)
     dataset = load(input_path,
                    in_prefix=in_prefix,
@@ -110,7 +111,7 @@ def load_log(log_file: str) -> IMATLogFile:
         return IMATLogFile(f.readlines(), log_file)
 
 
-def load_p(parameters: ImageParameters, dtype: npt.DTypeLike, progress: Progress) -> Images:
+def load_p(parameters: ImageParameters, dtype: 'npt.DTypeLike', progress: Progress) -> Images:
     return load(input_path=parameters.input_path,
                 in_prefix=parameters.prefix,
                 in_format=parameters.format,
@@ -134,7 +135,7 @@ def load(input_path: Optional[str] = None,
          input_path_dark_after: Optional[str] = None,
          in_prefix: str = '',
          in_format: str = DEFAULT_IO_FILE_FORMAT,
-         dtype: npt.DTypeLike = np.float32,
+         dtype: 'npt.DTypeLike' = np.float32,
          file_names: Optional[List[str]] = None,
          indices: Optional[Union[List[int], Indices]] = None,
          progress: Optional[Progress] = None) -> Dataset:

--- a/mantidimaging/core/io/loader/stack_loader.py
+++ b/mantidimaging/core/io/loader/stack_loader.py
@@ -1,9 +1,10 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-from typing import Optional, Callable, Union, List, Tuple
+from typing import Optional, Callable, Union, List, Tuple, TYPE_CHECKING
 
 import numpy as np
-import numpy.typing as npt
+if TYPE_CHECKING:
+    import numpy.typing as npt
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.parallel import utility as pu
@@ -36,7 +37,7 @@ def do_stack_load_seq(data: np.ndarray, new_data: np.ndarray, img_shape: Tuple[i
 
 def execute(load_func: Callable[[str], np.ndarray],
             file_name: str,
-            dtype: npt.DTypeLike,
+            dtype: 'npt.DTypeLike',
             name: str,
             indices: Union[List[int], Indices, None] = None,
             progress: Optional[Progress] = None) -> Images:

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -8,10 +8,11 @@ from functools import partial
 from logging import getLogger
 from multiprocessing import Array
 from multiprocessing.pool import Pool
-from typing import List, Tuple, Type, Union
+from typing import List, Tuple, Type, Union, TYPE_CHECKING
 
 import numpy as np
-import numpy.typing as npt
+if TYPE_CHECKING:
+    import numpy.typing as npt
 
 from mantidimaging.core.utility.memory_usage import system_free_memory
 from mantidimaging.core.utility.progress_reporting import Progress
@@ -27,7 +28,7 @@ def enough_memory(shape, dtype):
     return full_size_KB(shape=shape, axis=0, dtype=dtype) < system_free_memory().kb()
 
 
-def create_array(shape: Tuple[int, ...], dtype: npt.DTypeLike = np.float32) -> np.ndarray:
+def create_array(shape: Tuple[int, ...], dtype: 'npt.DTypeLike' = np.float32) -> np.ndarray:
     """
     Create an array, either in a memory file (if name provided), or purely in memory (if name is None)
 
@@ -44,7 +45,7 @@ def create_array(shape: Tuple[int, ...], dtype: npt.DTypeLike = np.float32) -> n
     return _create_shared_array(shape, dtype)
 
 
-def _create_shared_array(shape, dtype: npt.DTypeLike = np.float32) -> np.ndarray:
+def _create_shared_array(shape, dtype: 'npt.DTypeLike' = np.float32) -> np.ndarray:
     ctype: SimpleCType = ctypes.c_float  # default to numpy float32 / C type float
     if dtype == np.uint8 or dtype == 'uint8':
         ctype = ctypes.c_uint8

--- a/mantidimaging/core/reconstruct/__init__.py
+++ b/mantidimaging/core/reconstruct/__init__.py
@@ -1,14 +1,16 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-from typing import Union
-
 from .astra_recon import AstraRecon
 from .tomopy_recon import TomopyRecon
+from .cil_recon import CILRecon
+from .base_recon import BaseRecon
 
 
-def get_reconstructor_for(algorithm: str) -> Union[AstraRecon, TomopyRecon]:
+def get_reconstructor_for(algorithm: str) -> BaseRecon:
     if algorithm == "gridrec":
         return TomopyRecon()
+    if algorithm.startswith("CIL"):
+        return CILRecon()
     else:
         return AstraRecon()

--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -104,7 +104,7 @@ class AstraRecon(BaseRecon):
                     recon_params: ReconstructionParameters) -> np.ndarray:
         assert sino.ndim == 2, "Sinogram must be a 2D image"
 
-        sino = BaseRecon.sino_recon_prep(sino)
+        sino = BaseRecon.negative_log(sino)
         image_width = sino.shape[1]
         vectors = vec_geom_init2d(proj_angles, 1.0, cor.to_vec(image_width).value)
         vol_geom = astra.create_vol_geom((image_width, image_width))

--- a/mantidimaging/core/reconstruct/base_recon.py
+++ b/mantidimaging/core/reconstruct/base_recon.py
@@ -16,6 +16,10 @@ MIN_PIXEL_VALUE: float = 1e-6
 
 class BaseRecon:
     @staticmethod
+    def find_cor(images: Images, slice_idx: int, start_cor: float, recon_params: ReconstructionParameters) -> float:
+        raise NotImplementedError("Base class call")
+
+    @staticmethod
     def sino_recon_prep(sino: np.ndarray):
         return -np.log(np.maximum(sino, MIN_PIXEL_VALUE))
 
@@ -53,4 +57,4 @@ class BaseRecon:
 
     @staticmethod
     def allowed_filters() -> List[str]:
-        raise NotImplementedError("Base class call")
+        return []

--- a/mantidimaging/core/reconstruct/base_recon.py
+++ b/mantidimaging/core/reconstruct/base_recon.py
@@ -20,8 +20,8 @@ class BaseRecon:
         raise NotImplementedError("Base class call")
 
     @staticmethod
-    def sino_recon_prep(sino: np.ndarray):
-        return -np.log(np.maximum(sino, MIN_PIXEL_VALUE))
+    def negative_log(data: np.ndarray) -> np.ndarray:
+        return -np.log(np.maximum(data, MIN_PIXEL_VALUE))
 
     @staticmethod
     def single_sino(sino: np.ndarray, cor: ScalarCoR, proj_angles: ProjectionAngles,

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -55,7 +55,7 @@ class CILRecon(BaseRecon):
         pixel_size = (1.,1.)
         ag = AcquisitionGeometry.create_Parallel3D()\
               .set_panel([pixel_num_v, pixel_num_h], pixel_size=pixel_size)\
-              .set_angles(angles=angles)
+              .set_angles(angles=angles, angle_unit='radian')
         return ag
     @staticmethod
     def set_up_TV_regularisation(image_geometry, acquisition_data):
@@ -124,6 +124,8 @@ class CILRecon(BaseRecon):
         # alpha = 1.0
         # f1 =  alpha * MixedL21Norm()
         # f2 = 0.5 * L2NormSquared(b=ad2d)
+        alpha = recon_params.alpha
+        num_iter = recon_params.num_iter
         F = BlockFunction( alpha * f1, 0.5 * f2)
         normK =  K.norm()
         sigma = 1
@@ -179,6 +181,8 @@ class CILRecon(BaseRecon):
         # alpha = 1.0
         # f1 =  alpha * MixedL21Norm()
         # f2 = 0.5 * L2NormSquared(b=ad2d)
+        alpha = recon_params.alpha
+        num_iter = recon_params.num_iter
         F = BlockFunction( alpha * f1, 0.5 * f2)
         normK =  K.norm()
         sigma = 1

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -121,10 +121,11 @@ class CILRecon(BaseRecon):
         progress = Progress.ensure_instance(progress, task_name='CIL reconstruction')
 
         ag = CILRecon.get_IMAT_AcquisitionGeometry(images.projection_angles(recon_params.max_projection_angle).value)
-        ag.set_labels(DataOrder.ASTRA_AG_LABELS)
+        ag.set_labels(DataOrder.TIGRE_AG_LABELS)
         # stick it into an AcquisitionData
         data = ag.allocate(None)
         data.fill(images.data)
+        data.reorder('astra')
 
         ig = ag.get_ImageGeometry()
         # set up TV regularisation

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -1,0 +1,96 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+from logging import getLogger
+from typing import List
+
+import numpy as np
+
+# import cil
+
+from mantidimaging.core.data import Images
+from mantidimaging.core.reconstruct.base_recon import BaseRecon
+from mantidimaging.core.utility.data_containers import ProjectionAngles, ReconstructionParameters, ScalarCoR
+from mantidimaging.core.utility.optional_imports import safe_import
+from mantidimaging.core.utility.progress_reporting import Progress
+
+LOG = getLogger(__name__)
+tomopy = safe_import('tomopy')
+
+
+def empty_array(shape):
+    return (np.indices(shape).sum(axis=0) % 2).astype(np.float32)
+
+
+class CILRecon(BaseRecon):
+    @staticmethod
+    def find_cor(images: Images, slice_idx: int, start_cor: float, recon_params: ReconstructionParameters) -> float:
+        return tomopy.find_center(images.sinograms,
+                                  images.projection_angles(recon_params.max_projection_angle).value,
+                                  ind=slice_idx,
+                                  init=start_cor,
+                                  sinogram_order=True)
+
+    @staticmethod
+    def single_sino(sino: np.ndarray, cor: ScalarCoR, proj_angles: ProjectionAngles,
+                    recon_params: ReconstructionParameters):
+        """
+        Reconstruct a single slice from a single sinogram. Used for the preview and the single slice button.
+        Should return a numpy array,
+        """
+        sino = BaseRecon.sino_recon_prep(sino)
+        # volume = tomopy.recon(tomo=[sino],
+        #                      sinogram_order=True,
+        #                      theta=proj_angles.value,
+        #                      center=cor.value,
+        #                      algorithm=recon_params.algorithm,
+        #                      filter_name=recon_params.filter_name)
+
+        print("cor", cor)
+        print("sino.shape", sino.shape)
+        print("proj_angles", proj_angles.value[:10], "...")
+        print("recon_params", recon_params)
+        width = sino.shape[1]
+        slice = empty_array([width, width])
+        return slice
+
+    @staticmethod
+    def full(images: Images, cors: List[ScalarCoR], recon_params: ReconstructionParameters, progress=None):
+        """
+        Performs a volume reconstruction using sample data provided as sinograms.
+
+        :param images: Array of sinogram images
+        :param cors: Array of centre of rotation values
+        :param proj_angles: Array of projection angles in radians
+        :param recon_params: Reconstruction Parameters
+        :param progress: Optional progress reporter
+        :return: 3D image data for reconstructed volume
+        """
+        progress = Progress.ensure_instance(progress, task_name='CIL reconstruction')
+
+        import multiprocessing
+        ncores = multiprocessing.cpu_count()
+
+        kwargs = {
+            'ncore': ncores,
+            'tomo': images.data,
+            'sinogram_order': images._is_sinograms,
+            'theta': images.projection_angles(recon_params.max_projection_angle).value,
+            'center': [cor.value for cor in cors],
+            'alpha': recon_params.alpha,
+            'num_iter': recon_params.num_iter,
+        }
+        print("kwargs", kwargs)
+
+        with progress:
+            # volume = tomopy.recon(**kwargs)
+            width = images.width
+            slices = images.height
+            volume = empty_array([slices, width, width])
+            LOG.info('Reconstructed 3D volume with shape: {0}'.format(volume.shape))
+
+        return Images(volume)
+
+
+def allowed_recon_kwargs() -> dict:
+    return {'CIL': ['alpha', 'num_iter']}

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -86,7 +86,7 @@ class CILRecon(BaseRecon):
         Reconstruct a single slice from a single sinogram. Used for the preview and the single slice button.
         Should return a numpy array,
         """
-        sino = BaseRecon.sino_recon_prep(sino)
+        sino = BaseRecon.negative_log(sino)
 
         ag = CILRecon.get_IMAT_AcquisitionGeometry(proj_angles.value, sino.shape)
         ag.set_labels(DataOrder.ASTRA_AG_LABELS)

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -134,7 +134,7 @@ class CILRecon(BaseRecon):
 
         # stick it into an AcquisitionData
         data = ag.allocate(None)
-        data.fill(images.data)
+        data.fill(BaseRecon.negative_log(images.data))
         data.reorder('astra')
 
         ig = ag.get_ImageGeometry()

--- a/mantidimaging/core/reconstruct/tomopy_recon.py
+++ b/mantidimaging/core/reconstruct/tomopy_recon.py
@@ -28,7 +28,7 @@ class TomopyRecon(BaseRecon):
     @staticmethod
     def single_sino(sino: np.ndarray, cor: ScalarCoR, proj_angles: ProjectionAngles,
                     recon_params: ReconstructionParameters):
-        sino = BaseRecon.sino_recon_prep(sino)
+        sino = BaseRecon.negative_log(sino)
         volume = tomopy.recon(tomo=[sino],
                               sinogram_order=True,
                               theta=proj_angles.value,

--- a/mantidimaging/core/reconstruct/tomopy_recon.py
+++ b/mantidimaging/core/reconstruct/tomopy_recon.py
@@ -57,7 +57,7 @@ class TomopyRecon(BaseRecon):
 
         kwargs = {
             'ncore': ncores,
-            'tomo': images.data,
+            'tomo': BaseRecon.negative_log(images.data),
             'sinogram_order': images._is_sinograms,
             'theta': images.projection_angles(recon_params.max_projection_angle).value,
             'center': [cor.value for cor in cors],

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -100,6 +100,7 @@ class ReconstructionParameters:
     cor: Optional[ScalarCoR] = None
     tilt: Optional[Degrees] = None
     pixel_size: float = 0.0
+    alpha: float = 0.0
     max_projection_angle: float = 360.0
 
     def to_dict(self) -> dict:
@@ -109,7 +110,8 @@ class ReconstructionParameters:
             'num_iter': self.num_iter,
             'cor': str(self.cor),
             'tilt': str(self.tilt),
-            'pixel_size': self.pixel_size
+            'pixel_size': self.pixel_size,
+            'alpha': self.alpha
         }
 
 

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -337,63 +337,17 @@
            <layout class="QVBoxLayout" name="verticalLayout_6">
             <item>
              <layout class="QGridLayout" name="optionsLayout">
-              <item row="3" column="0">
-               <widget class="QLabel" name="numIterLabel">
+              <item row="5" column="0">
+               <widget class="QLabel" name="pixelSizeLabel">
                 <property name="text">
-                 <string>Number of iterations:</string>
+                 <string>Pixel size (microns)</string>
                 </property>
                </widget>
               </item>
-              <item row="1" column="1">
-               <widget class="QComboBox" name="algorithmName">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <item>
-                 <property name="text">
-                  <string>gridrec</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QSpinBox" name="numIter">
-                <property name="minimum">
-                 <number>1</number>
-                </property>
+              <item row="5" column="1">
+               <widget class="QDoubleSpinBox" name="pixelSize">
                 <property name="maximum">
-                 <number>99999</number>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="algorithmNameLabel">
-                <property name="text">
-                 <string>Algorithm:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="filterNameLabel">
-                <property name="text">
-                 <string>Reconstruction filter:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="maxProjAngleLabel">
-                <property name="text">
-                 <string>Maximum projection angle</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QDoubleSpinBox" name="maxProjAngle">
-                <property name="maximum">
-                 <double>9999.000000000000000</double>
-                </property>
-                <property name="value">
-                 <double>360.000000000000000</double>
+                 <double>99999.000000000000000</double>
                 </property>
                </widget>
               </item>
@@ -436,17 +390,80 @@
                 </item>
                </widget>
               </item>
-              <item row="4" column="0">
-               <widget class="QLabel" name="pixelSizeLabel">
+              <item row="1" column="1">
+               <widget class="QComboBox" name="algorithmName">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <item>
+                 <property name="text">
+                  <string>gridrec</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QDoubleSpinBox" name="maxProjAngle">
+                <property name="maximum">
+                 <double>9999.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>360.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QSpinBox" name="numIter">
+                <property name="minimum">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <number>99999</number>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="filterNameLabel">
                 <property name="text">
-                 <string>Pixel size (microns)</string>
+                 <string>Reconstruction filter:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="algorithmNameLabel">
+                <property name="text">
+                 <string>Algorithm:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="maxProjAngleLabel">
+                <property name="text">
+                 <string>Maximum projection angle</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="numIterLabel">
+                <property name="text">
+                 <string>Number of iterations:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="alphaLabel">
+                <property name="text">
+                 <string>Alpha</string>
                 </property>
                </widget>
               </item>
               <item row="4" column="1">
-               <widget class="QDoubleSpinBox" name="pixelSize">
-                <property name="maximum">
-                 <double>99999.000000000000000</double>
+               <widget class="QDoubleSpinBox" name="alphaSpinbox">
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+                <property name="value">
+                 <double>1.000000000000000</double>
                 </property>
                </widget>
               </item>

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -12,6 +12,7 @@ from mantidimaging.core.operations.divide import DivideFilter
 from mantidimaging.core.reconstruct import get_reconstructor_for
 from mantidimaging.core.reconstruct.astra_recon import allowed_recon_kwargs as astra_allowed_kwargs
 from mantidimaging.core.reconstruct.tomopy_recon import allowed_recon_kwargs as tomopy_allowed_kwargs
+from mantidimaging.core.reconstruct.cil_recon import allowed_recon_kwargs as cil_allowed_kwargs
 from mantidimaging.core.rotation.polyfit_correlation import find_center
 from mantidimaging.core.utility.cuda_check import CudaChecker
 from mantidimaging.core.utility.data_containers import (Degrees, ReconstructionParameters, ScalarCoR, Slope)
@@ -181,6 +182,7 @@ class ReconstructWindowModel(object):
         d = tomopy_allowed_kwargs()
         if CudaChecker().cuda_is_present():
             d.update(astra_allowed_kwargs())
+            d.update(cil_allowed_kwargs())
         return d
 
     @staticmethod

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -57,6 +57,7 @@ class ReconstructWindowPresenter(BasePresenter):
         self.restricted_arg_widgets: Dict[str, List[QWidget]] = {
             'filter_name': [self.view.filterName, self.view.filterNameLabel],
             'num_iter': [self.view.numIter, self.view.numIterLabel],
+            'alpha': [self.view.alphaSpinbox, self.view.alphaLabel],
         }
         self.main_window = main_window
 

--- a/mantidimaging/gui/windows/recon/test/model_test.py
+++ b/mantidimaging/gui/windows/recon/test/model_test.py
@@ -10,6 +10,7 @@ from mantidimaging.core.data import Images
 from mantidimaging.core.operation_history import const
 from mantidimaging.core.reconstruct.astra_recon import allowed_recon_kwargs as astra_allowed_kwargs
 from mantidimaging.core.reconstruct.tomopy_recon import allowed_recon_kwargs as tomopy_allowed_kwargs
+from mantidimaging.core.reconstruct.cil_recon import allowed_recon_kwargs as cil_allowed_kwargs
 from mantidimaging.core.rotation.data_model import Point
 from mantidimaging.core.utility.data_containers import Degrees, ScalarCoR, ReconstructionParameters
 from mantidimaging.gui.windows.recon import (ReconstructWindowModel, CorTiltPointQtModel)
@@ -184,5 +185,6 @@ class ReconWindowModelTest(unittest.TestCase):
     def test_load_allowed_recon_args_with_cuda(self):
         allowed_args = tomopy_allowed_kwargs()
         allowed_args.update(astra_allowed_kwargs())
+        allowed_args.update(cil_allowed_kwargs())
         with mock.patch("mantidimaging.gui.windows.recon.model.CudaChecker.cuda_is_present", return_value=True):
             assert self.model.load_allowed_recon_kwargs() == allowed_args

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -43,6 +43,8 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.view.numIter = mock.Mock()
         self.view.numIterLabel = mock.Mock()
         self.view.image_view = mock.Mock()
+        self.view.alphaSpinbox = mock.Mock()
+        self.view.alphaLabel = mock.Mock()
 
     @mock.patch('mantidimaging.gui.windows.recon.presenter.start_async_task_view')
     def test_set_stack_uuid(self, mock_start_async: mock.Mock):

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -29,6 +29,7 @@ class ReconstructWindowViewTest(unittest.TestCase):
         self.view.resultSlope = self.resultSlope = mock.Mock()
         self.view.numIter = self.numIter = mock.Mock()
         self.view.pixelSize = self.pixelSize = mock.Mock()
+        self.view.alphaSpinbox = self.alpha = mock.Mock()
         self.view.algorithmName = self.algorithmName = mock.Mock()
         self.view.filterName = self.filterName = mock.Mock()
         self.view.maxProjAngle = self.maxProjAngle = mock.Mock()
@@ -227,6 +228,7 @@ class ReconstructWindowViewTest(unittest.TestCase):
                                                   cor=ScalarCoR(self.resultCor.value.return_value),
                                                   tilt=Degrees(self.resultTilt.value.return_value),
                                                   pixel_size=self.pixelSize.value.return_value,
+                                                  alpha=self.alpha.value.return_value,
                                                   max_projection_angle=self.maxProjAngle.value.return_value)
 
     def test_set_table_point(self):

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -53,6 +53,7 @@ class ReconstructWindowView(BaseMainWindowView):
     numIter: QSpinBox
     maxProjAngle: QDoubleSpinBox
     pixelSize: QDoubleSpinBox
+    alphaSpinbox: QDoubleSpinBox
     resultCor: QDoubleSpinBox
     resultTilt: QDoubleSpinBox
     resultSlope: QDoubleSpinBox
@@ -74,6 +75,7 @@ class ReconstructWindowView(BaseMainWindowView):
         if CudaChecker().cuda_is_present():
             self.algorithmName.insertItem(0, "FBP_CUDA")
             self.algorithmName.insertItem(1, "SIRT_CUDA")
+            self.algorithmName.insertItem(2, "CIL")
             self.algorithmName.setCurrentIndex(0)
             self.algorithmName.setEnabled(True)
 
@@ -164,6 +166,7 @@ class ReconstructWindowView(BaseMainWindowView):
             lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))  # type: ignore
 
         self.pixelSize.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
+        self.alphaSpinbox.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
         self.reconHelpButton.clicked.connect(lambda: self.open_help_webpage("reconstructions/index"))
         self.corHelpButton.clicked.connect(lambda: self.open_help_webpage("reconstructions/center_of_rotation"))
 
@@ -343,6 +346,14 @@ class ReconstructWindowView(BaseMainWindowView):
         with QSignalBlocker(self.pixelSize):
             self.pixelSize.setValue(value)
 
+    @property
+    def alpha(self):
+        return self.alphaSpinbox.value()
+
+    @alpha.setter
+    def alpha(self, value: float):
+        self.alphaSpinbox.setValue(value)
+
     def recon_params(self) -> ReconstructionParameters:
         return ReconstructionParameters(algorithm=self.algorithm_name,
                                         filter_name=self.filter_name,
@@ -350,6 +361,7 @@ class ReconstructWindowView(BaseMainWindowView):
                                         cor=ScalarCoR(self.rotation_centre),
                                         tilt=Degrees(self.tilt),
                                         pixel_size=self.pixel_size,
+                                        alpha=self.alpha,
                                         max_projection_angle=self.max_proj_angle)
 
     def set_table_point(self, idx, slice_idx, cor):


### PR DESCRIPTION
### Issue

Closes #1025 

### Description

Merge initial version of CIL algorithm. This is not complete, but sufficient to do a simple reconstruction.

This also rolls numpy back to 1.18, the newest supported by current CIL.

### Testing 

After checking out the branch, you will need a new dev environment with CIL libraries and an older numpy

`python3 setup.py create_dev_env`

### Acceptance Criteria 

Docker tests are expected to fail, as they will not have the correct libraries. Conda tests should pass.

It should be possible to perform a reconstruction with the CIL algorithm, with the IMAT00010675 , no preprocessing and number of iterations set to 2. With just 2 iterations the output is very soft but you can see the rough shape. (takes about 5 mins to run, peaks at ~30GB RAM)

### Documentation

Release notes
