### PR TITLE
Set difference overlay colour to green

### DIFF
--- a/docs/user_guide/gui/operations_window.rst
+++ b/docs/user_guide/gui/operations_window.rst
@@ -20,7 +20,7 @@ The [?] button next to filter selector will open a webpage with an explanation o
 
 The right hand panel shows a slice from the original image stack, a preview of the filter applied to the slice, and the pixel intensity difference. Below a histogram of pixel values before and after is shown. The image views can be navigated as described in the :ref:`Image View` help page.
 
-Blue pixels in the after preview indicate that a value has changed. Red pixels
+Green pixels in the after preview indicate that a value has changed. Red pixels
 indicate that there are negative values in the result. Note that the negative
 values overlay is placed on top of the image difference overlay, so if a pixel
 has changed and is also negative then it will simply appear as red. The

--- a/mantidimaging/core/operations/base_filter.py
+++ b/mantidimaging/core/operations/base_filter.py
@@ -24,6 +24,7 @@ class FilterGroup(Enum):
 class BaseFilter:
     filter_name = "Unnamed Filter"
     link_histograms = False
+    show_negative_overlay = True
     __name__ = "BaseFilter"
     """
     The base class for filter algorithms, which should extend this class.

--- a/mantidimaging/core/operations/ring_removal/ring_removal.py
+++ b/mantidimaging/core/operations/ring_removal/ring_removal.py
@@ -23,6 +23,7 @@ class RingRemovalFilter(BaseFilter):
     """
     filter_name = "Ring Removal"
     link_histograms = True
+    show_negative_overlay = False
 
     @staticmethod
     def filter_func(images: Images,

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -25,6 +25,8 @@ after_pen = (0, 200, 0)
 diff_pen = (0, 0, 200)
 
 OVERLAY_THRESHOLD = 1e-3
+OVERLAY_COLOUR_NEGATIVE = [255, 0, 0, 255]
+OVERLAY_COLOUR_DIFFERENCE = [0, 255, 0, 255]
 
 Coord = namedtuple('Coord', ['row', 'col'])
 histogram_coords = Coord(4, 0)
@@ -195,7 +197,7 @@ class FilterPreviews(GraphicsLayoutWidget):
         diff[diff > OVERLAY_THRESHOLD] = 1.0
         diff[nan_change] = 1.0
         pos = np.array([0, 1])
-        color = np.array([[0, 0, 0, 0], [0, 0, 255, 255]], dtype=np.ubyte)
+        color = np.array([[0, 0, 0, 0], OVERLAY_COLOUR_DIFFERENCE], dtype=np.ubyte)
         map = ColorMap(pos, color)
         self.image_diff_overlay.setOpacity(1)
         self.image_diff_overlay.setImage(diff)
@@ -206,7 +208,7 @@ class FilterPreviews(GraphicsLayoutWidget):
         after[after > 0] = 0.0
         after[after < 0] = 1.0
         pos = np.array([0, 1])
-        color = np.array([[0, 0, 0, 0], [255, 0, 0, 255]], dtype=np.ubyte)
+        color = np.array([[0, 0, 0, 0], OVERLAY_COLOUR_NEGATIVE], dtype=np.ubyte)
         map = ColorMap(pos, color)
         self.negative_values_overlay.setOpacity(1)
         self.negative_values_overlay.setImage(after)

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -218,6 +218,9 @@ class FilterPreviews(GraphicsLayoutWidget):
     def hide_difference_overlay(self):
         self.image_diff_overlay.setOpacity(0)
 
+    def hide_negative_overlay(self):
+        self.negative_values_overlay.setOpacity(0)
+
     def auto_range(self):
         # This will cause the previews to all show by just causing autorange on self.image_before_vb
         self.image_before_vb.autoRange()

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -82,6 +82,9 @@ class FiltersWindowModel(object):
         """
         return self.selected_filter.link_histograms
 
+    def show_negative_overlay(self) -> bool:
+        return self.selected_filter.show_negative_overlay
+
     @property
     def params_needed_from_stack(self):
         return self.selected_filter.sv_params()

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -314,7 +314,11 @@ class FiltersWindowPresenter(BasePresenter):
                     self.view.previews.hide_difference_overlay()
                 if self.view.invertDifference.isChecked():
                     diff = np.negative(diff, out=diff)
-                self.view.previews.add_negative_overlay(filtered_image_data.copy())
+
+                if self.model.show_negative_overlay():
+                    self.view.previews.add_negative_overlay(filtered_image_data.copy())
+                else:
+                    self.view.previews.hide_negative_overlay()
                 self._update_preview_image(diff, self.view.preview_image_difference)
 
             # Ensure all of it is visible if the lock zoom isn't checked


### PR DESCRIPTION
### Issue

Closes #1098 

Note: applitools needs new baselines

### Description

Change colour to green. Also pull out into a named constant

### Testing 
In ops window differences should be shown in green

### Documentation

