### PR TITLE
Remove old overlay code

### DIFF
--- a/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
+++ b/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from collections import OrderedDict
-from typing import Callable, List
+from typing import Callable, List, Optional
 
 import numpy as np
 from pyqtgraph import ColorMap, ImageItem, ViewBox
@@ -93,17 +93,19 @@ class BadDataOverlay:
 
             check = BadDataCheck(func, nan_indicator, nan_overlay, color)
             self.enabled_checks[name] = check
+            self.check_for_bad_data()
 
     def disable_check(self, name: str):
         if name in self.enabled_checks:
             self.enabled_checks[name].clear()
             self.enabled_checks.pop(name, None)
 
-    def _get_current_slice(self) -> np.ndarray:
+    def _get_current_slice(self) -> Optional[np.ndarray]:
         data = self.image_item.image
         return data
 
     def check_for_bad_data(self):
         current_slice = self._get_current_slice()
-        for test in self.enabled_checks.values():
-            test.do_check(current_slice)
+        if current_slice is not None:
+            for test in self.enabled_checks.values():
+                test.do_check(current_slice)

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -79,10 +79,6 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.image_diff_overlay.setZValue(10)
         self.image_after_vb.addItem(self.image_diff_overlay)
 
-        self.negative_values_overlay = ImageItem()
-        self.negative_values_overlay.setZValue(11)
-        self.image_after_vb.addItem(self.negative_values_overlay)
-
         # Ensure images resize equally
         self.image_layout: GraphicsLayout = self.addLayout(colspan=3)
 
@@ -174,8 +170,6 @@ class FilterPreviews(GraphicsLayoutWidget):
 
     def hide_negative_overlay(self):
         self.imageview_after.enable_nonpositive_check(False)
-        return
-        self.negative_values_overlay.setOpacity(0)
 
     def auto_range(self):
         # This will cause the previews to all show by just causing autorange on self.image_before_vb

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -227,6 +227,8 @@ class FiltersWindowPresenter(BasePresenter):
 
     def _wait_for_stack_choice(self, new_stack: Images, stack_uuid: UUID):
         stack_choice = StackChoicePresenter(self.original_images_stack, new_stack, self, stack_uuid)
+        if self.model.show_negative_overlay():
+            stack_choice.enable_nonpositive_check()
         stack_choice.show()
 
         while not stack_choice.done:

--- a/mantidimaging/gui/windows/stack_choice/presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/presenter.py
@@ -82,3 +82,7 @@ class StackChoicePresenter(StackChoicePresenterMixin):
         self.view.close()
         self.stack = None
         self.done = True
+
+    def enable_nonpositive_check(self):
+        self.view.original_stack.enable_nonpositive_check()
+        self.view.new_stack.enable_nonpositive_check()


### PR DESCRIPTION
### Issue

Closes #1187

### Description

Remove old overlay code from operations and recon windows.

In stack choice dialog, enable the non-positive check if the current operation uses it.

When adding a new check, run it immediately (and handle the case where there is not an image yet)

### Testing & Acceptance Criteria 

Load a dataset with NaNs, the indicators should show in the main, operations and recon windows, overlays should show when mousing over.

Load the IMAT00010675 flower dataset, in flat fielding the yellow indicator should show and overlay should highlight the soil region. With safe apply on, apply to stack. Indicator should work here too. 

![image](https://user-images.githubusercontent.com/74248560/141121286-a90a28cb-dcfe-4748-9076-2585cf67b619.png)


### Documentation

Release notes from #1185 ok
