### PR TITLE
Remove the 1024x1024 tests

### DIFF
--- a/mantidimaging/core/operations/rebin/test/rebin_test.py
+++ b/mantidimaging/core/operations/rebin/test/rebin_test.py
@@ -76,17 +76,11 @@ class RebinTest(unittest.TestCase):
     def test_executed_xy_par_512_256(self):
         self.do_execute_xy(True, (512, 256))
 
-    def test_executed_xy_par_1024_1024(self):
-        self.do_execute_xy(True, (1024, 1024))
-
     def test_executed_xy_seq_128_256(self):
         self.do_execute_xy(False, (128, 256))
 
     def test_executed_xy_seq_512_256(self):
         self.do_execute_xy(False, (512, 256))
-
-    def test_executed_xy_seq_1024_1024(self):
-        self.do_execute_xy(False, (1024, 1024))
 
     def do_execute_xy(self, is_parallel: bool, val=(512, 512)):
         if is_parallel:


### PR DESCRIPTION
We sometimes see test failures here, and they don't add much give the
other tests.

### Issue

Closes #974 

### Description

The logs suggest that it is a github actions issue

`OSError: [Errno 28] No space left on device`

Given that the 1024x1024 does not add much useful (there are other tests for smaller resolutions), just remove it. 

### Testing & Acceptance Criteria 

Intermittent failure should be gone. Which is had to check

### Documentation

Just a small dev change, so no release notes.