### PR TITLE
1155: DeprecationWarning an integer is required self.progressBar.setValue

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -21,3 +21,4 @@ Developer Changes
 - #1022 : Switch to use Mambaforge
 - #1085 : Fix rotation of images in GUI tests
 - #1045 : Command line argument to open Operation or Reconstruction windows
+- #1155 : DeprecationWarning an integer is required self.progressBar.setValue

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -48,7 +48,7 @@ class AsyncTaskDialogView(BaseDialogView):
             self.infoText.setText(message)
 
         # Update progress bar
-        self.progressBar.setValue(progress * 1000)
+        self.progressBar.setValue(int(progress * 1000))
 
     def show_delayed(self, timeout):
         self.show_timer.singleShot(timeout, self.show_from_timer)

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -76,7 +76,7 @@ class GuiSystemBase(unittest.TestCase):
         for _ in range(max_retry):
             if test_func():
                 return True
-            QTest.qWait(delay * 1000)
+            QTest.qWait(int(delay * 1000))
         raise RuntimeError("_wait_until reach max retries")
 
     @classmethod


### PR DESCRIPTION
### Issue

Closes #1155

### Description

Converts the `qWait` argument to int.

### Acceptance Criteria 

Check that the warning to longer appears.

### Documentation

Updated the release notes.
