### PR TITLE
1026: NaN Warning

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -20,6 +20,7 @@ New features
 - #1025 : Add the Total Variation (TV) with Primal-Dual Hybrid Gradient (PDHG) from CIL
 - #1027 : Flat field warning if output has negative values
 - #1027 : NeXus Loader: Message when loading large files
+- #1026 : Recon warn if input has NaNs
 
 Fixes
 -----

--- a/docs/user_guide/gui/loading_saving.rst
+++ b/docs/user_guide/gui/loading_saving.rst
@@ -29,6 +29,9 @@ To quickly load only 10 images from a stack, press the preview button, which wil
 images will use 32bit floating point numbers as the pixel format so this can be
 left at the default value of *float32*.
 
+.. note::
+    Note that the image filenames must be in the form TITLE_XXXXX, with XXXXX being the image number.
+
 Saving
 ------
 

--- a/mantidimaging/eyes_tests/test_reconstruct_window.py
+++ b/mantidimaging/eyes_tests/test_reconstruct_window.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-# import numpy as np
-#
-# from mantidimaging.core.data import Images
+import numpy as np
+
+from mantidimaging.core.data import Images
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
 
 
@@ -40,12 +40,12 @@ class ReconstructionWindowTest(BaseEyesTest):
 
         self.check_target(widget=self.imaging.recon)
 
-    # def test_negative_nan_overlay(self):
-    #     data = np.random.rand(200, 200)
-    #     data[:, 5] = 0
-    #     data[:-5, ] = np.nan
-    #     self.imaging.presenter.create_new_stack(Images(data), "bad_data")
-    #
-    #     self.imaging.show_recon_window()
-    #     self.imaging.recon.stackSelector.setCurrentIndex(1)
-    #     self.check_target(widget=self.imaging.recon)
+    def test_negative_nan_overlay(self):
+        data = np.random.rand(200, 200)
+        data[:, 5] = 0
+        data[:-5, ] = np.nan
+        self.imaging.presenter.create_new_stack(Images(data), "bad_data")
+
+        self.imaging.show_recon_window()
+        self.imaging.recon.stackSelector.setCurrentIndex(1)
+        self.check_target(widget=self.imaging.recon)

--- a/mantidimaging/eyes_tests/test_reconstruct_window.py
+++ b/mantidimaging/eyes_tests/test_reconstruct_window.py
@@ -1,5 +1,8 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+import numpy as np
+
+from mantidimaging.core.data import Images
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
 
 
@@ -35,4 +38,14 @@ class ReconstructionWindowTest(BaseEyesTest):
 
         self.imaging.recon.tabWidget.setCurrentWidget(self.imaging.recon.reconTab)
 
+        self.check_target(widget=self.imaging.recon)
+
+    def test_negative_nan_overlay(self):
+        data = np.random.rand(200, 200)
+        data[:, 5] = 0
+        data[:-5, ] = np.nan
+        self.imaging.presenter.create_new_stack(Images(data), "bad_data")
+
+        self.imaging.show_recon_window()
+        self.imaging.recon.stackSelector.setCurrentIndex(1)
         self.check_target(widget=self.imaging.recon)

--- a/mantidimaging/eyes_tests/test_reconstruct_window.py
+++ b/mantidimaging/eyes_tests/test_reconstruct_window.py
@@ -41,11 +41,11 @@ class ReconstructionWindowTest(BaseEyesTest):
         self.check_target(widget=self.imaging.recon)
 
     def test_negative_nan_overlay(self):
-        data = np.random.rand(200, 200)
-        data[:, 5] = 0
-        data[:-5, ] = np.nan
+        data = np.random.rand(5, 200, 200)
+        images = Images(data)
         self.imaging.presenter.create_new_stack(Images(data), "bad_data")
+        images.data[0:, 190:] = 0
+        images.data[0:, 195:] = np.nan
 
         self.imaging.show_recon_window()
-        self.imaging.recon.stackSelector.setCurrentIndex(1)
         self.check_target(widget=self.imaging.recon)

--- a/mantidimaging/eyes_tests/test_reconstruct_window.py
+++ b/mantidimaging/eyes_tests/test_reconstruct_window.py
@@ -45,7 +45,7 @@ class ReconstructionWindowTest(BaseEyesTest):
         images = Images(data)
         self.imaging.presenter.create_new_stack(Images(data), "bad_data")
         images.data[0:, 190:] = 0
-        images.data[0:, 195:] = np.nan
+        images.data[0:, 0:10] = np.nan
 
         self.imaging.show_recon_window()
         self.check_target(widget=self.imaging.recon)

--- a/mantidimaging/eyes_tests/test_reconstruct_window.py
+++ b/mantidimaging/eyes_tests/test_reconstruct_window.py
@@ -2,8 +2,8 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 import numpy as np
 
-from mantidimaging.core.data import Images
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
+from mantidimaging.test_helpers.unit_test_helper import generate_images
 
 
 class ReconstructionWindowTest(BaseEyesTest):
@@ -41,11 +41,10 @@ class ReconstructionWindowTest(BaseEyesTest):
         self.check_target(widget=self.imaging.recon)
 
     def test_negative_nan_overlay(self):
-        data = np.random.rand(5, 200, 200)
-        images = Images(data)
-        self.imaging.presenter.create_new_stack(Images(data), "bad_data")
-        images.data[0:, 190:] = 0
-        images.data[0:, 0:10] = np.nan
+        images = generate_images(seed=10)
+        self.imaging.presenter.create_new_stack(images, "bad_data")
+        images.data[0:, 7:] = 0
+        images.data[0:, 0:1] = np.nan
 
         self.imaging.show_recon_window()
         self.check_target(widget=self.imaging.recon)

--- a/mantidimaging/eyes_tests/test_reconstruct_window.py
+++ b/mantidimaging/eyes_tests/test_reconstruct_window.py
@@ -44,6 +44,7 @@ class ReconstructionWindowTest(BaseEyesTest):
         images = generate_images(seed=10)
         self.imaging.presenter.create_new_stack(images, "bad_data")
         images.data[0:, 7:] = 0
+        images.data[0:, 3:4] = -1
         images.data[0:, 0:1] = np.nan
 
         self.imaging.show_recon_window()

--- a/mantidimaging/eyes_tests/test_reconstruct_window.py
+++ b/mantidimaging/eyes_tests/test_reconstruct_window.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-import numpy as np
-
-from mantidimaging.core.data import Images
+# import numpy as np
+#
+# from mantidimaging.core.data import Images
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
 
 
@@ -40,12 +40,12 @@ class ReconstructionWindowTest(BaseEyesTest):
 
         self.check_target(widget=self.imaging.recon)
 
-    def test_negative_nan_overlay(self):
-        data = np.random.rand(200, 200)
-        data[:, 5] = 0
-        data[:-5, ] = np.nan
-        self.imaging.presenter.create_new_stack(Images(data), "bad_data")
-
-        self.imaging.show_recon_window()
-        self.imaging.recon.stackSelector.setCurrentIndex(1)
-        self.check_target(widget=self.imaging.recon)
+    # def test_negative_nan_overlay(self):
+    #     data = np.random.rand(200, 200)
+    #     data[:, 5] = 0
+    #     data[:-5, ] = np.nan
+    #     self.imaging.presenter.create_new_stack(Images(data), "bad_data")
+    #
+    #     self.imaging.show_recon_window()
+    #     self.imaging.recon.stackSelector.setCurrentIndex(1)
+    #     self.check_target(widget=self.imaging.recon)

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -609,10 +609,16 @@
         </item>
         <item>
          <widget class="QGroupBox" name="groupBox_2">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="maximumSize">
            <size>
             <width>343</width>
-            <height>16777215</height>
+            <height>200</height>
            </size>
           </property>
           <property name="title">
@@ -620,16 +626,25 @@
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_5">
            <item>
-            <widget class="QLabel" name="label_2">
+            <widget class="QLabel" name="messageIcon">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="text">
               <string/>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
              </property>
             </widget>
            </item>
            <item>
             <widget class="QTextEdit" name="statusMessageTextEdit">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -608,7 +608,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QTextEdit" name="textEdit">
+         <widget class="QTextEdit" name="statusMessageTextEdit">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
             <horstretch>0</horstretch>

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -21,7 +21,7 @@
        <enum>Qt::Horizontal</enum>
       </property>
       <widget class="QWidget" name="formLayoutWidget">
-       <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0">
+       <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0">
         <property name="sizeConstraint">
          <enum>QLayout::SetMaximumSize</enum>
         </property>
@@ -44,6 +44,12 @@
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>343</width>
+            <height>0</height>
+           </size>
           </property>
           <property name="currentIndex">
            <number>0</number>
@@ -529,17 +535,16 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="minimumSize">
+           <size>
+            <width>343</width>
+            <height>0</height>
+           </size>
+          </property>
           <property name="title">
            <string>Preview</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_2">
-           <item row="0" column="0">
-            <widget class="QLabel" name="previewProjectionIndexLabel">
-             <property name="text">
-              <string>Projection index:</string>
-             </property>
-            </widget>
-           </item>
            <item row="1" column="1">
             <widget class="QSpinBox" name="previewSliceIndex">
              <property name="maximum">
@@ -547,17 +552,36 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
-            <widget class="QSpinBox" name="previewProjectionIndex">
-             <property name="maximum">
-              <number>99999</number>
+           <item row="0" column="0">
+            <widget class="QLabel" name="previewProjectionIndexLabel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Projection index:</string>
              </property>
             </widget>
            </item>
            <item row="1" column="0">
             <widget class="QLabel" name="previewSliceIndexLabel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="text">
               <string>Slice index:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="previewProjectionIndex">
+             <property name="maximum">
+              <number>99999</number>
              </property>
             </widget>
            </item>
@@ -572,8 +596,33 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="minimumSize">
+           <size>
+            <width>343</width>
+            <height>0</height>
+           </size>
+          </property>
           <property name="text">
            <string>Auto Change Colour Palette</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QTextEdit" name="textEdit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>343</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
           </property>
          </widget>
         </item>
@@ -582,7 +631,7 @@
       <widget class="QWidget" name="verticalLayoutWidget">
        <layout class="QVBoxLayout" name="imageLayout">
         <property name="sizeConstraint">
-         <enum>QLayout::SetMinimumSize</enum>
+         <enum>QLayout::SetMaximumSize</enum>
         </property>
        </layout>
       </widget>

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1495</width>
-    <height>903</height>
+    <height>1029</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -608,22 +608,44 @@
          </widget>
         </item>
         <item>
-         <widget class="QTextEdit" name="statusMessageTextEdit">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
+         <widget class="QGroupBox" name="groupBox_2">
+          <property name="maximumSize">
            <size>
             <width>343</width>
-            <height>0</height>
+            <height>16777215</height>
            </size>
           </property>
-          <property name="textInteractionFlags">
-           <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+          <property name="title">
+           <string/>
           </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <item>
+            <widget class="QLabel" name="label_2">
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QTextEdit" name="statusMessageTextEdit">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="textInteractionFlags">
+              <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </widget>
         </item>
        </layout>

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -150,6 +150,9 @@ class ReconImagesView(GraphicsLayoutWidget):
         self.recon_hist.autoHistogramRange()
 
     def _add_nan_zero_overlay(self):
+        """
+        Adds the NaN/zero overlay to the projection view box.
+        """
         copy = self.projection.image.copy()
         nans = np.isnan(copy)
         zeroes = copy == 0

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -83,7 +83,7 @@ class ReconImagesView(GraphicsLayoutWidget):
     def update_projection(self, image_data: np.ndarray, preview_slice_index: int, tilt_angle: Optional[Degrees]):
         self.projection.clear()
         self.projection.setImage(image_data)
-        self._add_nan_zero_overlay()
+        self._add_nan_zero_negative_overlay()
         self.projection_hist.imageChanged(autoLevel=True, autoRange=True)
         self.slice_line.setPos(preview_slice_index)
         if tilt_angle:
@@ -149,15 +149,15 @@ class ReconImagesView(GraphicsLayoutWidget):
     def reset_recon_histogram(self):
         self.recon_hist.autoHistogramRange()
 
-    def _add_nan_zero_overlay(self):
+    def _add_nan_zero_negative_overlay(self):
         """
         Adds the NaN/zero overlay to the projection view box.
         """
         copy = self.projection.image.copy()
         nans = np.isnan(copy)
-        zeroes = copy == 0
+        zero_negative = copy <= 0
 
-        overlay_idxs = np.logical_or(nans, zeroes)
+        overlay_idxs = np.logical_or(nans, zero_negative)
         overlay_arr = np.zeros(copy.shape)
         overlay_arr[overlay_idxs] = 1.0
 

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -3,9 +3,9 @@
 from math import isnan
 from typing import Tuple, Optional
 
-import numpy
+import numpy as np
 from PyQt5 import QtCore
-from pyqtgraph import GraphicsLayoutWidget, ImageItem, ViewBox, HistogramLUTItem, LabelItem, InfiniteLine
+from pyqtgraph import GraphicsLayoutWidget, ImageItem, ViewBox, HistogramLUTItem, LabelItem, InfiniteLine, ColorMap
 
 from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint
 from mantidimaging.core.utility.data_containers import Degrees
@@ -42,6 +42,10 @@ class ReconImagesView(GraphicsLayoutWidget):
         recon_details = LabelItem("Value")
         image_layout.addItem(recon_details, 3, 2, 1, 2)
 
+        self.negative_nan_overlay = ImageItem()
+        self.negative_nan_overlay.setZValue(11)
+        self.projection_vb.addItem(self.negative_nan_overlay)
+
         msg_format = "Value: {:.6f}"
         self.display_formatted_detail = {
             self.projection: lambda val: projection_details.setText(msg_format.format(val)),
@@ -76,9 +80,10 @@ class ReconImagesView(GraphicsLayoutWidget):
         hist = HistogramLUTItem(im)
         return im, vb, hist
 
-    def update_projection(self, image_data: numpy.ndarray, preview_slice_index: int, tilt_angle: Optional[Degrees]):
+    def update_projection(self, image_data: np.ndarray, preview_slice_index: int, tilt_angle: Optional[Degrees]):
         self.projection.clear()
         self.projection.setImage(image_data)
+        self._add_nan_zero_overlay()
         self.projection_hist.imageChanged(autoLevel=True, autoRange=True)
         self.slice_line.setPos(preview_slice_index)
         if tilt_angle:
@@ -143,3 +148,21 @@ class ReconImagesView(GraphicsLayoutWidget):
 
     def reset_recon_histogram(self):
         self.recon_hist.autoHistogramRange()
+
+    def _add_nan_zero_overlay(self):
+        copy = self.projection.image.copy()
+        nans = np.isnan(copy)
+        zeroes = copy == 0
+
+        overlay_idxs = np.logical_or(nans, zeroes)
+        overlay_arr = np.zeros(copy.shape)
+        overlay_arr[overlay_idxs] = 1.0
+
+        pos = np.array([0, 1])
+        color = np.array([[0, 0, 0, 0], [255, 0, 0, 255]], dtype=np.ubyte)
+        map = ColorMap(pos, color)
+
+        self.negative_nan_overlay.setOpacity(1)
+        self.negative_nan_overlay.setImage(overlay_arr)
+        lut = map.getLookupTable(0, 1, 2)
+        self.negative_nan_overlay.setLookupTable(lut)

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -266,3 +266,6 @@ class ReconstructWindowModel(object):
 
     def stack_contains_zeroes(self) -> bool:
         return not np.all(self.images.data)
+
+    def stack_contains_negative_values(self) -> bool:
+        return np.any(self.images.data < 0)

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -263,3 +263,6 @@ class ReconstructWindowModel(object):
 
     def stack_contains_nans(self) -> bool:
         return np.any(np.isnan(self.images.data))
+
+    def stack_contains_zeroes(self) -> bool:
+        return np.all(self.images.data)

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -260,3 +260,6 @@ class ReconstructWindowModel(object):
     def proj_180_degree_shape_matches_images(images):
         return images.has_proj180deg() and images.height == images.proj180deg.height \
                and images.width == images.proj180deg.width
+
+    def stack_contains_nans(self) -> bool:
+        return np.any(np.isnan(self.images.data))

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -265,4 +265,4 @@ class ReconstructWindowModel(object):
         return np.any(np.isnan(self.images.data))
 
     def stack_contains_zeroes(self) -> bool:
-        return np.all(self.images.data)
+        return not np.all(self.images.data)

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -359,6 +359,6 @@ class ReconstructWindowPresenter(BasePresenter):
         Checks if the data contains NaNs/zeroes and displays a message if they are found.
         """
         if self.model.stack_contains_nans():
-            self.view.show_error_dialog("Warning: NaN(s) found in the stack.")
+            self.view.show_status_message("Warning: NaN(s) found in the stack.")
         if self.model.stack_contains_zeroes():
-            self.view.show_error_dialog("Warning: Zero(es) found in the stack.")
+            self.view.show_status_messagae("Warning: Zero(es) found in the stack.")

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -43,6 +43,7 @@ class Notifications(Enum):
     REFINE_ITERS = auto()
     AUTO_FIND_COR_CORRELATE = auto()
     AUTO_FIND_COR_MINIMISE = auto()
+    DO_NAN_CHECK = auto()
 
 
 class ReconstructWindowPresenter(BasePresenter):
@@ -95,6 +96,8 @@ class ReconstructWindowPresenter(BasePresenter):
                 self._auto_find_correlation()
             elif notification == Notifications.AUTO_FIND_COR_MINIMISE:
                 self._auto_find_minimisation_square_sum()
+            elif notification == Notifications.DO_NAN_CHECK:
+                self._do_nan_check()
         except Exception as err:
             self.show_error(err, traceback.format_exc())
 
@@ -349,3 +352,7 @@ class ReconstructWindowPresenter(BasePresenter):
 
     def proj_180_degree_shape_matches_images(self, images):
         return self.model.proj_180_degree_shape_matches_images(images)
+
+    def _do_nan_check(self):
+        if self.model.stack_contains_nans():
+            self.view.show_error_dialog("Warning: NaNs found in the stack.")

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -126,7 +126,7 @@ class ReconstructWindowPresenter(BasePresenter):
         self.do_update_projection()
         self.view.update_recon_hist_needed = True
         self.do_preview_reconstruct_slice()
-        self._do_nan_and_zero_check()
+        self._do_nan_zero_negative_check()
 
     def set_preview_projection_idx(self, idx):
         self.model.preview_projection_idx = idx
@@ -354,7 +354,7 @@ class ReconstructWindowPresenter(BasePresenter):
     def proj_180_degree_shape_matches_images(self, images):
         return self.model.proj_180_degree_shape_matches_images(images)
 
-    def _do_nan_and_zero_check(self):
+    def _do_nan_zero_negative_check(self):
         """
         Checks if the data contains NaNs/zeroes and displays a message if they are found.
         """

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -43,7 +43,6 @@ class Notifications(Enum):
     REFINE_ITERS = auto()
     AUTO_FIND_COR_CORRELATE = auto()
     AUTO_FIND_COR_MINIMISE = auto()
-    DO_NAN_ZERO_CHECK = auto()
 
 
 class ReconstructWindowPresenter(BasePresenter):
@@ -96,8 +95,6 @@ class ReconstructWindowPresenter(BasePresenter):
                 self._auto_find_correlation()
             elif notification == Notifications.AUTO_FIND_COR_MINIMISE:
                 self._auto_find_minimisation_square_sum()
-            elif notification == Notifications.DO_NAN_ZERO_CHECK:
-                self._do_nan_and_zero_check()
         except Exception as err:
             self.show_error(err, traceback.format_exc())
 

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -363,6 +363,8 @@ class ReconstructWindowPresenter(BasePresenter):
             msg_list.append("NaN(s) found in the stack.")
         if self.model.stack_contains_zeroes():
             msg_list.append("Zero(es) found in the stack.")
+        if self.model.stack_contains_negative_values():
+            msg_list.append("Negative value(s) found in the stack.")
 
         if len(msg_list) == 0:
             self.view.show_status_message("")

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -358,6 +358,6 @@ class ReconstructWindowPresenter(BasePresenter):
         Checks if the data contains NaNs/zeroes and displays a message if they are found.
         """
         if self.model.stack_contains_nans():
-            self.view.show_error_dialog("Warning: NaNs found in the stack.")
+            self.view.show_error_dialog("Warning: NaN(s) found in the stack.")
         if self.model.stack_contains_zeroes():
-            self.view.show_error_dialog("Warning: Zeroes found in the stack.")
+            self.view.show_error_dialog("Warning: Zero(es) found in the stack.")

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -97,7 +97,7 @@ class ReconstructWindowPresenter(BasePresenter):
             elif notification == Notifications.AUTO_FIND_COR_MINIMISE:
                 self._auto_find_minimisation_square_sum()
             elif notification == Notifications.DO_NAN_CHECK:
-                self._do_nan_check()
+                self._do_nan_and_zero_check()
         except Exception as err:
             self.show_error(err, traceback.format_exc())
 
@@ -353,6 +353,8 @@ class ReconstructWindowPresenter(BasePresenter):
     def proj_180_degree_shape_matches_images(self, images):
         return self.model.proj_180_degree_shape_matches_images(images)
 
-    def _do_nan_check(self):
+    def _do_nan_and_zero_check(self):
         if self.model.stack_contains_nans():
             self.view.show_error_dialog("Warning: NaNs found in the stack.")
+        if self.model.stack_contains_zeroes():
+            self.view.show_error_dialog("Warning: Zeroes found in the stack.")

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -43,7 +43,7 @@ class Notifications(Enum):
     REFINE_ITERS = auto()
     AUTO_FIND_COR_CORRELATE = auto()
     AUTO_FIND_COR_MINIMISE = auto()
-    DO_NAN_CHECK = auto()
+    DO_NAN_ZERO_CHECK = auto()
 
 
 class ReconstructWindowPresenter(BasePresenter):
@@ -96,7 +96,7 @@ class ReconstructWindowPresenter(BasePresenter):
                 self._auto_find_correlation()
             elif notification == Notifications.AUTO_FIND_COR_MINIMISE:
                 self._auto_find_minimisation_square_sum()
-            elif notification == Notifications.DO_NAN_CHECK:
+            elif notification == Notifications.DO_NAN_ZERO_CHECK:
                 self._do_nan_and_zero_check()
         except Exception as err:
             self.show_error(err, traceback.format_exc())

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -354,6 +354,9 @@ class ReconstructWindowPresenter(BasePresenter):
         return self.model.proj_180_degree_shape_matches_images(images)
 
     def _do_nan_and_zero_check(self):
+        """
+        Checks if the data contains NaNs/zeroes and displays a message if they are found.
+        """
         if self.model.stack_contains_nans():
             self.view.show_error_dialog("Warning: NaNs found in the stack.")
         if self.model.stack_contains_zeroes():

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -358,7 +358,14 @@ class ReconstructWindowPresenter(BasePresenter):
         """
         Checks if the data contains NaNs/zeroes and displays a message if they are found.
         """
+        msg_list = []
         if self.model.stack_contains_nans():
-            self.view.show_status_message("Warning: NaN(s) found in the stack.")
+            msg_list.append("NaN(s) found in the stack.")
         if self.model.stack_contains_zeroes():
-            self.view.show_status_messagae("Warning: Zero(es) found in the stack.")
+            msg_list.append("Zero(es) found in the stack.")
+
+        if len(msg_list) == 0:
+            self.view.show_status_message("")
+        else:
+            msg_list.insert(0, "Warning:")
+            self.view.show_status_message(" ".join(msg_list))

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -129,6 +129,7 @@ class ReconstructWindowPresenter(BasePresenter):
         self.do_update_projection()
         self.view.update_recon_hist_needed = True
         self.do_preview_reconstruct_slice()
+        self._do_nan_and_zero_check()
 
     def set_preview_projection_idx(self, idx):
         self.model.preview_projection_idx = idx

--- a/mantidimaging/gui/windows/recon/test/model_test.py
+++ b/mantidimaging/gui/windows/recon/test/model_test.py
@@ -189,7 +189,18 @@ class ReconWindowModelTest(unittest.TestCase):
         with mock.patch("mantidimaging.gui.windows.recon.model.CudaChecker.cuda_is_present", return_value=True):
             assert self.model.load_allowed_recon_kwargs() == allowed_args
 
-    def test_stack_contains_nans(self):
+    def test_stack_contains_nans_returns_false(self):
+        self.model.images.data = np.array([1, 2, 3])
         self.assertFalse(self.model.stack_contains_nans())
+
+    def test_stack_contains_nans_returns_true(self):
         self.model.images.data[1][1][1] = np.nan
         self.assertTrue(self.model.stack_contains_nans())
+
+    def test_stack_contains_zeroes_returns_false(self):
+        self.model.images.data = np.array([1, 2, 3])
+        self.assertFalse(self.model.stack_contains_zeroes())
+
+    def test_stack_contains_zeroes_returns_true(self):
+        self.model.images.data = np.array([0, 0, 0])
+        self.assertTrue(self.model.stack_contains_zeroes())

--- a/mantidimaging/gui/windows/recon/test/model_test.py
+++ b/mantidimaging/gui/windows/recon/test/model_test.py
@@ -204,3 +204,11 @@ class ReconWindowModelTest(unittest.TestCase):
     def test_stack_contains_zeroes_returns_true(self):
         self.model.images.data = np.array([0, 0, 0])
         self.assertTrue(self.model.stack_contains_zeroes())
+
+    def test_stack_contains_negative_values_returns_true(self):
+        self.model.images.data = np.array([-1, 0, 0])
+        self.assertTrue(self.model.stack_contains_negative_values())
+
+    def test_stack_contains_negative_values_returns_false(self):
+        self.model.images.data = np.array([0, 0, 0])
+        self.assertTrue(self.model.stack_contains_negative_values())

--- a/mantidimaging/gui/windows/recon/test/model_test.py
+++ b/mantidimaging/gui/windows/recon/test/model_test.py
@@ -188,3 +188,8 @@ class ReconWindowModelTest(unittest.TestCase):
         allowed_args.update(cil_allowed_kwargs())
         with mock.patch("mantidimaging.gui.windows.recon.model.CudaChecker.cuda_is_present", return_value=True):
             assert self.model.load_allowed_recon_kwargs() == allowed_args
+
+    def test_stack_contains_nans(self):
+        self.assertFalse(self.model.stack_contains_nans())
+        self.model.images.data[1][1][1] = np.nan
+        self.assertTrue(self.model.stack_contains_nans())

--- a/mantidimaging/gui/windows/recon/test/model_test.py
+++ b/mantidimaging/gui/windows/recon/test/model_test.py
@@ -211,4 +211,4 @@ class ReconWindowModelTest(unittest.TestCase):
 
     def test_stack_contains_negative_values_returns_false(self):
         self.model.images.data = np.array([0, 0, 0])
-        self.assertTrue(self.model.stack_contains_negative_values())
+        self.assertFalse(self.model.stack_contains_negative_values())

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -320,7 +320,7 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.presenter.model.stack_contains_nans = mock.Mock(return_value=True)
         self.presenter.model.stack_contains_zeroes = mock.Mock(return_value=True)
 
-        self.presenter.notify(PresNotification.DO_NAN_ZERO_CHECK)
+        self.presenter._do_nan_and_zero_check()
         self.view.show_error_dialog.assert_has_calls(
             [mock.call("Warning: NaN(s) found in the stack."),
              mock.call("Warning: Zero(es) found in the stack.")])

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -322,5 +322,5 @@ class ReconWindowPresenterTest(unittest.TestCase):
 
         self.presenter.notify(PresNotification.DO_NAN_ZERO_CHECK)
         self.view.show_error_dialog.assert_has_calls(
-            [mock.call("Warning: NaNs found in the stack."),
-             mock.call("Warning: Zeroes found in the stack.")])
+            [mock.call("Warning: NaN(s) found in the stack."),
+             mock.call("Warning: Zero(es) found in the stack.")])

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -316,12 +316,12 @@ class ReconWindowPresenterTest(unittest.TestCase):
 
         self.assertFalse(self.presenter.proj_180_degree_shape_matches_images(images))
 
-    def test_status_message_shows_nan_zero_warning(self):
+    def test_status_message_shows_nan_zero_negative_warning(self):
         self.presenter.model.stack_contains_nans = mock.Mock(return_value=True)
         self.presenter.model.stack_contains_zeroes = mock.Mock(return_value=True)
         self.presenter.model.stack_contains_negative_values = mock.Mock(return_value=True)
 
-        self.presenter._do_nan_and_zero_check()
+        self.presenter._do_nan_zero_negative_check()
         self.view.show_status_message.assert_called_once_with(
             "Warning: NaN(s) found in the stack. Zero(es) found in the stack. Negative value(s) found in the stack.")
 
@@ -330,5 +330,5 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.presenter.model.stack_contains_zeroes = mock.Mock(return_value=False)
         self.presenter.model.stack_contains_negative_values = mock.Mock(return_value=False)
 
-        self.presenter._do_nan_and_zero_check()
+        self.presenter._do_nan_zero_negative_check()
         self.view.show_status_message.assert_called_once_with("")

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -319,14 +319,16 @@ class ReconWindowPresenterTest(unittest.TestCase):
     def test_status_message_shows_nan_zero_warning(self):
         self.presenter.model.stack_contains_nans = mock.Mock(return_value=True)
         self.presenter.model.stack_contains_zeroes = mock.Mock(return_value=True)
+        self.presenter.model.stack_contains_negative_values = mock.Mock(return_value=True)
 
         self.presenter._do_nan_and_zero_check()
         self.view.show_status_message.assert_called_once_with(
-            "Warning: NaN(s) found in the stack. Zero(es) found in the stack.")
+            "Warning: NaN(s) found in the stack. Zero(es) found in the stack. Negative value(s) found in the stack.")
 
     def test_status_message_cleared(self):
         self.presenter.model.stack_contains_nans = mock.Mock(return_value=False)
         self.presenter.model.stack_contains_zeroes = mock.Mock(return_value=False)
+        self.presenter.model.stack_contains_negative_values = mock.Mock(return_value=False)
 
         self.presenter._do_nan_and_zero_check()
         self.view.show_status_message.assert_called_once_with("")

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -316,11 +316,17 @@ class ReconWindowPresenterTest(unittest.TestCase):
 
         self.assertFalse(self.presenter.proj_180_degree_shape_matches_images(images))
 
-    def test_notify_nan_zero_check(self):
+    def test_status_message_shows_nan_zero_warning(self):
         self.presenter.model.stack_contains_nans = mock.Mock(return_value=True)
         self.presenter.model.stack_contains_zeroes = mock.Mock(return_value=True)
 
         self.presenter._do_nan_and_zero_check()
-        self.view.show_error_dialog.assert_has_calls(
-            [mock.call("Warning: NaN(s) found in the stack."),
-             mock.call("Warning: Zero(es) found in the stack.")])
+        self.view.show_status_message.assert_called_once_with(
+            "Warning: NaN(s) found in the stack. Zero(es) found in the stack.")
+
+    def test_status_message_cleared(self):
+        self.presenter.model.stack_contains_nans = mock.Mock(return_value=False)
+        self.presenter.model.stack_contains_zeroes = mock.Mock(return_value=False)
+
+        self.presenter._do_nan_and_zero_check()
+        self.view.show_status_message.assert_called_once_with("")

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -315,3 +315,12 @@ class ReconWindowPresenterTest(unittest.TestCase):
         images.has_proj180deg = has_proj180deg
 
         self.assertFalse(self.presenter.proj_180_degree_shape_matches_images(images))
+
+    def test_notify_nan_zero_check(self):
+        self.presenter.model.stack_contains_nans = mock.Mock(return_value=True)
+        self.presenter.model.stack_contains_zeroes = mock.Mock(return_value=True)
+
+        self.presenter.notify(PresNotification.DO_NAN_ZERO_CHECK)
+        self.view.show_error_dialog.assert_has_calls(
+            [mock.call("Warning: NaNs found in the stack."),
+             mock.call("Warning: Zeroes found in the stack.")])

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 import numpy
 from PyQt5.QtWidgets import (QAbstractItemView, QComboBox, QDoubleSpinBox, QInputDialog, QPushButton, QSpinBox,
-                             QVBoxLayout, QWidget, QMessageBox, QAction, QTextEdit)
+                             QVBoxLayout, QWidget, QMessageBox, QAction, QTextEdit, QLabel, QApplication, QStyle)
 from PyQt5.QtCore import pyqtSignal, QSignalBlocker
 
 from mantidimaging.core.data import Images
@@ -61,6 +61,7 @@ class ReconstructWindowView(BaseMainWindowView):
     reconstructSlice: QPushButton
 
     statusMessageTextEdit: QTextEdit
+    messageIcon: QLabel
 
     changeColourPaletteButton: QPushButton
 
@@ -438,3 +439,7 @@ class ReconstructWindowView(BaseMainWindowView):
 
     def show_status_message(self, msg: str):
         self.statusMessageTextEdit.setText(msg)
+        if msg:
+            self.messageIcon.setPixmap(QApplication.style().standardPixmap(QStyle.SP_MessageBoxCritical))
+        else:
+            self.messageIcon.clear()

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+import logging
 from typing import TYPE_CHECKING, List, Optional
 from uuid import UUID
 
@@ -429,3 +430,8 @@ class ReconstructWindowView(BaseMainWindowView):
                                                    [self.image_view.sinogram_hist, self.image_view.projection_hist],
                                                    True)
         change_colour_palette.show()
+
+    def show(self):
+        logging.getLogger(__name__).info("Showing recon window")
+        self.presenter.notify(PresN.DO_NAN_CHECK)
+        super().show()

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -433,7 +433,3 @@ class ReconstructWindowView(BaseMainWindowView):
                                                    [self.image_view.sinogram_hist, self.image_view.projection_hist],
                                                    True)
         change_colour_palette.show()
-
-    def show(self):
-        super().show()
-        self.presenter.notify(PresN.DO_NAN_ZERO_CHECK)

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -438,6 +438,11 @@ class ReconstructWindowView(BaseMainWindowView):
         change_colour_palette.show()
 
     def show_status_message(self, msg: str):
+        """
+        Shows a status message indicating that zero/negative/NaN pixels were found in the stack. If the msg argument is
+        empty then this is taken to mean that no such pixels were found, so the warning message and icon are cleared.
+        :param msg: The status message.
+        """
         self.statusMessageTextEdit.setText(msg)
         if msg:
             self.messageIcon.setPixmap(QApplication.style().standardPixmap(QStyle.SP_MessageBoxCritical))

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -433,5 +433,5 @@ class ReconstructWindowView(BaseMainWindowView):
 
     def show(self):
         logging.getLogger(__name__).info("Showing recon window")
-        self.presenter.notify(PresN.DO_NAN_CHECK)
+        self.presenter.notify(PresN.DO_NAN_ZERO_CHECK)
         super().show()

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-import logging
 from typing import TYPE_CHECKING, List, Optional
 from uuid import UUID
 
@@ -432,6 +431,5 @@ class ReconstructWindowView(BaseMainWindowView):
         change_colour_palette.show()
 
     def show(self):
-        logging.getLogger(__name__).info("Showing recon window")
-        self.presenter.notify(PresN.DO_NAN_ZERO_CHECK)
         super().show()
+        self.presenter.notify(PresN.DO_NAN_ZERO_CHECK)

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 import numpy
 from PyQt5.QtWidgets import (QAbstractItemView, QComboBox, QDoubleSpinBox, QInputDialog, QPushButton, QSpinBox,
-                             QVBoxLayout, QWidget, QMessageBox, QAction)
+                             QVBoxLayout, QWidget, QMessageBox, QAction, QTextEdit)
 from PyQt5.QtCore import pyqtSignal, QSignalBlocker
 
 from mantidimaging.core.data import Images
@@ -59,6 +59,8 @@ class ReconstructWindowView(BaseMainWindowView):
     resultSlope: QDoubleSpinBox
     reconstructVolume: QPushButton
     reconstructSlice: QPushButton
+
+    statusMessageTextEdit: QTextEdit
 
     changeColourPaletteButton: QPushButton
 
@@ -433,3 +435,6 @@ class ReconstructWindowView(BaseMainWindowView):
                                                    [self.image_view.sinogram_hist, self.image_view.projection_hist],
                                                    True)
         change_colour_palette.show()
+
+    def show_status_message(self, msg: str):
+        self.statusMessageTextEdit.setText(msg)


### PR DESCRIPTION
### Issue

Closes #1026

### Description

Shows messages if the image contains zeroes/NaNs/negative values when the recon window has been opened. Also shows an overlay of red pixels.

### Testing 

- Added a GUI test for the overlay
- Added tests for the error messages
- Added tests for the NaN/zero/negative value check methods

### Acceptance Criteria 

Check that the tests pass. Check that the message appears when an image contains the unwanted values.

### Documentation

Updated release notes. Also mentioned the underscore issue in the file loading documentation.
