### PR TITLE
1112: Use minimum value of slices for automatic CoR

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -56,6 +56,7 @@ Fixes
 - #1095: AttributeError loading 180 deg projection
 - #1110: Segmentation fault COR table refine
 - #1115: Copy everything from metadata dialog
+- #1112: Minimise Error, number of slices input should have minimum of 2
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -285,7 +285,7 @@ class ReconstructWindowViewTest(unittest.TestCase):
                                                          "Number of slices",
                                                          "On how many slices to run the automatic CoR finding?",
                                                          value=6,
-                                                         min=0,
+                                                         min=2,
                                                          max=30,
                                                          step=1)
 
@@ -300,7 +300,7 @@ class ReconstructWindowViewTest(unittest.TestCase):
                                                          "Number of slices",
                                                          "On how many slices to run the automatic CoR finding?",
                                                          value=6,
-                                                         min=0,
+                                                         min=2,
                                                          max=30,
                                                          step=1)
 

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -409,7 +409,7 @@ class ReconstructWindowView(BaseMainWindowView):
                                             "Number of slices",
                                             "On how many slices to run the automatic CoR finding?",
                                             value=6,
-                                            min=0,
+                                            min=2,
                                             max=30,
                                             step=1)
         if accepted:


### PR DESCRIPTION
### Issue

Closes #1112 

### Description

The dialog box has a minimum of 2.

### Testing 

Updated the existing tests.

### Acceptance Criteria 

Check that the value can't go below 2. Check that the tests pass.

### Documentation

Updated release notes.
