### PR TITLE
Add bad data overlay message

### DIFF
--- a/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
+++ b/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
@@ -86,12 +86,12 @@ class BadDataOverlay:
 
     def enable_check(self, name: str, color: List[int], pos: int, func: Callable, message: str):
         if name not in self.enabled_checks:
-            nan_icon_path = finder.ROOT_PATH + "/gui/ui/images/exclamation-triangle-red.png"
-            nan_indicator = IndicatorIconView(self.viewbox, nan_icon_path, pos, color, message)
-            nan_overlay = ImageItem()
-            self.viewbox.addItem(nan_overlay)
+            icon_path = finder.ROOT_PATH + "/gui/ui/images/exclamation-triangle-red.png"
+            indicator = IndicatorIconView(self.viewbox, icon_path, pos, color, message)
+            overlay = ImageItem()
+            self.viewbox.addItem(overlay)
 
-            check = BadDataCheck(func, nan_indicator, nan_overlay, color)
+            check = BadDataCheck(func, indicator, overlay, color)
             self.enabled_checks[name] = check
             self.check_for_bad_data()
 

--- a/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
+++ b/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
@@ -37,7 +37,7 @@ class BadDataCheck:
     def setup_overlay(self):
         color = np.array([[0, 0, 0, 0], self.color], dtype=np.ubyte)
         color_map = ColorMap([0, 1], color)
-        self.overlay.setOpacity(0)
+        self.overlay.setVisible(False)
         lut = color_map.getLookupTable(0, 1, 2)
         self.overlay.setLookupTable(lut)
         self.overlay.setZValue(11)

--- a/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
+++ b/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
@@ -70,7 +70,7 @@ class BadDataOverlay:
 
     def enable_nan_check(self, enable: bool = True):
         if enable:
-            self.enable_check("nan", OVERLAY_COLOUR_NAN, 0, np.isnan)
+            self.enable_check("nan", OVERLAY_COLOUR_NAN, 0, np.isnan, "Invalid values: Not a number")
         else:
             self.disable_check("nan")
 
@@ -80,14 +80,14 @@ class BadDataOverlay:
             def is_non_positive(data):
                 return data <= 0
 
-            self.enable_check("nonpos", OVERLAY_COLOUR_NONPOSITVE, 1, is_non_positive)
+            self.enable_check("nonpos", OVERLAY_COLOUR_NONPOSITVE, 1, is_non_positive, "Non-positive values")
         else:
             self.disable_check("nonpos")
 
-    def enable_check(self, name: str, color: List[int], pos: int, func: Callable):
+    def enable_check(self, name: str, color: List[int], pos: int, func: Callable, message: str):
         if name not in self.enabled_checks:
             nan_icon_path = finder.ROOT_PATH + "/gui/ui/images/exclamation-triangle-red.png"
-            nan_indicator = IndicatorIconView(self.viewbox, nan_icon_path, pos, color)
+            nan_indicator = IndicatorIconView(self.viewbox, nan_icon_path, pos, color, message)
             nan_overlay = ImageItem()
             self.viewbox.addItem(nan_overlay)
 

--- a/mantidimaging/gui/widgets/indicator_icon/view.py
+++ b/mantidimaging/gui/widgets/indicator_icon/view.py
@@ -83,10 +83,10 @@ class IndicatorIconView(QGraphicsPixmapItem):
 
     def hoverEnterEvent(self, event):
         if self.connected_overlay is not None:
-            self.connected_overlay.setOpacity(1)
+            self.connected_overlay.setVisible(True)
         self.label.setVisible(True)
 
     def hoverLeaveEvent(self, event):
         if self.connected_overlay is not None:
-            self.connected_overlay.setOpacity(0)
+            self.connected_overlay.setVisible(False)
         self.label.setVisible(False)

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -157,7 +157,7 @@ class FilterPreviews(GraphicsLayoutWidget):
         pos = np.array([0, 1])
         color = np.array([[0, 0, 0, 0], OVERLAY_COLOUR_DIFFERENCE], dtype=np.ubyte)
         map = ColorMap(pos, color)
-        self.image_diff_overlay.setOpacity(1)
+        self.image_diff_overlay.setVisible(True)
         self.image_diff_overlay.setImage(diff)
         lut = map.getLookupTable(0, 1, 2)
         self.image_diff_overlay.setLookupTable(lut)
@@ -166,7 +166,7 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.imageview_after.enable_nonpositive_check()
 
     def hide_difference_overlay(self):
-        self.image_diff_overlay.setOpacity(0)
+        self.image_diff_overlay.setVisible(False)
 
     def hide_negative_overlay(self):
         self.imageview_after.enable_nonpositive_check(False)


### PR DESCRIPTION
### Issue

Closes #1194

Note: needs rebasing after #1188 is merged

### Description

Add a message label to the bad data indicators, that shows on mouse over.

Also rename some things.

### Testing & Acceptance Criteria 

Hover mouse over the indicators to see the message

### Documentation

Still part of overlay work
