### PR TITLE
test_main_window_loaded_2_sets_of_data test fix

### DIFF
--- a/mantidimaging/eyes_tests/test_reconstruct_window.py
+++ b/mantidimaging/eyes_tests/test_reconstruct_window.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 import numpy as np
+from PyQt5.QtWidgets import QApplication
 
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
 from mantidimaging.test_helpers.unit_test_helper import generate_images
@@ -43,6 +44,8 @@ class ReconstructionWindowTest(BaseEyesTest):
     def test_negative_nan_overlay(self):
         images = generate_images(seed=10)
         self.imaging.presenter.create_new_stack(images, "bad_data")
+        QApplication.sendPostedEvents()
+
         images.data[0:, 7:] = 0
         images.data[0:, 3:4] = -1
         images.data[0:, 0:1] = np.nan

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -179,7 +179,7 @@ class MainWindowPresenter(BasePresenter):
         self.stacks[sample_stack_vis.uuid] = sample_stack_vis
 
         current_stack_visualisers = self.get_active_stack_visualisers()
-        if len(current_stack_visualisers) > 1:
+        if len(current_stack_visualisers) > 0:
             self.view.tabifyDockWidget(current_stack_visualisers[0], sample_stack_vis)
 
         dataset_tree_item = self.view.create_dataset_tree_widget_item(title, sample_stack_vis.uuid)

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -163,7 +163,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.active_stacks_changed.emit.assert_called_once()
 
         self.presenter.create_new_stack(images, "My title")
-        self.view.tabifyDockWidget.assert_called_once()
+        assert self.view.tabifyDockWidget.call_count == 2
         self.view.findChild.assert_called_once()
         mock_tab_bar = self.view.findChild.return_value
         expected_position = 1


### PR DESCRIPTION
### Description

Fixes the failing GUI tests. Changed when `tabifyDockWidget` is called as this seems to prevent the thing with the stacks being placed on top of each other.

### Testing 

Made a change to `test_create_new_stack_focuses_newest_tab` and `test_reconstruction_window_reconstruct_tab`

### Acceptance Criteria 

Check that the tests pass.

### Documentation

Haven't added anything as it's an extension of the previous PR.
