### PR TITLE
Make sure recon is added to model.images

### DIFF
--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -415,6 +415,7 @@ class ReconstructWindowView(BaseMainWindowView):
         self.cor_table_model.set_point(idx, slice_idx, cor, reset_results=False)
 
     def show_recon_volume(self, data: Images):
+        self.main_window.presenter.model.images[data.id] = data
         self.main_window.create_new_stack(data, "Recon")
 
     def get_stack_visualiser(self, uuid) -> Optional['StackVisualiserView']:


### PR DESCRIPTION
### Issue

Quick fix for #1221 

### Description

Add the reconstructed stack to model.images

Note, that model.images will go away soon, and the recon will become part of the dataset, so this will quickly be obsolete.

### Testing & Acceptance Criteria 

See #1221

### Documentation

No release note, this will be obsoleted by dataset changes before release
