### PR TITLE
Add a median mode to NaNRemovalFilter

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -12,6 +12,7 @@ New Features
 - #1167 : Bad data indicator icons
 - #1185 : Bad data overlays
 - #1168 : Dataset tree view
+- #1202 : NaN Removal filter - replace with median
 
 Fixes
 -----

--- a/mantidimaging/core/operations/nan_removal/nan_removal.py
+++ b/mantidimaging/core/operations/nan_removal/nan_removal.py
@@ -18,6 +18,10 @@ from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.utility.qt_helpers import Type
 
 
+def enable_correct_fields_only(mode_field, replace_value_field):
+    replace_value_field.setEnabled(mode_field.currentText() == "Constant")
+
+
 class NaNRemovalFilter(BaseFilter):
     """
     Replaces the NaNs with a specified value or the median of neighbouring pixels.
@@ -83,6 +87,8 @@ class NaNRemovalFilter(BaseFilter):
                                                       on_change=on_change,
                                                       tooltip="The value to replace the NaNs with")
         replace_value_field.setDecimals(7)
+
+        mode_field.currentTextChanged.connect(lambda text: enable_correct_fields_only(mode_field, replace_value_field))
 
         return {"mode_field": mode_field, "replace_value_field": replace_value_field}
 

--- a/mantidimaging/core/operations/nan_removal/nan_removal.py
+++ b/mantidimaging/core/operations/nan_removal/nan_removal.py
@@ -3,41 +3,63 @@
 
 from collections.abc import Callable
 from functools import partial
+from logging import getLogger
 from typing import Dict
 
 import numpy as np
 from PyQt5.QtWidgets import QFormLayout, QWidget
+import scipy.ndimage as scipy_ndimage
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.operations.base_filter import BaseFilter
+from mantidimaging.core.parallel import shared as ps
+from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.mvp_base import BaseMainWindowView
+from mantidimaging.gui.utility.qt_helpers import Type
 
 
 class NaNRemovalFilter(BaseFilter):
     """
-    Replaces all NaNs in the images with a specified value.
+    Replaces the NaNs with a specified value or the median of neighbouring pixels.
 
     Intended to be used on: Projections
 
     When: To remove NaNs before reconstruction.
+
+    Note that the median method cannot remove continuous blocks of NaNs.
     """
 
     filter_name = "NaN Removal"
     link_histograms = True
 
+    MODES = ["Constant", "Median"]
+
     @staticmethod
-    def filter_func(data, replace_value=None, progress=None) -> Images:
+    def filter_func(data,
+                    replace_value=None,
+                    mode_value="Constant",
+                    cores=None,
+                    chunksize=None,
+                    progress=None) -> Images:
         """
-        Replaces the NaNs with a specified value.
         :param data: The input data.
-        :param replace_value: The data to replace the NaNs with.
+        :param mode_value: Values to replace NaNs with. One of ["Constant", "Median"]
+        :param replace_value: In constant mode, the value to replace NaNs with.
+        :param cores: The number of cores that will be used to process the data.
+        :param chunksize: The number of chunks that each worker will receive.
         :param progress: The optional Progress object.
         :return: The Images object with the NaNs replaced.
         """
 
         sample = data.data
         nan_idxs = np.isnan(sample)
-        sample[nan_idxs] = replace_value
+
+        if mode_value == "Constant":
+            sample[nan_idxs] = replace_value
+        elif mode_value == "Median":
+            _execute(sample, 3, "reflect", cores, chunksize, progress)
+        else:
+            raise ValueError(f"Unknown mode: '{mode_value}'\nShould be one of {NaNRemovalFilter.MODES}")
 
         return data
 
@@ -47,6 +69,13 @@ class NaNRemovalFilter(BaseFilter):
 
         value_range = (-10000000, 10000000)
 
+        _, mode_field = add_property_to_form('Replace with',
+                                             Type.CHOICE,
+                                             valid_values=NaNRemovalFilter.MODES,
+                                             form=form,
+                                             on_change=on_change,
+                                             tooltip="Values used to replace NaNs")
+
         _, replace_value_field = add_property_to_form("Replacement Value",
                                                       'float',
                                                       valid_values=value_range,
@@ -55,9 +84,40 @@ class NaNRemovalFilter(BaseFilter):
                                                       tooltip="The value to replace the NaNs with")
         replace_value_field.setDecimals(7)
 
-        return {"replace_value_field": replace_value_field}
+        return {"mode_field": mode_field, "replace_value_field": replace_value_field}
 
     @staticmethod
-    def execute_wrapper(replace_value_field=None):
+    def execute_wrapper(mode_field=None, replace_value_field=None):
+        mode_value = mode_field.currentText()
         replace_value = replace_value_field.value()
-        return partial(NaNRemovalFilter.filter_func, replace_value=replace_value)
+        return partial(NaNRemovalFilter.filter_func, replace_value=replace_value, mode_value=mode_value)
+
+
+def _nan_to_median(data: np.ndarray, size: int, edgemode: str):
+    nans = np.isnan(data)
+    if np.any(nans):
+        median_data = np.where(nans, -np.inf, data)
+        median_data = scipy_ndimage.median_filter(median_data, size=size, mode=edgemode)
+        data = np.where(nans, median_data, data)
+
+        if np.any(data == -np.inf):
+            # Convert any left over -infs back to NaNs
+            data = np.where(np.logical_and(nans, data == -np.inf), np.NaN, data)
+
+    return data
+
+
+def _execute(data, size, edgemode, cores=None, chunksize=None, progress=None):
+    log = getLogger(__name__)
+    progress = Progress.ensure_instance(progress, task_name='NaN Removal')
+
+    # create the partial function to forward the parameters
+    f = ps.create_partial(_nan_to_median, ps.return_to_self, size=size, edgemode=edgemode)
+
+    with progress:
+        log.info("PARALLEL NaN Removal filter, with pixel data type: {0}".format(data.dtype))
+
+        ps.shared_list = [data]
+        ps.execute(f, data.shape[0], progress, msg="NaN Removal", cores=cores)
+
+    return data

--- a/mantidimaging/core/operations/nan_removal/test/nan_removal_test.py
+++ b/mantidimaging/core/operations/nan_removal/test/nan_removal_test.py
@@ -22,3 +22,17 @@ class NaNRemovalFilterTest(unittest.TestCase):
         result = NaNRemovalFilter().filter_func(images, 3.0)
         self.assertFalse(np.any(np.isnan(result.data)))
         npt.assert_allclose(result.data[nan_idxs], 3.0)
+
+    def test_unknown_mode(self):
+        images = th.generate_images()
+        self.assertRaises(ValueError, NaNRemovalFilter().filter_func, images, 3.0, "badmode")
+
+    def test_replace_nans_with_median(self):
+        images = th.generate_images()
+        images.data[:] = 7
+        images.data[3, 4, 5] = np.NaN
+
+        NaNRemovalFilter().filter_func(images, 0, "Median")
+
+        self.assertEqual(images.data[3, 4, 5], 7)
+        self.assertTrue(np.all(images.data == 7))

--- a/mantidimaging/eyes_tests/test_operations_window.py
+++ b/mantidimaging/eyes_tests/test_operations_window.py
@@ -136,6 +136,15 @@ class OperationsWindowTest(BaseEyesTest):
 
         self.check_target(widget=self.imaging.filters)
 
+    def test_operations_nan_removal_parameters(self):
+        self._load_data_set()
+
+        self.imaging.show_filters_window()
+        self.imaging.filters.filterSelector.setCurrentText("NaN Removal")
+        QApplication.processEvents()
+
+        self.check_target(widget=self.imaging.filters)
+
     def test_operations_rebin_parameters(self):
         self._load_data_set()
 


### PR DESCRIPTION
Replaces NaN pixels with the median of its neighbours

### Issue

Closes #1202

### Description

Add median mode to NaNRemovalFilter

### Testing 

Added test and applitools test

### Acceptance Criteria 

Open dataset with NaNs. Check that they are removed by the filter and replaced with the local median

### Documentation

Release notes and updated doc strings
