### PR TITLE
Only enable all and preview buttons once a dataset is selected

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -50,6 +50,7 @@ Fixes
 - #1082: CIL show memory warning
 - #1014: KeyError when closing stacks
 - #1029: Segmentation fault in image_in_vb
+- #1081: Error if pressing preview button before selecting a dataset
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/ui/load_dialog.ui
+++ b/mantidimaging/gui/ui/load_dialog.ui
@@ -155,6 +155,9 @@
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
         <widget class="QPushButton" name="step_preview">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
          <property name="text">
           <string>Preview</string>
          </property>
@@ -162,6 +165,9 @@
        </item>
        <item>
         <widget class="QPushButton" name="step_all">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
          <property name="text">
           <string>All</string>
          </property>

--- a/mantidimaging/gui/windows/load_dialog/field.py
+++ b/mantidimaging/gui/windows/load_dialog/field.py
@@ -87,7 +87,7 @@ class Field:
     def _init_indices(self):
         indices_item = QTreeWidgetItem(self._widget)
         indices_item.setText(0, "File indices")
-        _spinbox_layout = QHBoxLayout(self._tree.parent())
+        _spinbox_layout = QHBoxLayout()
 
         self._start_spinbox = QSpinBox(self._tree.parent())
         _spinbox_layout.addWidget(QLabel("Start", self._tree.parent()))

--- a/mantidimaging/gui/windows/load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/load_dialog/presenter.py
@@ -115,6 +115,7 @@ class LoadPresenter:
 
         self.view.sample.update_indices(self.last_file_info.shape[0])
         self.view.sample.update_shape(self.last_file_info.shape[1:])
+        self.view.enable_preview_all_buttons()
 
     def do_update_flat_or_dark(self, field: Field, name: str, suffix: str):
         selected_file = self.view.select_file(name)

--- a/mantidimaging/gui/windows/load_dialog/view.py
+++ b/mantidimaging/gui/windows/load_dialog/view.py
@@ -142,3 +142,7 @@ class MWLoadDialog(QDialog):
 
     def show_error(self, msg, traceback):
         self.parent_view.presenter.show_error(msg, traceback)
+
+    def enable_preview_all_buttons(self):
+        self.step_preview.setEnabled(True)
+        self.step_all.setEnabled(True)

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -136,7 +136,8 @@ class ReconImagesView(GraphicsLayoutWidget):
         (the line likes to be unbound when the degree isn't a multiple o 90 - and the tilt never is)
         :return:
         """
-        self.projection_vb.removeItem(self.tilt_line)
+        if self.tilt_line.scene() is not None:
+            self.projection_vb.removeItem(self.tilt_line)
 
     def set_tilt(self, tilt: Degrees, pos: Optional[int] = None):
         if not isnan(tilt.value):  # is isnan it means there is no tilt, i.e. the line is vertical


### PR DESCRIPTION
### Issue

Closes #1081 

### Description

Disable the buttons until a dataset is selected

And some warning fixes

### Testing 
Steps on #1081

### Acceptance Criteria 

Should not longer be possible to trigger the crash

### Documentation

release notes
