### PR TITLE
Add gui system tests for operations and recon

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -78,7 +78,7 @@ jobs:
           xvfb-run --auto-servernum python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov --run-system-tests
         timeout-minutes: 15
 
-      - name: GUI Tests Applitools
+      - name: GUI Tests Screenshots Applitools
         if: ${{ github.event_name == 'pull_request' }}
         shell: bash -l {0}
         env:

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -75,7 +75,7 @@ jobs:
       - name: GUI Tests System
         shell: bash -l {0}
         run: |
-          xvfb-run --auto-servernum python -m pytest -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov --run-system-tests
+          xvfb-run --auto-servernum python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov --run-system-tests
         timeout-minutes: 15
 
       - name: GUI Tests Applitools
@@ -86,7 +86,7 @@ jobs:
           APPLITOOLS_BATCH_ID: ${{ github.sha }}
           GITHUB_BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          xvfb-run --auto-servernum python -m pytest -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests
+          xvfb-run --auto-servernum python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests
         timeout-minutes: 15
 
       - name: Coveralls

--- a/docs/developer_guide/testing.rst
+++ b/docs/developer_guide/testing.rst
@@ -36,8 +36,8 @@ Static analysis
 Mantid Imaging uses `mypy <http://mypy-lang.org/>`_, `flake8 <https://flake8.pycqa.org/>`_ and `yapf <https://github.com/google/yapf>`_ for static analysis and formatting. They are run by :code:`make check`, or can be run individually, e.g. :code:`make mypy`.
 
 
-GUI Testing
------------
+GUI screenshot testing
+----------------------
 
 Mantid Imaging uses `Applitools Eyes <https://applitools.com/products-eyes/>`_ for GUI approval testing. Screenshots of windows are uploaded and compared to known good baseline images. This is run in the github action on pull requests.
 
@@ -55,3 +55,18 @@ To run without a key or to prevent uploads, set ``APPLITOOLS_API_KEY`` to ``loca
 
     mkdir /tmp/gui_test
     APPLITOOLS_API_KEY=local APPLITOOLS_IMAGE_DIR=/tmp/gui_test xvfb-run --auto-servernum pytest -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests
+
+GUI system tests
+----------------
+
+GUI system tests run work flows in Mantid Imaging in a 'realistic' way, where possible by using QTest methods to emulate mouse and keyboard actions. They use the same data files as the GUI screenshot tests. These take several minutes to run and so must be explicitly requested.
+
+.. code::
+
+    pytest -v --run-system-tests
+
+or in virtual X server xvfb-run
+
+.. code::
+
+    xvfb-run --auto-servernum pytest -v --run-system-tests

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -3,13 +3,13 @@
 
 import os
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Optional
 import unittest
 from unittest import mock
 
 from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtTest import QTest
-from PyQt5.QtWidgets import QApplication, QMessageBox
+from PyQt5.QtWidgets import QApplication, QMessageBox, QInputDialog
 import pytest
 
 from mantidimaging.core.utility.version_check import versions
@@ -54,6 +54,16 @@ class GuiSystemBase(unittest.TestCase):
                         return
                 button_texts = [button.text() for button in widget.buttons()]
                 raise ValueError(f"Could not find button '{button_text}' in {button_texts}")
+
+    @classmethod
+    def _click_InputDialog(cls, set_int: Optional[int] = None):
+        """Needs to be queued with QTimer.singleShot before triggering the message box"""
+        for widget in cls.app.topLevelWidgets():
+            if isinstance(widget, QInputDialog) and widget.isVisible():
+                if set_int:
+                    widget.setIntValue(set_int)
+                QTest.qWait(SHORT_DELAY)
+                widget.accept()
 
     def _close_welcome(self):
         self.main_window.welcome_window.view.close()

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -47,7 +47,7 @@ class GuiSystemBase(unittest.TestCase):
     def _click_messageBox(cls, button_text: str):
         """Needs to be queued with QTimer.singleShot before triggering the message box"""
         for widget in cls.app.topLevelWidgets():
-            if isinstance(widget, QMessageBox):
+            if isinstance(widget, QMessageBox) and widget.isVisible():
                 for button in widget.buttons():
                     if button.text().replace("&", "") == button_text:
                         QTest.mouseClick(button, Qt.LeftButton)

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -102,7 +102,7 @@ class GuiSystemBase(unittest.TestCase):
         self.main_window.load_dialogue.presenter.notify(Notification.UPDATE_ALL_FIELDS)
         QTest.qWait(SHOW_DELAY)
         self.main_window.load_dialogue.accept()
-        self._wait_until(test_func)
+        self._wait_until(test_func, max_retry=600)
 
     def _open_operations(self):
         self.main_window.actionFilters.trigger()

--- a/mantidimaging/gui/test/test_gui_system_loading.py
+++ b/mantidimaging/gui/test/test_gui_system_loading.py
@@ -27,7 +27,7 @@ class TestGuiSystemLoading(GuiSystemBase):
             current_stacks = len(self.main_window.presenter.model.get_all_stack_visualisers())
             return (current_stacks - initial_stacks) >= 1
 
-        self._wait_until(test_func)
+        self._wait_until(test_func, max_retry=600)
 
     @classmethod
     def _click_stack_selector(cls):

--- a/mantidimaging/gui/test/test_gui_system_operations.py
+++ b/mantidimaging/gui/test/test_gui_system_operations.py
@@ -1,0 +1,151 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+from itertools import product
+from unittest import mock
+from uuid import UUID
+
+from parameterized import parameterized
+from PyQt5.QtTest import QTest
+from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtWidgets import QFormLayout, QLabel, QWidget
+
+from mantidimaging.gui.windows.stack_choice.presenter import StackChoicePresenter
+from mantidimaging.core.data import Images
+from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHOW_DELAY, SHORT_DELAY
+from mantidimaging.gui.windows.stack_choice.view import StackChoiceView
+from mantidimaging.gui.windows.operations.view import FiltersWindowView
+
+OP_LIST = [
+    ("Arithmetic", [["Multiply", "2"]]),
+    ("Circular Mask", []),
+    ("Clip Values", [["Clip Max", "10000"]]),
+    ("Crop Coordinates", [["ROI", "10,10,100,100"]]),
+    ("Divide", []),
+    ("Flat-fielding", []),
+    ("Gaussian", []),
+    ("Median", []),
+    # ("Monitor Normalisation", []),
+    ("NaN Removal", []),
+    ("Remove Outliers", []),
+    ("Rebin", []),
+    # ("Remove all stripes", []),
+    # ("Remove dead stripes", []),
+    # ("Remove large stripes", []),
+    # ("Stripe Removal", []),
+    # ("Remove stripes with filtering", []),
+    # ("Remove stripes with sorting and fitting", []),
+    ("Rescale", [["Max input", "10000"]]),
+    ("Ring Removal", []),
+    ("ROI Normalisation", []),
+    ("Rotate Stack", []),
+]
+
+
+class TestGuiSystemOperations(GuiSystemBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._close_welcome()
+        self._load_data_set()
+
+        self._open_operations()
+        self.assertIsNotNone(self.main_window.filters)
+        assert isinstance(self.main_window.filters, FiltersWindowView)  # for yapf
+        self.assertTrue(self.main_window.filters.isVisible())
+        self.op_window = self.main_window.filters
+
+    def tearDown(self) -> None:
+        self._close_stack_tabs()
+        super().tearDown()
+        self.assertFalse(self.main_window.isVisible())
+
+    @staticmethod
+    def _get_operation_parameter_widget(form: QFormLayout, param_name: str) -> QWidget:
+        for i in range(form.rowCount()):
+            label_item = form.itemAt(i * 2)
+            widget_item = form.itemAt(i * 2 + 1)
+
+            if label_item is not None and widget_item is not None:
+                label = label_item.widget()
+                assert isinstance(label, QLabel)
+                if label.text() == param_name:
+                    return widget_item.widget()
+
+        raise ValueError(f"Could not find '{param_name}' in form")
+
+    @classmethod
+    def _click_stack_selector(cls, keep_new: bool):
+        cls._wait_for_widget_visible(StackChoiceView)
+        QTest.qWait(SHOW_DELAY)
+        for widget in cls.app.topLevelWidgets():
+            if isinstance(widget, StackChoiceView):
+                if keep_new:
+                    QTest.mouseClick(widget.newDataButton, Qt.MouseButton.LeftButton)
+                else:
+                    QTest.mouseClick(widget.originalDataButton, Qt.MouseButton.LeftButton)
+
+    @parameterized.expand(OP_LIST)
+    def test_run_operation_stack(self, op_name, params):
+        QTest.qWait(SHOW_DELAY)
+        index = self.op_window.filterSelector.findText(op_name)
+        self.assertGreaterEqual(index, 0, f'Operation "{op_name}" not found in filterSelector')
+        self.op_window.filterSelector.setCurrentIndex(index)
+        QTest.qWait(SHOW_DELAY)
+
+        for param_name, param_value in params:
+            widget = self._get_operation_parameter_widget(self.op_window.filterPropertiesLayout, param_name)
+            widget.selectAll()
+            QTest.keyClicks(widget, param_value)
+            QTest.keyClick(widget, Qt.Key_Return)
+            QTest.qWait(SHOW_DELAY)
+
+        self.op_window.safeApply.setChecked(False)
+        QTest.mouseClick(self.op_window.applyButton, Qt.MouseButton.LeftButton)
+        QTest.qWait(SHORT_DELAY)
+        self._wait_until(lambda: self.op_window.presenter.filter_is_running is False)
+
+        self.main_window.filters.close()
+        QTest.qWait(SHOW_DELAY)
+
+    @parameterized.expand(product(OP_LIST, ["new", "original"]))
+    def test_run_operation_stack_safe(self, op_info, keep_stack):
+        op_name, params = op_info
+        print(f"test_run_operation_stack_safe {op_name=} {params=} {keep_stack=}")
+        QTest.qWait(SHOW_DELAY)
+        index = self.op_window.filterSelector.findText(op_name)
+        self.assertGreaterEqual(index, 0, f'Operation "{op_name}" not found in filterSelector')
+        self.op_window.filterSelector.setCurrentIndex(index)
+        QTest.qWait(SHOW_DELAY)
+
+        for param_name, param_value in params:
+            widget = self._get_operation_parameter_widget(self.op_window.filterPropertiesLayout, param_name)
+            widget.selectAll()
+            QTest.keyClicks(widget, param_value)
+            QTest.keyClick(widget, Qt.Key_Return)
+            QTest.qWait(SHOW_DELAY)
+
+        self.op_window.safeApply.setChecked(True)
+        QTest.qWait(SHOW_DELAY)
+
+        def mock_wait_for_stack_choice(self, new_stack: Images, stack_uuid: UUID):
+            print("mock_wait_for_stack_choice")
+            stack_choice = StackChoicePresenter(self.original_images_stack, new_stack, self, stack_uuid)
+            stack_choice.show()
+            QTest.qWait(SHOW_DELAY)
+            if keep_stack == "new":
+                QTest.mouseClick(stack_choice.view.newDataButton, Qt.MouseButton.LeftButton)
+            else:
+                QTest.mouseClick(stack_choice.view.originalDataButton, Qt.MouseButton.LeftButton)
+
+            return stack_choice.use_new_data
+
+        with mock.patch("mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter._wait_for_stack_choice",
+                        mock_wait_for_stack_choice):
+
+            QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("OK"))
+            QTest.mouseClick(self.op_window.applyButton, Qt.MouseButton.LeftButton)
+
+            QTest.qWait(SHORT_DELAY)
+            self._wait_until(lambda: self.op_window.presenter.filter_is_running is False)
+            self.main_window.filters.close()
+            QTest.qWait(SHOW_DELAY)

--- a/mantidimaging/gui/test/test_gui_system_operations.py
+++ b/mantidimaging/gui/test/test_gui_system_operations.py
@@ -102,12 +102,12 @@ class TestGuiSystemOperations(GuiSystemBase):
         self.op_window.safeApply.setChecked(False)
         QTest.mouseClick(self.op_window.applyButton, Qt.MouseButton.LeftButton)
         QTest.qWait(SHORT_DELAY)
-        self._wait_until(lambda: self.op_window.presenter.filter_is_running is False)
+        self._wait_until(lambda: self.op_window.presenter.filter_is_running is False, max_retry=600)
 
         self.main_window.filters.close()
         QTest.qWait(SHOW_DELAY)
 
-    @parameterized.expand(product(OP_LIST, ["new", "original"]))
+    @parameterized.expand(product(OP_LIST[:3], ["new", "original"]))
     def test_run_operation_stack_safe(self, op_info, keep_stack):
         op_name, params = op_info
         print(f"test_run_operation_stack_safe {op_name=} {params=} {keep_stack=}")

--- a/mantidimaging/gui/test/test_gui_system_reconstruction.py
+++ b/mantidimaging/gui/test/test_gui_system_reconstruction.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+import pytest
+
+from PyQt5.QtTest import QTest
+from PyQt5.QtCore import Qt, QTimer
+
+from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHOW_DELAY, SHORT_DELAY
+from mantidimaging.gui.windows.recon.view import ReconstructWindowView
+from mantidimaging.gui.dialogs.cor_inspection.view import CORInspectionDialogView
+
+
+class TestGuiSystemReconstruction(GuiSystemBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._close_welcome()
+        self._load_data_set()
+
+        self._open_reconstruction()
+        self.assertIsNotNone(self.main_window.recon)
+        assert isinstance(self.main_window.recon, ReconstructWindowView)  # for yapf
+        self.assertTrue(self.main_window.recon.isVisible())
+        self.recon_window = self.main_window.recon
+
+    def tearDown(self) -> None:
+        self.recon_window.close()
+        assert isinstance(self.main_window.recon, ReconstructWindowView)
+        self.assertFalse(self.main_window.recon.isVisible())
+        self._close_stack_tabs()
+        super().tearDown()
+        self.assertFalse(self.main_window.isVisible())
+
+    def test_correlate(self):
+        for _ in range(5):
+            QTest.mouseClick(self.recon_window.correlateBtn, Qt.MouseButton.LeftButton)
+
+            QTest.qWait(SHORT_DELAY)
+            self._wait_until(lambda: self.recon_window.correlateBtn.isEnabled())
+
+    def test_minimise(self):
+        for i in range(2, 6):
+            QTimer.singleShot(SHORT_DELAY, lambda: self._click_InputDialog(set_int=i))
+            QTest.mouseClick(self.recon_window.minimiseBtn, Qt.MouseButton.LeftButton)
+
+            QTest.qWait(SHORT_DELAY)
+            self._wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=200)
+            QTest.qWait(SHORT_DELAY)
+
+    @classmethod
+    def _click_cor_inspect(cls):
+        cls._wait_for_widget_visible(CORInspectionDialogView)
+        for widget in cls.app.topLevelWidgets():
+            if isinstance(widget, CORInspectionDialogView):
+                QTest.qWait(SHORT_DELAY)
+                QTest.mouseClick(widget.finishButton, Qt.MouseButton.LeftButton)
+
+    def test_refine(self):
+        QTimer.singleShot(SHORT_DELAY, lambda: self._click_InputDialog(set_int=4))
+        QTest.mouseClick(self.recon_window.minimiseBtn, Qt.MouseButton.LeftButton)
+        self._wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=200)
+
+        for _ in range(5):
+            QTimer.singleShot(SHORT_DELAY, lambda: self._click_cor_inspect())
+            QTest.mouseClick(self.recon_window.refineCorBtn, Qt.MouseButton.LeftButton)
+            QTest.qWait(SHORT_DELAY * 2)
+
+        QTest.qWait(SHOW_DELAY)
+
+    @pytest.mark.skip(reason="Triggers #1110")
+    def test_refine_stress(self):
+        for i in range(20):
+            print(f"test_refine_stress iteration {i}")
+            QTest.mouseClick(self.recon_window.correlateBtn, Qt.MouseButton.LeftButton)
+            QTest.qWait(SHORT_DELAY)
+            self._wait_until(lambda: self.recon_window.correlateBtn.isEnabled())
+
+            QTimer.singleShot(SHORT_DELAY, lambda: self._click_InputDialog(set_int=3))
+            QTest.mouseClick(self.recon_window.minimiseBtn, Qt.MouseButton.LeftButton)
+            self._wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=200)
+
+            QTimer.singleShot(SHORT_DELAY, lambda: self._click_cor_inspect())
+            QTest.mouseClick(self.recon_window.refineCorBtn, Qt.MouseButton.LeftButton)
+            QTest.qWait(SHORT_DELAY * 2)
+
+        QTest.qWait(SHOW_DELAY)


### PR DESCRIPTION
### Issue

Closes #1113

### Description
Add a system gui test to run each operations (excluding those that operate on sinograms).

Add some recon window tests around the title and COR

Includes a test that triggers #1110 (disabled for now)

### Testing & Acceptance Criteria 

Github actions tests should run

### Documentation

TODO
