### PR TITLE
Remove pytest-repeat

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -60,7 +60,7 @@ jobs:
         timeout-minutes: 5
         shell: bash -l {0}
         run: |
-          xvfb-run --auto-servernum python -m pytest --cov --cov-report=xml -n auto --count 10 --ignore=mantidimaging/eyes_tests
+          xvfb-run --auto-servernum python -m pytest --cov --cov-report=xml -n auto --ignore=mantidimaging/eyes_tests
 
       - name: docs
         shell: bash -l {0}

--- a/.github/workflows/cos7_testing.yml
+++ b/.github/workflows/cos7_testing.yml
@@ -54,7 +54,7 @@ jobs:
       timeout-minutes: 5
       uses: ./.github/actions/test
       with:
-        command: xvfb-run pytest -n auto --count 10 --ignore=mantidimaging/eyes_tests
+        command: xvfb-run pytest -n auto --ignore=mantidimaging/eyes_tests
         label: centos7
 
     - name: docs

--- a/.github/workflows/u18_testing.yml
+++ b/.github/workflows/u18_testing.yml
@@ -49,7 +49,7 @@ jobs:
       timeout-minutes: 5
       uses: ./.github/actions/test
       with:
-        command: xvfb-run pytest -n auto --count 10 --ignore=mantidimaging/eyes_tests
+        command: xvfb-run pytest -n auto --ignore=mantidimaging/eyes_tests
 
     - name: docs
       uses: ./.github/actions/test

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -37,3 +37,4 @@ Developer Changes
 - #1155 : DeprecationWarning an integer is required self.progressBar.setValue
 - #1153 : Remove package_name argument from load_filter_packages
 - #1172 : Add MIMiniImageView widget
+- #1070 : Remove pytest repeat

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -29,7 +29,6 @@ dependencies:
       - git+https://github.com/samtygier-stfc/sphinx-multiversion.git@prebuild_command
       - pytest-randomly==3.10.*
       - pytest-xdist==2.4.*
-      - pytest-repeat==0.9.1
       - isort==5.9.*
       - eyes-images==4.25.*
       - parameterized==0.8.*


### PR DESCRIPTION
### Issue
Closes #1070

### Description
Remove pytest-repeat

pytest-repeat does not work for us as we use unittest.TestCase

### Testing && Acceptance Criteria 

Tests should pass. They should be completely uneffected.

### Documentation

release notes
