### PR TITLE
Set imageAxisOrder in GUI tests

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -18,3 +18,4 @@ Developer Changes
 -----------------
 
 - #1022 : Switch to use Mambaforge
+- #1085 : Fix rotation of images in GUI tests

--- a/mantidimaging/test_helpers/start_qapplication.py
+++ b/mantidimaging/test_helpers/start_qapplication.py
@@ -16,12 +16,15 @@ import os
 import pytest
 import sys
 
+import pyqtgraph
 from PyQt5.QtWidgets import QApplication
 
 _QAPP = QApplication.instance()
 
 uncaught_exception = None
 current_excepthook = sys.excepthook
+
+pyqtgraph.setConfigOptions(imageAxisOrder="row-major")
 
 
 def get_application(name=''):


### PR DESCRIPTION


### Issue
Closes #1085

### Description

This causes pyqtgraph to display arrays in the row-major order used in
MI. Makes GUI tests match the behaviour of the real application.

### Testing & Acceptance Criteria 

Images should be the correct way up in the applitools tests.

This will break all our current baselines

### Documentation

release_notes
