### PR TITLE
Revert screenshot paddding work around

### DIFF
--- a/mantidimaging/eyes_tests/eyes_manager.py
+++ b/mantidimaging/eyes_tests/eyes_manager.py
@@ -8,7 +8,6 @@ import time
 from uuid import uuid4
 
 from PyQt5.QtWidgets import QWidget, QApplication
-from PyQt5.QtGui import QImage, QPainter, QColor
 from applitools.common import BatchInfo, MatchLevel
 from applitools.images import Eyes
 
@@ -90,18 +89,12 @@ class EyesManager:
         QApplication.processEvents()
         window_image = widget.grab()
 
-        image = QImage(VIEWPORT_WIDTH, VIEWPORT_HEIGHT, QImage.Format.Format_RGB32)
-        image.fill(QColor(255, 255, 255))
-        painter = QPainter(image)
-        painter.drawPixmap(0, 0, window_image)
-        painter.end()
-
         if image_name is None:
             image_name = str(uuid4())
 
         file_path = os.path.join(directory, image_name) + ".png"
 
-        if image.save(file_path, "PNG"):
+        if window_image.save(file_path, "PNG"):
             return file_path
         else:
             raise IOError("Failed to save", file_path)

--- a/mantidimaging/eyes_tests/test_compare_images_window.py
+++ b/mantidimaging/eyes_tests/test_compare_images_window.py
@@ -14,7 +14,7 @@ class CompareImagesWindowTest(BaseEyesTest):
     def test_compare_images_window_opens(self, multi_stack_select):
         multi_stack_select.return_value.exec.return_value = QDialog.DialogCode.Accepted
         self.imaging.presenter.get_stack_visualiser = mock.MagicMock()
-        self.imaging.presenter.get_stack_visualiser.return_value.presenter.images = generate_images()
+        self.imaging.presenter.get_stack_visualiser.return_value.presenter.images = generate_images(seed=2021)
         self.imaging.find_images_stack_title = mock.MagicMock(return_value="Stack 1")
 
         stack_compare = self.imaging.show_stack_select_dialog()

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -31,7 +31,7 @@ def generate_shared_array_and_copy(shape=g_shape) -> Tuple[np.ndarray, np.ndarra
 
 def generate_shared_array(shape=g_shape, dtype=np.float32) -> np.ndarray:
     generated_array = pu.create_array(shape, dtype)
-    np.copyto(generated_array, np.random.rand(shape[0], shape[1], shape[2]).astype(dtype))
+    np.copyto(generated_array, gen_img_numpy_rand(shape).astype(dtype))
     return generated_array
 
 
@@ -50,7 +50,7 @@ def generate_images_for_parallel(shape=(15, 8, 10), dtype=np.float32) -> Images:
 
 
 def _set_random_data(data, shape):
-    n = np.random.rand(*shape)
+    n = gen_img_numpy_rand(shape)
     # move the data in the shared array
     data[:] = n[:]
 

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -4,10 +4,11 @@
 import os
 import sys
 from functools import partial
-from typing import Tuple
+from typing import Tuple, Optional
 
 from unittest import mock
 import numpy as np
+import numpy.random
 import numpy.testing as npt
 from io import StringIO
 
@@ -19,8 +20,13 @@ backup_mp_avail = None
 g_shape = (10, 8, 10)
 
 
-def gen_img_numpy_rand(shape=g_shape) -> np.ndarray:
-    return np.random.rand(*shape)
+def gen_img_numpy_rand(shape=g_shape, seed: Optional[int] = None) -> np.ndarray:
+    if seed is not None:
+        bg = np.random.PCG64(seed)
+    else:
+        bg = np.random.PCG64()
+    rng = numpy.random.Generator(bg)
+    return rng.random(shape)
 
 
 def generate_shared_array_and_copy(shape=g_shape) -> Tuple[np.ndarray, np.ndarray]:
@@ -29,28 +35,28 @@ def generate_shared_array_and_copy(shape=g_shape) -> Tuple[np.ndarray, np.ndarra
     return arr, copy
 
 
-def generate_shared_array(shape=g_shape, dtype=np.float32) -> np.ndarray:
+def generate_shared_array(shape=g_shape, dtype=np.float32, seed: Optional[int] = None) -> np.ndarray:
     generated_array = pu.create_array(shape, dtype)
-    np.copyto(generated_array, gen_img_numpy_rand(shape).astype(dtype))
+    np.copyto(generated_array, gen_img_numpy_rand(shape, seed=seed).astype(dtype))
     return generated_array
 
 
-def generate_images(shape=g_shape, dtype=np.float32) -> Images:
+def generate_images(shape=g_shape, dtype=np.float32, seed: Optional[int] = None) -> Images:
     d = pu.create_array(shape, dtype)
-    return _set_random_data(d, shape)
+    return _set_random_data(d, shape, seed=seed)
 
 
-def generate_images_for_parallel(shape=(15, 8, 10), dtype=np.float32) -> Images:
+def generate_images_for_parallel(shape=(15, 8, 10), dtype=np.float32, seed: Optional[int] = None) -> Images:
     """
     Doesn't do anything special, just makes a number of images big enough to be
     ran in parallel from the logic of multiprocessing_necessary
     """
     d = pu.create_array(shape, dtype)
-    return _set_random_data(d, shape)
+    return _set_random_data(d, shape, seed=seed)
 
 
-def _set_random_data(data, shape):
-    n = gen_img_numpy_rand(shape)
+def _set_random_data(data, shape, seed: Optional[int] = None):
+    n = gen_img_numpy_rand(shape, seed=seed)
     # move the data in the shared array
     data[:] = n[:]
 


### PR DESCRIPTION
Padding screenshots so that a fixed image size is sent to applitools
should no longer be needed.

### Issue
Reverts change in #1004

### Description

Remove padding

Also use a seed when generating a 'random' image, so that ignore regions are no longer needed.

### Testing & Acceptance Criteria 

Actions tests should pass.

### Documentation

Not needed
