### PR TITLE
Fix x-y coordinates when showing pixel value in operations

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -51,6 +51,7 @@ Fixes
 - #1014: KeyError when closing stacks
 - #1029: Segmentation fault in image_in_vb
 - #1081: Error if pressing preview button before selecting a dataset
+- #940: Ops window, pixel value not updating for part of image
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -172,8 +172,9 @@ class FilterPreviews(GraphicsLayoutWidget):
         if ev.exit:
             return
         pos = CloseEnoughPoint(ev.pos())
+        # Update values for all 3 images
         for img in self.image_before, self.image_after, self.image_difference:
-            if img.image is not None and pos.x < img.image.shape[0] and pos.y < img.image.shape[1]:
+            if img.image is not None and pos.y < img.image.shape[0] and pos.x < img.image.shape[1]:
                 pixel_value = img.image[pos.y, pos.x]
                 self.display_formatted_detail[img](pixel_value)
 

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -111,9 +111,9 @@ class ReconImagesView(GraphicsLayoutWidget):
         if ev.exit:
             return
         pos = CloseEnoughPoint(ev.pos())
-        if img.image is not None and pos.x < img.image.shape[0] and pos.y < img.image.shape[1]:
-            pixel_value = img.image[pos.y, pos.x]
-            self.display_formatted_detail[img](pixel_value)
+
+        pixel_value = img.image[pos.y, pos.x]
+        self.display_formatted_detail[img](pixel_value)
 
     def mouse_click(self, ev, line: InfiniteLine):
         line.setPos(ev.pos())


### PR DESCRIPTION
Correct ordering of coordinates.

Check is needed. In the case of crop, with the mouse over before, the
position might be out of bounds for the after.

### Issue
Closes #940 

### Description

Check that position is within the image had the x and y coordinates swapped. Test is not actually needed in the recon window.

### Testing 

Steps on #940

### Acceptance Criteria 

Pixel value should be shown bellow image and updated on mouse movements

### Documentation

release_notes
