### PR TITLE
Update progress bar during CIL reconstruction

### DIFF
--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -23,7 +23,7 @@ astra_mutex = Lock()
 # Full credit for following code to Daniil Kazantzev
 # Source:
 # https://github.com/dkazanc/ToMoBAR/blob/5990aaa264e2f08bd9b0069c8847e5021fbf2ee2/src/Python/tomobar/supp/astraOP.py#L20-L70
-def rotation_matrix2d(theta):
+def rotation_matrix2d(theta: float):
     return np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
 
 
@@ -41,7 +41,7 @@ def vec_geom_init2d(angles_rad: ProjectionAngles, detector_spacing_x: float, cen
 
 
 @contextmanager
-def _managed_recon(sino, cfg, proj_geom, vol_geom) -> Generator[Tuple[int, int], None, None]:
+def _managed_recon(sino: np.ndarray, cfg, proj_geom, vol_geom) -> Generator[Tuple[int, int], None, None]:
     proj_id = None
     sino_id = None
     rec_id = None
@@ -94,7 +94,7 @@ class AstraRecon(BaseRecon):
         def get_sumsq(image: np.ndarray) -> float:
             return np.sum(image**2)
 
-        def minimizer_function(cor):
+        def minimizer_function(cor: float):
             return -get_sumsq(AstraRecon.single_sino(images.sino(slice_idx), ScalarCoR(cor), proj_angles, recon_params))
 
         return minimize(minimizer_function, start_cor, method='nelder-mead', tol=0.1).x[0]
@@ -141,7 +141,7 @@ class AstraRecon(BaseRecon):
         return output_images
 
     @staticmethod
-    def allowed_filters():
+    def allowed_filters() -> List[str]:
         # removed from list: 'kaiser' as it hard crashes ASTRA
         #                    'projection', 'sinogram', 'rprojection', 'rsinogram' as they error
         return [

--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -100,8 +100,11 @@ class AstraRecon(BaseRecon):
         return minimize(minimizer_function, start_cor, method='nelder-mead', tol=0.1).x[0]
 
     @staticmethod
-    def single_sino(sino: np.ndarray, cor: ScalarCoR, proj_angles: ProjectionAngles,
-                    recon_params: ReconstructionParameters) -> np.ndarray:
+    def single_sino(sino: np.ndarray,
+                    cor: ScalarCoR,
+                    proj_angles: ProjectionAngles,
+                    recon_params: ReconstructionParameters,
+                    progress: Optional[Progress] = None) -> np.ndarray:
         assert sino.ndim == 2, "Sinogram must be a 2D image"
 
         sino = BaseRecon.negative_log(sino)

--- a/mantidimaging/core/reconstruct/base_recon.py
+++ b/mantidimaging/core/reconstruct/base_recon.py
@@ -24,7 +24,7 @@ class BaseRecon:
                     cor: ScalarCoR,
                     proj_angles: ProjectionAngles,
                     recon_params: ReconstructionParameters,
-                    progress=None) -> np.ndarray:
+                    progress: Optional[Progress] = None) -> np.ndarray:
         """
         Reconstruct a single sinogram
 

--- a/mantidimaging/core/reconstruct/base_recon.py
+++ b/mantidimaging/core/reconstruct/base_recon.py
@@ -20,8 +20,11 @@ class BaseRecon:
         return -np.log(data)
 
     @staticmethod
-    def single_sino(sino: np.ndarray, cor: ScalarCoR, proj_angles: ProjectionAngles,
-                    recon_params: ReconstructionParameters) -> np.ndarray:
+    def single_sino(sino: np.ndarray,
+                    cor: ScalarCoR,
+                    proj_angles: ProjectionAngles,
+                    recon_params: ReconstructionParameters,
+                    progress=None) -> np.ndarray:
         """
         Reconstruct a single sinogram
 

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -3,7 +3,7 @@
 
 from logging import getLogger
 from threading import Lock
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 
@@ -16,8 +16,6 @@ from cil.optimisation.functions import MixedL21Norm, L2NormSquared, BlockFunctio
 
 # CIL ASTRA plugin
 from cil.plugins.astra.operators import ProjectionOperator
-
-import functools
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.reconstruct.base_recon import BaseRecon
@@ -65,12 +63,19 @@ class CILRecon(BaseRecon):
                                   sinogram_order=True)
 
     @staticmethod
-    def single_sino(sino: np.ndarray, cor: ScalarCoR, proj_angles: ProjectionAngles,
-                    recon_params: ReconstructionParameters):
+    def single_sino(sino: np.ndarray,
+                    cor: ScalarCoR,
+                    proj_angles: ProjectionAngles,
+                    recon_params: ReconstructionParameters,
+                    progress: Optional[Progress] = None):
         """
         Reconstruct a single slice from a single sinogram. Used for the preview and the single slice button.
         Should return a numpy array,
         """
+
+        if progress:
+            progress.add_estimated_steps(recon_params.num_iter + 1)
+            progress.update(steps=1, msg='CIL: Setting up reconstruction', force_continue=False)
 
         if cil_mutex.locked():
             LOG.warning("CIL recon already in progress")
@@ -98,7 +103,6 @@ class CILRecon(BaseRecon):
             # f1 =  alpha * MixedL21Norm()
             # f2 = 0.5 * L2NormSquared(b=ad2d)
             alpha = recon_params.alpha
-            num_iter = recon_params.num_iter
             F = BlockFunction(alpha * f1, 0.5 * f2)
             normK = K.norm()
             sigma = 1
@@ -106,7 +110,16 @@ class CILRecon(BaseRecon):
 
             pdhg = PDHG(f=F, g=G, operator=K, tau=tau, sigma=sigma, max_iteration=100000, update_objective_interval=10)
 
-            pdhg.run(num_iter, verbose=0, callback=None)
+            try:
+                for iter in range(recon_params.num_iter):
+                    if progress:
+                        progress.update(steps=1,
+                                        msg=f'CIL: Iteration {iter + 1} of {recon_params.num_iter}',
+                                        force_continue=False)
+                    pdhg.next()
+            finally:
+                if progress:
+                    progress.mark_complete()
             return pdhg.solution.as_array()
 
     @staticmethod
@@ -121,7 +134,10 @@ class CILRecon(BaseRecon):
         :param progress: Optional progress reporter
         :return: 3D image data for reconstructed volume
         """
-        progress = Progress.ensure_instance(progress, task_name='CIL reconstruction')
+
+        progress = Progress.ensure_instance(progress,
+                                            task_name='CIL reconstruction',
+                                            num_steps=recon_params.num_iter + 1)
 
         projection_size = full_size_KB(images.data.shape, images.dtype)
         recon_volume_shape = images.data.shape[2], images.data.shape[2], images.data.shape[1]
@@ -139,6 +155,7 @@ class CILRecon(BaseRecon):
             LOG.warning("CIL recon already in progress")
 
         with cil_mutex:
+            progress.update(steps=1, msg='CIL: Setting up reconstruction', force_continue=False)
             angles = images.projection_angles(recon_params.max_projection_angle).value
             shape = images.data.shape
             pixel_num_h, pixel_num_v = shape[2], shape[1]
@@ -168,7 +185,6 @@ class CILRecon(BaseRecon):
             # f1 =  alpha * MixedL21Norm()
             # f2 = 0.5 * L2NormSquared(b=ad2d)
             alpha = recon_params.alpha
-            num_iter = recon_params.num_iter
             F = BlockFunction(alpha * f1, 0.5 * f2)
             normK = K.norm()
             sigma = 1
@@ -176,12 +192,12 @@ class CILRecon(BaseRecon):
 
             algo = PDHG(f=F, g=G, operator=K, tau=tau, sigma=sigma, max_iteration=100000, update_objective_interval=10)
 
-            def myprogress(p, iter, obj, solution):
-                p.update(steps=1, msg='', force_continue=False)
-
             with progress:
-                prg = functools.partial(myprogress, progress)
-                algo.run(num_iter, verbose=0, callback=prg)
+                for iter in range(recon_params.num_iter):
+                    progress.update(steps=1,
+                                    msg=f'CIL: Iteration {iter+1} of {recon_params.num_iter}',
+                                    force_continue=False)
+                    algo.next()
                 volume = algo.solution.as_array()
                 LOG.info('Reconstructed 3D volume with shape: {0}'.format(volume.shape))
             return Images(volume)

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 import numpy as np
 
 # import cil
-from cil.framework import AcquisitionGeometry, DataOrder
+from cil.framework import AcquisitionData, AcquisitionGeometry, DataOrder, ImageGeometry
 
 from cil.optimisation.algorithms import PDHG
 from cil.optimisation.operators import GradientOperator, BlockOperator
@@ -32,7 +32,7 @@ cil_mutex = Lock()
 
 class CILRecon(BaseRecon):
     @staticmethod
-    def set_up_TV_regularisation(image_geometry, acquisition_data):
+    def set_up_TV_regularisation(image_geometry: ImageGeometry, acquisition_data: AcquisitionData):
         # Forward operator
         A2d = ProjectionOperator(image_geometry, acquisition_data.geometry, 'gpu')
 
@@ -123,7 +123,10 @@ class CILRecon(BaseRecon):
             return pdhg.solution.as_array()
 
     @staticmethod
-    def full(images: Images, cors: List[ScalarCoR], recon_params: ReconstructionParameters, progress=None):
+    def full(images: Images,
+             cors: List[ScalarCoR],
+             recon_params: ReconstructionParameters,
+             progress: Optional[Progress] = None):
         """
         Performs a volume reconstruction using sample data provided as sinograms.
 

--- a/mantidimaging/core/reconstruct/tomopy_recon.py
+++ b/mantidimaging/core/reconstruct/tomopy_recon.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from logging import getLogger
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 
@@ -26,8 +26,11 @@ class TomopyRecon(BaseRecon):
                                   sinogram_order=True)
 
     @staticmethod
-    def single_sino(sino: np.ndarray, cor: ScalarCoR, proj_angles: ProjectionAngles,
-                    recon_params: ReconstructionParameters):
+    def single_sino(sino: np.ndarray,
+                    cor: ScalarCoR,
+                    proj_angles: ProjectionAngles,
+                    recon_params: ReconstructionParameters,
+                    progress: Optional[Progress] = None):
         sino = BaseRecon.negative_log(sino)
         volume = tomopy.recon(tomo=[sino],
                               sinogram_order=True,

--- a/mantidimaging/core/reconstruct/tomopy_recon.py
+++ b/mantidimaging/core/reconstruct/tomopy_recon.py
@@ -42,7 +42,10 @@ class TomopyRecon(BaseRecon):
         return volume[0]
 
     @staticmethod
-    def full(images: Images, cors: List[ScalarCoR], recon_params: ReconstructionParameters, progress=None):
+    def full(images: Images,
+             cors: List[ScalarCoR],
+             recon_params: ReconstructionParameters,
+             progress: Optional[Progress] = None):
         """
         Performs a volume reconstruction using sample data provided as sinograms.
 

--- a/mantidimaging/core/utility/progress_reporting/progress.py
+++ b/mantidimaging/core/utility/progress_reporting/progress.py
@@ -7,8 +7,6 @@ from collections import namedtuple
 from logging import getLogger
 from typing import List, Optional
 
-import numpy
-
 from mantidimaging.core.utility.memory_usage import get_memory_usage_linux_str
 
 ProgressHistory = namedtuple('ProgressHistory', ['time', 'step', 'msg'])
@@ -205,13 +203,10 @@ class Progress(object):
     @staticmethod
     def calculate_mean_time(progress_history: List[ProgressHistory]) -> float:
         if len(progress_history) > 1:
-            times = numpy.asarray([elem.time for elem in progress_history[-1:-STEPS_TO_AVERAGE:-1]],
-                                  dtype=numpy.float32)
-            # get the differences between them (in reverse, to avoid dealing with negative number)
-            # and then the mean time
-            mean_time = numpy.diff(times[::-1]).mean()
+            average_over_steps = min(STEPS_TO_AVERAGE, len(progress_history))
+            time_diff = progress_history[-1].time - progress_history[-average_over_steps].time
 
-            return mean_time
+            return time_diff / (average_over_steps - 1)
         else:
             return 0
 

--- a/mantidimaging/core/utility/progress_reporting/progress.py
+++ b/mantidimaging/core/utility/progress_reporting/progress.py
@@ -165,6 +165,11 @@ class Progress(object):
         self.progress_handlers.append(handler)
         handler.progress = self
 
+    @staticmethod
+    def _format_time(t: int) -> str:
+        t = int(t)
+        return f'{t // 3600:02}:{t % 3600 // 60:02}:{t % 60:02}'
+
     def update(self, steps: int = 1, msg: str = "", force_continue: bool = False) -> None:
         """
         Updates the progress of the task.
@@ -192,12 +197,8 @@ class Progress(object):
 
             eta = self._average_time * (self.end_step - self.current_step)
 
-            def fmt(t):
-                t = int(t)
-                return f'{t // 3600:02}:{t % 3600 // 60:02}:{t % 60:02}'
-
             msg = f"{f'{msg}' if len(msg) > 0 else ''} | {self.current_step}/{self.end_step} | " \
-                  f"Time: {fmt(self.execution_time())}, ETA: {fmt(eta)}"
+                  f"Time: {self._format_time(self.execution_time())}, ETA: {self._format_time(eta)}"
             step_details = ProgressHistory(time.perf_counter(), self.current_step, msg)
             self.progress_history.append(step_details)
 

--- a/mantidimaging/core/utility/progress_reporting/test/progress_test.py
+++ b/mantidimaging/core/utility/progress_reporting/test/progress_test.py
@@ -247,6 +247,13 @@ class ProgressTest(unittest.TestCase):
         self.assertFalse(p.is_completed())
         self.assertTrue(p.should_cancel)
 
+    def test_format_time(self):
+        self.assertEqual(Progress._format_time(0), "00:00:00")
+        self.assertEqual(Progress._format_time(1), "00:00:01")
+        self.assertEqual(Progress._format_time(61), "00:01:01")
+        self.assertEqual(Progress._format_time(3599), "00:59:59")
+        self.assertEqual(Progress._format_time(3666), "01:01:06")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/mantidimaging/core/utility/progress_reporting/test/progress_test.py
+++ b/mantidimaging/core/utility/progress_reporting/test/progress_test.py
@@ -6,6 +6,7 @@ import unittest
 from unittest import mock
 
 from mantidimaging.core.utility.progress_reporting import Progress, ProgressHandler
+from mantidimaging.core.utility.progress_reporting.progress import ProgressHistory
 
 
 class ProgressTest(unittest.TestCase):
@@ -253,6 +254,25 @@ class ProgressTest(unittest.TestCase):
         self.assertEqual(Progress._format_time(61), "00:01:01")
         self.assertEqual(Progress._format_time(3599), "00:59:59")
         self.assertEqual(Progress._format_time(3666), "01:01:06")
+
+    def test_calculate_mean_time(self):
+        progress_history = []
+
+        progress_history.append(ProgressHistory(100, 0, ""))
+        self.assertEqual(Progress.calculate_mean_time(progress_history), 0)
+
+        # first step 5 seconds
+        progress_history.append(ProgressHistory(105, 1, ""))
+        self.assertEqual(Progress.calculate_mean_time(progress_history), 5)
+
+        # second step 10 seconds
+        progress_history.append(ProgressHistory(115, 2, ""))
+        self.assertEqual(Progress.calculate_mean_time(progress_history), 7.5)
+
+        for i in range(1, 50):
+            # add many 2 second steps
+            progress_history.append(ProgressHistory(115 + (i * 2), 2 + (i * 2), ""))
+        self.assertEqual(Progress.calculate_mean_time(progress_history), 2)
 
 
 if __name__ == "__main__":

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -124,7 +124,7 @@ class ReconstructWindowModel(object):
         return True
 
     def run_preview_recon(self,
-                          slice_idx,
+                          slice_idx: int,
                           cor: ScalarCoR,
                           recon_params: ReconstructionParameters,
                           progress: Progress = None) -> Optional[Images]:
@@ -157,7 +157,7 @@ class ReconstructWindowModel(object):
         return recon
 
     @staticmethod
-    def _apply_pixel_size(recon, recon_params, progress=None):
+    def _apply_pixel_size(recon, recon_params: ReconstructionParameters, progress=None):
         if recon_params.pixel_size > 0.:
             recon = DivideFilter.filter_func(recon, value=recon_params.pixel_size, unit="micron", progress=progress)
             # update the reconstructed stack pixel size with the value actually used for division
@@ -196,7 +196,7 @@ class ReconstructWindowModel(object):
         reconstructor = get_reconstructor_for(alg_name)
         return reconstructor.allowed_filters()
 
-    def get_me_a_cor(self, cor=None):
+    def get_me_a_cor(self, cor: Optional[ScalarCoR] = None):
         if cor is not None:
             # a rotation has been passed in!
             return cor
@@ -259,7 +259,7 @@ class ReconstructWindowModel(object):
             progress.update(msg=f"Calculating COR for slice {slice}")
         return cors
 
-    def auto_find_correlation(self, progress) -> Tuple[ScalarCoR, Degrees]:
+    def auto_find_correlation(self, progress: Progress) -> Tuple[ScalarCoR, Degrees]:
         return find_center(self.images, progress)
 
     @staticmethod

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -123,7 +123,11 @@ class ReconstructWindowModel(object):
         # Async task needs a non-None result of some sort
         return True
 
-    def run_preview_recon(self, slice_idx, cor: ScalarCoR, recon_params: ReconstructionParameters) -> Optional[Images]:
+    def run_preview_recon(self,
+                          slice_idx,
+                          cor: ScalarCoR,
+                          recon_params: ReconstructionParameters,
+                          progress: Progress = None) -> Optional[Images]:
         # Ensure we have some sample data
         if self.images is None:
             return None
@@ -132,9 +136,11 @@ class ReconstructWindowModel(object):
         reconstructor = get_reconstructor_for(recon_params.algorithm)
         output_shape = (1, self.images.width, self.images.width)
         recon: Images = Images.create_empty_images(output_shape, self.images.dtype, self.images.metadata)
-        recon.data[0] = reconstructor.single_sino(self.images.sino(slice_idx), cor,
+        recon.data[0] = reconstructor.single_sino(self.images.sino(slice_idx),
+                                                  cor,
                                                   self.images.projection_angles(recon_params.max_projection_angle),
-                                                  recon_params)
+                                                  recon_params,
+                                                  progress=progress)
         recon = self._apply_pixel_size(recon, recon_params)
         return recon
 


### PR DESCRIPTION

### Issue
Fixes #1099 

### Description

Allow progress to be passed into single_sino

Update the progress are various points during recon. Use next method in
a loop rather than the run convenience function.


### Testing  & Acceptance Criteria 
Progress bar should be updated during CIL recon with a usefil message

### Documentation

Not needed, polishing a new feature.

![image](https://user-images.githubusercontent.com/74248560/129583507-4b220f70-87fe-4bec-b6f5-f3487d67384f.png)

