### PR TITLE
Update dependancies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ install-build-requirements:
 	@echo "Installing packages required for starting the build process"
 	conda create -n build-env
 	$(CONDA_ACTIVATE) build-env ; conda install --yes conda-build anaconda-client conda-verify
+	$(CONDA_ACTIVATE) build-env ; conda config --env --add channels dtasev --add channels astra-toolbox/label/dev --add channels conda-forge --add channels ccpi
 
 install-dev-requirements:
 	conda env create -f environment-dev.yml

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -16,10 +16,7 @@ source:
 requirements:
   build:
     - python=3.8.*
-    - pip
-    - setuptools=49.6.0
-    - sphinx=3.3.1
-    - numpy=1.18.*
+    - setuptools=58.*
   run:
     - python=3.8.*
     - pip

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - scikit-image=0.18.*
     - numpy=1.18.*
     - algotom=1.0.*
+    - tomopy=1.10.*
     - cudatoolkit=9.2*
     - cupy=9.4.*
     - astra-toolbox=1.9.9.dev4

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -20,23 +20,21 @@ requirements:
   run:
     - python=3.8.*
     - pip
-    - astropy=4.2
-    - scipy=1.5.3
+    - astropy=4.3.*
+    - scipy=1.7.*
     - scikit-image=0.18.*
     - numpy=1.18.*
-    - tomopy=1.9.*=cuda*
+    - algotom=1.0.*
     - cudatoolkit=9.2*
-    - cupy
+    - cupy=9.4.*
     - astra-toolbox=1.9.9.dev4
-    - requests=2.25.1
-    - h5py=3.1.0
+    - requests=2.26.*
+    - h5py=3.4.*
     - sarepy=2020.07
     - psutil=5.8.*
     - cil=21.2.*
     - cil-astra=21.2.*
     - ccpi-regulariser=20.9
-    - tomophantom=1.4.*
-    - algotom=1.0.*
 
 build:
   number: 1

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -9,9 +9,9 @@
 
 {%- block rootrellink %}
   {% if versions %}
-        <li class="nav-item nav-item-0"><a href="{{ pathto(master_doc)|e }}">{{ project }} {{ current_version.name }} Documentation</a>{{ reldelim1 }}</li>
+        <li class="nav-item nav-item-0"><a href="{{ pathto(root_doc)|e }}">{{ project }} {{ current_version.name }} Documentation</a>{{ reldelim1 }}</li>
   {% else %}
-        <li class="nav-item nav-item-0"><a href="{{ pathto(master_doc)|e }}">{{ shorttitle|e }}</a>{{ reldelim1 }}</li>
+        <li class="nav-item nav-item-0"><a href="{{ pathto(root_doc)|e }}">{{ shorttitle|e }}</a>{{ reldelim1 }}</li>
   {% endif %}
 {%- endblock %}
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,8 +61,8 @@ templates_path = ['_templates']
 # source_suffix = ['.rst', '.md']
 source_suffix = '.rst'
 
-# The master toctree document.
-master_doc = 'index'
+# The root toctree document.
+root_doc = 'index'
 
 # General information about the project.
 project = u'MantidImaging'
@@ -144,14 +144,14 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'MantidImaging.tex', u'MantidImaging Documentation', u'Dimitar Tasev, Dan Nixon', 'manual'),
+    (root_doc, 'MantidImaging.tex', u'MantidImaging Documentation', u'Dimitar Tasev, Dan Nixon', 'manual'),
 ]
 
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, 'mantidimaging', u'MantidImaging Documentation', [author], 1)]
+man_pages = [(root_doc, 'mantidimaging', u'MantidImaging Documentation', [author], 1)]
 
 # -- Options for Texinfo output -------------------------------------------
 
@@ -159,7 +159,7 @@ man_pages = [(master_doc, 'mantidimaging', u'MantidImaging Documentation', [auth
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'MantidImaging', u'MantidImaging Documentation', author, 'MantidImaging',
+    (root_doc, 'MantidImaging', u'MantidImaging Documentation', author, 'MantidImaging',
      'One line description of project.', 'Miscellaneous'),
 ]
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -15,22 +15,22 @@ dependencies:
       - pyqtgraph>=0.12.1,<0.13
       - jenkspy==0.2.0
       # For developement
-      - pytest==6.2.1
-      - pytest-cov==2.10.1
-      - coveralls==2.2.0
-      - yapf==0.30.0
+      - pytest==6.2.*
+      - pytest-cov==2.12.*
+      - coveralls==3.2.*
+      - yapf==0.31.*
       - mypy==0.790
-      - flake8==3.8.4
-      - testfixtures==6.17.0
-      - coverage==5.3
-      - gitpython==3.1.11
-      - pylint==2.6.0
+      - flake8==3.9.*
+      - testfixtures==6.18.*
+      - coverage==5.5
+      - gitpython==3.1.*
+      - pylint==2.11.*
       - sphinx==3.3.1
       - git+https://github.com/samtygier-stfc/sphinx-multiversion.git@prebuild_command
-      - pytest-randomly==3.5.0
-      - pytest-xdist==2.2.0
+      - pytest-randomly==3.10.*
+      - pytest-xdist==2.4.*
       - pytest-repeat==0.9.1
-      - isort==5.6.4
-      - eyes-images==4.20.*
-      - parameterized==0.8.1
-      - pre-commit
+      - isort==5.9.*
+      - eyes-images==4.25.*
+      - parameterized==0.8.*
+      - pre-commit==2.15.*

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -25,7 +25,7 @@ dependencies:
       - coverage==5.5
       - gitpython==3.1.*
       - pylint==2.11.*
-      - sphinx==3.3.1
+      - sphinx==4.2.*
       - git+https://github.com/samtygier-stfc/sphinx-multiversion.git@prebuild_command
       - pytest-randomly==3.10.*
       - pytest-xdist==2.4.*

--- a/mantidimaging/core/gpu/test/import_test.py
+++ b/mantidimaging/core/gpu/test/import_test.py
@@ -6,6 +6,7 @@ import unittest
 from unittest import mock
 
 from mantidimaging.core.gpu import utility as gpu
+
 GPU_NOT_AVAIL = not gpu.gpu_available()
 
 

--- a/mantidimaging/core/operations/gaussian/__init__.py
+++ b/mantidimaging/core/operations/gaussian/__init__.py
@@ -2,4 +2,5 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .gaussian import GaussianFilter, modes  # noqa:F401
+
 FILTER_CLASS = GaussianFilter

--- a/mantidimaging/core/operations/median_filter/__init__.py
+++ b/mantidimaging/core/operations/median_filter/__init__.py
@@ -2,4 +2,5 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .median_filter import MedianFilter, modes  # noqa:F401
+
 FILTER_CLASS = MedianFilter

--- a/mantidimaging/core/operations/outliers/__init__.py
+++ b/mantidimaging/core/operations/outliers/__init__.py
@@ -2,4 +2,5 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .outliers import OutliersFilter, modes  # noqa:F401
+
 FILTER_CLASS = OutliersFilter

--- a/mantidimaging/core/operations/rebin/__init__.py
+++ b/mantidimaging/core/operations/rebin/__init__.py
@@ -2,4 +2,5 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .rebin import RebinFilter, modes  # noqa:F401
+
 FILTER_CLASS = RebinFilter

--- a/mantidimaging/core/operations/remove_stripe/__init__.py
+++ b/mantidimaging/core/operations/remove_stripe/__init__.py
@@ -2,4 +2,5 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .stripe_removal import StripeRemovalFilter, wavelet_names  # noqa:F401
+
 FILTER_CLASS = StripeRemovalFilter

--- a/mantidimaging/core/operations/ring_removal/__init__.py
+++ b/mantidimaging/core/operations/ring_removal/__init__.py
@@ -2,4 +2,5 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .ring_removal import RingRemovalFilter  # noqa:F401
+
 FILTER_CLASS = RingRemovalFilter

--- a/mantidimaging/core/operations/rotate_stack/__init__.py
+++ b/mantidimaging/core/operations/rotate_stack/__init__.py
@@ -2,4 +2,5 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from .rotate_stack import RotateFilter  # noqa:F401
+
 FILTER_CLASS = RotateFilter

--- a/mantidimaging/gui/windows/load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/load_dialog/presenter.py
@@ -16,6 +16,7 @@ from mantidimaging.gui.windows.load_dialog.field import Field
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.load_dialog import MWLoadDialog  # pragma: no cover
+
 logger = getLogger(__name__)
 
 

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -16,6 +16,7 @@ from mantidimaging.test_helpers import start_qapplication
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
 from mantidimaging.core.utility.version_check import versions
+
 versions._use_test_values()
 
 

--- a/mantidimaging/gui/windows/operations/test/test_view.py
+++ b/mantidimaging/gui/windows/operations/test/test_view.py
@@ -9,6 +9,7 @@ from mantidimaging.gui.windows.operations.view import FiltersWindowView
 from mantidimaging.test_helpers import start_qapplication
 
 from mantidimaging.core.utility.version_check import versions
+
 versions._use_test_values()
 
 

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -12,6 +12,7 @@ from mantidimaging.gui.windows.recon.presenter import AutoCorMethod
 from mantidimaging.test_helpers import start_qapplication
 
 from mantidimaging.core.utility.version_check import versions
+
 versions._use_test_values()
 
 

--- a/mantidimaging/gui/windows/wizard/test/test_view.py
+++ b/mantidimaging/gui/windows/wizard/test/test_view.py
@@ -8,6 +8,7 @@ from mantidimaging.gui.windows.wizard.view import WizardView, WizardStep, Wizard
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.test_helpers import start_qapplication
 from mantidimaging.core.utility.version_check import versions
+
 versions._use_test_values()
 
 STEP_DATA = {'name': 'Loading files', 'description': 'desc'}


### PR DESCRIPTION
### Issue

Closes #1135
Closes #970

### Description

    setuptools=49.6.0  -> 58.*
    astropy=4.2 -> 4.3.*
    tomopy=1.9.*=cuda* -> 1.10.*
    scipy=1.5.3 -> 1.7.*
    cupy  -> 9.4.*
    requests=2.25.1 -> 2.26.*
    h5py=3.1.0 -> 3.4.*
    pytest==6.2.1 -> 6.2.*
    pytest-cov==2.10.1 -> 2.12.*
    coveralls==2.2.0 -> 3.2.*
    yapf==0.30.0 -> 0.31.*
    flake8==3.8.4 -> 3.9.*
    testfixtures==6.17.0 -> 6.18.*
    coverage==5.3 -> coverage==5.5
    gitpython==3.1.11 -> 3.1.*
    pylint==2.6.0 -> 2.11.*
    pytest-randomly==3.5.0 -> 3.10
    pytest-xdist==2.2.0 -> 2.4.*
    isort==5.6.4 -> 5.9.*
    eyes-images==4.20.* -> 4.25.*
    parameterized==0.8.1 -> 0.8.*
    pre-commit -> 2.15.*
   sphinx==3.3.1 -> 4.2.*

Remove unneeded requirements for building
Specify channels in Makefile for building the package

### Testing & Acceptance Criteria 

Conda tests should pass.

Check that 
`python3 ./setup.py create_dev_env`
works on IDAaaS (Tested by Sam)

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*
