### PR TITLE
Prevent Crash in RingRemovalFilter

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -40,6 +40,7 @@ Fixes
 - #1055: Arithmetic operation breaks flat-fielding
 - #898: Improve user documentation for operations
 - #1059: Crash in recon Minimise Error with CIL
+- #1032: Crash in RingRemovalFilter
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/operations/ring_removal/test/ring_removal_test.py
+++ b/mantidimaging/core/operations/ring_removal/test/ring_removal_test.py
@@ -35,7 +35,7 @@ class RingRemovalTest(unittest.TestCase):
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
         """
         images = th.generate_images()
-        mocks = [Mock() for _ in range(8)]
+        mocks = [Mock()] + [Mock(value=lambda: 0) for _ in range(7)]
         RingRemovalFilter.execute_wrapper(*mocks)(images)
 
 


### PR DESCRIPTION
Work around https://github.com/tomopy/tomopy/issues/551 until we can
upgrade to a fixed version

### Issue
Closes #1032 

### Description

Catch values that will cause tomopy 1.10.1 or older to crash

### Testing 

Load a stack. In Operations, Ring Removal set Theta to a large number.


### Acceptance Criteria 
You should now get an error message in the GUI, rather than MI crashing

### Documentation

release_notes
