### PR TITLE
Give useful warning in the UI for NaNs in ROI Norm

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -42,6 +42,7 @@ Fixes
 - #1059: Crash in recon Minimise Error with CIL
 - #1032: Crash in RingRemovalFilter
 - #1057: Fix crash when refining COR
+- #1056: Cannot set range [nan, nan] in ROI normalisation
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -198,6 +198,9 @@ def _execute(data: np.ndarray,
             ps.shared_list = [data, air_maxs]
             ps.execute(do_calculate_air_max, data.shape[0], progress, cores=cores)
 
+            if np.isnan(air_maxs).any():
+                raise ValueError("Image contains invalid (NaN) pixels")
+
             # calculate the before and after maximum
             init_max = air_maxs.max()
             post_max = (air_maxs / air_means).max()
@@ -211,6 +214,9 @@ def _execute(data: np.ndarray,
             ps.shared_list = [flat_field, flat_mean]
             ps.execute(do_calculate_air_means, flat_field.shape[0], progress, cores=cores)
             air_means /= flat_mean.mean()
+
+        if np.isnan(air_means).any():
+            raise ValueError("Air region contains invalid (NaN) pixels")
 
         do_divide = ps.create_partial(_divide_by_air, fwd_function=ps.inplace2)
         ps.shared_list = [data, air_means]

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -129,8 +129,9 @@ class FilterPreviews(GraphicsLayoutWidget):
         hist = HistogramLUTItem(im)
         return im, vb, hist
 
-    def clear_items(self):
-        self.image_before.clear()
+    def clear_items(self, clear_before: bool = True):
+        if clear_before:
+            self.image_before.clear()
         self.image_after.clear()
         self.image_difference.clear()
         self.image_diff_overlay.clear()

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -253,7 +253,7 @@ class FiltersWindowPresenter(BasePresenter):
         self.model.do_apply_filter_sync(apply_to, partial(self._post_filter, apply_to))
 
     def do_update_previews(self):
-        self.view.clear_previews()
+        self.view.clear_previews(clear_before=False)
         if self.stack is not None:
             lock_scale = self.view.lockScaleCheckBox.isChecked()
             if lock_scale:

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -151,8 +151,8 @@ class FiltersWindowView(BaseMainWindowView):
         # Enable the spinbox widget once the preview has been created
         self.previewImageIndex.setEnabled(True)
 
-    def clear_previews(self):
-        self.previews.clear_items()
+    def clear_previews(self, clear_before: bool = True):
+        self.previews.clear_items(clear_before=clear_before)
 
     def link_images_changed(self):
         if self.linkImages.isChecked():


### PR DESCRIPTION
### Issue

Closes #1056

### Description

Catch the NaNs and give a warning message to the user.

In "preserve max" mode a NaN anywhere in the image is a problem. For other modes only NaNs in the slected air region are a problem.

### Testing 

Do a ROI norm with a dataset containing NaNs.

### Acceptance CrIiteria 

Warning in message box.

### Documentation

release_notes
