### PR TITLE
Use nanmin to find minimum value when scaling for int tif export

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -52,6 +52,7 @@ Fixes
 - #1029: Segmentation fault in image_in_vb
 - #1081: Error if pressing preview button before selecting a dataset
 - #940: Ops window, pixel value not updating for part of image
+- #1093: TIFF output blank if NaN in stack
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -149,7 +149,6 @@ def save(images: Images,
             names[i] = os.path.join(output_dir, names[i])
 
         with progress:
-            min_value = images.data.min()
             for idx in range(num_images):
                 # Overwrite images with the copy that has been rescaled.
                 if pixel_depth == "int16":


### PR DESCRIPTION
### Issue
Closes #1093 

### Description

min_value was being overwritten without using nanmin

### Testing 

See #1093

### Acceptance Criteria 

Files saved correctly

### Documentation

release_notes
