### PR TITLE
User friendly docs for operations

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,9 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
+import sys
+import os
+
 # -*- coding: utf-8 -*-
 #
 # MantidImaging documentation build configuration file, created by
@@ -44,6 +47,10 @@ extensions = [
     'sphinx.ext.autosectionlabel',
     'sphinx_multiversion',
 ]
+
+# Add custom extensions
+sys.path.append(os.path.abspath("./ext"))
+extensions.append("operations_user_doc")
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/ext/operations_user_doc.py
+++ b/docs/ext/operations_user_doc.py
@@ -72,6 +72,9 @@ class OperationsUserDoc(Directive):
                 rst_lines += get_params(op.filter_func.__doc__)
                 rst_lines.append("")
 
+            rst_lines.append(f":class:`{op.filter_name} API docs<{op.__module__}>`")
+            rst_lines.append("")
+
         rst = ViewList()
         for n, rst_line in enumerate(rst_lines):
             rst.append(rst_line, "generated.rst", n)

--- a/docs/ext/operations_user_doc.py
+++ b/docs/ext/operations_user_doc.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+"""Custom extension to add nicely formatted documentation for the operations.
+
+Use:
+.. operations_user_doc::
+
+in a documentation rst file to generate.
+"""
+
+
+class OperationsUserDoc(Directive):
+    def run(self):
+
+        paragraphs = []
+        try:
+            from mantidimaging.core.operations.loader import load_filter_packages
+        except ImportError:
+            raise ValueError("operations_user_doc could not import load_filter_packages")
+
+        operations = load_filter_packages()
+        for op in operations:
+            paragraphs.append(nodes.paragraph(text=op.filter_name))
+
+        return paragraphs
+
+
+def setup(app):
+    app.add_directive("operations_user_doc", OperationsUserDoc)
+
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/docs/ext/operations_user_doc.py
+++ b/docs/ext/operations_user_doc.py
@@ -1,8 +1,13 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
+from typing import List
+
 from docutils import nodes
+from docutils.nodes import Node
+from docutils.statemachine import ViewList
 from docutils.parsers.rst import Directive
+from sphinx.util.nodes import nested_parse_with_titles
 """Custom extension to add nicely formatted documentation for the operations.
 
 Use:
@@ -12,20 +17,70 @@ in a documentation rst file to generate.
 """
 
 
-class OperationsUserDoc(Directive):
-    def run(self):
+def make_heading(s: str, char: str) -> List[str]:
+    return [s, len(s) * char, ""]
 
-        paragraphs = []
+
+def split_lines(s: str) -> List[str]:
+    s = s.replace("\n\n", "DOUBLE_NEW_LINE")
+    s = s.replace("\n", " ")
+    s = s.replace("DOUBLE_NEW_LINE", "\n\n")
+    return s.split("\n")
+
+
+PARAM_SKIP_LIST = ["images", "cores", "chunksize", "progress"]
+
+
+def get_params(s: str) -> List[str]:
+    ret = []
+    for line in s.split("\n"):
+        if line.strip().startswith(":param"):
+            param_name = line.strip().split()[1].strip(':')
+            if param_name in PARAM_SKIP_LIST:
+                continue
+            ret.append(line.strip())
+        elif line.strip().startswith(":return"):
+            pass
+        elif line.strip() and ret:
+            ret[-1] = ret[-1] + " " + line.strip()
+
+    return ret
+
+
+class OperationsUserDoc(Directive):
+    def run(self) -> List[Node]:
+
         try:
             from mantidimaging.core.operations.loader import load_filter_packages
         except ImportError:
             raise ValueError("operations_user_doc could not import load_filter_packages")
 
+        rst_lines = []
+
         operations = load_filter_packages()
         for op in operations:
-            paragraphs.append(nodes.paragraph(text=op.filter_name))
+            # Title
+            rst_lines += make_heading(op.filter_name, "-")
 
-        return paragraphs
+            # Description from class doc string
+            rst_lines += split_lines(op.__doc__)
+            rst_lines.append("")
+
+            # parameters from filter_func
+            if op.filter_func.__doc__ is not None:
+                rst_lines += get_params(op.filter_func.__doc__)
+                rst_lines.append("")
+
+        rst = ViewList()
+        for n, rst_line in enumerate(rst_lines):
+            rst.append(rst_line, "generated.rst", n)
+
+        node = nodes.section()
+        node.document = self.state.document
+
+        nested_parse_with_titles(self.state, rst, node)
+
+        return node.children
 
 
 def setup(app):

--- a/docs/ext/operations_user_doc.py
+++ b/docs/ext/operations_user_doc.py
@@ -2,6 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from typing import List
+import inspect
 
 from docutils import nodes
 from docutils.nodes import Node
@@ -63,7 +64,7 @@ class OperationsUserDoc(Directive):
             rst_lines += make_heading(op.filter_name, "-")
 
             # Description from class doc string
-            rst_lines += split_lines(op.__doc__)
+            rst_lines += split_lines(inspect.cleandoc(op.__doc__))
             rst_lines.append("")
 
             # parameters from filter_func

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -37,6 +37,7 @@ Fixes
 - #1046 : Can't rotate NeXus images
 - #1048 : NeXus Loader: ValueError: Illegal slicing argument for scalar dataspace
 - #1055: Arithmetic operation breaks flat-fielding
+- #898: Improve user documentation for operations
 
 Developer Changes
 -----------------

--- a/docs/user_guide/operations/index.rst
+++ b/docs/user_guide/operations/index.rst
@@ -3,19 +3,7 @@
 Operations
 ==========
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Contents:
+Operations List
+---------------
 
-   ../../api/mantidimaging.core.operations.circular_mask.circular_mask
-   ../../api/mantidimaging.core.operations.clip_values.clip_values
-   ../../api/mantidimaging.core.operations.crop_coords.crop_coords
-   ../../api/mantidimaging.core.operations.flat_fielding.flat_fielding
-   ../../api/mantidimaging.core.operations.gaussian.gaussian
-   ../../api/mantidimaging.core.operations.median_filter.median_filter
-   ../../api/mantidimaging.core.operations.outliers.outliers
-   ../../api/mantidimaging.core.operations.rebin.rebin
-   ../../api/mantidimaging.core.operations.ring_removal.ring_removal
-   ../../api/mantidimaging.core.operations.roi_normalisation.roi_normalisation
-   ../../api/mantidimaging.core.operations.rotate_stack.rotate_stack
-   ../../api/mantidimaging.core.operations.remove_stripe.stripe_removal
+.. operations_user_doc::

--- a/mantidimaging/core/net/help_pages.py
+++ b/mantidimaging/core/net/help_pages.py
@@ -1,19 +1,26 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
+from typing import Optional
+
 from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QDesktopServices
 
 DOCS_BASE = "https://mantidproject.github.io/mantidimaging"
-SECTION_API = f"{DOCS_BASE}/api/"
 SECTION_USER_GUIDE = f"{DOCS_BASE}/user_guide/"
 
 
-def open_api_webpage(page_url: str):
-    open_help_webpage(SECTION_API, page_url)
+def open_user_operation_docs(operation_name: str):
+    page_url = "operations/index"
+    section = operation_name.lower().replace(" ", "-")
+    open_help_webpage(SECTION_USER_GUIDE, page_url, section)
 
 
-def open_help_webpage(section_url: str, page_url: str):
-    url = QUrl(f"{section_url}{page_url}.html")
-    if not QDesktopServices.openUrl(url):
-        raise RuntimeError(f"Url could not be opened: {url.toString()}")
+def open_help_webpage(section_url: str, page_url: str, section: Optional[str] = None):
+    if section is not None:
+        url = f"{section_url}{page_url}.html#{section}"
+    else:
+        url = f"{section_url}{page_url}.html"
+
+    if not QDesktopServices.openUrl(QUrl(url)):
+        raise RuntimeError(f"Url could not be opened: {url}")

--- a/mantidimaging/core/net/test/__init__.py
+++ b/mantidimaging/core/net/test/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/net/test/test_help_pages.py
+++ b/mantidimaging/core/net/test/test_help_pages.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+import unittest
+from unittest import mock
+from PyQt5.QtCore import QUrl
+
+from mantidimaging.core.net.help_pages import open_user_operation_docs, open_help_webpage, SECTION_USER_GUIDE
+
+
+class HelpPagesTest(unittest.TestCase):
+    @mock.patch("mantidimaging.core.net.help_pages.open_help_webpage")
+    def test_open_user_operation_docs(self, open_func: mock.Mock):
+        open_user_operation_docs("Crop Coordinates")
+        open_func.assert_called_with(SECTION_USER_GUIDE, "operations/index", "crop-coordinates")
+
+    @mock.patch("mantidimaging.core.net.help_pages.QDesktopServices.openUrl")
+    def test_open_help_webpage(self, open_url: mock.Mock):
+        open_help_webpage(SECTION_USER_GUIDE, "reconstructions/center_of_rotation")
+        expected = QUrl(
+            "https://mantidproject.github.io/mantidimaging/user_guide/reconstructions/center_of_rotation.html")
+        open_url.assert_called_with(expected)
+
+    @mock.patch("mantidimaging.core.net.help_pages.QDesktopServices.openUrl")
+    def test_open_help_webpage_with_section(self, open_url: mock.Mock):
+        open_help_webpage(SECTION_USER_GUIDE, "operations/index", "crop-coordinates")
+        expected = QUrl(
+            "https://mantidproject.github.io/mantidimaging/user_guide/operations/index.html#crop-coordinates")
+        open_url.assert_called_with(expected)
+
+    @mock.patch("mantidimaging.core.net.help_pages.QDesktopServices.openUrl")
+    def test_open_help_webpage_error(self, open_url: mock.Mock):
+        open_url.return_value = False
+        self.assertRaises(RuntimeError, open_help_webpage, SECTION_USER_GUIDE, "reconstructions/center_of_rotation")

--- a/mantidimaging/core/operations/arithmetic/arithmetic.py
+++ b/mantidimaging/core/operations/arithmetic/arithmetic.py
@@ -29,7 +29,7 @@ def _arithmetic_func(data: np.ndarray, div_val: float, mult_val: float, add_val:
 
 
 class ArithmeticFilter(BaseFilter):
-    """Add, subtract, multiply, or divide an image with given values.
+    """Add, subtract, multiply, or divide all gray values of an image with the given values.
 
     Intended to be used on: Any
 

--- a/mantidimaging/core/operations/arithmetic/arithmetic.py
+++ b/mantidimaging/core/operations/arithmetic/arithmetic.py
@@ -29,7 +29,7 @@ def _arithmetic_func(data: np.ndarray, div_val: float, mult_val: float, add_val:
 
 
 class ArithmeticFilter(BaseFilter):
-    """Add, subtract, multiply, or divide all gray values of an image with the given values.
+    """Add, subtract, multiply, or divide all grey values of an image with the given values.
 
     Intended to be used on: Any
 

--- a/mantidimaging/core/operations/circular_mask/circular_mask.py
+++ b/mantidimaging/core/operations/circular_mask/circular_mask.py
@@ -16,7 +16,7 @@ class CircularMaskFilter(BaseFilter):
 
     Intended to be used on: Reconstructed slices
 
-    When: To remove reconstruction artifacts near the outside of the image.
+    When: To remove reconstruction artifacts on the outside of the image.
 
     Caution: Ensure that the radius does not mask data from the sample.
     """

--- a/mantidimaging/core/operations/circular_mask/circular_mask.py
+++ b/mantidimaging/core/operations/circular_mask/circular_mask.py
@@ -16,7 +16,7 @@ class CircularMaskFilter(BaseFilter):
 
     Intended to be used on: Reconstructed slices
 
-    When: To remove reconstruction artifacts on the outside of the image.
+    When: To remove reconstruction artifacts on the outer edge of the image.
 
     Caution: Ensure that the radius does not mask data from the sample.
     """

--- a/mantidimaging/core/operations/clip_values/clip_values.py
+++ b/mantidimaging/core/operations/clip_values/clip_values.py
@@ -9,10 +9,10 @@ from mantidimaging.core.utility.progress_reporting import Progress
 
 
 class ClipValuesFilter(BaseFilter):
-    """Clips pixel values of the image based on the parameters. Can be used as
-    a way to mask a.
+    """Clips grey values of the image based on the parameters. Can be used to remove outliers
+    and noise (e.g. negative values) from reconstructed images.
 
-    Intended to be used on: Projections
+    Intended to be used on: Projections and reconstructed slices
 
     When: To remove a range of pixel values from the data.
 

--- a/mantidimaging/core/operations/crop_coords/crop_coords.py
+++ b/mantidimaging/core/operations/crop_coords/crop_coords.py
@@ -18,9 +18,9 @@ from mantidimaging.gui.utility.qt_helpers import Type
 class CropCoordinatesFilter(BaseFilter):
     """Crop a region of interest from the image.
 
-    Intended to be used on: Projections, or reconstructed slices
+    Intended to be used on: A stack of projections, or reconstructed slices
 
-    When: To remove part of the image that contains only noise, this reduces
+    When: To select part of the image that is to be processed further; this reduces
     memory usage and can greatly improve the speed of reconstruction.
 
     Caution: Make sure the region of cropping does not crop parts of the sample

--- a/mantidimaging/core/operations/divide/divide.py
+++ b/mantidimaging/core/operations/divide/divide.py
@@ -27,12 +27,12 @@ class DivideFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images: Images, value: Union[int, float] = 0e7, unit="micron", progress=None) -> Images:
+    def filter_func(images: Images, value: Union[int, float] = 0, unit="micron", progress=None) -> Images:
         if unit == "micron":
             value *= 1e-4
 
         h.check_data_stack(images)
-        if value != 0e7 or value != -0e7:
+        if value != 0:
             images.data /= value
         return images
 

--- a/mantidimaging/core/operations/divide/divide.py
+++ b/mantidimaging/core/operations/divide/divide.py
@@ -14,11 +14,12 @@ from mantidimaging.gui.utility.qt_helpers import Type
 
 
 class DivideFilter(BaseFilter):
-    """Divides the images by a value. That value is usually the pixel value,
-    and can be specified in either microns or cms.
+    """Divides a stack of images by a value. That value can be the pixel size,
+    and can be specified in either microns or cms, to obtain attenuation values.
+
     Intended to be used on: Reconstructed slices
 
-    When: To calculate attenuation values by dividing by the pixel size in Microns
+    When: To calculate attenuation values by dividing by the pixel size in microns
 
     Caution: Check preview values before applying divide
     """

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -73,13 +73,14 @@ class FlatFieldFilter(BaseFilter):
                     progress=None) -> Images:
         """Do background correction with flat and dark images.
 
-        :param data: Sample data which is to be processed. Expected in radiograms
+        :param images: Sample data which is to be processed. Expected in radiograms
         :param flat_before: Flat (open beam) image to use in normalization, for before the sample is imaged
         :param flat_after: Flat (open beam) image to use in normalization, for after the sample is imaged
         :param dark_before: Dark image to use in normalization, for before the sample is imaged
         :param dark_after: Dark image to use in normalization, for before the sample is imaged
         :param selected_flat_fielding: Select which of the flat fielding methods to use, just Before stacks, just After
                                        stacks or combined.
+        :param use_dark: Whether to use dark frame subtraction
         :param cores: The number of cores that will be used to process the data.
         :param chunksize: The number of chunks that each worker will receive.
         :return: Filtered data (stack of images)

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -46,17 +46,20 @@ def enable_correct_fields_only(selected_flat_fielding_widget, flat_before_widget
 
 
 class FlatFieldFilter(BaseFilter):
-    """Uses the flat (open beam) and dark images to reduce the noise in the
-    projection images.
+    """Uses the flat (open beam) and dark images to normalise a stack of images (radiograms, projections),
+    and to correct for a beam profile, scintillator imperfections and/or  detector inhomogeneities. This
+    operation produces images of transmission values.
+
+    In practice, several open beam and dark images are averaged in the flat-fielding process.
 
     Intended to be used on: Projections
 
-    When: As one of the first pre-processing steps to greatly reduce noise in the data
+    When: As one of the first pre-processing steps
 
     Caution: Make sure the correct stacks are selected for flat and dark.
 
     Caution: Check that the flat and dark images don't have any very bright pixels,
-    or this will introduce additional noise in the sample.
+    or this will introduce additional noise in the sample. Remove outliers before flat-fielding.
     """
     filter_name = 'Flat-fielding'
 
@@ -74,10 +77,10 @@ class FlatFieldFilter(BaseFilter):
         """Do background correction with flat and dark images.
 
         :param images: Sample data which is to be processed. Expected in radiograms
-        :param flat_before: Flat (open beam) image to use in normalization, for before the sample is imaged
-        :param flat_after: Flat (open beam) image to use in normalization, for after the sample is imaged
-        :param dark_before: Dark image to use in normalization, for before the sample is imaged
-        :param dark_after: Dark image to use in normalization, for before the sample is imaged
+        :param flat_before: Flat (open beam) image to use in normalization, collected before the sample was imaged
+        :param flat_after: Flat (open beam) image to use in normalization, collected after the sample was imaged
+        :param dark_before: Dark image to use in normalization, collected before the sample was imaged
+        :param dark_after: Dark image to use in normalization, collected before the sample was imaged
         :param selected_flat_fielding: Select which of the flat fielding methods to use, just Before stacks, just After
                                        stacks or combined.
         :param use_dark: Whether to use dark frame subtraction

--- a/mantidimaging/core/operations/gaussian/gaussian.py
+++ b/mantidimaging/core/operations/gaussian/gaussian.py
@@ -19,9 +19,9 @@ from mantidimaging.gui.utility.qt_helpers import Type
 class GaussianFilter(BaseFilter):
     """Applies Gaussian filter to the data.
 
-    Intended to be used on: Projections
+    Intended to be used on: Projections or reconstructed slices
 
-    When: As a pre-processing step to reduce noise.
+    When: As a pre-processing or post-reconstruction step to reduce noise.
     """
     filter_name = "Gaussian"
     link_histograms = True

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -55,9 +55,9 @@ class KernelSpinBox(QSpinBox):
 class MedianFilter(BaseFilter):
     """Applies Median filter to the data.
 
-    Intended to be used on: Projections
+    Intended to be used on: Projections or reconstructed slices
 
-    When: As a pre-processing step to reduce noise.
+    When: As a pre-processing or post-reconstruction step to reduce noise.
     """
     filter_name = "Median"
     link_histograms = True

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -17,11 +17,13 @@ def _divide_by_counts(data=None, counts=None):
 
 
 class MonitorNormalisation(BaseFilter):
-    """Normalises the values of the data by the monitor counts read from the Sample log file.
+    """Normalises the image data using the average count of a beam monitor from the
+    experiment log file. This scaling operation is an alternative to ROI normalisation
+    and allows to account for beam fluctuations and different exposure times of projections.
 
     Intended to be used on: Projections
 
-    When: As a pre-processing step to normalise the value ranges of the data.
+    When: As a pre-processing step to normalise the grey value ranges of the data.
     """
     filter_name = "Monitor Normalisation"
     link_histograms = True

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -22,14 +22,14 @@ DIM_1D = "1D"
 
 
 class OutliersFilter(BaseFilter):
-    """Removes pixel values that are found to be outliers by the parameters.
+    """Removes pixel values that are found to be outliers as defined by the given parameters.
 
     Intended to be used on: Projections
 
     When: As a pre-processing step to reduce very bright or dead pixels in the data.
 
-    Caution: This should usually be the first step applied to the data, flat and dark
-    images, to remove pixels with very large values that will cause issues in the flat-fielding.
+    Caution: This should usually be one of the first steps applied to the data, flat and dark
+    images, to remove pixels with very large values that will cause issues for flat-fielding.
     """
     filter_name = "Remove Outliers"
     link_histograms = True

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -14,14 +14,14 @@ from mantidimaging.gui.utility.qt_helpers import Type
 
 
 class RebinFilter(BaseFilter):
-    """Rebins the image to the given parameter.
+    """Rebin the image to reduce the resolution.
 
     This filter temporarily increases memory usage, while the image is being rebinned.
     The memory usage will be lowered after the filter has finished executing.
 
     Intended to be used on: Any data
 
-    When: If you want to reduce the data size by losing information.
+    When: If you want to reduce the data size and to smoothen the image.
     """
     filter_name = "Rebin"
     link_histograms = True

--- a/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
+++ b/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
@@ -15,7 +15,6 @@ from mantidimaging.gui.utility.qt_helpers import Type
 class RemoveAllStripesFilter(BaseFilter):
     """Stripe and ring artifact removal. Remove all types of stripe artifacts by
     combining algorithm 6, 5, and 3  in Vo et al., Optics Express 28396 (2018).
-    Angular direction is along the axis 0.
 
     Source: https://github.com/nghia-vo/sarepy
 

--- a/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
+++ b/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
@@ -13,7 +13,8 @@ from mantidimaging.gui.utility.qt_helpers import Type
 
 
 class RemoveAllStripesFilter(BaseFilter):
-    """Remove all types of stripe artifacts by combining algorithm 6, 5, and 3.
+    """Stripe and ring artifact removal. Remove all types of stripe artifacts by
+    combining algorithm 6, 5, and 3  in Vo et al., Optics Express 28396 (2018).
     Angular direction is along the axis 0.
 
     Source: https://github.com/nghia-vo/sarepy
@@ -23,8 +24,8 @@ class RemoveAllStripesFilter(BaseFilter):
     When: If stripes artifacts are present that have not been
     removed with outliers + flat-fielding the projections
 
-    Caution: Horizontal stripes are caused by changes in image intensity (pixel values),
-    and should be fixed by ROI Normalisation instead!
+    Caution: Horizontal stripes caused by changes in image intensity (pixel values)
+    should be fixed by ROI Normalisation instead!
     """
     filter_name = "Remove all stripes"
     link_histograms = True

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -15,7 +15,6 @@ from mantidimaging.gui.utility.qt_helpers import Type
 class RemoveDeadStripesFilter(BaseFilter):
     """Stripe and ring artifact removal. Algorithm 6 in Vo et al., Optics Express 28396 (2018).
     Remove unresponsive or fluctuating stripes by: locating stripes, correction by interpolation.
-    Angular direction is along the axis 0.
 
     Source: https://github.com/nghia-vo/sarepy
 

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -13,18 +13,19 @@ from mantidimaging.gui.utility.qt_helpers import Type
 
 
 class RemoveDeadStripesFilter(BaseFilter):
-    """Algorithm 6 in the paper. Remove unresponsive or fluctuating stripes by:
-    locating stripes, correcting by interpolation. Angular direction is along
-    the axis 0.
+    """Stripe and ring artifact removal. Algorithm 6 in Vo et al., Optics Express 28396 (2018).
+    Remove unresponsive or fluctuating stripes by: locating stripes, correction by interpolation.
+    Angular direction is along the axis 0.
 
     Source: https://github.com/nghia-vo/sarepy
 
     Intended to be used on: Sinograms
+
     When: If stripes artifacts are present that have not been
     removed with outliers + flat-fielding the projections
 
-    Caution: Horizontal stripes are caused by changes in image intensity (pixel values),
-    and should be fixed by ROI Normalisation instead!
+    Caution: Horizontal stripes caused by changes in image intensity (pixel values)
+    should be fixed by ROI Normalisation instead!
     """
     filter_name = "Remove dead stripes"
     link_histograms = True

--- a/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
+++ b/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
@@ -14,7 +14,7 @@ from mantidimaging.gui.utility.qt_helpers import Type
 class RemoveLargeStripesFilter(BaseFilter):
     """Stripe and ring artifact removal: Algorithm 5 in Vo et al., Optics Express 28396 (2018).
     Remove large stripes by: locating stripes, normalizing them to remove full stripes, using
-    the sorting technique to remove partial stripes. Angular direction is along the axis 0.
+    the sorting technique to remove partial stripes.
 
     Source: https://github.com/nghia-vo/sarepy
 

--- a/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
+++ b/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
@@ -12,9 +12,9 @@ from mantidimaging.gui.utility.qt_helpers import Type
 
 
 class RemoveLargeStripesFilter(BaseFilter):
-    """Algorithm 5 in the paper. Remove large stripes by: locating stripes,
-    normalizing to remove full stripes, using the sorting technique to remove
-    partial stripes. Angular direction is along the axis 0.
+    """Stripe and ring artifact removal: Algorithm 5 in Vo et al., Optics Express 28396 (2018).
+    Remove large stripes by: locating stripes, normalizing them to remove full stripes, using
+    the sorting technique to remove partial stripes. Angular direction is along the axis 0.
 
     Source: https://github.com/nghia-vo/sarepy
 
@@ -22,8 +22,8 @@ class RemoveLargeStripesFilter(BaseFilter):
     When: If stripes artifacts are present that have not been
     removed with outliers + flat-fielding the projections
 
-    Caution: Horizontal stripes are caused by changes in image intensity (pixel values),
-    and should be fixed by ROI Normalisation instead!
+    Caution: Horizontal stripes caused by changes in image intensity (pixel values)
+    should be fixed by ROI Normalisation instead!
     """
     filter_name = "Remove large stripes"
     link_histograms = True

--- a/mantidimaging/core/operations/remove_stripe/stripe_removal.py
+++ b/mantidimaging/core/operations/remove_stripe/stripe_removal.py
@@ -10,7 +10,7 @@ from mantidimaging.gui.utility.qt_helpers import Type
 
 
 class StripeRemovalFilter(BaseFilter):
-    """Stripe removal operations wrapped from TomoPy.
+    """Stripe and ring artifact removal operations wrapped from TomoPy.
 
     Source: https://tomopy.readthedocs.io/en/latest/api/tomopy.prep.stripe.html
 
@@ -19,8 +19,8 @@ class StripeRemovalFilter(BaseFilter):
     When: If stripes artifacts are present that have not been
     removed with outliers + flat-fielding the projections
 
-    Caution: Horizontal stripes are caused by changes in image intensity (pixel values),
-    and should be fixed by ROI Normalisation instead!
+    Caution: Horizontal stripes caused by changes in image intensity (pixel values)
+    should be fixed by ROI Normalisation instead!
     """
     filter_name = "Stripe Removal"
     link_histograms = True
@@ -33,12 +33,12 @@ class StripeRemovalFilter(BaseFilter):
         Multiple operations can be executed, if they are specified on the command
         line.
 
-        The order for that execution will always be: wavelett-fourier, titarenko,
+        The order for that execution will always be: wavelet-fourier, Titarenko,
         smoothing-filter.
 
         :param images: Sample data which is to be processed. Expected in radiograms
 
-        :param wf: Specify parameters for the wavelett-fourier filter.
+        :param wf: Specify parameters for the wavelet-fourier filter.
                    Acceptable keywords are:
 
                         level (default None, type int, optional parameter)
@@ -54,7 +54,7 @@ class StripeRemovalFilter(BaseFilter):
                                 If True, extend the size of the sinogram by
                                 padding with zeros.
 
-        :param ti: Specify parameters for the titarenko filter.
+        :param ti: Specify parameters for the Titarenko filter.
                    Acceptable keywords are:
 
                         nblock (default:0, int, optional) Number of blocks.

--- a/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
@@ -16,7 +16,6 @@ from mantidimaging.gui.utility.qt_helpers import Type
 class RemoveStripeFilteringFilter(BaseFilter):
     """Stripe and ring artifact removal. Combination of algorithm 2 and algorithm 3 in Vo et al.,
     Optics Express 28396 (2018). Removing stripes using the filtering and sorting technique.
-    Angular direction is along the axis 0.
 
     Source: https://github.com/nghia-vo/sarepy
 

--- a/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
@@ -14,9 +14,9 @@ from mantidimaging.gui.utility.qt_helpers import Type
 
 
 class RemoveStripeFilteringFilter(BaseFilter):
-    """Combination of algorithm 2 and algorithm 3 in [1]. Removing stripes
-    using the filtering and sorting technique. Angular direction is along the
-    axis 0.
+    """Stripe and ring artifact removal. Combination of algorithm 2 and algorithm 3 in Vo et al.,
+    Optics Express 28396 (2018). Removing stripes using the filtering and sorting technique.
+    Angular direction is along the axis 0.
 
     Source: https://github.com/nghia-vo/sarepy
 
@@ -25,8 +25,8 @@ class RemoveStripeFilteringFilter(BaseFilter):
     When: If stripes artifacts are present that have not been
     removed with outliers + flat-fielding the projections
 
-    Caution: Horizontal stripes are caused by changes in image intensity (pixel values),
-    and should be fixed by ROI Normalisation instead!
+    Caution: Horizontal stripes caused by changes in image intensity (pixel values)
+    should be fixed by ROI Normalisation instead!
     """
     filter_name = "Remove stripes with filtering"
     link_histograms = True

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
@@ -15,7 +15,6 @@ from mantidimaging.gui.utility.qt_helpers import Type
 class RemoveStripeSortingFittingFilter(BaseFilter):
     """Stripe and ring artifact removal. Combination of algorithm 3 and 1 in Vo et al.,
     Optics Express 28396 (2018). Remove stripes using the sorting and fitting technique.
-    Angular direction is along the axis 0.
 
     Source: https://github.com/nghia-vo/sarepy
 

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
@@ -13,8 +13,9 @@ from mantidimaging.gui.utility.qt_helpers import Type
 
 
 class RemoveStripeSortingFittingFilter(BaseFilter):
-    """Combination of algorithm 3 and 1 in [1]. Remove stripes using the
-    sorting and fitting technique. Angular direction is along the axis 0.
+    """Stripe and ring artifact removal. Combination of algorithm 3 and 1 in Vo et al.,
+    Optics Express 28396 (2018). Remove stripes using the sorting and fitting technique.
+    Angular direction is along the axis 0.
 
     Source: https://github.com/nghia-vo/sarepy
 
@@ -23,8 +24,8 @@ class RemoveStripeSortingFittingFilter(BaseFilter):
     When: If stripes artifacts are present that have not been
     removed with outliers + flat-fielding the projections
 
-    Caution: Horizontal stripes are caused by changes in image intensity (pixel values),
-    and should be fixed by ROI Normalisation instead!
+    Caution: Horizontal stripes caused by changes in image intensity (pixel values)
+    should be fixed by ROI Normalisation instead!
     """
     filter_name = "Remove stripes with sorting and fitting"
     link_histograms = True

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -19,7 +19,7 @@ class RescaleFilter(BaseFilter):
 
     Intended to be used on: Any
 
-    When: Automatically used when saving images to unsigned int
+    When: Automatically used when saving as unsigned integer image formats, to avoid clipping negative values
     """
     filter_name = 'Rescale'
 

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -19,9 +19,7 @@ class RescaleFilter(BaseFilter):
 
     Intended to be used on: Any
 
-    When: Can be used to crop-out value regions of interest
-
-    When: Automatically used when saving images to uint16
+    When: Automatically used when saving images to unsigned int
     """
     filter_name = 'Rescale'
 

--- a/mantidimaging/core/operations/ring_removal/ring_removal.py
+++ b/mantidimaging/core/operations/ring_removal/ring_removal.py
@@ -18,7 +18,8 @@ class RingRemovalFilter(BaseFilter):
 
     Intended to be used on: Reconstructed slices
 
-    When: To remove ring-filters that have not been removed by the pre-processing
+    When: To remove ring-artifacts that have not been removed, or have been introduced
+    by pre-processing
     """
     filter_name = "Ring Removal"
     link_histograms = True

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -56,7 +56,7 @@ class RoiNormalisationFilter(BaseFilter):
         :param images: Sample data which is to be processed. Expected in radiograms
 
         :param region_of_interest: The order is - Left Top Right Bottom. The air
-        region for which grayvalues are summed up and used for normalisation/scaling.
+        region for which grey values are summed up and used for normalisation/scaling.
 
         :param normalisation_mode: Controls what the ROI counts are normalised to.
             'Preserve Max' : Normalisation is scaled such that the maximum pixel value of the stack is equal before

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -24,14 +24,16 @@ def modes() -> List[str]:
 
 
 class RoiNormalisationFilter(BaseFilter):
-    """Normalises the image data by the average values in a region of interest.
+    """Normalises the image data by using the average value in a no-sample (air) region of interest (ROI) of the
+    image. This scaling operation allows to account for beam fluctuations and different exposure times of
+    projections.
 
     Intended to be used on: Projections
 
     When: Always, to ensure that any fluctuations in beam intensity are normalised.
 
-    Caution: If you see horizontal lines in the sinogram this means some projections
-    are brighter/darker than the rest. This can be fixed with this operation.
+    Note: Beam fluctuations are visible by horizontal lines in the sinograms, as  some projections are
+    brighter/darker than the neighbours. This can be fixed with this operation.
     """
     filter_name = "ROI Normalisation"
     link_histograms = True
@@ -53,18 +55,17 @@ class RoiNormalisationFilter(BaseFilter):
 
         :param images: Sample data which is to be processed. Expected in radiograms
 
-        :param region_of_interest: The order is - Left Top Right Bottom. The air region
-                           from which sums will be calculated and all images will
-                           be normalised.
+        :param region_of_interest: The order is - Left Top Right Bottom. The air
+        region for which grayvalues are summed up and used for normalisation/scaling.
 
-        :param normalisation_mode: Controls what the air regions are normalised to.
-            'Preserve Max' : Normalisation is scaled such that the the maximum pixel value of the stack is equal before
+        :param normalisation_mode: Controls what the ROI counts are normalised to.
+            'Preserve Max' : Normalisation is scaled such that the maximum pixel value of the stack is equal before
                              and after the operation.
             'Stack Average' : The mean value of the air region across all projections is preserved.
             'Flat Field' : The mean value of the air regions in the projections is made equal to the mean value of the
-                           air region in the flat field.
+                           air region in the flat field image.
 
-        :param flat_field: If 'Flat Field' mode is used, pass in the flat field images.
+        :param flat_field: Flat field to use if 'Flat Field' mode is enabled.
 
         :param cores: The number of cores that will be used to process the data.
 

--- a/mantidimaging/core/operations/rotate_stack/rotate_stack.py
+++ b/mantidimaging/core/operations/rotate_stack/rotate_stack.py
@@ -19,11 +19,11 @@ class RotateFilter(BaseFilter):
 
     Intended to be used on: Projections
 
-    When: Rarely/never, ASTRA vector geometry will take care of the tilt correction
+    When: 90 or 270 degree rotation for rotation axis to be vertical for some camera types.
 
-    Caution: Manually rotating could introduce additional artifacts in the
-    reconstructed volume, and it is not strictly required as using
-    vector geometry will correct for the tilt without manual rotation.
+    Caution: Rotations of images others than multiples of 90 degrees could introduce additional
+    artifacts in the reconstructed volume. Such rotations are usually not required as
+    small tilts can taken into account at the reconstruction stage.
     """
     filter_name = "Rotate Stack"
     link_histograms = True

--- a/mantidimaging/core/operations/rotate_stack/rotate_stack.py
+++ b/mantidimaging/core/operations/rotate_stack/rotate_stack.py
@@ -23,7 +23,7 @@ class RotateFilter(BaseFilter):
 
     Caution: Rotations of images others than multiples of 90 degrees could introduce additional
     artifacts in the reconstructed volume. Such rotations are usually not required as
-    small tilts can taken into account at the reconstruction stage.
+    small tilts can be taken into account at the reconstruction stage.
     """
     filter_name = "Rotate Stack"
     link_histograms = True

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -24,18 +24,14 @@ if APPLITOOLS_BATCH_ID is None:
     APPLITOOLS_BATCH_ID = str(uuid4())
 
 API_KEY_PRESENT = os.getenv("APPLITOOLS_API_KEY")
-if API_KEY_PRESENT is None:
-    raise unittest.SkipTest("API Key is not defined in the environment, so Eyes tests are skipped.")
 
 TEST_NAME = os.getenv("GITHUB_BRANCH_NAME")
 if TEST_NAME is None:
     TEST_NAME = f"{getpass.getuser()}'s Local Test"
 
 LOAD_SAMPLE = str(Path.home()) + "/mantidimaging-data-master/ISIS/IMAT/IMAT00010675/Tomo/IMAT_Flower_Tomo_000000.tif"
-if not os.path.exists(LOAD_SAMPLE):
-    raise unittest.SkipTest(
-        "Data not present, please clone to your home directory e.g. git clone https://github.com/mantidproject/mantidim"
-        "aging-data.git ~/mantidimaging-data-master")
+LOAD_SAMPLE_MISSING_MESSAGE = """Data not present, please clone to your home directory e.g.
+git clone https://github.com/mantidproject/mantidimaging-data.git ~/mantidimaging-data-master"""
 
 NEXUS_SAMPLE = str(
     Path.home()) + "/mantidimaging-data-master/Diamond/i13/AKingUVA_7050wSSwire_InSitu_95RH_2MMgCl2_p4ul_p4h/24737.nxs"
@@ -50,6 +46,8 @@ else:
 QApplication.setFont(QFont("Sans Serif", 10))
 
 
+@unittest.skipIf(API_KEY_PRESENT is None, "API Key is not defined in the environment, so Eyes tests are skipped.")
+@unittest.skipUnless(os.path.exists(LOAD_SAMPLE), LOAD_SAMPLE_MISSING_MESSAGE)
 @start_qapplication
 class BaseEyesTest(unittest.TestCase):
     eyes_manager: EyesManager

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -9,7 +9,7 @@ from PyQt5.QtWidgets import (QAction, QApplication, QCheckBox, QComboBox, QLabel
                              QPushButton, QSizePolicy, QSplitter, QStyle, QVBoxLayout)
 from pyqtgraph import ImageItem
 
-from mantidimaging.core.net.help_pages import open_api_webpage
+from mantidimaging.core.net.help_pages import open_user_operation_docs
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.utility import delete_all_widgets_from_layout
 from mantidimaging.gui.widgets.mi_image_view.view import MIImageView
@@ -188,11 +188,10 @@ class FiltersWindowView(BaseMainWindowView):
         self.notification_text.setText(f"{operation_name} completed successfully!")
 
     def open_help_webpage(self):
-        filter_id = self.presenter.model._find_filter_index_from_filter_name(self.filterSelector.currentText())
-        filter_module_path = self.presenter.get_filter_module_name(filter_id)
+        filter_name = self.filterSelector.currentText()
 
         try:
-            open_api_webpage(filter_module_path)
+            open_user_operation_docs(filter_name)
         except RuntimeError as err:
             self.show_error_dialog(str(err))
 


### PR DESCRIPTION
### Issue

Closes #898

(note the number is the branch name is wrong)

### Description

Add extension to generate user friendly documentation for operations. Takes the docstring for the class, and the parameters from the `filter_func` method (with some standard parameters removed).

Update doc strings for operations

Also: Move test skipping into decorators to avoid errors with sphinx

### Testing & Acceptance Criteria 

To build the docs locally run:

`python3 ./setup.py docs`

Docs will be written to docs/build/html , so for me operations docs are in ~/git/mantidimaging/docs/build/html/user_guide/operations/index.html

Help button in the operations window should link to something like https://mantidproject.github.io/mantidimaging/user_guide/operations/index.html#crop-coordinates

### Documentation
Updated release notes

