### PR TITLE
Median filter preserve NaNs

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -19,6 +19,7 @@ Fixes
 - #1138 : Improve version number handling
 - #1134 : NeXus Loader: OSError
 - #1178 : --operation argument sometimes opens wrong operation
+- #1117 : Median operation preserves NaNs
 
 
 Developer Changes

--- a/mantidimaging/core/operations/median_filter/test/median_filter_test.py
+++ b/mantidimaging/core/operations/median_filter/test/median_filter_test.py
@@ -2,7 +2,6 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from parameterized import parameterized
-import pytest
 import unittest
 from unittest import mock
 
@@ -94,7 +93,6 @@ class MedianTest(unittest.TestCase):
         self.assertEqual(use_gpu_field.isChecked.call_count, 1)
 
     @parameterized.expand([("CPU", True), ("GPU", False)])
-    @pytest.mark.xfail(reason="Bug #1117")
     def test_executed_with_nan(self, _, use_cpu):
         if not use_cpu and not gpu.gpu_available():
             self.skipTest(reason="Skip GPU tests if cupy isn't installed")


### PR DESCRIPTION
### Issue

Closes #1117 

### Description

Make sure that NaNs to not spread to neighbouring pixels, but preserve existing ones.

### Testing 

Includes a test to check that the NaNs in the original match the NaNs in the output.

### Acceptance Criteria 

Open a dataset with NaN pixels. Check that they are preserved by the median filter.

### Documentation

release_notes
