### PR TITLE
1208: Show tab from treeview

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -15,6 +15,7 @@ New Features
 - #1202 : NaN Removal filter - replace with median
 - #1205 : Linearisation correction for beam hardening
 - #1197 : Dataset Tree View: Delete image stack
+- #1197 : Dataset Tree View : Show tab from treeview
 
 Fixes
 -----

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -35,6 +35,7 @@ class Notification(Enum):
     REMOVE_STACK = auto()
     RENAME_STACK = auto()
     NEXUS_LOAD = auto()
+    FOCUS_TAB = auto()
 
 
 class MainWindowPresenter(BasePresenter):
@@ -60,6 +61,8 @@ class MainWindowPresenter(BasePresenter):
                 self._do_rename_stack(**baggage)
             elif signal == Notification.NEXUS_LOAD:
                 self.load_nexus_file()
+            elif signal == Notification.FOCUS_TAB:
+                self._focus_tab(**baggage)
 
         except Exception as e:
             self.show_error(e, traceback.format_exc())
@@ -379,3 +382,6 @@ class MainWindowPresenter(BasePresenter):
         self.stacks[stack_id].presenter.delete_data()
         self.stacks[stack_id].deleteLater()
         del self.stacks[stack_id]
+
+    def _focus_tab(self, stack_id: uuid.UUID):
+        self.stacks[stack_id].setVisible(True)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -384,4 +384,9 @@ class MainWindowPresenter(BasePresenter):
         del self.stacks[stack_id]
 
     def _focus_tab(self, stack_id: uuid.UUID):
+        """
+        Makes a stack tab visible and brings it to the front.
+        :param stack_id: The ID of the stack tab to focus on.
+        """
         self.stacks[stack_id].setVisible(True)
+        self.stacks[stack_id].raise_()

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -385,8 +385,13 @@ class MainWindowPresenter(BasePresenter):
 
     def _focus_tab(self, stack_id: uuid.UUID):
         """
-        Makes a stack tab visible and brings it to the front.
+        Makes a stack tab visible and brings it to the front. If dataset ID is given then nothing happens.
         :param stack_id: The ID of the stack tab to focus on.
         """
-        self.stacks[stack_id].setVisible(True)
-        self.stacks[stack_id].raise_()
+        if stack_id in self.model.datasets:
+            return
+        if stack_id in self.model.images:
+            self.stacks[stack_id].setVisible(True)
+            self.stacks[stack_id].raise_()
+        else:
+            raise RuntimeError(f"Unable to find stack with ID {stack_id}")

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -14,6 +14,7 @@ from mantidimaging.core.utility.data_containers import ProjectionAngles
 from mantidimaging.gui.dialogs.async_task import TaskWorkerThread
 from mantidimaging.gui.windows.load_dialog import MWLoadDialog
 from mantidimaging.gui.windows.main import MainWindowView, MainWindowPresenter
+from mantidimaging.gui.windows.main.presenter import Notification
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
 
@@ -553,6 +554,14 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.model.remove_container = mock.Mock(return_value=None)
         self.presenter._delete_container("bad-id")
         self.view.model_changed.emit.assert_not_called()
+
+    def test_focus_tab(self):
+        stack_id = "stack-id"
+        self.presenter.stacks[stack_id] = mock_stack_tab = mock.Mock()
+        self.presenter.notify(Notification.FOCUS_TAB, stack_id=stack_id)
+
+        mock_stack_tab.setVisible.assert_called_once_with(True)
+        mock_stack_tab.raise_.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -555,13 +555,33 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter._delete_container("bad-id")
         self.view.model_changed.emit.assert_not_called()
 
-    def test_focus_tab(self):
+    def test_focus_tab_with_id_in_images(self):
         stack_id = "stack-id"
+        self.model.images = [stack_id]
+        self.model.datasets = []
         self.presenter.stacks[stack_id] = mock_stack_tab = mock.Mock()
         self.presenter.notify(Notification.FOCUS_TAB, stack_id=stack_id)
 
         mock_stack_tab.setVisible.assert_called_once_with(True)
         mock_stack_tab.raise_.assert_called_once()
+
+    def test_focus_tab_with_id_not_found(self):
+        self.model.images = []
+        self.model.datasets = []
+
+        with self.assertRaises(Exception):
+            self.presenter._focus_tab(stack_id="not-in-the-stacks-dict")
+
+    def test_focus_tab_with_id_in_dataset(self):
+        stack_id = "stack-id"
+        self.model.images = []
+        self.model.datasets = [stack_id]
+        self.presenter.stacks = dict()
+        self.presenter.stacks["other-id"] = mock_stack_tab = mock.Mock()
+        self.presenter.notify(Notification.FOCUS_TAB, stack_id=stack_id)
+
+        mock_stack_tab.setVisible.assert_not_called()
+        mock_stack_tab.raise_.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -126,6 +126,7 @@ class MainWindowView(BaseMainWindowView):
         self.dataset_tree_widget = QTreeWidget()
         self.dataset_tree_widget.setContextMenuPolicy(Qt.CustomContextMenu)
         self.dataset_tree_widget.customContextMenuRequested.connect(self._open_tree_menu)
+        self.dataset_tree_widget.itemDoubleClicked.connect(self._bring_stack_tab_to_front)
 
         self.splitter = QSplitter(Qt.Horizontal, self)
         self.splitter.addWidget(self.dataset_tree_widget)
@@ -482,3 +483,10 @@ class MainWindowView(BaseMainWindowView):
         """
         container_id = self.dataset_tree_widget.selectedItems()[0].id
         self.presenter.notify(PresNotification.REMOVE_STACK, container_id=container_id)
+
+    def _bring_stack_tab_to_front(self, item: QTreeDatasetWidgetItem):
+        """
+        Sends the signal to the presenter to bring a make a stack tab visible and bring it to the front.
+        :param item: The QTreeDatasetWidgetItem that was double clicked.
+        """
+        self.presenter.notify(PresNotification.FOCUS_TAB, stack_id=item.id)


### PR DESCRIPTION
### Issue

Closes #1208 

### Description

Tab can be brought to front with tree view.

### Testing 

Added some presenter tests.

### Acceptance Criteria 

Check that double-clicking images from tree view opens stack + brings it to the front. Check that double-clicking dataset name does nothing.

### Documentation

Updated release notes.
