### PR TITLE
Try to make upload problem cause action failure

### DIFF
--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -36,4 +36,6 @@ runs:
       conda activate build-env
       conda config --set anaconda_upload yes
       # if the upload silently fails - check the token expiration. Conda can fail silently!
-      conda build --user ${{ inputs.repository }} --token ${{ inputs.token }} --label ${{ inputs.label }} $GITHUB_WORKSPACE/conda
+      conda build --user ${{ inputs.repository }} --token ${{ inputs.token }} --label ${{ inputs.label }} $GITHUB_WORKSPACE/conda | tee upload.log
+      # Check that upload completed
+      grep "Upload complete" upload.log


### PR DESCRIPTION
`conda build` returns success even if the upload failed.

Record the output to a log file and check for the string "Upload complete"

