### PR TITLE
Beam hardening correction

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -13,6 +13,7 @@ New Features
 - #1185 : Bad data overlays
 - #1168 : Dataset tree view
 - #1202 : NaN Removal filter - replace with median
+- #1205 : Linearisation correction for beam hardening
 
 Fixes
 -----

--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -107,7 +107,7 @@ class AstraRecon(BaseRecon):
                     progress: Optional[Progress] = None) -> np.ndarray:
         assert sino.ndim == 2, "Sinogram must be a 2D image"
 
-        sino = BaseRecon.negative_log(sino)
+        sino = BaseRecon.prepare_sinogram(sino, recon_params)
         image_width = sino.shape[1]
 
         if astra_mutex.locked():

--- a/mantidimaging/core/reconstruct/base_recon.py
+++ b/mantidimaging/core/reconstruct/base_recon.py
@@ -4,6 +4,7 @@
 from typing import List, Optional
 
 import numpy as np
+from numpy.polynomial import Polynomial
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.utility.data_containers import ScalarCoR, ProjectionAngles, ReconstructionParameters
@@ -14,6 +15,17 @@ class BaseRecon:
     @staticmethod
     def find_cor(images: Images, slice_idx: int, start_cor: float, recon_params: ReconstructionParameters) -> float:
         raise NotImplementedError("Base class call")
+
+    @staticmethod
+    def prepare_sinogram(data: np.ndarray, recon_params: ReconstructionParameters):
+        if recon_params.beam_hardening_coefs is not None:
+            a0, a1, a2, a3 = recon_params.beam_hardening_coefs
+            bhc_poly = Polynomial([0, 1, a0, a1, a2, a3])
+            logged_data = BaseRecon.negative_log(data)
+            corrected_data = bhc_poly(logged_data)
+            return corrected_data
+        else:
+            return BaseRecon.negative_log(data)
 
     @staticmethod
     def negative_log(data: np.ndarray) -> np.ndarray:

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -81,7 +81,7 @@ class CILRecon(BaseRecon):
             LOG.warning("CIL recon already in progress")
 
         with cil_mutex:
-            sino = BaseRecon.negative_log(sino)
+            sino = BaseRecon.prepare_sinogram(sino, recon_params)
             pixel_num_h = sino.shape[1]
             pixel_size = 1.
             rot_pos_x = (cor.value - pixel_num_h / 2) * pixel_size
@@ -180,7 +180,7 @@ class CILRecon(BaseRecon):
 
             # stick it into an AcquisitionData
             data = ag.allocate(None)
-            data.fill(BaseRecon.negative_log(images.data))
+            data.fill(BaseRecon.prepare_sinogram(images, recon_params))
             data.reorder('astra')
 
             alpha = recon_params.alpha

--- a/mantidimaging/core/reconstruct/tomopy_recon.py
+++ b/mantidimaging/core/reconstruct/tomopy_recon.py
@@ -31,7 +31,7 @@ class TomopyRecon(BaseRecon):
                     proj_angles: ProjectionAngles,
                     recon_params: ReconstructionParameters,
                     progress: Optional[Progress] = None):
-        sino = BaseRecon.negative_log(sino)
+        sino = BaseRecon.prepare_sinogram(sino, recon_params)
         volume = tomopy.recon(tomo=[sino],
                               sinogram_order=True,
                               theta=proj_angles.value,
@@ -63,7 +63,7 @@ class TomopyRecon(BaseRecon):
 
         kwargs = {
             'ncore': ncores,
-            'tomo': BaseRecon.negative_log(images.data),
+            'tomo': BaseRecon.prepare_sinogram(images, recon_params),
             'sinogram_order': images._is_sinograms,
             'theta': images.projection_angles(recon_params.max_projection_angle).value,
             'center': [cor.value for cor in cors],

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -10,7 +10,7 @@ while they're both Float underneath and the value can be used, it just will prod
 """
 from collections import namedtuple
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional
 
 import numpy
 
@@ -102,6 +102,7 @@ class ReconstructionParameters:
     pixel_size: float = 0.0
     alpha: float = 0.0
     max_projection_angle: float = 360.0
+    beam_hardening_coefs: Optional[List[float]] = None
 
     def to_dict(self) -> dict:
         return {

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -336,6 +336,119 @@
             </item>
            </layout>
           </widget>
+          <widget class="QWidget" name="bhcTab">
+           <attribute name="title">
+            <string>BHC</string>
+           </attribute>
+           <layout class="QVBoxLayout" name="verticalLayout_2">
+            <item>
+             <widget class="QGroupBox" name="bhcGroupBox">
+              <property name="title">
+               <string>Linear Beam Hardening Correction</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_7">
+               <item>
+                <layout class="QGridLayout" name="bhcGroup_4">
+                 <item row="0" column="1">
+                  <widget class="QDoubleSpinBox" name="lbhc_a0">
+                   <property name="decimals">
+                    <number>3</number>
+                   </property>
+                   <property name="minimum">
+                    <double>-99.989999999999995</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
+                  <widget class="QDoubleSpinBox" name="lbhc_a1">
+                   <property name="decimals">
+                    <number>3</number>
+                   </property>
+                   <property name="minimum">
+                    <double>-99.989999999999995</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="3" column="0">
+                  <widget class="QLabel" name="label_a3">
+                   <property name="text">
+                    <string>a3</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QLabel" name="label_a1">
+                   <property name="text">
+                    <string>a1</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="0">
+                  <widget class="QLabel" name="label_a0">
+                   <property name="text">
+                    <string>a0</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="0">
+                  <widget class="QLabel" name="label_a2">
+                   <property name="text">
+                    <string>a2</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="3" column="1">
+                  <widget class="QDoubleSpinBox" name="lbhc_a3">
+                   <property name="decimals">
+                    <number>3</number>
+                   </property>
+                   <property name="minimum">
+                    <double>-99.989999999999995</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="1">
+                  <widget class="QDoubleSpinBox" name="lbhc_a2">
+                   <property name="decimals">
+                    <number>3</number>
+                   </property>
+                   <property name="minimum">
+                    <double>-99.989999999999995</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
           <widget class="QWidget" name="reconTab">
            <attribute name="title">
             <string>Reconstruct</string>
@@ -554,26 +667,6 @@
            <string>Preview</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_2">
-           <item row="1" column="1">
-            <widget class="QSpinBox" name="previewSliceIndex">
-             <property name="maximum">
-              <number>99999</number>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="0">
-            <widget class="QLabel" name="previewProjectionIndexLabel">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Projection index:</string>
-             </property>
-            </widget>
-           </item>
            <item row="1" column="0">
             <widget class="QLabel" name="previewSliceIndexLabel">
              <property name="sizePolicy">
@@ -591,6 +684,26 @@
             <widget class="QSpinBox" name="previewProjectionIndex">
              <property name="maximum">
               <number>99999</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QSpinBox" name="previewSliceIndex">
+             <property name="maximum">
+              <number>99999</number>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="previewProjectionIndexLabel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Projection index:</string>
              </property>
             </widget>
            </item>

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -349,8 +349,71 @@
               <layout class="QVBoxLayout" name="verticalLayout_7">
                <item>
                 <layout class="QGridLayout" name="bhcGroup_4">
-                 <item row="0" column="1">
-                  <widget class="QDoubleSpinBox" name="lbhc_a0">
+                 <item row="3" column="0">
+                  <widget class="QLabel" name="label_a2">
+                   <property name="text">
+                    <string>a2</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="1">
+                  <widget class="QDoubleSpinBox" name="lbhc_a1">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="decimals">
+                    <number>3</number>
+                   </property>
+                   <property name="minimum">
+                    <double>-99.989999999999995</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QLabel" name="label_a0">
+                   <property name="text">
+                    <string>a0</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="4" column="1">
+                  <widget class="QDoubleSpinBox" name="lbhc_a3">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="decimals">
+                    <number>3</number>
+                   </property>
+                   <property name="minimum">
+                    <double>-99.989999999999995</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="4" column="0">
+                  <widget class="QLabel" name="label_a3">
+                   <property name="text">
+                    <string>a3</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="0">
+                  <widget class="QLabel" name="label_a1">
+                   <property name="text">
+                    <string>a1</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="3" column="1">
+                  <widget class="QDoubleSpinBox" name="lbhc_a2">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
                    <property name="decimals">
                     <number>3</number>
                    </property>
@@ -363,7 +426,10 @@
                   </widget>
                  </item>
                  <item row="1" column="1">
-                  <widget class="QDoubleSpinBox" name="lbhc_a1">
+                  <widget class="QDoubleSpinBox" name="lbhc_a0">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
                    <property name="decimals">
                     <number>3</number>
                    </property>
@@ -372,60 +438,13 @@
                    </property>
                    <property name="singleStep">
                     <double>0.100000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="0">
-                  <widget class="QLabel" name="label_a3">
-                   <property name="text">
-                    <string>a3</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QLabel" name="label_a1">
-                   <property name="text">
-                    <string>a1</string>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="0">
-                  <widget class="QLabel" name="label_a0">
+                  <widget class="QCheckBox" name="lbhc_enabled">
                    <property name="text">
-                    <string>a0</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="0">
-                  <widget class="QLabel" name="label_a2">
-                   <property name="text">
-                    <string>a2</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="1">
-                  <widget class="QDoubleSpinBox" name="lbhc_a3">
-                   <property name="decimals">
-                    <number>3</number>
-                   </property>
-                   <property name="minimum">
-                    <double>-99.989999999999995</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.100000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="1">
-                  <widget class="QDoubleSpinBox" name="lbhc_a2">
-                   <property name="decimals">
-                    <number>3</number>
-                   </property>
-                   <property name="minimum">
-                    <double>-99.989999999999995</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.100000000000000</double>
+                    <string>Enabled</string>
                    </property>
                   </widget>
                  </item>

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -239,7 +239,8 @@ class ReconstructWindowViewTest(unittest.TestCase):
                                                   tilt=Degrees(self.resultTilt.value.return_value),
                                                   pixel_size=self.pixelSize.value.return_value,
                                                   alpha=self.alpha.value.return_value,
-                                                  max_projection_angle=self.maxProjAngle.value.return_value)
+                                                  max_projection_angle=self.maxProjAngle.value.return_value,
+                                                  beam_hardening_coefs=self.view.beam_hardening_coefs)
 
     def test_set_table_point(self):
         idx = 12

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -64,6 +64,11 @@ class ReconstructWindowView(BaseMainWindowView):
     reconstructVolume: QPushButton
     reconstructSlice: QPushButton
 
+    lbhc_a0: QDoubleSpinBox
+    lbhc_a1: QDoubleSpinBox
+    lbhc_a2: QDoubleSpinBox
+    lbhc_a3: QDoubleSpinBox
+
     statusMessageTextEdit: QTextEdit
     messageIcon: QLabel
 
@@ -184,6 +189,9 @@ class ReconstructWindowView(BaseMainWindowView):
         action = self.image_view.recon_hist.gradient.menu.actions()[12]
         self.image_view.recon_hist.gradient.menu.insertAction(action, self.auto_colour_action)
         self.image_view.recon_hist.gradient.menu.insertSeparator(self.auto_colour_action)
+
+        for spinbox in [self.lbhc_a0, self.lbhc_a1, self.lbhc_a2, self.lbhc_a3]:
+            spinbox.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
 
     def closeEvent(self, e):
         if self.presenter.recon_is_running:
@@ -370,6 +378,16 @@ class ReconstructWindowView(BaseMainWindowView):
     def alpha(self, value: float):
         self.alphaSpinbox.setValue(value)
 
+    @property
+    def beam_hardening_coefs(self) -> Optional[List[float]]:
+        params = []
+        for spinbox in [self.lbhc_a0, self.lbhc_a1, self.lbhc_a2, self.lbhc_a3]:
+            params.append(spinbox.value())
+        if any(params):
+            return params
+        else:
+            return None
+
     def recon_params(self) -> ReconstructionParameters:
         return ReconstructionParameters(algorithm=self.algorithm_name,
                                         filter_name=self.filter_name,
@@ -378,7 +396,8 @@ class ReconstructWindowView(BaseMainWindowView):
                                         tilt=Degrees(self.tilt),
                                         pixel_size=self.pixel_size,
                                         alpha=self.alpha,
-                                        max_projection_angle=self.max_proj_angle)
+                                        max_projection_angle=self.max_proj_angle,
+                                        beam_hardening_coefs=self.beam_hardening_coefs)
 
     def set_table_point(self, idx, slice_idx, cor):
         # reset_results=False stops the resetting of the data model on

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -7,7 +7,8 @@ from uuid import UUID
 
 import numpy
 from PyQt5.QtWidgets import (QAbstractItemView, QComboBox, QDoubleSpinBox, QInputDialog, QPushButton, QSpinBox,
-                             QVBoxLayout, QWidget, QMessageBox, QAction, QTextEdit, QLabel, QApplication, QStyle)
+                             QVBoxLayout, QWidget, QMessageBox, QAction, QTextEdit, QLabel, QApplication, QStyle,
+                             QCheckBox)
 from PyQt5.QtCore import pyqtSignal, QSignalBlocker
 
 from mantidimaging.core.data import Images
@@ -64,6 +65,7 @@ class ReconstructWindowView(BaseMainWindowView):
     reconstructVolume: QPushButton
     reconstructSlice: QPushButton
 
+    lbhc_enabled: QCheckBox
     lbhc_a0: QDoubleSpinBox
     lbhc_a1: QDoubleSpinBox
     lbhc_a2: QDoubleSpinBox
@@ -192,6 +194,8 @@ class ReconstructWindowView(BaseMainWindowView):
 
         for spinbox in [self.lbhc_a0, self.lbhc_a1, self.lbhc_a2, self.lbhc_a3]:
             spinbox.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
+            self.lbhc_enabled.toggled.connect(spinbox.setEnabled)
+        self.lbhc_enabled.toggled.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
 
     def closeEvent(self, e):
         if self.presenter.recon_is_running:
@@ -380,6 +384,8 @@ class ReconstructWindowView(BaseMainWindowView):
 
     @property
     def beam_hardening_coefs(self) -> Optional[List[float]]:
+        if not self.lbhc_enabled.isChecked():
+            return None
         params = []
         for spinbox in [self.lbhc_a0, self.lbhc_a1, self.lbhc_a2, self.lbhc_a3]:
             params.append(spinbox.value())


### PR DESCRIPTION
### Issue
Closes #1205 

### Description
Basic linearisation correction for beam hardening

Previously the sinogram is just processed with:

![image](https://user-images.githubusercontent.com/74248560/143071716-ee660db4-be89-4ef1-9a9e-6d1e0d815b6f.png)

Now we add a correction

![image](https://user-images.githubusercontent.com/74248560/143071589-49a58cb3-85d8-49a2-8717-9357e27c5948.png)


### Testing & Acceptance Criteria 

I have a simple phantom dataset to test with, but it will need the scientist to have a look at.


### Documentation

release notes

Full documentation will done in #1210
