### PR TITLE
Add GUI system tests

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -65,7 +65,20 @@ jobs:
         run: |
           python setup.py docs
 
-      - name: GUI Tests
+      - name: Get test data
+        shell: bash -l {0}
+        run: |
+          wget -nv https://github.com/mantidproject/mantidimaging-data/archive/refs/heads/master.zip
+          unzip -q master.zip -d ~
+        timeout-minutes: 5
+
+      - name: GUI Tests System
+        shell: bash -l {0}
+        run: |
+          xvfb-run --auto-servernum python -m pytest -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov --run-system-tests
+        timeout-minutes: 15
+
+      - name: GUI Tests Applitools
         if: ${{ github.event_name == 'pull_request' }}
         shell: bash -l {0}
         env:
@@ -73,8 +86,6 @@ jobs:
           APPLITOOLS_BATCH_ID: ${{ github.sha }}
           GITHUB_BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          wget -nv https://github.com/mantidproject/mantidimaging-data/archive/refs/heads/master.zip
-          unzip -q master.zip -d ~
           xvfb-run --auto-servernum python -m pytest -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests
         timeout-minutes: 15
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--run-system-tests", action="store_true", default=False, help="Run GUI system tests")
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "system: GUI system tests")
+
+
+def pytest_ignore_collect(path, config):
+    # When running GUI system tests, ignore all other files
+    if (config.getoption("--run-system-tests") and path.isfile() and not path.basename == "gui_system_test.py"):
+        return True
+    else:
+        return False
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--run-system-tests"):
+        skip_system = pytest.mark.skip(reason="use --run-system-tests option to run")
+        for item in items:
+            if "system" in item.keywords:
+                item.add_marker(skip_system)

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -58,6 +58,7 @@ Developer Changes
 - #998 : setup.py command to install current developer requirements
 - #969 : Improve mypy coverage in core.io
 - #1007 : Change applitools check level to content
+- #1086 : GUI system tests
 
 Dependency updates
 ------------------

--- a/mantidimaging/gui/test/__init__.py
+++ b/mantidimaging/gui/test/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/test/gui_system_test.py
+++ b/mantidimaging/gui/test/gui_system_test.py
@@ -97,6 +97,17 @@ class TestMainWindow(unittest.TestCase):
     def _open_operations(self):
         self.main_window.actionFilters.trigger()
 
+    def _open_reconstruction(self):
+        self.main_window.actionRecon.trigger()
+
+    def _close_stack_tabs(self):
+        stack_tabs = self.main_window.presenter.model.get_all_stack_visualisers()
+        while stack_tabs:
+            last_stack_tab = stack_tabs.pop()
+            QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("OK"))
+            last_stack_tab.close()
+            QTest.qWait(SHOW_DELAY // 10)
+
     def test_main_window_shows(self):
         self.assertTrue(self.main_window.isVisible())
         self.assertTrue(self.main_window.welcome_window.view.isVisible())
@@ -119,4 +130,19 @@ class TestMainWindow(unittest.TestCase):
         self.assertTrue(self.main_window.filters.isVisible())
         QTest.qWait(SHOW_DELAY)
         self.main_window.filters.close()
+        QTest.qWait(SHOW_DELAY)
+
+    @pytest.mark.xfail(reason="Bug #1014")
+    def test_open_reconstruction(self):
+        self._close_welcome()
+        self._load_data_set()
+
+        self._open_reconstruction()
+
+        self.assertIsNotNone(self.main_window.recon)
+        self.assertTrue(self.main_window.recon.isVisible())
+        QTest.qWait(SHOW_DELAY)
+        self.main_window.recon.close()
+        QTest.qWait(SHOW_DELAY)
+        self._close_stack_tabs()
         QTest.qWait(SHOW_DELAY)

--- a/mantidimaging/gui/test/gui_system_test.py
+++ b/mantidimaging/gui/test/gui_system_test.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+import os
+from pathlib import Path
+import unittest
+
+from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtTest import QTest
+from PyQt5.QtWidgets import QApplication, QMessageBox
+import pytest
+
+from mantidimaging.core.utility.version_check import versions
+from mantidimaging.gui.windows.main import MainWindowView
+
+versions._use_test_values()
+
+LOAD_SAMPLE = str(Path.home()) + "/mantidimaging-data-master/ISIS/IMAT/IMAT00010675/Tomo/IMAT_Flower_Tomo_000000.tif"
+LOAD_SAMPLE_MISSING_MESSAGE = """Data not present, please clone to your home directory e.g.
+git clone https://github.com/mantidproject/mantidimaging-data.git ~/mantidimaging-data-master"""
+
+SHOW_DELAY = 10  # Can be increased to watch tests
+SHORT_DELAY = 100
+LOAD_DELAY = 5000
+
+
+@pytest.mark.system
+@unittest.skipUnless(os.path.exists(LOAD_SAMPLE), LOAD_SAMPLE_MISSING_MESSAGE)
+class TestMainWindow(unittest.TestCase):
+    app: QApplication
+
+    @classmethod
+    def setUpClass(cls):
+        cls.app = QApplication([])
+
+    def setUp(self) -> None:
+        self.main_window = MainWindowView()
+        self.main_window.show()
+        QTest.qWait(SHORT_DELAY)
+
+    def tearDown(self) -> None:
+        QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("Yes"))
+        self.main_window.close()
+        QTest.qWait(SHORT_DELAY)
+
+    @classmethod
+    def _click_messageBox(cls, button_text: str):
+        """Needs to be queued with QTimer.singleShot before triggering the message box"""
+        for widget in cls.app.topLevelWidgets():
+            if isinstance(widget, QMessageBox):
+                for button in widget.buttons():
+                    if button.text().replace("&", "") == button_text:
+                        QTest.mouseClick(button, Qt.LeftButton)
+                        return
+                button_texts = [button.text() for button in widget.buttons()]
+                raise ValueError(f"Could not find button '{button_text}' in {button_texts}")
+
+    def _close_welcome(self):
+        self.main_window.welcome_window.view.close()
+
+    def test_main_window_shows(self):
+        self.assertTrue(self.main_window.isVisible())
+        self.assertTrue(self.main_window.welcome_window.view.isVisible())
+        QTest.qWait(SHOW_DELAY)
+        self._close_welcome()
+        self.assertFalse(self.main_window.welcome_window.view.isVisible())
+        QTest.qWait(SHOW_DELAY)


### PR DESCRIPTION
### Issue

Closes #1086 

### Description

Add tests with QTest.
A few simple test cases
A known failing case for bug #1014

### Testing & Acceptance Criteria 

`pytest -v --run-system-tests`

Should run the GUI tests and show the expected failure (XFAIL) for `test_open_reconstruction`

Note: like the applitools tests these expect https://github.com/mantidproject/mantidimaging-data to be at ~/mantidimaging-data-master

### Documentation

TODO
