### PR TITLE
Make sure the before image is still displayed if preview fails

### DIFF
--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -291,6 +291,9 @@ class FiltersWindowPresenter(BasePresenter):
             except Exception as e:
                 msg = f"Error applying filter for preview: {e}"
                 self.show_error(msg, traceback.format_exc())
+
+                # Can't continue be need the before image drawn
+                self._update_preview_image(before_image, self.view.preview_image_before)
                 return
 
             # Update image after first in order to prevent wrong histogram ranges being shared


### PR DESCRIPTION
### Issue

Closes #1084 

### Description

If the preview fails, (e.g. because the parameters are invalid), and we have just changed stacks (e.g. after applying an operation), then we still need to redraw the before image

### Testing  & Acceptance Criteria 

Follow steps on bug report. Before image should still show. even when preview can't be generated

### Documentation

not needed
