### PR TITLE
Prevent errors when previewing operations after a stack is deleted

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -44,6 +44,7 @@ Fixes
 - #1032: Crash in RingRemovalFilter
 - #1057: Fix crash when refining COR
 - #1056: Cannot set range [nan, nan] in ROI normalisation
+- #1019: ERROR: Presenter error: Error applying filter for preview - when closing stacks
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/operations/base_filter.py
+++ b/mantidimaging/core/operations/base_filter.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Dict
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 from enum import Enum, auto
 
 import numpy as np
@@ -12,6 +12,7 @@ from mantidimaging.core.data import Images
 if TYPE_CHECKING:
     from PyQt5.QtWidgets import QFormLayout, QWidget  # noqa: F401   # pragma: no cover
     from mantidimaging.gui.mvp_base import BaseMainWindowView  # pragma: no cover
+    from mantidimaging.gui.widgets.stack_selector import StackSelectorWidgetView
 
 
 class FilterGroup(Enum):
@@ -84,6 +85,15 @@ class BaseFilter:
     @staticmethod
     def group_name() -> FilterGroup:
         return FilterGroup.NoGroup
+
+    @staticmethod
+    def get_images_from_stack(widget: "StackSelectorWidgetView", msg: str) -> Optional[Images]:
+        try:
+            stack = widget.main_window.get_stack_visualiser(widget.current())
+        except KeyError:
+            # Can happen if stack is closed while selected in the form
+            raise ValueError(f"Selected stack for {msg} does not exist")
+        return stack.presenter.images
 
 
 def raise_not_implemented(function_name):

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -224,15 +224,12 @@ class FlatFieldFilter(BaseFilter):
             flat_before_widget: StackSelectorWidgetView, flat_after_widget: StackSelectorWidgetView,
             dark_before_widget: StackSelectorWidgetView, dark_after_widget: StackSelectorWidgetView,
             selected_flat_fielding_widget: QComboBox, use_dark_widget: QCheckBox) -> partial:
-        flat_before_stack = flat_before_widget.main_window.get_stack_visualiser(flat_before_widget.current())
-        flat_before_images = flat_before_stack.presenter.images
-        flat_after_stack = flat_after_widget.main_window.get_stack_visualiser(flat_after_widget.current())
-        flat_after_images = flat_after_stack.presenter.images
 
-        dark_before_stack = dark_before_widget.main_window.get_stack_visualiser(dark_before_widget.current())
-        dark_before_images = dark_before_stack.presenter.images
-        dark_after_stack = dark_after_widget.main_window.get_stack_visualiser(dark_after_widget.current())
-        dark_after_images = dark_after_stack.presenter.images
+        flat_before_images = BaseFilter.get_images_from_stack(flat_before_widget, "flat before")
+        flat_after_images = BaseFilter.get_images_from_stack(flat_after_widget, "flat after")
+
+        dark_before_images = BaseFilter.get_images_from_stack(dark_before_widget, "dark before")
+        dark_after_images = BaseFilter.get_images_from_stack(dark_after_widget, "dark after")
 
         selected_flat_fielding = selected_flat_fielding_widget.currentText()
 

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -136,15 +136,15 @@ class RoiNormalisationFilter(BaseFilter):
     def execute_wrapper(roi_field, norm_mode, flat_field):
         try:
             roi = SensibleROI.from_list([int(number) for number in roi_field.text().strip("[").strip("]").split(",")])
-            mode = norm_mode.currentText()
-            flat = flat_field.main_window.get_stack_visualiser(flat_field.current())
-            flat_images = flat.presenter.images
-            return partial(RoiNormalisationFilter.filter_func,
-                           region_of_interest=roi,
-                           normalisation_mode=mode,
-                           flat_field=flat_images)
         except Exception as e:
             raise ValueError(f"The provided ROI string is invalid! Error: {e}")
+
+        mode = norm_mode.currentText()
+        flat_images = BaseFilter.get_images_from_stack(flat_field, "flat field")
+        return partial(RoiNormalisationFilter.filter_func,
+                       region_of_interest=roi,
+                       normalisation_mode=mode,
+                       flat_field=flat_images)
 
     @staticmethod
     def group_name() -> FilterGroup:

--- a/mantidimaging/gui/widgets/stack_selector/presenter.py
+++ b/mantidimaging/gui/widgets/stack_selector/presenter.py
@@ -65,8 +65,6 @@ class StackSelectorWidgetPresenter(BasePresenter):
         self.handle_selection(new_selected_index)
 
     def handle_selection(self, index):
-        self.view.stack_selected_int.emit(index)
-
         uuid = self.stack_uuids[index] if self.stack_uuids else None
         self.current_stack = uuid
         self.view.stack_selected_uuid.emit(uuid)

--- a/mantidimaging/gui/widgets/stack_selector/view.py
+++ b/mantidimaging/gui/widgets/stack_selector/view.py
@@ -22,7 +22,6 @@ def _string_contains_all_parts(string: str, parts: list) -> bool:
 class StackSelectorWidgetView(QComboBox):
     stacks_updated = pyqtSignal()
 
-    stack_selected_int = pyqtSignal(int)
     stack_selected_uuid = pyqtSignal('PyQt_PyObject')
 
     main_window: 'MainWindowView'

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -19,6 +19,7 @@ from mantidimaging.gui.utility import BlockQtSignals
 from mantidimaging.gui.utility.common import operation_in_progress
 from mantidimaging.gui.windows.stack_choice.presenter import StackChoicePresenter
 from mantidimaging.gui.windows.stack_visualiser.view import StackVisualiserView
+from mantidimaging.gui.widgets.stack_selector import StackSelectorWidgetView
 
 from .model import FiltersWindowModel
 
@@ -111,6 +112,11 @@ class FiltersWindowPresenter(BasePresenter):
         with BlockQtSignals([self.view]):
             self.set_preview_image_index(0)
             self.view.previewImageIndex.setMaximum(self.max_preview_image_idx)
+
+            for row_id in range(self.view.filterPropertiesLayout.count()):
+                widget = self.view.filterPropertiesLayout.itemAt(row_id).widget()
+                if isinstance(widget, StackSelectorWidgetView):
+                    widget._handle_loaded_stacks_changed()
 
         self.do_update_previews()
 


### PR DESCRIPTION
### Issue

Closes #1019

### Description
Changes to improve error messages in case a non-existing stack is selected when preview is called.

Call _handle_loaded_stacks_changed() to update selector widget before preview

Fix same issue in ROI norm. And narrow a try block, to prevent wrong error message being shown

### Testing 

Steps to test on #1019

### Acceptance Criteria 
There should be no errors shown

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*
