### PR TITLE
Use selected slice in table

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -41,6 +41,7 @@ Fixes
 - #898: Improve user documentation for operations
 - #1059: Crash in recon Minimise Error with CIL
 - #1032: Crash in RingRemovalFilter
+- #1057: Fix crash when refining COR
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/rotation/data_model.py
+++ b/mantidimaging/core/rotation/data_model.py
@@ -57,13 +57,13 @@ class CorTiltDataModel:
             if cor is not None:
                 self._points[idx] = Point(self._points[idx].slice_index, float(cor))
 
-    def _get_data_idx_from_slice_idx(self, slice_idx):
+    def _get_data_idx_from_slice_idx(self, slice_idx) -> int:
         for i, p in enumerate(self._points):
             if p.slice_index == slice_idx:
                 return i
-        return None
+        raise ValueError(f"Slice {slice_idx} that is not in COR table")
 
-    def set_cor_at_slice(self, slice_idx, cor: float):
+    def set_cor_at_slice(self, slice_idx: int, cor: float):
         data_idx = self._get_data_idx_from_slice_idx(slice_idx)
         self.set_point(data_idx, cor=cor)
 

--- a/mantidimaging/core/rotation/test/data_model_test.py
+++ b/mantidimaging/core/rotation/test/data_model_test.py
@@ -202,7 +202,7 @@ class CorTiltDataModelTest(TestCase):
         m.add_point(None, 40, 8.0)
 
         self.assertEqual(m._get_data_idx_from_slice_idx(10), 0)
-        self.assertIsNone(m._get_data_idx_from_slice_idx(100))
+        self.assertRaises(ValueError, m._get_data_idx_from_slice_idx, 100)
 
     def test_set_cor_at_slice(self):
         m = CorTiltDataModel()

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -234,7 +234,11 @@ class ReconstructWindowPresenter(BasePresenter):
                                     **self.view.recon_params().to_dict())
 
     def _do_refine_selected_cor(self):
-        slice_idx = self.model.preview_slice_idx
+        selected_rows = self.view.get_cor_table_selected_rows()
+        if len(selected_rows):
+            slice_idx = self.model.slices[selected_rows[0]]
+        else:
+            raise ValueError("No slice selected in COR table")
 
         dialog = CORInspectionDialogView(self.view, self.model.images, slice_idx, self.model.last_cor,
                                          self.view.recon_params(), False)

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -180,8 +180,7 @@ class ReconstructWindowPresenter(BasePresenter):
         start_async_task_view(self.view, self.model.run_full_recon, self._on_volume_recon_done,
                               {'recon_params': self.view.recon_params()})
 
-    def _get_reconstruct_slice(self, cor, slice_idx: Optional[int], call_back: Callable[[TaskWorkerThread],
-                                                                                        None]) -> None:
+    def _get_reconstruct_slice(self, cor, slice_idx: int, call_back: Callable[[TaskWorkerThread], None]) -> None:
         # If no COR is provided and there are regression results then calculate
         # the COR for the selected preview slice
         cor = self.model.get_me_a_cor(cor)
@@ -191,7 +190,7 @@ class ReconstructWindowPresenter(BasePresenter):
             'recon_params': self.view.recon_params()
         })
 
-    def _get_slice_index(self, slice_idx: Optional[int]):
+    def _get_slice_index(self, slice_idx: Optional[int]) -> int:
         if slice_idx is None:
             slice_idx = self.model.preview_slice_idx
         else:

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -251,7 +251,7 @@ class ReconstructWindowPresenter(BasePresenter):
             self.model.data_model.set_cor_at_slice(slice_idx, new_cor.value)
             self.model.last_cor = new_cor
             # Update reconstruction preview with new COR
-            self.do_preview_reconstruct_slice(new_cor, slice_idx)
+            self.set_preview_slice_idx(slice_idx)
 
     def _do_refine_iterations(self):
         slice_idx = self.model.preview_slice_idx

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -154,9 +154,9 @@ class ReconWindowPresenterTest(unittest.TestCase):
 
     @mock.patch('mantidimaging.gui.windows.recon.presenter.CORInspectionDialogView')
     def test_do_refine_selected_cor_declined(self, mock_corview):
-        self.presenter.model.preview_slice_idx = 155
         self.presenter.model.last_cor = ScalarCoR(314)
         self.presenter.do_preview_reconstruct_slice = mock.Mock()
+        self.view.get_cor_table_selected_rows = mock.Mock(return_value=[155])
 
         mock_dialog = mock.Mock()
         mock_corview.return_value = mock_dialog
@@ -169,9 +169,9 @@ class ReconWindowPresenterTest(unittest.TestCase):
 
     @mock.patch('mantidimaging.gui.windows.recon.presenter.CORInspectionDialogView')
     def test_do_refine_selected_cor_accepted(self, mock_corview):
-        self.presenter.model.preview_slice_idx = 155
         self.presenter.model.last_cor = ScalarCoR(314)
         self.presenter.do_preview_reconstruct_slice = mock.Mock()
+        self.view.get_cor_table_selected_rows = mock.Mock(return_value=[155])
         mock_dialog = mock.Mock()
         mock_dialog.exec.return_value = mock_corview.Accepted
         mock_corview.return_value = mock_dialog

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -94,6 +94,15 @@ class ReconstructWindowViewTest(unittest.TestCase):
         cortiltpointqtmodel_mock.assert_not_called()
         self.tableView.setModel.assert_not_called()
 
+    def test_cor_table_model_selected_rows(self):
+        mock_row = mock.Mock(row=mock.Mock(return_value=1))
+        mock_selection_model = mock.Mock(selectedRows=lambda: [mock_row, mock_row])
+        self.tableView.selectionModel = mock.Mock(return_value=mock_selection_model)
+
+        ret = self.view.get_cor_table_selected_rows()
+
+        self.assertEqual(ret, [1, 1])
+
     def test_set_results(self):
         cor_val = 20
         tilt_val = 30

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -293,6 +293,10 @@ class ReconstructWindowView(BaseMainWindowView):
         self.cor_table_model.appendNewRow(row, slice_index, cor)
         self.tableView.selectRow(row)
 
+    def get_cor_table_selected_rows(self) -> List[int]:
+        rows = self.tableView.selectionModel().selectedRows()
+        return [row.row() for row in rows]
+
     @property
     def rotation_centre(self):
         return self.resultCor.value()


### PR DESCRIPTION
### Issue

Closes #1057 

### Description

Previously, the refine step used the slice that was selected in the projection view and slice spinbox. When the refine was complete it tried to update the COR table for a slice that was not in the table.

Now use the slice that is selected in the COR table.

### Testing 
Follow steps on the issue. 

### Acceptance Criteria 
Should not give an error message.

### Documentation

release notes