### PR TITLE
819: NaN Removal Filter

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -21,6 +21,7 @@ New features
 - #1027 : Flat field warning if output has negative values
 - #1027 : NeXus Loader: Message when loading large files
 - #1026 : Recon warn if input has NaNs
+- #816 : NaN Removal Filter
 
 Fixes
 -----

--- a/mantidimaging/core/operations/nan_removal/__init__.py
+++ b/mantidimaging/core/operations/nan_removal/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+from .nan_removal import NaNRemovalFilter  # noqa:F401
+
+FILTER_CLASS = NaNRemovalFilter

--- a/mantidimaging/core/operations/nan_removal/nan_removal.py
+++ b/mantidimaging/core/operations/nan_removal/nan_removal.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+from collections import Callable
+from functools import partial
+from typing import Dict
+
+import numpy as np
+from PyQt5.QtWidgets import QFormLayout, QWidget
+
+from mantidimaging.core.data import Images
+from mantidimaging.core.operations.base_filter import BaseFilter
+from mantidimaging.gui.mvp_base import BaseMainWindowView
+
+
+class NaNRemovalFilter(BaseFilter):
+
+    filter_name = "NaN Removal"
+
+    @staticmethod
+    def filter_func(images: Images, replace_value=float, progress=None) -> Images:
+
+        data = images.data
+        nan_idxs = np.isnan(data)
+        data[nan_idxs] = replace_value
+
+        return images
+
+    @staticmethod
+    def register_gui(form: 'QFormLayout', on_change: Callable, view: 'BaseMainWindowView') -> Dict[str, 'QWidget']:
+        from mantidimaging.gui.utility import add_property_to_form
+
+        value_range = (-10000000, 10000000)
+
+        _, replace_value_field = add_property_to_form("Replacement Value",
+                                                      'float',
+                                                      valid_values=value_range,
+                                                      form=form,
+                                                      on_change=on_change,
+                                                      tooltip="The value to replace the NaNs with")
+        replace_value_field.setDecimals(7)
+
+        return {"replace_value_field": replace_value_field}
+
+    @staticmethod
+    def execute_wrapper(replace_value_field=None):
+        replace_value = replace_value_field.value()
+        return partial(NaNRemovalFilter.filter_func, replace_value=replace_value)

--- a/mantidimaging/core/operations/nan_removal/nan_removal.py
+++ b/mantidimaging/core/operations/nan_removal/nan_removal.py
@@ -23,6 +23,7 @@ class NaNRemovalFilter(BaseFilter):
     """
 
     filter_name = "NaN Removal"
+    link_histograms = True
 
     @staticmethod
     def filter_func(data: Images, replace_value: float, progress=None) -> Images:
@@ -30,7 +31,7 @@ class NaNRemovalFilter(BaseFilter):
         Replaces the NaNs with a specified value.
         :param data: The input data.
         :param replace_value: The data to replace the NaNs with.
-        :param progress: The optional Progress oebject.
+        :param progress: The optional Progress object.
         :return: The Images object with the NaNs replaced.
         """
 

--- a/mantidimaging/core/operations/nan_removal/nan_removal.py
+++ b/mantidimaging/core/operations/nan_removal/nan_removal.py
@@ -14,17 +14,31 @@ from mantidimaging.gui.mvp_base import BaseMainWindowView
 
 
 class NaNRemovalFilter(BaseFilter):
+    """
+    Replaces all NaNs in the images with a specified value.
+
+    Intended to be used on: Projections
+
+    When: To remove NaNs before reconstruction.
+    """
 
     filter_name = "NaN Removal"
 
     @staticmethod
-    def filter_func(images: Images, replace_value=float, progress=None) -> Images:
+    def filter_func(data: Images, replace_value: float, progress=None) -> Images:
+        """
+        Replaces the NaNs with a specified value.
+        :param data: The input data.
+        :param replace_value: The data to replace the NaNs with.
+        :param progress: The optional Progress oebject.
+        :return: The Images object with the NaNs replaced.
+        """
 
-        data = images.data
-        nan_idxs = np.isnan(data)
-        data[nan_idxs] = replace_value
+        sample = data.data
+        nan_idxs = np.isnan(sample)
+        sample[nan_idxs] = replace_value
 
-        return images
+        return data
 
     @staticmethod
     def register_gui(form: 'QFormLayout', on_change: Callable, view: 'BaseMainWindowView') -> Dict[str, 'QWidget']:

--- a/mantidimaging/core/operations/nan_removal/nan_removal.py
+++ b/mantidimaging/core/operations/nan_removal/nan_removal.py
@@ -26,7 +26,7 @@ class NaNRemovalFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(data: Images, replace_value: float, progress=None) -> Images:
+    def filter_func(data, replace_value=None, progress=None) -> Images:
         """
         Replaces the NaNs with a specified value.
         :param data: The input data.

--- a/mantidimaging/core/operations/nan_removal/test/__init__.py
+++ b/mantidimaging/core/operations/nan_removal/test/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/nan_removal/test/nan_removal_test.py
+++ b/mantidimaging/core/operations/nan_removal/test/nan_removal_test.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+import mantidimaging.test_helpers.unit_test_helper as th
+from mantidimaging.core.operations.nan_removal import NaNRemovalFilter
+
+
+class NaNRemovalFilterTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(NaNRemovalFilterTest, self).__init__(*args, **kwargs)
+
+    def test_replace_nans(self):
+        images = th.generate_images()
+        images.data[::, 0] = np.nan
+        nan_idxs = np.isnan(images.data)
+
+        result = NaNRemovalFilter().filter_func(images, 3.0)
+        self.assertFalse(np.any(np.isnan(result.data)))
+        npt.assert_allclose(result.data[nan_idxs], 3.0)

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -187,9 +187,10 @@ class FilterPreviews(GraphicsLayoutWidget):
             view.linkView(ViewBox.XAxis, None)
             view.linkView(ViewBox.YAxis, None)
 
-    def add_difference_overlay(self, diff):
+    def add_difference_overlay(self, diff, nan_change):
         diff = np.absolute(diff)
         diff[diff > OVERLAY_THRESHOLD] = 1.0
+        diff[nan_change] = 1.0
         pos = np.array([0, 1])
         color = np.array([[0, 0, 0, 0], [0, 0, 255, 255]], dtype=np.ubyte)
         map = ColorMap(pos, color)

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -298,8 +298,8 @@ class FiltersWindowPresenter(BasePresenter):
 
             if filtered_image_data.shape == before_image.shape:
                 diff = np.subtract(filtered_image_data, before_image)
-                nan_change = _find_nan_change(before_image, filtered_image_data)
                 if self.view.overlayDifference.isChecked():
+                    nan_change = _find_nan_change(before_image, filtered_image_data)
                     self.view.previews.add_difference_overlay(diff, nan_change)
                 else:
                     self.view.previews.hide_difference_overlay()

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -41,6 +41,12 @@ class Notification(Enum):
 
 
 def _find_nan_change(before_image, filtered_image_data):
+    """
+    Returns a bool array of all the placed where a NaN has been removed.
+    :param before_image: The before image.
+    :param filtered_image_data: The filter result.
+    :return: The indexes of the pixels with removed NaNs.
+    """
     before_nan = np.isnan(before_image)
     after_nan = np.isnan(filtered_image_data)
     nan_change = np.logical_and(before_nan, ~after_nan)

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -43,7 +43,7 @@ class Notification(Enum):
 def _find_nan_change(before_image, filtered_image_data):
     before_nan = np.isnan(before_image)
     after_nan = np.isnan(filtered_image_data)
-    nan_change = np.logical_xor(before_nan, after_nan)
+    nan_change = np.logical_and(before_nan, ~after_nan)
     return nan_change
 
 

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -40,6 +40,13 @@ class Notification(Enum):
     SCROLL_PREVIEW_DOWN = auto()
 
 
+def _find_nan_change(before_image, filtered_image_data):
+    before_nan = np.isnan(before_image)
+    after_nan = np.isnan(filtered_image_data)
+    nan_change = np.logical_xor(before_nan, after_nan)
+    return nan_change
+
+
 class FiltersWindowPresenter(BasePresenter):
     view: 'FiltersWindowView'
     stack: Optional[StackVisualiserView] = None
@@ -285,8 +292,9 @@ class FiltersWindowPresenter(BasePresenter):
 
             if filtered_image_data.shape == before_image.shape:
                 diff = np.subtract(filtered_image_data, before_image)
+                nan_change = _find_nan_change(before_image, filtered_image_data)
                 if self.view.overlayDifference.isChecked():
-                    self.view.previews.add_difference_overlay(diff)
+                    self.view.previews.add_difference_overlay(diff, nan_change)
                 else:
                     self.view.previews.hide_difference_overlay()
                 if self.view.invertDifference.isChecked():

--- a/mantidimaging/gui/windows/operations/test/test_model.py
+++ b/mantidimaging/gui/windows/operations/test/test_model.py
@@ -184,9 +184,9 @@ class FiltersWindowModelTest(unittest.TestCase):
         self.assertEqual([
             'Crop Coordinates', 'Flat-fielding', 'Remove Outliers', 'ROI Normalisation', "-----------------",
             'Arithmetic', 'Circular Mask', 'Clip Values', 'Divide', 'Gaussian', 'Median', 'Monitor Normalisation',
-            'Rebin', 'Rescale', 'Ring Removal', 'Rotate Stack', "-----------------", 'Remove all stripes',
-            'Remove dead stripes', 'Remove large stripes', 'Stripe Removal', 'Remove stripes with filtering',
-            'Remove stripes with sorting and fitting'
+            'NaN Removal', 'Rebin', 'Rescale', 'Ring Removal', 'Rotate Stack', "-----------------",
+            'Remove all stripes', 'Remove dead stripes', 'Remove large stripes', 'Stripe Removal',
+            'Remove stripes with filtering', 'Remove stripes with sorting and fitting'
         ], filter_names)
 
 

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -3,6 +3,7 @@
 import logging
 import unittest
 import numpy as np
+import numpy.testing as npt
 from functools import partial
 
 from unittest import mock
@@ -13,7 +14,7 @@ from parameterized import parameterized
 from mantidimaging.core.operation_history.const import OPERATION_HISTORY, OPERATION_DISPLAY_NAME
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.operations import FiltersWindowPresenter
-from mantidimaging.gui.windows.operations.presenter import REPEAT_FLAT_FIELDING_MSG, FLAT_FIELDING
+from mantidimaging.gui.windows.operations.presenter import REPEAT_FLAT_FIELDING_MSG, FLAT_FIELDING, _find_nan_change
 from mantidimaging.test_helpers.unit_test_helper import assert_called_once_with, generate_images
 
 
@@ -444,3 +445,8 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.presenter.do_update_previews()
 
         self.view.show_error_dialog.assert_not_called()
+
+    def test_find_nan_change(self):
+        before_image = np.array([np.nan, 1, 2])
+        after_image = np.array([1, 1, np.nan])
+        npt.assert_array_equal(np.array([True, False, False]), _find_nan_change(before_image, after_image))


### PR DESCRIPTION
### Issue

Closes #819

### Description

Adds a NaN Removal filter.

### Testing 

Wrote a test for the filter_func method and the method for finding NaN changes in the before/after image which is used to generate the overlay.

### Acceptance Criteria 

Check that NaNs are replaced and that the difference overlay appears.

### Documentation

Updated the release notes.
