### PR TITLE
Fix segfault due to ViewBox deletetion in CompareSlicesView

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -54,6 +54,7 @@ Fixes
 - #940: Ops window, pixel value not updating for part of image
 - #1093: TIFF output blank if NaN in stack
 - #1095: AttributeError loading 180 deg projection
+- #1110: Segmentation fault COR table refine
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/dialogs/cor_inspection/recon_slice_view.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/recon_slice_view.py
@@ -13,6 +13,8 @@ from mantidimaging.gui.dialogs.cor_inspection.types import ImageType
 if TYPE_CHECKING:
     from mantidimaging.gui.dialogs.cor_inspection import CORInspectionDialogView  # pragma: no cover
 
+graveyard = []
+
 
 class CompareSlicesView(GraphicsLayoutWidget):
     less_img: ImageItem
@@ -124,6 +126,7 @@ class CompareSlicesView(GraphicsLayoutWidget):
         vb = ViewBox(invertY=True, lockAspect=True, name=name)
         vb.addItem(im)
         hist = HistogramLUTItem(im)
+        graveyard.append(vb)
         return im, vb, hist
 
     def set_image(self, image_type: ImageType, recon_data: np.ndarray, title: str):

--- a/mantidimaging/gui/test/test_gui_system_reconstruction.py
+++ b/mantidimaging/gui/test/test_gui_system_reconstruction.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-import pytest
-
 from PyQt5.QtTest import QTest
 from PyQt5.QtCore import Qt, QTimer
 
@@ -67,9 +65,8 @@ class TestGuiSystemReconstruction(GuiSystemBase):
 
         QTest.qWait(SHOW_DELAY)
 
-    @pytest.mark.skip(reason="Triggers #1110")
     def test_refine_stress(self):
-        for i in range(20):
+        for i in range(5):
             print(f"test_refine_stress iteration {i}")
             QTest.mouseClick(self.recon_window.correlateBtn, Qt.MouseButton.LeftButton)
             QTest.qWait(SHORT_DELAY)


### PR DESCRIPTION
### Issue
Closes #1110 

### Description

Use graveyard to prevent deletion (see #894)

### Testing  & Acceptance Criteria 

Tests should pass. Following steps on bug report should not cause a crash

### Documentation

release_notes
