### PR TITLE
1118: Remove outliers does not remove NaN

### DIFF
--- a/docs/release_notes/2.2.rst
+++ b/docs/release_notes/2.2.rst
@@ -61,6 +61,7 @@ Fixes
 - #1112: Minimise Error, number of slices input should have minimum of 2
 - #1067: Failed to load stack "log file is not recognised"
 - #1121: FF when negative values in output, no completed message
+- #1118: Remove outliers does not remove NaN
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -39,9 +39,9 @@ class OutliersFilter(BaseFilter):
         # Adapted from tomopy source
         median = scipy_ndimage.median_filter(data, radius)
         if mode == OUTLIERS_BRIGHT:
-            return np.where(np.logical_or((data - median) > diff, np.isnan(data)), median, data)
+            return np.where(np.logical_or(np.isnan(data), (data - median) > diff), median, data)
         else:
-            return np.where(np.logical_or((median - data) > diff, np.isnan(data)), median, data)
+            return np.where(np.logical_or(np.isnan(data), (median - data) > diff), median, data)
 
     @staticmethod
     def filter_func(images: Images,

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -39,9 +39,9 @@ class OutliersFilter(BaseFilter):
         # Adapted from tomopy source
         median = scipy_ndimage.median_filter(data, radius)
         if mode == OUTLIERS_BRIGHT:
-            return np.where((data - median) > diff, median, data)
+            return np.where(np.logical_or((data - median) > diff, np.isnan(data)), median, data)
         else:
-            return np.where((median - data) > diff, median, data)
+            return np.where(np.logical_or((median - data) > diff, np.isnan(data)), median, data)
 
     @staticmethod
     def filter_func(images: Images,

--- a/mantidimaging/core/operations/outliers/test/outliers_test.py
+++ b/mantidimaging/core/operations/outliers/test/outliers_test.py
@@ -67,6 +67,17 @@ class OutliersTest(unittest.TestCase):
 
         self.assertEqual(0, gui_dict["diff_field"].minimum())
 
+    def test_nan_removal(self):
+        images = th.generate_images()
+        images.data[::2, 0, 0] = np.nan
+
+        radius = 8
+        threshold = 0.1
+
+        result = OutliersFilter.filter_func(images, threshold, radius, cores=1)
+
+        assert not np.any(np.isnan(result.data))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Issue

Closes #1118 

### Description

Makes remove outliers remove NaN pixels.

### Testing 

Added a `test_nan_removal` test.

### Acceptance Criteria 

Check that the tests pass. Check that NaNs are removed when the filter is used.

### Documentation

Updated release notes.
