### PR TITLE
Recon: Set recon_is_running earlier

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -31,6 +31,7 @@ Fixes
 - #1001 : Exception when selecting Log in Load Dataset dialog
 - #991 : Handle longer running previews better
 - #1021 : Prevent simultaneous Astra calls
+- #1036 : Exception in ReconstructWindowView.show_recon_volume prevents recon closing
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -268,8 +268,8 @@ class ReconstructWindowPresenter(BasePresenter):
         self.do_preview_reconstruct_slice()
 
     def _on_volume_recon_done(self, task):
-        self.view.show_recon_volume(task.result)
         self.recon_is_running = False
+        self.view.show_recon_volume(task.result)
         self.view.recon_applied.emit()
 
     def do_clear_all_cors(self):


### PR DESCRIPTION
### Issue

close #1036 

### Description

Set
self.recon_is_running = False
As soon as done, to avoid it being stuck true if show_recon_volume()
fails.

### Testing & Acceptance Criteria 

Instructions on #1036

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*
