### PR TITLE
1048: Nexus title value error

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -35,6 +35,7 @@ Fixes
 - #1021 : Prevent simultaneous Astra calls
 - #1036 : Exception in ReconstructWindowView.show_recon_volume prevents recon closing
 - #1046 : Can't rotate NeXus images
+- #1048 : NeXus Loader: ValueError: Illegal slicing argument for scalar dataspace
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -198,7 +198,7 @@ class NexusLoadPresenter:
         assert self.tomo_entry is not None
         try:
             return self.tomo_entry["title"][0].decode("UTF-8")
-        except KeyError:
+        except (KeyError, ValueError):
             return "NeXus Data"
 
     def get_dataset(self) -> Tuple[Dataset, str]:

--- a/mantidimaging/gui/windows/nexus_load_dialog/test/test_presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/test/test_presenter.py
@@ -244,3 +244,9 @@ class NexusLoaderTest(unittest.TestCase):
         assert dataset.dark_before.filenames[0] == "Dark Before " + self.title
         assert dataset.dark_after.filenames[0] == "Dark After " + self.title
         assert dataset.flat_after.filenames[0] == "Flat After " + self.title
+
+    def test_empty_name_field(self):
+        del self.tomo_entry["title"]
+        self.tomo_entry["title"] = "".encode("UTF-8")
+        self.nexus_loader.tomo_entry = self.tomo_entry
+        assert self.nexus_loader._find_data_title() == "NeXus Data"


### PR DESCRIPTION
### Issue

Closes #1048

### Description

Handles the ValueError caused when the NeXus file has an empty name field.

### Testing 

Added a test that checks for "NeXus Data" being returned by `_find_data_title` if the title field exists but is empty.

### Acceptance Criteria 

Check that the tests pass.

### Documentation

Updated the release notes.
