### PR TITLE
Use correct dimension in remove stripe for sinograms

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -21,6 +21,7 @@ Fixes
 - #1134 : NeXus Loader: OSError
 - #1178 : --operation argument sometimes opens wrong operation
 - #1117 : Median operation preserves NaNs
+- #1151 : IndexError with sinograms and stripe tools
 
 
 Developer Changes

--- a/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
+++ b/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
@@ -33,7 +33,7 @@ class RemoveAllStripesFilter(BaseFilter):
     def filter_func(images: Images, snr=3, la_size=61, sm_size=21, dim=1, cores=None, chunksize=None, progress=None):
         f = ps.create_partial(remove_all_stripe, ps.return_to_self, snr=snr, la_size=la_size, sm_size=sm_size, dim=dim)
         ps.shared_list = [images.data]
-        ps.execute(f, images.num_projections, progress, cores=cores)
+        ps.execute(f, images.data.shape[0], progress, cores=cores)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_all_stripe/test/remove_all_stripe_test.py
+++ b/mantidimaging/core/operations/remove_all_stripe/test/remove_all_stripe_test.py
@@ -25,6 +25,15 @@ class RemoveAllStripesTest(unittest.TestCase):
 
         th.assert_not_equals(result.data, control.data)
 
+    def test_executed_sinogram(self):
+        images = th.generate_images(shape=(1, 10, 20))
+        images._is_sinograms = True
+        control = images.copy()
+
+        result = RemoveAllStripesFilter.filter_func(images)
+
+        th.assert_not_equals(result.data, control.data)
+
     def test_execute_wrapper_return_is_runnable(self):
         """
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -33,7 +33,7 @@ class RemoveDeadStripesFilter(BaseFilter):
     def filter_func(images: Images, snr=3, size=61, cores=None, chunksize=None, progress=None):
         f = ps.create_partial(remove_dead_stripe, ps.return_to_self, snr=snr, size=size, residual=False)
         ps.shared_list = [images.data]
-        ps.execute(f, images.num_projections, progress, cores=cores)
+        ps.execute(f, images.data.shape[0], progress, cores=cores)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
+++ b/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
@@ -37,7 +37,7 @@ class RemoveLargeStripesFilter(BaseFilter):
             size=la_size,
         )
         ps.shared_list = [images.data]
-        ps.execute(f, images.num_projections, progress, cores=cores)
+        ps.execute(f, images.data.shape[0], progress, cores=cores)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
@@ -52,7 +52,7 @@ class RemoveStripeFilteringFilter(BaseFilter):
                                   size=size,
                                   dim=window_dim)
         ps.shared_list = [images.data]
-        ps.execute(f, images.num_projections, progress, cores=cores)
+        ps.execute(f, images.data.shape[0], progress, cores=cores)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
@@ -34,7 +34,7 @@ class RemoveStripeSortingFittingFilter(BaseFilter):
         f = ps.create_partial(remove_stripe_based_fitting, ps.return_to_self, order=order, sigma=sigma, sort=True)
 
         ps.shared_list = [images.data]
-        ps.execute(f, images.num_projections, progress, cores=cores)
+        ps.execute(f, images.data.shape[0], progress, cores=cores)
         return images
 
     @staticmethod


### PR DESCRIPTION
### Issue
Closes #1151

### Description

`images.num_projections` gives the height of the sinogram, not the number of slices like it does for a stack of projections. For the filter we want to act on those slices. So use shape[0] instead.

### Testing 

New test with an image set to be a sinogram

### Acceptance Criteria 

Follow steps on #1151

### Documentation

release_notes
