### PR TITLE
Fix errors when closing stacks

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -48,6 +48,7 @@ Fixes
 - #1019: ERROR: Presenter error: Error applying filter for preview - when closing stacks
 - #1068: Don't show misleading success message when operation cancelled
 - #1082: CIL show memory warning
+- #1014: KeyError when closing stacks
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/test/gui_system_test.py
+++ b/mantidimaging/gui/test/gui_system_test.py
@@ -132,7 +132,6 @@ class TestMainWindow(unittest.TestCase):
         self.main_window.filters.close()
         QTest.qWait(SHOW_DELAY)
 
-    @pytest.mark.xfail(reason="Bug #1014")
     def test_open_reconstruction(self):
         self._close_welcome()
         self._load_data_set()

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -125,6 +125,8 @@ class ReconstructWindowPresenter(BasePresenter):
         self.view.pixel_size = self.get_pixel_size_from_images()
         self.do_update_projection()
         self.view.update_recon_hist_needed = True
+        if stack is None:
+            return
         self.do_preview_reconstruct_slice()
         self._do_nan_zero_negative_check()
 

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+
+from logging import getLogger
 from typing import TYPE_CHECKING, List, Optional
 from uuid import UUID
 
@@ -25,6 +27,8 @@ from mantidimaging.gui.windows.recon.presenter import ReconstructWindowPresenter
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
     from mantidimaging.gui.windows.stack_visualiser.view import StackVisualiserView  # pragma: no cover
+
+LOG = getLogger(__name__)
 
 
 class ReconstructWindowView(BaseMainWindowView):
@@ -188,7 +192,12 @@ class ReconstructWindowView(BaseMainWindowView):
             self.hide()
 
     def check_stack_for_invalid_180_deg_proj(self, uuid: UUID):
-        selected_images = self.main_window.get_images_from_stack_uuid(uuid)
+        try:
+            selected_images = self.main_window.get_images_from_stack_uuid(uuid)
+        except KeyError:
+            # Likely due to stack no longer existing, e.g. when all stacks closed
+            LOG.debug("UUID did not match open stack")
+            return
         if selected_images.has_proj180deg() and \
                 not self.presenter.proj_180_degree_shape_matches_images(selected_images):
             self.warn_user(


### PR DESCRIPTION
Note: needs rebasing once PR #1087 merged

### Issue

Closes #1014 

### Description

Closing stacks triggers set_stack_uuid() and check_stack_for_invalid_180_deg_proj() in the recon window to run. Make these both handle the case where there is no stack left.

### Testing 

Steps on #1014 

### Acceptance Criteria 

No error message following steps.

`pytest -rs -vs --run-system-tests`
should pass

### Documentation

release notes
