### PR TITLE
Remove capping of non-positive values in recon

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -28,7 +28,6 @@ Fixes
 - #939 : median: NameError: name 'cp' is not defined
 - #957 : Crop Coordinates ROI not changing
 - #961 : Test failure: ImportError: libcuda.so.1
-- #953 : NaNs in result when reconstructing with FBP_CUDA
 - #959 : Median GPU does not work with even values
 - #990 : Remove combine histogram checkbox
 - #989 : Remove legend checkbox

--- a/mantidimaging/core/reconstruct/base_recon.py
+++ b/mantidimaging/core/reconstruct/base_recon.py
@@ -9,10 +9,6 @@ from mantidimaging.core.data import Images
 from mantidimaging.core.utility.data_containers import ScalarCoR, ProjectionAngles, ReconstructionParameters
 from mantidimaging.core.utility.progress_reporting import Progress
 
-# Prevents undefined and infinite values due to negative or zero pixels in
-# projection being passed into the negative log
-MIN_PIXEL_VALUE: float = 1e-6
-
 
 class BaseRecon:
     @staticmethod
@@ -21,7 +17,7 @@ class BaseRecon:
 
     @staticmethod
     def negative_log(data: np.ndarray) -> np.ndarray:
-        return -np.log(np.maximum(data, MIN_PIXEL_VALUE))
+        return -np.log(data)
 
     @staticmethod
     def single_sino(sino: np.ndarray, cor: ScalarCoR, proj_angles: ProjectionAngles,


### PR DESCRIPTION
### Issue

Fixes #1074 

### Description

Effectively reverts 4645f6f97e6a62a302a5ff4fc19e7cbceface6b2

Now have better warnings, so negative can be dealt with manually.

### Testing &  Acceptance Criteria 

When doing a recon with some negative valued pixels, some slices in the output should contain mostly NaNs. 

### Documentation

I removed the old release not entry.

