### PR TITLE
1197: Delete image stack from tree view

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -13,6 +13,7 @@ New Features
 - #1185 : Bad data overlays
 - #1168 : Dataset tree view
 - #1202 : NaN Removal filter - replace with median
+- #1197 : Dataset Tree View: Delete image stack
 
 Fixes
 -----

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -75,5 +75,7 @@ class Dataset:
 
     @property
     def all_image_ids(self) -> List[uuid.UUID]:
-        image_stacks = [self.sample, self.flat_before, self.flat_after, self.dark_before, self.dark_after]
+        image_stacks = [
+            self.sample, self.sample.proj180deg, self.flat_before, self.flat_after, self.dark_before, self.dark_after
+        ]
         return [image_stack.id for image_stack in image_stacks if image_stack is not None]

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -3,7 +3,7 @@
 import uuid
 import weakref
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, List
 
 from mantidimaging.core.data import Images
 
@@ -72,3 +72,8 @@ class Dataset:
     @property
     def id(self) -> uuid.UUID:
         return self._id
+
+    @property
+    def all_image_ids(self) -> List[uuid.UUID]:
+        image_stacks = [self.sample, self.flat_before, self.flat_after, self.dark_before, self.dark_after]
+        return [image_stack.id for image_stack in image_stacks if image_stack is not None]

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -93,7 +93,8 @@ class BaseEyesTest(unittest.TestCase):
         menu.popup(widget.mapFromGlobal(menu_location))
 
     def _load_data_set(self):
-        dataset = loader.load(file_names=[LOAD_SAMPLE])
+        loading_dataset = loader.load(file_names=[LOAD_SAMPLE])
+        dataset = self.imaging.presenter.model.convert_loading_dataset(loading_dataset)
         vis = self.imaging.presenter.create_new_stack(dataset, "Stack 1")
 
         QApplication.sendPostedEvents()

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -111,18 +111,18 @@ class GuiSystemBase(unittest.TestCase):
         self.main_window.actionRecon.trigger()
 
     def _close_stack_tabs(self):
-        stack_tabs = list(self.main_window.presenter.stacks.values())
-        # while stack_tabs:
-        #     last_stack_tab = stack_tabs.pop()
-        #     QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("OK"))
-        #     last_stack_tab.close()
-        #     QTest.qWait(SHOW_DELAY // 10)
-        for stack_tab in stack_tabs:
-            # This should be replaced when it is possible to close an image stack from
-            # the dataset treeview
-            # self.main_window.presenter.model.images.pop(last_stack_tab.uuid, None)
-            # last_stack_tab.image_view.close()
-            # last_stack_tab.presenter.delete_data()
+        stack_tabs = self.main_window.presenter.stacks.values()
+        while stack_tabs:
+            last_stack_tab = stack_tabs.pop()
             QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("OK"))
-            self.main_window.presenter._delete_container(stack_tab.id)
+            self.main_window.presenter._delete_container(last_stack_tab.id)
             QTest.qWait(SHOW_DELAY // 10)
+        # for stack_tab in stack_tabs:
+        #     # This should be replaced when it is possible to close an image stack from
+        #     # the dataset treeview
+        #     # self.main_window.presenter.model.images.pop(last_stack_tab.uuid, None)
+        #     # last_stack_tab.image_view.close()
+        #     # last_stack_tab.presenter.delete_data()
+        #     QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("OK"))
+        #
+        #     QTest.qWait(SHOW_DELAY // 10)

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -123,4 +123,4 @@ class GuiSystemBase(unittest.TestCase):
             # self.main_window.presenter.model.images.pop(last_stack_tab.uuid, None)
             # last_stack_tab.image_view.close()
             # last_stack_tab.presenter.delete_data()
-            self.main_window.presenter.delete_container(last_stack_tab.id)
+            self.main_window.presenter._delete_container(last_stack_tab.id)

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -112,15 +112,17 @@ class GuiSystemBase(unittest.TestCase):
 
     def _close_stack_tabs(self):
         stack_tabs = self.main_window.presenter.stacks.values()
-        while stack_tabs:
-            last_stack_tab = stack_tabs.pop()
-            QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("OK"))
-            last_stack_tab.close()
-            QTest.qWait(SHOW_DELAY // 10)
-
+        # while stack_tabs:
+        #     last_stack_tab = stack_tabs.pop()
+        #     QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("OK"))
+        #     last_stack_tab.close()
+        #     QTest.qWait(SHOW_DELAY // 10)
+        for stack_tab in stack_tabs:
             # This should be replaced when it is possible to close an image stack from
             # the dataset treeview
             # self.main_window.presenter.model.images.pop(last_stack_tab.uuid, None)
             # last_stack_tab.image_view.close()
             # last_stack_tab.presenter.delete_data()
-            self.main_window.presenter._delete_container(last_stack_tab.id)
+            QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("OK"))
+            self.main_window.presenter._delete_container(stack_tab.id)
+            QTest.qWait(SHOW_DELAY // 10)

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -111,6 +111,16 @@ class GuiSystemBase(unittest.TestCase):
         self.main_window.actionRecon.trigger()
 
     def _close_stack_tabs(self):
-        self.main_window.dataset_tree_widget.selectAll()
-        for _ in range(len(self.main_window.dataset_tree_widget.selectedItems())):
-            self.main_window._delete_contaier()
+        stack_tab_keys = self.main_window.presenter.stacks.keys()
+        for stack_key in stack_tab_keys:
+            last_stack_tab = self.main_window.presenter.staks[stack_key]
+            QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("OK"))
+            last_stack_tab.close()
+            QTest.qWait(SHOW_DELAY // 10)
+
+            # This should be replaced when it is possible to close an image stack from
+            # the dataset treeview
+            self.main_window.presenter.model.images.pop(last_stack_tab.id, None)
+            self.main_window.presenter.stacks.pop(last_stack_tab.id, None)
+            last_stack_tab.image_view.close()
+            last_stack_tab.presenter.delete_data()

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -120,6 +120,7 @@ class GuiSystemBase(unittest.TestCase):
 
             # This should be replaced when it is possible to close an image stack from
             # the dataset treeview
-            self.main_window.presenter.model.images.pop(last_stack_tab.uuid, None)
-            last_stack_tab.image_view.close()
-            last_stack_tab.presenter.delete_data()
+            # self.main_window.presenter.model.images.pop(last_stack_tab.uuid, None)
+            # last_stack_tab.image_view.close()
+            # last_stack_tab.presenter.delete_data()
+            self.main_window.presenter.delete_container(last_stack_tab.id)

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -111,18 +111,18 @@ class GuiSystemBase(unittest.TestCase):
         self.main_window.actionRecon.trigger()
 
     def _close_stack_tabs(self):
-        stack_tabs = self.main_window.presenter.stacks.values()
-        while stack_tabs:
-            last_stack_tab = stack_tabs.pop()
-            QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("OK"))
-            self.main_window.presenter._delete_container(last_stack_tab.id)
-            QTest.qWait(SHOW_DELAY // 10)
-        # for stack_tab in stack_tabs:
-        #     # This should be replaced when it is possible to close an image stack from
-        #     # the dataset treeview
-        #     # self.main_window.presenter.model.images.pop(last_stack_tab.uuid, None)
-        #     # last_stack_tab.image_view.close()
-        #     # last_stack_tab.presenter.delete_data()
+        stack_tab_ids = list(self.main_window.presenter.stacks.keys())
+        # while stack_tabs:
+        #     last_stack_tab = stack_tabs.pop()
         #     QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("OK"))
-        #
+        #     self.main_window.presenter._delete_container(last_stack_tab.id)
         #     QTest.qWait(SHOW_DELAY // 10)
+        for stack_tab_id in stack_tab_ids:
+            # This should be replaced when it is possible to close an image stack from
+            # the dataset treeview
+            # self.main_window.presenter.model.images.pop(last_stack_tab.uuid, None)
+            # last_stack_tab.image_view.close()
+            # last_stack_tab.presenter.delete_data()
+            QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("OK"))
+            self.main_window.presenter._delete_container(stack_tab_id)
+            QTest.qWait(SHOW_DELAY // 10)

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -111,7 +111,7 @@ class GuiSystemBase(unittest.TestCase):
         self.main_window.actionRecon.trigger()
 
     def _close_stack_tabs(self):
-        stack_tabs = self.main_window.presenter.stacks.values()
+        stack_tabs = list(self.main_window.presenter.stacks.values())
         # while stack_tabs:
         #     last_stack_tab = stack_tabs.pop()
         #     QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("OK"))

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -111,18 +111,6 @@ class GuiSystemBase(unittest.TestCase):
         self.main_window.actionRecon.trigger()
 
     def _close_stack_tabs(self):
-        stack_tab_ids = list(self.main_window.presenter.stacks.keys())
-        # while stack_tabs:
-        #     last_stack_tab = stack_tabs.pop()
-        #     QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("OK"))
-        #     self.main_window.presenter._delete_container(last_stack_tab.id)
-        #     QTest.qWait(SHOW_DELAY // 10)
-        for stack_tab_id in stack_tab_ids:
-            # This should be replaced when it is possible to close an image stack from
-            # the dataset treeview
-            # self.main_window.presenter.model.images.pop(last_stack_tab.uuid, None)
-            # last_stack_tab.image_view.close()
-            # last_stack_tab.presenter.delete_data()
-            QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("OK"))
-            self.main_window.presenter._delete_container(stack_tab_id)
-            QTest.qWait(SHOW_DELAY // 10)
+        self.main_window.dataset_tree_widget.selectAll()
+        for _ in range(len(self.main_window.dataset_tree_widget.selectedItems())):
+            self.main_window._delete_contaier()

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -111,7 +111,7 @@ class GuiSystemBase(unittest.TestCase):
         self.main_window.actionRecon.trigger()
 
     def _close_stack_tabs(self):
-        stack_tabs = self.main_window.presenter.get_active_stack_visualisers()
+        stack_tabs = self.main_window.presenter.stacks.values()
         while stack_tabs:
             last_stack_tab = stack_tabs.pop()
             QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("OK"))

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -112,8 +112,8 @@ class GuiSystemBase(unittest.TestCase):
 
     def _close_stack_tabs(self):
         stack_tab_keys = self.main_window.presenter.stacks.keys()
-        for stack_key in stack_tab_keys:
-            last_stack_tab = self.main_window.presenter.staks[stack_key]
+        for stack_key in list(stack_tab_keys):
+            last_stack_tab = self.main_window.presenter.stacks[stack_key]
             QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("OK"))
             last_stack_tab.close()
             QTest.qWait(SHOW_DELAY // 10)

--- a/mantidimaging/gui/widgets/stack_selector/view.py
+++ b/mantidimaging/gui/widgets/stack_selector/view.py
@@ -40,7 +40,7 @@ class StackSelectorWidgetView(QComboBox):
         self.presenter.notify(Notification.RELOAD_STACKS)
 
         # Connect signal for auto update on stack change
-        self.main_window.active_stacks_changed.connect(self._handle_loaded_stacks_changed)
+        self.main_window.model_changed.connect(self._handle_loaded_stacks_changed)
 
     def unsubscribe_from_main_window(self):
         """
@@ -50,7 +50,7 @@ class StackSelectorWidgetView(QComboBox):
         """
         if self.main_window:
             # Disconnect signal
-            self.main_window.active_stacks_changed.disconnect(self._handle_loaded_stacks_changed)
+            self.main_window.model_changed.disconnect(self._handle_loaded_stacks_changed)
 
     def _handle_loaded_stacks_changed(self):
         """

--- a/mantidimaging/gui/widgets/stack_selector_dialog/test/test_stack_selector_dialog.py
+++ b/mantidimaging/gui/widgets/stack_selector_dialog/test/test_stack_selector_dialog.py
@@ -12,7 +12,7 @@ from mantidimaging.test_helpers import start_qapplication
 class FakeMainWindowView(QWidget):
     def __init__(self):
         super().__init__()
-        self.active_stacks_changed = mock.MagicMock()
+        self.model_changed = mock.MagicMock()
 
 
 @start_qapplication

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -15,9 +15,11 @@ from mantidimaging.core.utility.data_containers import LoadingParameters, Projec
 
 logger = getLogger(__name__)
 
+
 class ChangeType(Enum):
     DELETE_IMAGE_STACK = auto()
     DELETE_DATASET = auto()
+
 
 def _matching_dataset_attribute(dataset_attribute: Optional[Images], images_id: uuid.UUID) -> bool:
     return isinstance(dataset_attribute, Images) and dataset_attribute.id == images_id

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -172,8 +172,9 @@ class MainWindowModel(object):
     def remove_container(self, container_id: uuid.UUID) -> ChangeType:
         if container_id in self.images:
             del self.images[container_id]
-            return ChangeType.DELETE_IMAGE_STACK
+            return [container_id]
         if container_id in self.datasets:
+            stacks_in_dataset = self.datasets[container_id].all_image_ids
             self._remove_dataset(container_id)
-            return ChangeType.DELETE_DATASET
+            return stacks_in_dataset
         self.raise_error_when_images_not_found(container_id)

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 import uuid
+from enum import Enum, auto
 from logging import getLogger
 from typing import Dict, Optional
 
@@ -14,6 +15,9 @@ from mantidimaging.core.utility.data_containers import LoadingParameters, Projec
 
 logger = getLogger(__name__)
 
+class ChangeType(Enum):
+    DELETE_IMAGE_STACK = auto()
+    DELETE_DATASET = auto()
 
 def _matching_dataset_attribute(dataset_attribute: Optional[Images], images_id: uuid.UUID) -> bool:
     return isinstance(dataset_attribute, Images) and dataset_attribute.id == images_id
@@ -163,11 +167,11 @@ class MainWindowModel(object):
 
         del self.datasets[dataset_id]
 
-    def remove_container(self, container_id: uuid.UUID):
+    def remove_container(self, container_id: uuid.UUID) -> ChangeType:
         if container_id in self.images:
             del self.images[container_id]
-            return
+            return ChangeType.DELETE_IMAGE_STACK
         if container_id in self.datasets:
             self._remove_dataset(container_id)
-            return
+            return ChangeType.DELETE_DATASET
         self.raise_error_when_images_not_found(container_id)

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -1,9 +1,8 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 import uuid
-from enum import Enum, auto
 from logging import getLogger
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 import numpy as np
 
@@ -14,11 +13,6 @@ from mantidimaging.core.io import loader, saver
 from mantidimaging.core.utility.data_containers import LoadingParameters, ProjectionAngles
 
 logger = getLogger(__name__)
-
-
-class ChangeType(Enum):
-    DELETE_IMAGE_STACK = auto()
-    DELETE_DATASET = auto()
 
 
 def _matching_dataset_attribute(dataset_attribute: Optional[Images], images_id: uuid.UUID) -> bool:
@@ -169,7 +163,7 @@ class MainWindowModel(object):
 
         del self.datasets[dataset_id]
 
-    def remove_container(self, container_id: uuid.UUID) -> ChangeType:
+    def remove_container(self, container_id: uuid.UUID) -> Optional[List[uuid.UUID]]:
         if container_id in self.images:
             del self.images[container_id]
             return [container_id]

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -149,6 +149,10 @@ class MainWindowModel(object):
         images.log_file = log
 
     def _remove_dataset(self, dataset_id: uuid.UUID):
+        """
+        Removes a dataset and the image stacks it contains from the model.
+        :param dataset_id: The dataset ID.
+        """
         dataset = self.datasets[dataset_id]
         del self.images[dataset.sample.id]
 
@@ -164,6 +168,12 @@ class MainWindowModel(object):
         del self.datasets[dataset_id]
 
     def remove_container(self, container_id: uuid.UUID) -> Optional[List[uuid.UUID]]:
+        """
+        Removes a container from the model.
+        :param container_id: The ID of the dataset or image stack.
+        :return: A list of the IDs of all the image stacks that were deleted from the model if a match was found, None
+            otherwise.
+        """
         if container_id in self.images:
             del self.images[container_id]
             return [container_id]

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -172,3 +172,4 @@ class MainWindowModel(object):
             self._remove_dataset(container_id)
             return stacks_in_dataset
         self.raise_error_when_images_not_found(container_id)
+        return None

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -184,7 +184,7 @@ class MainWindowPresenter(BasePresenter):
         self.stacks[sample_stack_vis.id] = sample_stack_vis
 
         current_stack_visualisers = self.get_active_stack_visualisers()
-        if len(current_stack_visualisers) > 0:
+        if len(current_stack_visualisers) > 1:
             self.view.tabifyDockWidget(current_stack_visualisers[0], sample_stack_vis)
 
         dataset_tree_item = self.view.create_dataset_tree_widget_item(title, container.id)
@@ -224,7 +224,7 @@ class MainWindowPresenter(BasePresenter):
         if len(current_stack_visualisers) > 1:
             tab_bar = self.view.findChild(QTabBar)
             if tab_bar is not None:
-                last_stack_pos = len(current_stack_visualisers) - 1
+                last_stack_pos = len(current_stack_visualisers)
                 # make Qt process the addition of the dock onto the main window
                 QApplication.sendPostedEvents()
                 tab_bar.setCurrentIndex(last_stack_pos)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -360,3 +360,6 @@ class MainWindowPresenter(BasePresenter):
 
     def add_stack_to_dictionary(self, stack: StackVisualiserView):
         self.stacks[stack.uuid] = stack
+
+    def delete_container(self, container_id):
+        self.model.remove_container(container_id)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -55,7 +55,7 @@ class MainWindowPresenter(BasePresenter):
             elif signal == Notification.SAVE:
                 self.save()
             elif signal == Notification.REMOVE_STACK:
-                self.delete_container(**baggage)
+                self._delete_container(**baggage)
             elif signal == Notification.RENAME_STACK:
                 self._do_rename_stack(**baggage)
             elif signal == Notification.NEXUS_LOAD:
@@ -354,7 +354,7 @@ class MainWindowPresenter(BasePresenter):
     def add_stack_to_dictionary(self, stack: StackVisualiserView):
         self.stacks[stack.id] = stack
 
-    def delete_container(self, container_id: uuid.UUID):
+    def _delete_container(self, container_id: uuid.UUID):
         """
         Informs the model to delete a container, then updates the view elements.
         :param container_id: The ID of the container to delete.

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -21,7 +21,7 @@ from mantidimaging.gui.dialogs.async_task import start_async_task_view
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.windows.stack_visualiser.presenter import SVNotification
 from mantidimaging.gui.windows.stack_visualiser.view import StackVisualiserView
-from .model import MainWindowModel
+from .model import MainWindowModel, ChangeType
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # pragma: no cover
@@ -36,6 +36,8 @@ class Notification(Enum):
     REMOVE_STACK = auto()
     RENAME_STACK = auto()
     NEXUS_LOAD = auto()
+    DATASET_DELETE = auto()
+    IMAGES_DELETE = auto()
 
 
 class MainWindowPresenter(BasePresenter):
@@ -61,6 +63,10 @@ class MainWindowPresenter(BasePresenter):
                 self._do_rename_stack(**baggage)
             elif signal == Notification.NEXUS_LOAD:
                 self.load_nexus_file()
+            elif signal == Notification.IMAGES_DELETE:
+                pass
+            elif signal == Notification.DATASET_DELETE:
+                pass
 
         except Exception as e:
             self.show_error(e, traceback.format_exc())
@@ -362,4 +368,9 @@ class MainWindowPresenter(BasePresenter):
         self.stacks[stack.uuid] = stack
 
     def delete_container(self, container_id):
-        self.model.remove_container(container_id)
+        change_type = self.model.remove_container(container_id)
+        if change_type == ChangeType.DELETE_IMAGE_STACK:
+            self.stacks[container_id].deleteLater()
+            del self.stacks[container_id]
+        if change_type == ChangeType.DELETE_DATASET:
+            pass

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -369,12 +369,14 @@ class MainWindowPresenter(BasePresenter):
     def delete_container(self, container_id: uuid.UUID):
         ids_to_remove = self.model.remove_container(container_id)
         if len(ids_to_remove) == 1:
+            self.stacks[container_id].image_view.close()
             self.stacks[container_id].presenter.delete_data()
             self.stacks[container_id].deleteLater()
             del self.stacks[container_id]
             self.remove_item_from_tree_view(container_id)
         elif len(ids_to_remove) > 1:
             for stack_id in ids_to_remove:
+                self.stacks[stack_id].image_view.close()
                 self.stacks[stack_id].presenter.delete_data()
                 self.stacks[stack_id].deleteLater()
                 del self.stacks[stack_id]

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -35,8 +35,6 @@ class Notification(Enum):
     REMOVE_STACK = auto()
     RENAME_STACK = auto()
     NEXUS_LOAD = auto()
-    DATASET_DELETE = auto()
-    IMAGES_DELETE = auto()
 
 
 class MainWindowPresenter(BasePresenter):
@@ -62,10 +60,6 @@ class MainWindowPresenter(BasePresenter):
                 self._do_rename_stack(**baggage)
             elif signal == Notification.NEXUS_LOAD:
                 self.load_nexus_file()
-            elif signal == Notification.IMAGES_DELETE:
-                pass
-            elif signal == Notification.DATASET_DELETE:
-                pass
 
         except Exception as e:
             self.show_error(e, traceback.format_exc())
@@ -368,26 +362,24 @@ class MainWindowPresenter(BasePresenter):
 
     def delete_container(self, container_id: uuid.UUID):
         """
-
-        :param container_id:
-        :return:
+        Informs the model to delete a container, then updates the view elements.
+        :param container_id: The ID of the container to delete.
         """
         ids_to_remove = self.model.remove_container(container_id)
         if ids_to_remove is None:
             return
         if len(ids_to_remove) == 1:
             self._delete_stack(container_id)
-        elif len(ids_to_remove) > 1:
+        else:
             for stack_id in ids_to_remove:
                 self._delete_stack(stack_id)
         self.remove_item_from_tree_view(container_id)
         self.view.model_changed.emit()
 
-    def _delete_stack(self, stack_id):
+    def _delete_stack(self, stack_id: uuid.UUID):
         """
-
-        :param stack_id:
-        :return:
+        Deletes a stack and frees memory.
+        :param stack_id: The ID of the stack to delete.
         """
         self.stacks[stack_id].image_view.close()
         self.stacks[stack_id].presenter.delete_data()

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -373,23 +373,22 @@ class MainWindowPresenter(BasePresenter):
         :return:
         """
         ids_to_remove = self.model.remove_container(container_id)
+        if ids_to_remove is None:
+            return
         if len(ids_to_remove) == 1:
             self._delete_stack(container_id)
-            self.remove_item_from_tree_view(container_id)
         elif len(ids_to_remove) > 1:
             for stack_id in ids_to_remove:
                 self._delete_stack(stack_id)
-            self.remove_item_from_tree_view(container_id)
+        self.remove_item_from_tree_view(container_id)
 
     def _delete_stack(self, stack_id):
         """
 
         :param stack_id:
-        :return: 
+        :return:
         """
         self.stacks[stack_id].image_view.close()
         self.stacks[stack_id].presenter.delete_data()
         self.stacks[stack_id].deleteLater()
         del self.stacks[stack_id]
-
-

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -88,12 +88,6 @@ class MainWindowPresenter(BasePresenter):
             raise RuntimeError(f"Failed to get stack with name {stack_name}")
         self.model.add_log_to_sample(stack_id, log_file)
 
-    def _do_remove_stack(self, stack_id: uuid.UUID):
-        self.remove_item_from_tree_view(stack_id)
-        self.model.remove_container(stack_id)
-        del self.stacks[stack_id]
-        self.view.model_changed.emit()
-
     def _do_rename_stack(self, current_name: str, new_name: str):
         dock = self._get_stack_widget_by_name(current_name)
         if dock:

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -353,14 +353,14 @@ class MainWindowPresenter(BasePresenter):
 
         for i in range(top_level_item_count):
             top_level_item = self.view.dataset_tree_widget.topLevelItem(i)
-            if top_level_item.uuid == uuid_remove:
+            if top_level_item.id == uuid_remove:
                 self.view.dataset_tree_widget.takeTopLevelItem(top_level_item)
                 return
 
             child_count = top_level_item.childCount()
             for j in range(child_count):
                 child_item = top_level_item.child(j)
-                if child_item.uuid == uuid_remove:
+                if child_item.id == uuid_remove:
                     top_level_item.takeChild(j)
                     return
 
@@ -372,5 +372,6 @@ class MainWindowPresenter(BasePresenter):
         if change_type == ChangeType.DELETE_IMAGE_STACK:
             self.stacks[container_id].deleteLater()
             del self.stacks[container_id]
+            self.remove_item_from_tree_view(container_id)
         if change_type == ChangeType.DELETE_DATASET:
             pass

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -55,7 +55,7 @@ class MainWindowPresenter(BasePresenter):
             elif signal == Notification.SAVE:
                 self.save()
             elif signal == Notification.REMOVE_STACK:
-                self._do_remove_stack(**baggage)
+                self.delete_container(**baggage)
             elif signal == Notification.RENAME_STACK:
                 self._do_rename_stack(**baggage)
             elif signal == Notification.NEXUS_LOAD:

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -172,7 +172,7 @@ class MainWindowPresenter(BasePresenter):
         self.stacks[sample_stack_vis.id] = sample_stack_vis
 
         current_stack_visualisers = self.get_active_stack_visualisers()
-        if len(current_stack_visualisers) > 1:
+        if len(current_stack_visualisers) > 0:
             self.view.tabifyDockWidget(current_stack_visualisers[0], sample_stack_vis)
 
         dataset_tree_item = self.view.create_dataset_tree_widget_item(title, container.id)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -153,7 +153,7 @@ class MainWindowPresenter(BasePresenter):
         name = self.create_stack_name(os.path.basename(filename))
         stack_visualiser = self.view.create_stack_window(images, title=f"{name}")
         self.view.tabifyDockWidget(sample_dock, stack_visualiser)
-        self.stacks[stack_visualiser.uuid] = stack_visualiser
+        self.stacks[images.id] = stack_visualiser
 
     def get_active_stack_visualisers(self) -> List[StackVisualiserView]:
         return [stack for stack in self.active_stacks.values()]  # type:ignore
@@ -182,13 +182,13 @@ class MainWindowPresenter(BasePresenter):
 
         sample = container if isinstance(container, Images) else container.sample
         sample_stack_vis = self.view.create_stack_window(sample, title)
-        self.stacks[sample_stack_vis.uuid] = sample_stack_vis
+        self.stacks[sample_stack_vis.id] = sample_stack_vis
 
         current_stack_visualisers = self.get_active_stack_visualisers()
         if len(current_stack_visualisers) > 0:
             self.view.tabifyDockWidget(current_stack_visualisers[0], sample_stack_vis)
 
-        dataset_tree_item = self.view.create_dataset_tree_widget_item(title, sample_stack_vis.uuid)
+        dataset_tree_item = self.view.create_dataset_tree_widget_item(title, container.id)
 
         if isinstance(container, Dataset):
             self.view.create_child_tree_item(dataset_tree_item, container.sample.id, "Projections")
@@ -365,16 +365,19 @@ class MainWindowPresenter(BasePresenter):
                     return
 
     def add_stack_to_dictionary(self, stack: StackVisualiserView):
-        self.stacks[stack.uuid] = stack
+        self.stacks[stack.id] = stack
 
     def delete_container(self, container_id):
         ids_to_remove = self.model.remove_container(container_id)
         if len(ids_to_remove) == 1:
+            self.stacks[container_id].presenter.delete_data()
             self.stacks[container_id].deleteLater()
             del self.stacks[container_id]
             self.remove_item_from_tree_view(container_id)
         if len(ids_to_remove) > 1:
             for stack_id in ids_to_remove:
+                self.stacks[stack_id].presenter.delete_data()
                 self.stacks[stack_id].deleteLater()
                 del self.stacks[stack_id]
-            # self.remove_item_from_tree_view(container_id)
+                print(stack_id)
+            self.remove_item_from_tree_view(container_id)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -367,17 +367,29 @@ class MainWindowPresenter(BasePresenter):
         self.stacks[stack.id] = stack
 
     def delete_container(self, container_id: uuid.UUID):
+        """
+
+        :param container_id:
+        :return:
+        """
         ids_to_remove = self.model.remove_container(container_id)
         if len(ids_to_remove) == 1:
-            self.stacks[container_id].image_view.close()
-            self.stacks[container_id].presenter.delete_data()
-            self.stacks[container_id].deleteLater()
-            del self.stacks[container_id]
+            self._delete_stack(container_id)
             self.remove_item_from_tree_view(container_id)
         elif len(ids_to_remove) > 1:
             for stack_id in ids_to_remove:
-                self.stacks[stack_id].image_view.close()
-                self.stacks[stack_id].presenter.delete_data()
-                self.stacks[stack_id].deleteLater()
-                del self.stacks[stack_id]
+                self._delete_stack(stack_id)
             self.remove_item_from_tree_view(container_id)
+
+    def _delete_stack(self, stack_id):
+        """
+
+        :param stack_id:
+        :return: 
+        """
+        self.stacks[stack_id].image_view.close()
+        self.stacks[stack_id].presenter.delete_data()
+        self.stacks[stack_id].deleteLater()
+        del self.stacks[stack_id]
+
+

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -21,7 +21,7 @@ from mantidimaging.gui.dialogs.async_task import start_async_task_view
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.windows.stack_visualiser.presenter import SVNotification
 from mantidimaging.gui.windows.stack_visualiser.view import StackVisualiserView
-from .model import MainWindowModel, ChangeType
+from .model import MainWindowModel
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # pragma: no cover

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -98,13 +98,13 @@ class MainWindowPresenter(BasePresenter):
         self.remove_item_from_tree_view(stack_id)
         self.model.remove_container(stack_id)
         del self.stacks[stack_id]
-        self.view.active_stacks_changed.emit()  # TODO: change to stacks changed?
+        self.view.model_changed.emit()
 
     def _do_rename_stack(self, current_name: str, new_name: str):
         dock = self._get_stack_widget_by_name(current_name)
         if dock:
             dock.setWindowTitle(new_name)
-            self.view.active_stacks_changed.emit()
+            self.view.model_changed.emit()
 
     def load_dataset(self, par: Optional[LoadingParameters] = None):
         if par is None and self.view.load_dialogue is not None:
@@ -172,7 +172,7 @@ class MainWindowPresenter(BasePresenter):
                 QApplication.sendPostedEvents()
                 tab_bar.setCurrentIndex(last_stack_pos)
 
-        self.view.active_stacks_changed.emit()
+        self.view.model_changed.emit()
 
         return _180_stack_vis
 
@@ -229,7 +229,7 @@ class MainWindowPresenter(BasePresenter):
                 QApplication.sendPostedEvents()
                 tab_bar.setCurrentIndex(last_stack_pos)
 
-        self.view.active_stacks_changed.emit()
+        self.view.model_changed.emit()
         self.view.add_item_to_tree_view(dataset_tree_item)
 
         return sample_stack_vis
@@ -381,6 +381,7 @@ class MainWindowPresenter(BasePresenter):
             for stack_id in ids_to_remove:
                 self._delete_stack(stack_id)
         self.remove_item_from_tree_view(container_id)
+        self.view.model_changed.emit()
 
     def _delete_stack(self, stack_id):
         """

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -354,7 +354,7 @@ class MainWindowPresenter(BasePresenter):
         for i in range(top_level_item_count):
             top_level_item = self.view.dataset_tree_widget.topLevelItem(i)
             if top_level_item.id == uuid_remove:
-                self.view.dataset_tree_widget.takeTopLevelItem(top_level_item)
+                self.view.dataset_tree_widget.takeTopLevelItem(i)
                 return
 
             child_count = top_level_item.childCount()
@@ -368,10 +368,13 @@ class MainWindowPresenter(BasePresenter):
         self.stacks[stack.uuid] = stack
 
     def delete_container(self, container_id):
-        change_type = self.model.remove_container(container_id)
-        if change_type == ChangeType.DELETE_IMAGE_STACK:
+        ids_to_remove = self.model.remove_container(container_id)
+        if len(ids_to_remove) == 1:
             self.stacks[container_id].deleteLater()
             del self.stacks[container_id]
             self.remove_item_from_tree_view(container_id)
-        if change_type == ChangeType.DELETE_DATASET:
-            pass
+        if len(ids_to_remove) > 1:
+            for stack_id in ids_to_remove:
+                self.stacks[stack_id].deleteLater()
+                del self.stacks[stack_id]
+            # self.remove_item_from_tree_view(container_id)

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -558,6 +558,11 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.remove_item_from_tree_view.assert_called_once_with(dataset_id)
         self.view.model_changed.emit.assert_called_once()
 
+    def test_delete_fails_then_presenter_does_nothing(self):
+        self.model.remove_container = mock.Mock(return_value=None)
+        self.presenter.delete_container("bad-id")
+        self.view.model_changed.emit.assert_not_called()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -34,7 +34,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.model = self.model = mock.Mock()
 
         self.view.create_stack_window.return_value = dock_mock = mock.Mock()
-        self.view.active_stacks_changed = mock.Mock()
+        self.view.model_changed = mock.Mock()
         self.view.dataset_tree_widget = mock.Mock()
 
         def stack_id():
@@ -148,19 +148,19 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.assertEqual(2, self.view.tabifyDockWidget.call_count)
 
     def test_create_new_stack_images(self):
-        self.view.active_stacks_changed.emit = mock.Mock()
+        self.view.model_changed.emit = mock.Mock()
         images = generate_images()
         self.presenter.create_new_stack(images, "My title")
         self.assertEqual(1, len(self.presenter.stacks))
-        self.view.active_stacks_changed.emit.assert_called_once()
+        self.view.model_changed.emit.assert_called_once()
 
     @mock.patch("mantidimaging.gui.windows.main.presenter.QApplication")
     def test_create_new_stack_images_focuses_newest_tab(self, mock_QApp):
-        self.view.active_stacks_changed.emit = mock.Mock()
+        self.view.model_changed.emit = mock.Mock()
         images = generate_images()
         self.presenter.create_new_stack(images, "My title")
         self.assertEqual(1, len(self.presenter.stacks))
-        self.view.active_stacks_changed.emit.assert_called_once()
+        self.view.model_changed.emit.assert_called_once()
 
         self.presenter.create_new_stack(images, "My title")
         assert self.view.tabifyDockWidget.call_count == 2
@@ -178,7 +178,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         dock_mock.widget.return_value = stack_visualiser_mock
         dock_mock.windowTitle.return_value = "somename"
-        self.view.active_stacks_changed.emit = mock.Mock()
+        self.view.model_changed.emit = mock.Mock()
 
         self.dataset.flat_before.filenames = ["filename"] * 10
         self.dataset.dark_before.filenames = ["filename"] * 10
@@ -188,7 +188,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.create_new_stack(self.dataset, "My title")
 
         self.assertEqual(6, len(self.presenter.stacks))
-        self.view.active_stacks_changed.emit.assert_called_once()
+        self.view.model_changed.emit.assert_called_once()
 
     def test_create_new_stack_dataset_and_use_threshold_180(self):
         dock_mock = self.view.create_stack_window.return_value
@@ -198,7 +198,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         dock_mock.widget.return_value = stack_visualiser_mock
         dock_mock.windowTitle.return_value = "somename"
-        self.view.active_stacks_changed.emit = mock.Mock()
+        self.view.model_changed.emit = mock.Mock()
 
         self.dataset.flat_before.filenames = ["filename"] * 10
         self.dataset.dark_before.filenames = ["filename"] * 10
@@ -210,7 +210,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.create_new_stack(self.dataset, "My title")
 
         self.assertEqual(6, len(self.presenter.stacks))
-        self.view.active_stacks_changed.emit.assert_called_once()
+        self.view.model_changed.emit.assert_called_once()
 
     def test_create_new_stack_dataset_and_reject_180(self):
         dock_mock = self.view.create_stack_window.return_value
@@ -218,7 +218,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         dock_mock.widget.return_value = stack_visualiser_mock
         dock_mock.windowTitle.return_value = "somename"
-        self.view.active_stacks_changed.emit = mock.Mock()
+        self.view.model_changed.emit = mock.Mock()
 
         self.dataset.flat_before.filenames = ["filename"] * 10
         self.dataset.dark_before.filenames = ["filename"] * 10
@@ -230,7 +230,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.create_new_stack(self.dataset, "My title")
 
         self.assertEqual(5, len(self.presenter.stacks))
-        self.view.active_stacks_changed.emit.assert_called_once()
+        self.view.model_changed.emit.assert_called_once()
 
     def test_create_new_stack_dataset_and_accept_180(self):
         dock_mock = self.view.create_stack_window.return_value
@@ -238,7 +238,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         dock_mock.widget.return_value = stack_visualiser_mock
         dock_mock.windowTitle.return_value = "somename"
-        self.view.active_stacks_changed.emit = mock.Mock()
+        self.view.model_changed.emit = mock.Mock()
 
         self.dataset.flat_before.filenames = ["filename"] * 10
         self.dataset.dark_before.filenames = ["filename"] * 10
@@ -250,7 +250,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.create_new_stack(self.dataset, "My title")
 
         self.assertEqual(6, len(self.presenter.stacks))
-        self.view.active_stacks_changed.emit.assert_called_once()
+        self.view.model_changed.emit.assert_called_once()
 
     def test_wizard_action_load(self):
         self.presenter.wizard_action_load()
@@ -330,7 +330,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         new_title = "new title"
         self.presenter._do_rename_stack(previous_title, new_title)
         mock_stack.setWindowTitle.assert_called_once_with(new_title)
-        self.view.active_stacks_changed.emit.assert_called_once()
+        self.view.model_changed.emit.assert_called_once()
 
     def test_create_new_180_stack_with_multiple_visible_stacks(self):
         stacks = dict()
@@ -348,7 +348,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         self.assertIs(self.presenter.create_new_180_stack(images_180, title), stack_vis_180)
         self.view.tabifyDockWidget.assert_called_once()
-        self.view.active_stacks_changed.emit.assert_called_once()
+        self.view.model_changed.emit.assert_called_once()
         tab_bar_mock.setCurrentIndex.assert_called_once_with(2)
 
     def test_create_new_180_stack_with_no_visible_stacks(self):
@@ -366,7 +366,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         self.assertIs(self.presenter.create_new_180_stack(images_180, title), stack_vis_180)
         self.view.tabifyDockWidget.assert_not_called()
-        self.view.active_stacks_changed.emit.assert_called_once()
+        self.view.model_changed.emit.assert_called_once()
         self.view.findChild.assert_not_called()
 
     def test_get_stack_visualiser_success(self):
@@ -447,12 +447,12 @@ class MainWindowPresenterTest(unittest.TestCase):
         Removing an ID that corresponds with a top-level item means a dataset is being removed.
         """
         top_level_item_mock = mock.Mock()
-        top_level_item_mock.uuid = stack_id = "stack-id"
+        top_level_item_mock.id = stack_id = "stack-id"
         self.view.dataset_tree_widget.topLevelItemCount.return_value = 1
         self.view.dataset_tree_widget.topLevelItem.return_value = top_level_item_mock
 
         self.presenter.remove_item_from_tree_view(stack_id)
-        self.view.dataset_tree_widget.takeTopLevelItem.assert_called_once_with(top_level_item_mock)
+        self.view.dataset_tree_widget.takeTopLevelItem.assert_called_once_with(0)
 
     def test_remove_images_from_tree_view(self):
         """
@@ -463,7 +463,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.dataset_tree_widget.topLevelItem.return_value = top_level_item_mock
         top_level_item_mock.childCount.return_value = 1
         top_level_item_mock.child.return_value = child_item_mock = mock.Mock()
-        child_item_mock.uuid = stack_id = "stack-id"
+        child_item_mock.id = stack_id = "stack-id"
 
         self.presenter.remove_item_from_tree_view(stack_id)
         top_level_item_mock.takeChild.assert_called_once_with(0)

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -332,15 +332,6 @@ class MainWindowPresenterTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.presenter.add_log_to_sample("doesn't exist", "log file")
 
-    def test_remove_stack(self):
-        stack_uuid = "stack-id"
-        self.presenter.stacks[stack_uuid] = mock.Mock()
-        self.presenter.remove_item_from_tree_view = mock.Mock()
-        self.presenter._do_remove_stack(stack_uuid)
-        self.model.remove_container.assert_called_once_with(stack_uuid)
-        self.assertNotIn(stack_uuid, self.presenter.stacks)
-        self.presenter.remove_item_from_tree_view.assert_called_once_with(stack_uuid)
-
     def test_do_rename_stack(self):
         self.presenter.stacks["stack-id"] = mock_stack = mock.Mock()
         mock_stack.windowTitle.return_value = previous_title = "previous title"

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -156,17 +156,27 @@ class MainWindowPresenterTest(unittest.TestCase):
 
     @mock.patch("mantidimaging.gui.windows.main.presenter.QApplication")
     def test_create_new_stack_images_focuses_newest_tab(self, mock_QApp):
+        first_images = generate_images()
+        second_images = generate_images()
+
+        first_stack_window = mock.Mock()
+        second_stack_window = mock.Mock()
+
+        first_stack_window.id = first_images.id
+        second_stack_window.id = second_images.id
+
+        self.view.create_stack_window.side_effect = [first_stack_window, second_stack_window]
+
         self.view.model_changed.emit = mock.Mock()
-        images = generate_images()
-        self.presenter.create_new_stack(images, "My title")
+        self.presenter.create_new_stack(first_images, "My title")
         self.assertEqual(1, len(self.presenter.stacks))
         self.view.model_changed.emit.assert_called_once()
 
-        self.presenter.create_new_stack(images, "My title")
-        assert self.view.tabifyDockWidget.call_count == 2
-        self.view.findChild.assert_called_once()
+        self.presenter.create_new_stack(second_images, "My title")
+        assert self.view.tabifyDockWidget.call_count == 1
+        assert self.view.findChild.call_count == 1
         mock_tab_bar = self.view.findChild.return_value
-        expected_position = 1
+        expected_position = 2
         mock_tab_bar.setCurrentIndex.assert_called_once_with(expected_position)
         mock_QApp.sendPostedEvents.assert_called_once()
 

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -513,7 +513,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         self.presenter.stacks[id_to_remove] = mock_stack = mock.Mock()
         self.presenter.remove_item_from_tree_view = mock.Mock()
-        self.presenter.delete_container(id_to_remove)
+        self.presenter._delete_container(id_to_remove)
 
         self.assertNotIn(id_to_remove, self.presenter.stacks.keys())
         self.assertNotIn(mock_stack, self.presenter.stacks.values())
@@ -537,7 +537,7 @@ class MainWindowPresenterTest(unittest.TestCase):
             self.presenter.stacks[ids_to_remove[i]] = mock_stacks[i]
 
         self.presenter.remove_item_from_tree_view = mock.Mock()
-        self.presenter.delete_container(dataset_id)
+        self.presenter._delete_container(dataset_id)
 
         for i in range(n_dataset_images):
             self.assertNotIn(ids_to_remove[i], self.presenter.stacks.keys())
@@ -551,7 +551,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
     def test_delete_fails_then_presenter_does_nothing(self):
         self.model.remove_container = mock.Mock(return_value=None)
-        self.presenter.delete_container("bad-id")
+        self.presenter._delete_container("bad-id")
         self.view.model_changed.emit.assert_not_called()
 
 

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -180,7 +180,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.model_changed.emit.assert_called_once()
 
         self.presenter.create_new_stack(second_images, "My title")
-        assert self.view.tabifyDockWidget.call_count == 1
+        assert self.view.tabifyDockWidget.call_count == 2
         assert self.view.findChild.call_count == 1
         mock_tab_bar = self.view.findChild.return_value
         expected_position = 2

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -139,7 +139,7 @@ class MainWindowViewTest(unittest.TestCase):
 
     def test_remove_stack(self):
         fake_stack_vis = mock.Mock()
-        fake_stack_vis.uuid = "test-uuid"
+        fake_stack_vis.id = "test-uuid"
         self.view.remove_stack(fake_stack_vis)
 
         self.presenter.notify.assert_called_once_with(PresNotification.REMOVE_STACK, uuid="test-uuid")

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -137,13 +137,6 @@ class MainWindowViewTest(unittest.TestCase):
 
         self.presenter.update_stack_with_images.assert_called_once_with(images)
 
-    def test_remove_stack(self):
-        fake_stack_vis = mock.Mock()
-        fake_stack_vis.id = "test-uuid"
-        self.view.remove_stack(fake_stack_vis)
-
-        self.presenter.notify.assert_called_once_with(PresNotification.REMOVE_STACK, uuid="test-uuid")
-
     def test_rename_stack(self):
         self.view.rename_stack("apples", "oranges")
 

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -8,7 +8,7 @@ from typing import Optional
 from uuid import UUID
 
 import numpy as np
-from PyQt5.QtCore import Qt, pyqtSignal, QUrl
+from PyQt5.QtCore import Qt, pyqtSignal, QUrl, QPoint
 from PyQt5.QtGui import QIcon, QDragEnterEvent, QDropEvent, QDesktopServices
 from PyQt5.QtWidgets import QAction, QDialog, QLabel, QMessageBox, QMenu, QFileDialog, QSplitter, \
     QTreeWidgetItem, QTreeWidget
@@ -39,8 +39,12 @@ LOG = getLogger(__file__)
 
 class QTreeDatasetWidgetItem(QTreeWidgetItem):
     def __init__(self, parent: QTreeWidget, dataset_id: UUID):
-        self.uuid = dataset_id
+        self._id = dataset_id
         super().__init__(parent)
+
+    @property
+    def id(self):
+        return self._id
 
 
 class MainWindowView(BaseMainWindowView):
@@ -465,12 +469,19 @@ class MainWindowView(BaseMainWindowView):
         self.dataset_tree_widget.insertTopLevelItem(self.dataset_tree_widget.topLevelItemCount(), item)
         item.setExpanded(True)
 
-    def _open_tree_menu(self, position):
+    def _open_tree_menu(self, position: QPoint):
+        """
+        Opens the tree view menu.
+        :param position: The position of the cursor when the menu was opened relative to the main window.
+        """
         menu = QMenu()
         delete_action = menu.addAction("Delete")
-        delete_action.triggered.connect(lambda: self._delete_container(position))
-
+        delete_action.triggered.connect(self._delete_container)
         menu.exec_(self.dataset_tree_widget.viewport().mapToGlobal(position))
 
-    def _delete_container(self, position):
-        print(position)
+    def _delete_container(self):
+        """
+        Sends the signal to the presenter to delete data corresponding with an item on the dataset tree view.
+        """
+        container_id = self.dataset_tree_widget.selectedItems()[0].id
+        self.presenter.delete_container(container_id)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -51,7 +51,7 @@ class MainWindowView(BaseMainWindowView):
     NOT_THE_LATEST_VERSION = "This is not the latest version"
     UNCAUGHT_EXCEPTION = "Uncaught exception"
 
-    active_stacks_changed = pyqtSignal()
+    model_changed = pyqtSignal()
     filter_applied = pyqtSignal()
     recon_applied = pyqtSignal()
     backend_message = pyqtSignal(bytes)
@@ -157,7 +157,7 @@ class MainWindowView(BaseMainWindowView):
 
         self.actionCompareImages.triggered.connect(self.show_stack_select_dialog)
 
-        self.active_stacks_changed.connect(self.update_shortcuts)
+        self.model_changed.connect(self.update_shortcuts)
 
     def populate_image_menu(self):
         self.menuImage.clear()

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -373,9 +373,6 @@ class MainWindowView(BaseMainWindowView):
         self.presenter.add_stack_to_dictionary(stack_vis)
         return stack_vis
 
-    def remove_stack(self, obj: StackVisualiserView):
-        self.presenter.notify(PresNotification.REMOVE_STACK, uuid=obj.id)
-
     def rename_stack(self, current_name: str, new_name: str):
         self.presenter.notify(PresNotification.RENAME_STACK, current_name=current_name, new_name=new_name)
 
@@ -484,4 +481,4 @@ class MainWindowView(BaseMainWindowView):
         Sends the signal to the presenter to delete data corresponding with an item on the dataset tree view.
         """
         container_id = self.dataset_tree_widget.selectedItems()[0].id
-        self.presenter.delete_container(container_id)
+        self.presenter.notify(PresNotification.REMOVE_STACK, container_id=container_id)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -120,6 +120,8 @@ class MainWindowView(BaseMainWindowView):
             self.show_recon_window()
 
         self.dataset_tree_widget = QTreeWidget()
+        self.dataset_tree_widget.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.dataset_tree_widget.customContextMenuRequested.connect(self._open_tree_menu)
 
         self.splitter = QSplitter(Qt.Horizontal, self)
         self.splitter.addWidget(self.dataset_tree_widget)
@@ -462,3 +464,13 @@ class MainWindowView(BaseMainWindowView):
     def add_item_to_tree_view(self, item: QTreeWidgetItem):
         self.dataset_tree_widget.insertTopLevelItem(self.dataset_tree_widget.topLevelItemCount(), item)
         item.setExpanded(True)
+
+    def _open_tree_menu(self, position):
+        menu = QMenu()
+        delete_action = menu.addAction("Delete")
+        delete_action.triggered.connect(lambda: self._delete_container(position))
+
+        menu.exec_(self.dataset_tree_widget.viewport().mapToGlobal(position))
+
+    def _delete_container(self, position):
+        print(position)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -374,7 +374,7 @@ class MainWindowView(BaseMainWindowView):
         return stack_vis
 
     def remove_stack(self, obj: StackVisualiserView):
-        self.presenter.notify(PresNotification.REMOVE_STACK, uuid=obj.uuid)
+        self.presenter.notify(PresNotification.REMOVE_STACK, uuid=obj.id)
 
     def rename_stack(self, current_name: str, new_name: str):
         self.presenter.notify(PresNotification.RENAME_STACK, current_name=current_name, new_name=new_name)

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -219,7 +219,7 @@ class FiltersWindowPresenter(BasePresenter):
             with operation_in_progress("Safe Apply: Copying Data", "-------------------------------------", self.view):
                 self.original_images_stack = []
                 for stack in stacks:
-                    self.original_images_stack.append((stack.presenter.images.copy(), stack.uuid))
+                    self.original_images_stack.append((stack.presenter.images.copy(), stack.id))
 
         if len(stacks) > 0:
             self.applying_to_all = True
@@ -259,7 +259,7 @@ class FiltersWindowPresenter(BasePresenter):
             # If the operation encountered an error during processing,
             # try to restore the original data else continue processing as usual
             if attempt_repair:
-                self.main_window.presenter.set_images_in_stack(stack.uuid, stack.presenter.images)
+                self.main_window.presenter.set_images_in_stack(stack.id, stack.presenter.images)
             # Ensure there is no error if we are to continue with safe apply and 180 degree.
             elif task.error is None:
                 # otherwise check with user which one to keep

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -264,7 +264,7 @@ class FiltersWindowPresenter(BasePresenter):
             elif task.error is None:
                 # otherwise check with user which one to keep
                 if self.view.safeApply.isChecked():
-                    use_new_data = self._wait_for_stack_choice(stack.presenter.images, stack.uuid)
+                    use_new_data = self._wait_for_stack_choice(stack.presenter.images, stack.id)
                 # if the stack that was kept happened to have a proj180 stack - then apply the filter to that too
                 if stack.presenter.images.has_proj180deg() and use_new_data and not self.applying_to_all:
                     self.view.clear_previews()

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -26,7 +26,6 @@ class StackVisualiserViewTest(unittest.TestCase):
     def setUp(self):
         with mock.patch("mantidimaging.gui.windows.main.view.WelcomeScreenPresenter"):
             self.window = MainWindowView()
-        self.window.remove_stack = mock.Mock()
         self.view, self.test_data = self._add_stack_visualiser()
 
     def _add_stack_visualiser(self) -> Tuple[StackVisualiserView, Images]:

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -105,7 +105,7 @@ class StackVisualiserView(QDockWidget):
         return self._actions
 
     @property
-    def uuid(self):
+    def id(self):
         return self.presenter.images.id
 
     def closeEvent(self, event):

--- a/mantidimaging/gui/windows/wizard/presenter.py
+++ b/mantidimaging/gui/windows/wizard/presenter.py
@@ -20,7 +20,7 @@ class WizardPresenter(BasePresenter):
         self.main_window_presenter = parent.presenter
         self.wizard_data = yaml.safe_load(wizard_data_file.open())
         self.populate()
-        parent.active_stacks_changed.connect(self.handle_stack_change)
+        parent.model_changed.connect(self.handle_stack_change)
         parent.filter_applied.connect(self.handle_stack_change)
         parent.recon_applied.connect(self.handle_stack_change)
         self.handle_stack_change()


### PR DESCRIPTION
### Issue

Closes #1197

### Description

Allows a user to delete datasets/image stacks from the dataset tree view.

### Testing 

Added tests for the `delete_container` method in the presenter and also updated some other tests.

### Acceptance Criteria 

Check that the tests pass. Check that deleting an image stack in a dataset, deleting an image stack not in a dataset, and deleting an entire all work.

### Documentation

Updated release notes.
