### PR TITLE
Clarify message when FF operation creates negative values

### DIFF
--- a/docs/release_notes/2.2.rst
+++ b/docs/release_notes/2.2.rst
@@ -59,6 +59,7 @@ Fixes
 - #1115: Copy everything from metadata dialog
 - #1112: Minimise Error, number of slices input should have minimum of 2
 - #1067: Failed to load stack "log file is not recognised"
+- #1121: FF when negative values in output, no completed message
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -256,7 +256,7 @@ class FiltersWindowPresenter(BasePresenter):
             self.view.clear_notification_dialog()
             self.view.show_operation_cancelled(self.model.selected_filter.filter_name)
 
-        if self.view.filterSelector.currentText() == FLAT_FIELDING and negative_stacks:
+        if use_new_data and self.view.filterSelector.currentText() == FLAT_FIELDING and negative_stacks:
             self._show_negative_values_error(negative_stacks)
 
         self.view.filter_applied.emit()
@@ -392,7 +392,9 @@ class FiltersWindowPresenter(BasePresenter):
         :param negative_stacks: A list of stacks with negative values in the data.
         """
         names = [stack.name for stack in negative_stacks]
-        self.view.show_error_dialog(f"Negative values found in stack(s) {', '.join(names)}. See log for more details.")
+        operation_name = self.model.selected_filter.filter_name
+        self.view.show_error_dialog(f"{operation_name} completed. "
+                                    f"Negative values found in stack(s) {', '.join(names)}. See log for more details.")
 
         for stack in negative_stacks:
             negative_slices = []

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -431,8 +431,8 @@ class FiltersWindowPresenterTest(unittest.TestCase):
             self.assertIn(f"Slices containing negative values in {negative_stack_name}: {[i for i in range(3)]}",
                           mock_logger.output[0])
 
-        self.view.show_error_dialog.assert_called_once_with(
-            f"Negative values found in stack(s) {negative_stack_name}. See log for more details.")
+        self.assertIn("Negative values found in stack", self.view.show_error_dialog.call_args[0][0])
+        self.assertIn(f"{negative_stack_name}", self.view.show_error_dialog.call_args[0][0])
 
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter._do_apply_filter_sync')
     def test_no_negative_values_in_flat_fielding_shows_no_error(self, do_apply_filter_sync_mock):


### PR DESCRIPTION
Say that the operation completed.

### Issue

Closes #1121 

### Description
Change the message to 
"{operation_name} completed. Negative values found in stack(s) {', '.join(names)}. See log for more details."

### Testing 

Run flat fielding on the mantidimaging-data IMAT00010675 dataset

### Acceptance Criteria 

New message

### Documentation

release_notes
