### PR TITLE
Replaces grep and awk usage in version check with Python equivalent

### DIFF
--- a/mantidimaging/core/utility/test/version_check_test.py
+++ b/mantidimaging/core/utility/test/version_check_test.py
@@ -74,9 +74,17 @@ class TestCheckVersion(unittest.TestCase):
 
     @mock.patch("subprocess.check_output")
     def test_retrieve_conda_installed_version(self, mock_check_output):
-        mock_check_output.return_value = b"1.1.0_1018 mantid/label/unstable"
+        no_package = "# packages in environment at mantidimaging-dev:\n#\n# Name  Version Build  Channel"
+        package = f"{no_package}\nmantidimaging 1.1.0_1018 py38_1 mantid/label/main"
+        mock_check_output.return_value = no_package.encode()
+        self.versions._retrieve_conda_installed_version()
+        self.assertEqual(self.versions.get_conda_installed_version(), "")
+        self.assertEqual(self.versions.get_conda_installed_label(), "unstable")
+
+        mock_check_output.return_value = package.encode()
         self.versions._retrieve_conda_installed_version()
         self.assertEqual(self.versions.get_conda_installed_version(), "1.1.0_1018")
+        self.assertEqual(self.versions.get_conda_installed_label(), "main")
 
     @mock.patch("requests.get")
     def test_retrieve_conda_available_version(self, mock_get):

--- a/mantidimaging/core/utility/version_check.py
+++ b/mantidimaging/core/utility/version_check.py
@@ -103,9 +103,9 @@ class CheckVersion:
         return msg, detailed
 
     def _retrieve_conda_installed_version(self) -> None:
-        local_packages = subprocess.check_output("conda list mantidimaging", 
-                                                shell=True, env=os.environ).decode("utf-8").strip()
-        local_packages = [line.split() for line in local_packages.splitlines() if not line.startswith('#')]
+        query_result = subprocess.check_output("conda list mantidimaging", shell=True,
+                                               env=os.environ).decode("utf-8").strip()
+        local_packages = [line.split() for line in query_result.splitlines() if not line.startswith('#')]
 
         if not local_packages:
             LOG.info("Running a development build without a local Mantid Imaging package installation.")


### PR DESCRIPTION
### Issue

None

### Description
In _version_check.py_, the installed version and label is extracted using

`conda list mantidimaging | grep '^[^#]' | awk 'END{print $2,$4}'`

The **grep** command gets every line that does not start with # then the **awk** command extracts version number and label from the last line.

This replaces grep and awk usage in _version_check.py_ with Python equivalent and updates unit test. 

### Testing 

The unit test is updated to reflect changes 

### Acceptance Criteria 

The code should extract the correct version and label (if present) from the string returned by `conda list mantidimaging` 

### Documentation

No change to docs
