### PR TITLE
1122: Compressed negative slices list

### DIFF
--- a/docs/release_notes/2.2.rst
+++ b/docs/release_notes/2.2.rst
@@ -24,6 +24,7 @@ New features
 - #1026 : Recon warn if input has NaNs
 - #816 : NaN Removal Filter
 - #1035 : NeXus Loader: Select every Nth image
+- #1035 : List of bad slices in error message could be compressed
 
 Fixes
 -----

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -66,7 +66,7 @@ def sub(x: List[int]) -> int:
 
 def _generate_slices_range_list(slices: List[int]) -> List[str]:
     ranges = []
-    for k, iterable in groupby(enumerate(slices), sub):
+    for k, iterable in groupby([(i, j) for i, j in enumerate(slices)], sub):
         rng = list(iterable)
         if len(rng) == 1:
             s = str(rng[0][1])

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -428,13 +428,18 @@ class FiltersWindowPresenter(BasePresenter):
             for i in range(len(stack.presenter.images.data)):
                 if np.any(stack.presenter.images.data[i] < 0):
                     negative_slices.append(i)
-            slices_msg = f'Slices containing negative values in {stack.name}: '
+            stack_msg = f'Slices containing negative values in {stack.name}: '
             if len(negative_slices) == len(stack.presenter.images.data):
-                slices_msg += "all slices."
+                slices_msg = stack_msg + "all slices."
+                gui_error.append(slices_msg)
             else:
-                slices_msg += f'{", ".join(_group_consecutive_values(negative_slices))}.'
+                ranges = _group_consecutive_values(negative_slices)
+                slices_msg = stack_msg + f'{", ".join(ranges)}.'
+                if len(negative_slices) <= 12:
+                    gui_error.append(slices_msg)
+                else:
+                    gui_error.append(f'{stack_msg}{", ".join(ranges[:10])} ... {ranges[-1]}.')
             getLogger(__name__).error(slices_msg)
-            gui_error.append(slices_msg)
         self.view.show_error_dialog(" ".join(gui_error))
 
     def _show_preview_negative_values_error(self, slice_idx: int):

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -421,7 +421,7 @@ class FiltersWindowPresenter(BasePresenter):
                 if np.any(stack.presenter.images.data[i] < 0):
                     negative_slices.append(i)
             getLogger(__name__).error(f'Slices containing negative values in {stack.name}: '
-                                      '{", ".join(_generate_slices_range_list(negative_slices))}')
+                                      f'{", ".join(_generate_slices_range_list(negative_slices))}')
 
     def _show_preview_negative_values_error(self, slice_idx: int):
         """

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -60,13 +60,13 @@ def _find_nan_change(before_image, filtered_image_data):
     return nan_change
 
 
-def sub(x: List[int]) -> int:
+def sub(x: Tuple[int, int]) -> int:
     return x[1] - x[0]
 
 
 def _generate_slices_range_list(slices: List[int]) -> List[str]:
     ranges = []
-    for k, iterable in groupby([(i, j) for i, j in enumerate(slices)], sub):
+    for k, iterable in groupby(enumerate(slices), sub):
         rng = list(iterable)
         if len(rng) == 1:
             s = str(rng[0][1])

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -420,10 +420,8 @@ class FiltersWindowPresenter(BasePresenter):
         Shows information on the view and in the log about negative values in the output.
         :param negative_stacks: A list of stacks with negative values in the data.
         """
-        names = [stack.name for stack in negative_stacks]
         operation_name = self.model.selected_filter.filter_name
-        self.view.show_error_dialog(f"{operation_name} completed. "
-                                    f"Negative values found in stack(s) {', '.join(names)}. See log for more details.")
+        gui_error = [f"{operation_name} completed."]
 
         for stack in negative_stacks:
             negative_slices = []
@@ -434,8 +432,10 @@ class FiltersWindowPresenter(BasePresenter):
             if len(negative_slices) == len(stack.presenter.images.data):
                 slices_msg += "all slices."
             else:
-                slices_msg += f'{", ".join(_group_consecutive_values(negative_slices))}'
+                slices_msg += f'{", ".join(_group_consecutive_values(negative_slices))}.'
             getLogger(__name__).error(slices_msg)
+            gui_error.append(slices_msg)
+        self.view.show_error_dialog(" ".join(gui_error))
 
     def _show_preview_negative_values_error(self, slice_idx: int):
         """

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -69,7 +69,7 @@ def sub(x: Tuple[int, int]) -> int:
     return x[1] - x[0]
 
 
-def _generate_slices_range_list(slices: List[int]) -> List[str]:
+def _group_consecutive_values(slices: List[int]) -> List[str]:
     """
     Creates a list of slices with negative indices in a readable format.
     :param slices: The list of indices of the slices that contain negative values.
@@ -434,7 +434,7 @@ class FiltersWindowPresenter(BasePresenter):
             if len(negative_slices) == len(stack.presenter.images.data):
                 slices_msg += "all slices."
             else:
-                slices_msg += f'{", ".join(_generate_slices_range_list(negative_slices))}'
+                slices_msg += f'{", ".join(_group_consecutive_values(negative_slices))}'
             getLogger(__name__).error(slices_msg)
 
     def _show_preview_negative_values_error(self, slice_idx: int):

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -420,8 +420,12 @@ class FiltersWindowPresenter(BasePresenter):
             for i in range(len(stack.presenter.images.data)):
                 if np.any(stack.presenter.images.data[i] < 0):
                     negative_slices.append(i)
-            getLogger(__name__).error(f'Slices containing negative values in {stack.name}: '
-                                      f'{", ".join(_generate_slices_range_list(negative_slices))}')
+            slices_msg = f'Slices containing negative values in {stack.name}: '
+            if len(negative_slices) == len(stack.presenter.images.data):
+                slices_msg += "all slices."
+            else:
+                slices_msg += f'{", ".join(_generate_slices_range_list(negative_slices))}'
+            getLogger(__name__).error(slices_msg)
 
     def _show_preview_negative_values_error(self, slice_idx: int):
         """

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -61,10 +61,20 @@ def _find_nan_change(before_image, filtered_image_data):
 
 
 def sub(x: Tuple[int, int]) -> int:
+    """
+    Subtracts two tuples. Helper method for generating the negative slice list.
+    :param x: The int tuple.
+    :return: The first value subtracted from the second value.
+    """
     return x[1] - x[0]
 
 
 def _generate_slices_range_list(slices: List[int]) -> List[str]:
+    """
+    Creates a list of slices with negative indices in a readable format.
+    :param slices: The list of indices of the slices that contain negative values.
+    :return: A list of strings for the index ranges e.g. 1-5, 7-20, etc
+    """
     ranges = []
     for k, iterable in groupby(enumerate(slices), sub):
         rng = list(iterable)

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -429,7 +429,6 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         images.data[4][0][0] = -1
         images.data[5][0][0] = -1
         images.data[7][0][0] = -1
-        self.presenter.model.selected_filter.filter_name = "Filter Name"
         self.mock_stack_visualisers[0].presenter.images = images
         self.mock_stack_visualisers[0].name = negative_stack_name = "StackWithNegativeValues"
 
@@ -451,7 +450,6 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         images = generate_images()
         for i in range(len(images.data)):
             images.data[i][0][0] = -1
-        self.presenter.model.selected_filter.filter_name = "Filter Name"
         self.mock_stack_visualisers[0].presenter.images = images
         self.mock_stack_visualisers[0].name = negative_stack_name = "StackWithNegativeValues"
 

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -475,3 +475,16 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         before_image = np.array([np.nan, 1, 2])
         after_image = np.array([1, 1, np.nan])
         npt.assert_array_equal(np.array([True, False, False]), _find_nan_change(before_image, after_image))
+
+    def test_generate_slices_index_list(self):
+        negative_stack = mock.Mock()
+        negative_stack.name = "Data Name"
+        images = generate_images()
+        images.data[0][0][0] = -1
+        images.data[2][0][0] = -1
+        images.data[5][0][0] = -1
+        images.data[7][0][0] = -1
+        negative_stack.presenter.images = images
+
+        self.presenter.model.selected_filter.filter_name = "Filter Name"
+        self.presenter._show_negative_values_error([negative_stack])

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -449,8 +449,8 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         mock_task = mock.Mock()
         mock_task.error = None
         images = generate_images()
-        for i in range(len(images.data)):
-            images.data[i][0][0] = -1
+        images.data[:, 0, 0] = -1
+
         self.mock_stack_visualisers[0].presenter.images = images
         self.mock_stack_visualisers[0].name = negative_stack_name = "StackWithNegativeValues"
 

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -424,12 +424,12 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         mock_task = mock.Mock()
         mock_task.error = None
         images = generate_images()
-        images.data[0][0][0] = -1
-        images.data[1][0][0] = -1
-        images.data[2][0][0] = -1
-        images.data[4][0][0] = -1
-        images.data[5][0][0] = -1
-        images.data[7][0][0] = -1
+        images.data[0, 0, 0] = -1
+        images.data[1, 0, 0] = -1
+        images.data[2, 0, 0] = -1
+        images.data[4, 0, 0] = -1
+        images.data[5, 0, 0] = -1
+        images.data[7, 0, 0] = -1
         self.mock_stack_visualisers[0].presenter.images = images
         self.mock_stack_visualisers[0].name = negative_stack_name = "StackWithNegativeValues"
 

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -14,7 +14,8 @@ from parameterized import parameterized
 from mantidimaging.core.operation_history.const import OPERATION_HISTORY, OPERATION_DISPLAY_NAME
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.operations import FiltersWindowPresenter
-from mantidimaging.gui.windows.operations.presenter import REPEAT_FLAT_FIELDING_MSG, FLAT_FIELDING, _find_nan_change
+from mantidimaging.gui.windows.operations.presenter import REPEAT_FLAT_FIELDING_MSG, FLAT_FIELDING, _find_nan_change, \
+    _group_consecutive_values
 from mantidimaging.test_helpers.unit_test_helper import assert_called_once_with, generate_images
 
 
@@ -503,3 +504,8 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         before_image = np.array([np.nan, 1, 2])
         after_image = np.array([1, 1, np.nan])
         npt.assert_array_equal(np.array([True, False, False]), _find_nan_change(before_image, after_image))
+
+    def test_group_consecutive_values(self):
+        slices = [i for i in range(8)] + [i for i in range(10, 15)]
+        ranges = _group_consecutive_values(slices)
+        self.assertListEqual(ranges, ["0-7", "10-14"])

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -422,13 +422,21 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.presenter.view.filterSelector.currentText.return_value = FLAT_FIELDING
         mock_task = mock.Mock()
         mock_task.error = None
-        self.mock_stack_visualisers[0].presenter.images.data = np.array([-1 for _ in range(3)])
+        images = generate_images()
+        images.data[0][0][0] = -1
+        images.data[1][0][0] = -1
+        images.data[2][0][0] = -1
+        images.data[4][0][0] = -1
+        images.data[5][0][0] = -1
+        images.data[7][0][0] = -1
+        self.presenter.model.selected_filter.filter_name = "Filter Name"
+        self.mock_stack_visualisers[0].presenter.images = images
         self.mock_stack_visualisers[0].name = negative_stack_name = "StackWithNegativeValues"
 
         with self.assertLogs(logging.getLogger('mantidimaging.gui.windows.operations.presenter'),
                              level="ERROR") as mock_logger:
             self.presenter._post_filter(self.mock_stack_visualisers, mock_task)
-            self.assertIn(f"Slices containing negative values in {negative_stack_name}: {[i for i in range(3)]}",
+            self.assertIn(f"Slices containing negative values in {negative_stack_name}: 0-2, 4-5, 7",
                           mock_logger.output[0])
 
         self.assertIn("Negative values found in stack", self.view.show_error_dialog.call_args[0][0])
@@ -475,16 +483,3 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         before_image = np.array([np.nan, 1, 2])
         after_image = np.array([1, 1, np.nan])
         npt.assert_array_equal(np.array([True, False, False]), _find_nan_change(before_image, after_image))
-
-    def test_generate_slices_index_list(self):
-        negative_stack = mock.Mock()
-        negative_stack.name = "Data Name"
-        images = generate_images()
-        images.data[0][0][0] = -1
-        images.data[2][0][0] = -1
-        images.data[5][0][0] = -1
-        images.data[7][0][0] = -1
-        negative_stack.presenter.images = images
-
-        self.presenter.model.selected_filter.filter_name = "Filter Name"
-        self.presenter._show_negative_values_error([negative_stack])


### PR DESCRIPTION
### Issue

Closes #1122

### Description

Simplifies the list of slices with negative values after flat fielding.

### Testing 

Updated an existing test to check that the log message contains ranges "0-2, 4-5, 7" rather than printing the index of every slice with a negative value. Also added a test for an "all slices" are message if all slices contain negative values.

### Acceptance Criteria 

Check that the tests pass. Check that the slice range is displayed in the log message after running flat-fielding.

### Documentation

Updated release notes.
