### PR TITLE
1055: Arithmetic operation breaks flat-fielding

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -36,6 +36,7 @@ Fixes
 - #1036 : Exception in ReconstructWindowView.show_recon_volume prevents recon closing
 - #1046 : Can't rotate NeXus images
 - #1048 : NeXus Loader: ValueError: Illegal slicing argument for scalar dataspace
+- #1055: Arithmetic operation breaks flat-fielding
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/operations/arithmetic/arithmetic.py
+++ b/mantidimaging/core/operations/arithmetic/arithmetic.py
@@ -2,8 +2,10 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial
+from multiprocessing import Process
 from typing import Callable, Dict
 
+import numpy as np
 from PyQt5.QtWidgets import QFormLayout, QWidget, QDoubleSpinBox
 
 from mantidimaging.gui.mvp_base import BaseMainWindowView
@@ -11,6 +13,11 @@ from mantidimaging.gui.utility.qt_helpers import add_property_to_form, MAX_SPIN_
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.operations.base_filter import BaseFilter
+
+
+def _arithmetic_func(data: np.ndarray, div: float, mult: float, add: float, sub: float):
+    for i in range(len(data)):
+        data[i] = data[i] / div * mult + add - sub
 
 
 class ArithmeticFilter(BaseFilter):
@@ -41,11 +48,10 @@ class ArithmeticFilter(BaseFilter):
         :param progress: The Progress object isn't used.
         :return: The processed Images object.
         """
-        if div_val != 0:
-            images.data /= div_val
-        if mult_val != 0:
-            images.data *= mult_val
-        images.data = images.data + add_val - sub_val
+        if div_val != 0 and mult_val != 0:
+            p = Process(target=_arithmetic_func, args=(images.data, div_val, mult_val, add_val, sub_val))
+            p.start()
+            p.join()
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/arithmetic/arithmetic.py
+++ b/mantidimaging/core/operations/arithmetic/arithmetic.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-
+import logging
 from functools import partial
 from multiprocessing import Process
 from typing import Callable, Dict
@@ -15,9 +15,17 @@ from mantidimaging.core.data import Images
 from mantidimaging.core.operations.base_filter import BaseFilter
 
 
-def _arithmetic_func(data: np.ndarray, div: float, mult: float, add: float, sub: float):
+def _arithmetic_func(data: np.ndarray, div_val: float, mult_val: float, add_val: float, sub_val: float):
+    """
+    Process target function for the arithmetic operation.
+    :param data: The data array.
+    :param div_val: The division value.
+    :param mult_val: The multiplication value.
+    :param add_val: The addition value.
+    :param sub_val: The subtraction value.
+    """
     for i in range(len(data)):
-        data[i] = data[i] / div * mult + add - sub
+        data[i] = data[i] / div_val * mult_val + add_val - sub_val
 
 
 class ArithmeticFilter(BaseFilter):
@@ -39,7 +47,6 @@ class ArithmeticFilter(BaseFilter):
                     progress=None) -> Images:
         """
         Apply arithmetic operations to the pixels.
-
         :param images: The Images object.
         :param mult_val: The multiplication value.
         :param div_val: The division value.
@@ -52,6 +59,9 @@ class ArithmeticFilter(BaseFilter):
             p = Process(target=_arithmetic_func, args=(images.data, div_val, mult_val, add_val, sub_val))
             p.start()
             p.join()
+        else:
+            logging.getLogger(__name__).error("Unable to proceed with operation because dividion/multiplication value "
+                                              "is zero.")
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/arithmetic/arithmetic.py
+++ b/mantidimaging/core/operations/arithmetic/arithmetic.py
@@ -60,7 +60,7 @@ class ArithmeticFilter(BaseFilter):
             p.start()
             p.join()
         else:
-            logging.getLogger(__name__).error("Unable to proceed with operation because dividion/multiplication value "
+            logging.getLogger(__name__).error("Unable to proceed with operation because division/multiplication value "
                                               "is zero.")
         return images
 

--- a/mantidimaging/core/operations/arithmetic/test/arithmetic_test.py
+++ b/mantidimaging/core/operations/arithmetic/test/arithmetic_test.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-
+import logging
 import unittest
 
 import numpy.testing as npt
@@ -33,10 +33,13 @@ class ArithmeticTest(unittest.TestCase):
     def test_cant_divide_or_multiply_by_zero(self):
         images = th.generate_images()
 
-        result = ArithmeticFilter().filter_func(images.copy(), mult_val=0.0)
+        logger = logging.getLogger("mantidimaging.core.operations.arithmetic.arithmetic")
+        with self.assertLogs(logger, level="ERROR"):
+            result = ArithmeticFilter().filter_func(images.copy(), mult_val=0.0)
         npt.assert_array_equal(images.data, result.data)
 
-        result = ArithmeticFilter().filter_func(images.copy(), div_val=0.0)
+        with self.assertLogs(logger, level="ERROR"):
+            result = ArithmeticFilter().filter_func(images.copy(), div_val=0.0)
         npt.assert_array_equal(images.data, result.data)
 
     def test_add_only(self):

--- a/mantidimaging/core/operations/arithmetic/test/arithmetic_test.py
+++ b/mantidimaging/core/operations/arithmetic/test/arithmetic_test.py
@@ -15,6 +15,7 @@ class ArithmeticTest(unittest.TestCase):
     """
     def __init__(self, *args, **kwargs):
         super(ArithmeticTest, self).__init__(*args, **kwargs)
+        self.logger = logging.getLogger("mantidimaging.core.operations.arithmetic.arithmetic")
 
     def test_div_only(self):
         images = th.generate_images()
@@ -30,16 +31,20 @@ class ArithmeticTest(unittest.TestCase):
 
         npt.assert_array_equal(images.data * 2.0, result.data)
 
-    def test_cant_divide_or_multiply_by_zero(self):
+    def test_cant_multiply_by_zero(self):
         images = th.generate_images()
 
-        logger = logging.getLogger("mantidimaging.core.operations.arithmetic.arithmetic")
-        with self.assertLogs(logger, level="ERROR"):
+        with self.assertLogs(self.logger, level="ERROR") as log_mock:
             result = ArithmeticFilter().filter_func(images.copy(), mult_val=0.0)
+        self.assertIn("Unable to proceed with operation", log_mock.output[0])
         npt.assert_array_equal(images.data, result.data)
 
-        with self.assertLogs(logger, level="ERROR"):
+    def test_cant_divide_by_zero(self):
+        images = th.generate_images()
+
+        with self.assertLogs(self.logger, level="ERROR") as log_mock:
             result = ArithmeticFilter().filter_func(images.copy(), div_val=0.0)
+        self.assertIn("Unable to proceed with operation", log_mock.output[0])
         npt.assert_array_equal(images.data, result.data)
 
     def test_add_only(self):

--- a/mantidimaging/core/parallel/shared.py
+++ b/mantidimaging/core/parallel/shared.py
@@ -46,6 +46,11 @@ def return_to_second_at_i(func, i, **kwargs):
     shared_list[1][i] = func(shared_list[0][i], **kwargs)
 
 
+def arithmetic(func, i, **kwargs):
+    global shared_list
+    func(shared_list[0][i], *shared_list[1:])
+
+
 def create_partial(func, fwd_function, **kwargs):
     """
     Create a partial using functools.partial, to forward the kwargs to the

--- a/mantidimaging/core/parallel/shared.py
+++ b/mantidimaging/core/parallel/shared.py
@@ -46,7 +46,7 @@ def return_to_second_at_i(func, i, **kwargs):
     shared_list[1][i] = func(shared_list[0][i], **kwargs)
 
 
-def arithmetic(func, i, **kwargs):
+def arithmetic(func, i):
     global shared_list
     func(shared_list[0][i], *shared_list[1:])
 


### PR DESCRIPTION
### Issue

Closes #1055

### Description

Uses `Process` to do the arithmetic operations which ensures it remains as a shared array. Also added a log error for when the division/multiplication value is zero.

### Testing 

Added tests for the log messages.

### Acceptance Criteria 

Run the arithmetic filter and then flat-fielding on a dataset and check that it works.

### Documentation

Updated release notes.
