### PR TITLE
Make sure commandline singleton is reset in teardown

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -39,3 +39,4 @@ Developer Changes
 - #1172 : Add MIMiniImageView widget
 - #1070 : Remove pytest repeat
 - #1182 : Handle exception in _post_filter
+- #1173 : Sometimes tests open many operations windows

--- a/mantidimaging/core/utility/test/command_line_arguments_test.py
+++ b/mantidimaging/core/utility/test/command_line_arguments_test.py
@@ -10,12 +10,19 @@ from mantidimaging.core.utility.command_line_arguments import CommandLineArgumen
 
 class CommandLineArgumentsTest(unittest.TestCase):
     def setUp(self) -> None:
-        # Reset the singleton
+        self.reset_singleton()
+        self.logger = logging.getLogger("mantidimaging.core.utility.command_line_arguments")
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.reset_singleton()
+
+    @staticmethod
+    def reset_singleton():
         CommandLineArguments._instance = None
         CommandLineArguments._images_path = ""
         CommandLineArguments._init_operation = ""
         CommandLineArguments._show_recon = False
-        self.logger = logging.getLogger("mantidimaging.core.utility.command_line_arguments")
 
     def test_bad_path_calls_exit(self):
         bad_path = "does/not/exist"


### PR DESCRIPTION
### Issue

Closes #1173 

### Description

Move singleton reset code into a function so it can be called in tearDownClass().

In the case where windows would open, this saves about 40 seconds locally.

### Testing & Acceptance Criteria 
Tests should pass

`pytest -v -p no:randomly mantidimaging/core/utility/test/command_line_arguments_test.py mantidimaging/gui/windows/recon/test/view_test.py -k "test_set_valid_operation_with_path or test_add_cor_table_row"`

or
`pytest -v --randomly-seed=514603203  mantidimaging/core/utility/test/command_line_arguments_test.py mantidimaging/gui/windows/recon/test/view_test.py`

should not open any GUI windows.

### Documentation

release_notes
