### PR TITLE
Use continue-on-error for coveralls test

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -96,6 +96,7 @@ jobs:
         shell: bash -l {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
         run: |
           coveralls
 


### PR DESCRIPTION
Work around coveralls outage

Currently getting

```
Submitting coverage to coveralls.io...
Could not submit coverage: 503 Server Error: Service Unavailable for url: https://coveralls.io/api/v1/jobs
Traceback (most recent call last):
  File "/usr/share/miniconda3/envs/mantidimaging-dev/lib/python3.8/site-packages/coveralls/api.py", line 237, in wear
    response.raise_for_status()
  File "/usr/share/miniconda3/envs/mantidimaging-dev/lib/python3.8/site-packages/requests/models.py", line 943, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 503 Server Error: Service Unavailable for url: https://coveralls.io/api/v1/jobs

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/miniconda3/envs/mantidimaging-dev/lib/python3.8/site-packages/coveralls/cli.py", line 85, in main
    result = coverallz.wear()
  File "/usr/share/miniconda3/envs/mantidimaging-dev/lib/python3.8/site-packages/coveralls/api.py", line 240, in wear
    raise CoverallsException('Could not submit coverage: {}'.format(e))
coveralls.exception.CoverallsException: Could not submit coverage: 503 Server Error: Service Unavailable for url: https://coveralls.io/api/v1/jobs
Error: Process completed with exit code 1.
```
