### PR TITLE
Don't show misleading success message when operation cancelled

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -46,6 +46,7 @@ Fixes
 - #1057: Fix crash when refining COR
 - #1056: Cannot set range [nan, nan] in ROI normalisation
 - #1019: ERROR: Presenter error: Error applying filter for preview - when closing stacks
+- #1068: Don't show misleading success message when operation cancelled
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -212,7 +212,7 @@ class FiltersWindowPresenter(BasePresenter):
         return False
 
     def _post_filter(self, updated_stacks: List[StackVisualiserView], task):
-        do_180deg = True
+        use_new_data = True
         attempt_repair = task.error is not None
         negative_stacks = []
         for stack in updated_stacks:
@@ -224,9 +224,9 @@ class FiltersWindowPresenter(BasePresenter):
             elif task.error is None:
                 # otherwise check with user which one to keep
                 if self.view.safeApply.isChecked():
-                    do_180deg = self._wait_for_stack_choice(stack.presenter.images, stack.uuid)
+                    use_new_data = self._wait_for_stack_choice(stack.presenter.images, stack.uuid)
                 # if the stack that was kept happened to have a proj180 stack - then apply the filter to that too
-                if stack.presenter.images.has_proj180deg() and do_180deg and not self.applying_to_all:
+                if stack.presenter.images.has_proj180deg() and use_new_data and not self.applying_to_all:
                     self.view.clear_previews()
                     # Apply to proj180 synchronously - this function is already running async
                     # and running another async instance causes a race condition in the parallel module

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -248,10 +248,13 @@ class FiltersWindowPresenter(BasePresenter):
         if task.error is not None:
             # task failed, show why
             self.view.show_error_dialog(f"Operation failed: {task.error}")
-        else:
+        elif use_new_data:
             # Feedback to user
             self.view.clear_notification_dialog()
             self.view.show_operation_completed(self.model.selected_filter.filter_name)
+        else:
+            self.view.clear_notification_dialog()
+            self.view.show_operation_cancelled(self.model.selected_filter.filter_name)
 
         if self.view.filterSelector.currentText() == FLAT_FIELDING and negative_stacks:
             self._show_negative_values_error(negative_stacks)

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -132,6 +132,31 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         do_update_previews.assert_called_once()
         self.presenter.main_window.presenter.model.set_images_in_stack.assert_called_once()
 
+    @mock.patch.multiple('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter',
+                         do_update_previews=DEFAULT,
+                         _wait_for_stack_choice=DEFAULT,
+                         _do_apply_filter_sync=DEFAULT)
+    def test_post_filter_keep_original(self,
+                                       do_update_previews: Mock = Mock(),
+                                       _wait_for_stack_choice: Mock = Mock(),
+                                       _do_apply_filter_sync: Mock = Mock()):
+        """
+        Tests when the operation has applied successfully, but user choose to keep original
+        """
+        self.presenter.view.safeApply.isChecked.return_value = True
+        mock_task = mock.Mock()
+        mock_task.error = None
+        _wait_for_stack_choice.return_value = False  # user clicked keep original
+
+        self.presenter._post_filter(self.mock_stack_visualisers[0:1], mock_task)
+
+        do_update_previews.assert_called_once()
+        _wait_for_stack_choice.assert_called_once()
+
+        self.view.clear_notification_dialog.assert_called_once()
+        self.view.show_operation_completed.assert_not_called()
+        self.view.show_operation_cancelled.assert_called_once_with(self.presenter.model.selected_filter.filter_name)
+
     @mock.patch.multiple(
         'mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter',
         _do_apply_filter=DEFAULT,

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -187,6 +187,11 @@ class FiltersWindowView(BaseMainWindowView):
         self.notification_icon.setPixmap(QApplication.style().standardPixmap(QStyle.SP_DialogYesButton))
         self.notification_text.setText(f"{operation_name} completed successfully!")
 
+    def show_operation_cancelled(self, operation_name):
+        self.notification_text.show()
+        self.notification_icon.setPixmap(QApplication.style().standardPixmap(QStyle.SP_DialogYesButton))
+        self.notification_text.setText(f"{operation_name} cancelled, original data restored")
+
     def open_help_webpage(self):
         filter_name = self.filterSelector.currentText()
 


### PR DESCRIPTION
### Issue

Closes #1068 

### Description

Show "{operation_name} cancelled, original data restored" instead of "{operation_name} completed successfully!"

### Testing 

Run an operation with safe apply enabled.

### Acceptance Criteria 

Success message should only show if the new data was chosen

### Documentation

release notes
