### PR TITLE
Clean up super calls to use simpler python 3 syntax

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -39,3 +39,4 @@ Developer Changes
 - #1172 : Add MIMiniImageView widget
 - #1070 : Remove pytest repeat
 - #1182 : Handle exception in _post_filter
+- #860  : Clean up super calls to use python 3 syntax

--- a/mantidimaging/core/gpu/test/gpu_test.py
+++ b/mantidimaging/core/gpu/test/gpu_test.py
@@ -22,7 +22,7 @@ class GPUTest(unittest.TestCase):
     Tests return value and in-place modified data.
     """
     def __init__(self, *args, **kwargs):
-        super(GPUTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @unittest.skipIf(GPU_NOT_AVAIL, reason=GPU_SKIP_REASON)
     def test_numpy_pad_modes_match_scipy_median_modes(self):

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -16,7 +16,7 @@ from mantidimaging.test_helpers import FileOutputtingTestCase
 
 class IOTest(FileOutputtingTestCase):
     def __init__(self, *args, **kwargs):
-        super(IOTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # force silent outputs
         initialise_logging()

--- a/mantidimaging/core/io/test/utility_test.py
+++ b/mantidimaging/core/io/test/utility_test.py
@@ -11,7 +11,7 @@ from mantidimaging.test_helpers import FileOutputtingTestCase
 
 class UtilityTest(FileOutputtingTestCase):
     def __init__(self, *args, **kwargs):
-        super(UtilityTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # force silent outputs
         initialise_logging()

--- a/mantidimaging/core/operations/arithmetic/test/arithmetic_test.py
+++ b/mantidimaging/core/operations/arithmetic/test/arithmetic_test.py
@@ -14,7 +14,7 @@ class ArithmeticTest(unittest.TestCase):
     Test arithmetic filter.
     """
     def __init__(self, *args, **kwargs):
-        super(ArithmeticTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.logger = logging.getLogger("mantidimaging.core.operations.arithmetic.arithmetic")
 
     def test_div_only(self):

--- a/mantidimaging/core/operations/circular_mask/test/circular_mask_test.py
+++ b/mantidimaging/core/operations/circular_mask/test/circular_mask_test.py
@@ -15,7 +15,7 @@ class CircularMaskTest(unittest.TestCase):
     Tests return value and in-place modified data.
     """
     def __init__(self, *args, **kwargs):
-        super(CircularMaskTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_executed(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/clip_values/test/clip_values_test.py
+++ b/mantidimaging/core/operations/clip_values/test/clip_values_test.py
@@ -17,7 +17,7 @@ class ClipValuesFilterTest(unittest.TestCase):
     Tests return value and in-place modified data.
     """
     def __init__(self, *args, **kwargs):
-        super(ClipValuesFilterTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_execute_min_only(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
+++ b/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
@@ -18,7 +18,7 @@ class CropCoordsTest(unittest.TestCase):
     Tests return value only.
     """
     def __init__(self, *args, **kwargs):
-        super(CropCoordsTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_executed_only_volume(self):
         # Check that the filter is  executed when:

--- a/mantidimaging/core/operations/divide/test/divide_test.py
+++ b/mantidimaging/core/operations/divide/test/divide_test.py
@@ -13,7 +13,7 @@ from mantidimaging.core.operations.divide import DivideFilter
 
 class DivideTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
-        super(DivideTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_divide_with_zero_does_nothing(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
+++ b/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
@@ -21,7 +21,7 @@ class FlatFieldingTest(unittest.TestCase):
     Tests return value and in-place modified data.
     """
     def __init__(self, *args, **kwargs):
-        super(FlatFieldingTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def _make_images(self) -> Tuple[Images, Images, Images, Images, Images]:
         images = th.generate_images()

--- a/mantidimaging/core/operations/gaussian/test/gaussian_test.py
+++ b/mantidimaging/core/operations/gaussian/test/gaussian_test.py
@@ -23,7 +23,7 @@ class GaussianTest(unittest.TestCase):
     reasonably sized data (e.g. 143,512,512)
     """
     def __init__(self, *args, **kwargs):
-        super(GaussianTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_not_executed(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/median_filter/test/median_filter_test.py
+++ b/mantidimaging/core/operations/median_filter/test/median_filter_test.py
@@ -23,7 +23,7 @@ class MedianTest(unittest.TestCase):
     Tests return value and in-place modified data.
     """
     def __init__(self, *args, **kwargs):
-        super(MedianTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_not_executed(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/nan_removal/test/nan_removal_test.py
+++ b/mantidimaging/core/operations/nan_removal/test/nan_removal_test.py
@@ -12,7 +12,7 @@ from mantidimaging.core.operations.nan_removal import NaNRemovalFilter
 
 class NaNRemovalFilterTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
-        super(NaNRemovalFilterTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_replace_nans(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/outliers/test/outliers_test.py
+++ b/mantidimaging/core/operations/outliers/test/outliers_test.py
@@ -21,7 +21,7 @@ class OutliersTest(unittest.TestCase):
     Tests return value only.
     """
     def __init__(self, *args, **kwargs):
-        super(OutliersTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_executed(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/rebin/test/rebin_test.py
+++ b/mantidimaging/core/operations/rebin/test/rebin_test.py
@@ -18,7 +18,7 @@ class RebinTest(unittest.TestCase):
     Tests return value only.
     """
     def __init__(self, *args, **kwargs):
-        super(RebinTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_not_executed_rebin_negative(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/remove_all_stripe/test/remove_all_stripe_test.py
+++ b/mantidimaging/core/operations/remove_all_stripe/test/remove_all_stripe_test.py
@@ -15,7 +15,7 @@ class RemoveAllStripesTest(unittest.TestCase):
     Tests that it executes and returns a valid object, but does not verify the numerical results.
     """
     def __init__(self, *args, **kwargs):
-        super(RemoveAllStripesTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_executed(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/remove_dead_stripe/test/remove_dead_stripe_test.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/test/remove_dead_stripe_test.py
@@ -15,7 +15,7 @@ class RemoveDeadStripesTest(unittest.TestCase):
     Tests that it executes and returns a valid object, but does not verify the numerical results.
     """
     def __init__(self, *args, **kwargs):
-        super(RemoveDeadStripesTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_executed(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/remove_large_stripe/test/remove_large_stripe_test.py
+++ b/mantidimaging/core/operations/remove_large_stripe/test/remove_large_stripe_test.py
@@ -15,7 +15,7 @@ class RemoveLargeStripesTest(unittest.TestCase):
     Tests that it executes and returns a valid object, but does not verify the numerical results.
     """
     def __init__(self, *args, **kwargs):
-        super(RemoveLargeStripesTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_executed(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/remove_stripe/test/stripe_removal_test.py
+++ b/mantidimaging/core/operations/remove_stripe/test/stripe_removal_test.py
@@ -15,7 +15,7 @@ class StripeRemovalTest(unittest.TestCase):
     Tests that it executes and returns a valid object, but does not verify the numerical results.
     """
     def __init__(self, *args, **kwargs):
-        super(StripeRemovalTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def do_stripe_removal(self, wf=None, ti=None, sf=None):
         images = th.generate_images()

--- a/mantidimaging/core/operations/remove_stripe_filtering/test/remove_stripe_filtering_test.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/test/remove_stripe_filtering_test.py
@@ -15,7 +15,7 @@ class RemoveStripeFilteringTest(unittest.TestCase):
     Tests that it executes and returns a valid object, but does not verify the numerical results.
     """
     def __init__(self, *args, **kwargs):
-        super(RemoveStripeFilteringTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_executed_1d(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/test/remove_stripe_sorting_fitting_test.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/test/remove_stripe_sorting_fitting_test.py
@@ -15,7 +15,7 @@ class RemoveStripeSortingFittingTest(unittest.TestCase):
     Tests that it executes and returns a valid object, but does not verify the numerical results.
     """
     def __init__(self, *args, **kwargs):
-        super(RemoveStripeSortingFittingTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_executed(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/ring_removal/test/ring_removal_test.py
+++ b/mantidimaging/core/operations/ring_removal/test/ring_removal_test.py
@@ -18,7 +18,7 @@ class RingRemovalTest(unittest.TestCase):
     Tests return value and in-place modified data.
     """
     def __init__(self, *args, **kwargs):
-        super(RingRemovalTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_not_executed(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
@@ -20,7 +20,7 @@ class ROINormalisationTest(unittest.TestCase):
     Tests return value and in-place modified data.
     """
     def __init__(self, *args, **kwargs):
-        super(ROINormalisationTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_not_executed_empty_params(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/rotate_stack/test/rotate_stack_test.py
+++ b/mantidimaging/core/operations/rotate_stack/test/rotate_stack_test.py
@@ -17,7 +17,7 @@ class RotateStackTest(unittest.TestCase):
     Tests return value and in-place modified data.
     """
     def __init__(self, *args, **kwargs):
-        super(RotateStackTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_executed_par(self):
         self.do_execute()

--- a/mantidimaging/core/utility/command_line_arguments.py
+++ b/mantidimaging/core/utility/command_line_arguments.py
@@ -43,7 +43,7 @@ class CommandLineArguments:
         Creates a singleton for storing the command line arguments.
         """
         if cls._instance is None:
-            cls._instance = super(CommandLineArguments, cls).__new__(cls)
+            cls._instance = super().__new__(cls)
             if path:
                 if not os.path.exists(path):
                     _log_and_exit(f"Path {path} doesn't exist. Exiting.")

--- a/mantidimaging/core/utility/cuda_check.py
+++ b/mantidimaging/core/utility/cuda_check.py
@@ -62,7 +62,7 @@ class CudaChecker:
         Creates a singleton for storing the result of the Cuda check.
         """
         if cls._instance is None:
-            cls._instance = super(CudaChecker, cls).__new__(cls)
+            cls._instance = super().__new__(cls)
             cls._cuda_is_present = _cuda_is_present()
         return cls._instance
 

--- a/mantidimaging/core/utility/progress_reporting/console_progress_bar.py
+++ b/mantidimaging/core/utility/progress_reporting/console_progress_bar.py
@@ -20,7 +20,7 @@ def _print_ascii_progress_bar(progress, bar_len, prefix='', suffix=''):
 
 class ConsoleProgressBar(ProgressHandler):
     def __init__(self, width=70):
-        super(ConsoleProgressBar, self).__init__()
+        super().__init__()
         self.width = width
 
     def progress_update(self):

--- a/mantidimaging/core/utility/progress_reporting/test/progress_test.py
+++ b/mantidimaging/core/utility/progress_reporting/test/progress_test.py
@@ -11,7 +11,7 @@ from mantidimaging.core.utility.progress_reporting.progress import ProgressHisto
 
 class ProgressTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
-        super(ProgressTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_basic_single_step(self):
         p = Progress(num_steps=2)

--- a/mantidimaging/core/utility/test/execution_timer_test.py
+++ b/mantidimaging/core/utility/test/execution_timer_test.py
@@ -9,7 +9,7 @@ from mantidimaging.core.utility import ExecutionTimer
 
 class ExecutionTimerTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
-        super(ExecutionTimerTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_execute(self):
         t = ExecutionTimer()

--- a/mantidimaging/core/utility/test/size_calculator_test.py
+++ b/mantidimaging/core/utility/test/size_calculator_test.py
@@ -10,7 +10,7 @@ from mantidimaging.core.utility import size_calculator
 
 class SizeCalculatorTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
-        super(SizeCalculatorTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_full_size_mb(self):
         shape = (40234079, 1, 13)

--- a/mantidimaging/eyes_tests/test_main_window.py
+++ b/mantidimaging/eyes_tests/test_main_window.py
@@ -8,7 +8,7 @@ from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
 
 class MainWindowTest(BaseEyesTest):
     def setUp(self):
-        super(MainWindowTest, self).setUp()
+        super().setUp()
 
     def test_main_window_opens(self):
         self.check_target()

--- a/mantidimaging/eyes_tests/test_operations_window.py
+++ b/mantidimaging/eyes_tests/test_operations_window.py
@@ -8,7 +8,7 @@ from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
 
 class OperationsWindowTest(BaseEyesTest):
     def setUp(self):
-        super(OperationsWindowTest, self).setUp()
+        super().setUp()
 
     def tearDown(self):
         self.imaging.filters.close()

--- a/mantidimaging/eyes_tests/test_reconstruct_window.py
+++ b/mantidimaging/eyes_tests/test_reconstruct_window.py
@@ -9,7 +9,7 @@ from mantidimaging.test_helpers.unit_test_helper import generate_images
 
 class ReconstructionWindowTest(BaseEyesTest):
     def setUp(self):
-        super(ReconstructionWindowTest, self).setUp()
+        super().setUp()
 
     def tearDown(self):
         self.imaging.recon.close()

--- a/mantidimaging/eyes_tests/test_welcome_window.py
+++ b/mantidimaging/eyes_tests/test_welcome_window.py
@@ -7,7 +7,7 @@ from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
 
 class WelcomeWindowTest(BaseEyesTest):
     def setUp(self):
-        super(WelcomeWindowTest, self).setUp()
+        super().setUp()
 
     @mock.patch("mantidimaging.gui.windows.welcome_screen.presenter.versions")
     @mock.patch("mantidimaging.gui.windows.welcome_screen.presenter.cuda_check")

--- a/mantidimaging/gui/dialogs/async_task/model.py
+++ b/mantidimaging/gui/dialogs/async_task/model.py
@@ -15,7 +15,7 @@ class AsyncTaskDialogModel(QObject):
     task_done = pyqtSignal(bool)
 
     def __init__(self):
-        super(AsyncTaskDialogModel, self).__init__()
+        super().__init__()
 
         self.task = TaskWorkerThread()
         self.task.finished.connect(self._on_task_exit)

--- a/mantidimaging/gui/dialogs/async_task/presenter.py
+++ b/mantidimaging/gui/dialogs/async_task/presenter.py
@@ -21,7 +21,7 @@ class AsyncTaskDialogPresenter(QObject, ProgressHandler):
     progress_updated = pyqtSignal(float, str)
 
     def __init__(self, view):
-        super(AsyncTaskDialogPresenter, self).__init__()
+        super().__init__()
 
         self.view = view
         self.progress_updated.connect(self.view.set_progress)

--- a/mantidimaging/gui/dialogs/async_task/task.py
+++ b/mantidimaging/gui/dialogs/async_task/task.py
@@ -25,7 +25,7 @@ class TaskWorkerThread(QThread):
         t.error
     """
     def __init__(self, parent=None):
-        super(TaskWorkerThread, self).__init__(parent)
+        super().__init__(parent)
 
         self.task_function = None
 

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -13,7 +13,7 @@ from PyQt5.QtCore import QTimer
 
 class AsyncTaskDialogView(BaseDialogView):
     def __init__(self, parent: QMainWindow, auto_close: bool = False):
-        super(AsyncTaskDialogView, self).__init__(parent, 'gui/ui/async_task_dialog.ui')
+        super().__init__(parent, 'gui/ui/async_task_dialog.ui')
 
         self.parent_view = parent
         self.presenter = AsyncTaskDialogPresenter(self)

--- a/mantidimaging/gui/dialogs/op_history_copy/presenter.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/presenter.py
@@ -21,7 +21,7 @@ class OpHistoryCopyDialogPresenter(BasePresenter):
     view: 'OpHistoryCopyDialogView'
 
     def __init__(self, view, images: Images, main_window):
-        super(OpHistoryCopyDialogPresenter, self).__init__(view)
+        super().__init__(view)
         self.view = view
         self.model = OpHistoryCopyDialogModel(images)
         self.main_window = main_window

--- a/mantidimaging/gui/dialogs/op_history_copy/view.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/view.py
@@ -17,7 +17,7 @@ class OpHistoryCopyDialogView(BaseDialogView):
     previewsLayout: QVBoxLayout
 
     def __init__(self, parent, images, main_window):
-        super(OpHistoryCopyDialogView, self).__init__(parent, "gui/ui/op_history_copy_dialog.ui")
+        super().__init__(parent, "gui/ui/op_history_copy_dialog.ui")
         self.presenter = OpHistoryCopyDialogPresenter(self, images, main_window)
 
         self.stackTargetSelector.stack_selected_uuid.connect(self.presenter.set_target_stack)

--- a/mantidimaging/gui/mvp_base/view.py
+++ b/mantidimaging/gui/mvp_base/view.py
@@ -12,7 +12,7 @@ LOG = getLogger(__name__)
 
 class BaseMainWindowView(QMainWindow):
     def __init__(self, parent, ui_file=None):
-        super(BaseMainWindowView, self).__init__(parent)
+        super().__init__(parent)
 
         if ui_file is not None:
             compile_ui(ui_file, self)
@@ -20,7 +20,7 @@ class BaseMainWindowView(QMainWindow):
     def closeEvent(self, e):
         LOG.debug('UI window closed')
         self.cleanup()
-        super(BaseMainWindowView, self).closeEvent(e)
+        super().closeEvent(e)
 
     def cleanup(self):
         """
@@ -47,7 +47,7 @@ class BaseMainWindowView(QMainWindow):
 
 class BaseDialogView(QDialog):
     def __init__(self, parent, ui_file=None):
-        super(BaseDialogView, self).__init__(parent)
+        super().__init__(parent)
 
         if ui_file is not None:
             compile_ui(ui_file, self)

--- a/mantidimaging/gui/widgets/palette_changer/presenter.py
+++ b/mantidimaging/gui/widgets/palette_changer/presenter.py
@@ -17,7 +17,7 @@ SAMPLE_SIZE = 15000  # Chosen to avoid Jenks becoming slow
 class PaletteChangerPresenter(BasePresenter):
     def __init__(self, view, other_hists: 'List[HistogramLUTItem]', main_hist: 'HistogramLUTItem', image: np.ndarray,
                  recon_mode: bool):
-        super(PaletteChangerPresenter, self).__init__(view)
+        super().__init__(view)
         self.rng = np.random.default_rng()
         self.other_hists = other_hists
         self.image = image

--- a/mantidimaging/gui/widgets/palette_changer/view.py
+++ b/mantidimaging/gui/widgets/palette_changer/view.py
@@ -14,7 +14,7 @@ class PaletteChangerView(BaseDialogView):
     colourMapComboBox: QComboBox
 
     def __init__(self, parent, main_hist, image, other_hists=[], recon_mode=False):
-        super(PaletteChangerView, self).__init__(parent, "gui/ui/palette_changer.ui")
+        super().__init__(parent, "gui/ui/palette_changer.ui")
         self.presenter = PaletteChangerPresenter(self, other_hists, main_hist, image, recon_mode)
         self.accepted.connect(self.presenter.change_colour_palette)
         self.colourMapComboBox.setCurrentText("spectrum")

--- a/mantidimaging/gui/widgets/removable_row_table_view.py
+++ b/mantidimaging/gui/widgets/removable_row_table_view.py
@@ -7,7 +7,7 @@ from PyQt5.QtWidgets import QTableView
 
 class RemovableRowTableView(QTableView):
     def keyPressEvent(self, e):
-        super(RemovableRowTableView, self).keyPressEvent(e)
+        super().keyPressEvent(e)
 
         # Handle deletion of a row from the table by pressing the [Delete] key
         if e.key() == Qt.Key.Key_Delete:

--- a/mantidimaging/gui/widgets/stack_selector/presenter.py
+++ b/mantidimaging/gui/widgets/stack_selector/presenter.py
@@ -23,7 +23,7 @@ class StackSelectorWidgetPresenter(BasePresenter):
     view: 'StackSelectorWidgetView'
 
     def __init__(self, view):
-        super(StackSelectorWidgetPresenter, self).__init__(view)
+        super().__init__(view)
 
         self.stack_uuids = []
         self.current_stack = None

--- a/mantidimaging/gui/widgets/stack_selector/view.py
+++ b/mantidimaging/gui/widgets/stack_selector/view.py
@@ -27,7 +27,7 @@ class StackSelectorWidgetView(QComboBox):
     main_window: 'MainWindowView'
 
     def __init__(self, parent):
-        super(StackSelectorWidgetView, self).__init__(parent)
+        super().__init__(parent)
 
         self.presenter = StackSelectorWidgetPresenter(self)
 

--- a/mantidimaging/gui/windows/load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/load_dialog/test/presenter_test.py
@@ -12,7 +12,7 @@ from mantidimaging.gui.windows.load_dialog.presenter import LoadPresenter, Notif
 
 class LoadDialogPresenterTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
-        super(LoadDialogPresenterTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def setUp(self):
         self.v = mock.MagicMock()

--- a/mantidimaging/gui/windows/load_dialog/view.py
+++ b/mantidimaging/gui/windows/load_dialog/view.py
@@ -33,7 +33,7 @@ class MWLoadDialog(QDialog):
     _flat_log_path: Optional[QTreeWidgetItem] = None
 
     def __init__(self, parent):
-        super(MWLoadDialog, self).__init__(parent)
+        super().__init__(parent)
         compile_ui('gui/ui/load_dialog.ui', self)
 
         self.parent_view = parent

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -21,7 +21,7 @@ def _matching_dataset_attribute(dataset_attribute: Optional[Images], images_id: 
 
 class MainWindowModel(object):
     def __init__(self):
-        super(MainWindowModel, self).__init__()
+        super().__init__()
 
         self.datasets: Dict[uuid.UUID, Dataset] = {}
         self.images: Dict[uuid.UUID, Images] = {}

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -45,7 +45,7 @@ class MainWindowPresenter(BasePresenter):
     view: 'MainWindowView'
 
     def __init__(self, view):
-        super(MainWindowPresenter, self).__init__(view)
+        super().__init__(view)
         self.model = MainWindowModel()
         self.stacks: Dict[uuid.UUID, StackVisualiserView] = {}
 

--- a/mantidimaging/gui/windows/main/save_dialog.py
+++ b/mantidimaging/gui/windows/main/save_dialog.py
@@ -20,7 +20,7 @@ def sort_by_tomo_and_recon(stack_id: StackId):
 
 class MWSaveDialog(QDialog):
     def __init__(self, parent, stack_list):
-        super(MWSaveDialog, self).__init__(parent)
+        super().__init__(parent)
         compile_ui('gui/ui/save_dialog.ui', self)
 
         self.browseButton.clicked.connect(lambda: select_directory(self.savePath, "Browse"))

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -32,7 +32,7 @@ def test_matching_dataset_attribute_returns_false_for_none():
 
 class MainWindowModelTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
-        super(MainWindowModelTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def setUp(self):
         self.model = MainWindowModel()

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -20,7 +20,7 @@ from mantidimaging.test_helpers.unit_test_helper import generate_images
 
 class MainWindowPresenterTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
-        super(MainWindowPresenterTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def setUp(self):
         self.view = mock.create_autospec(MainWindowView)

--- a/mantidimaging/gui/windows/main/test/save_test.py
+++ b/mantidimaging/gui/windows/main/test/save_test.py
@@ -11,7 +11,7 @@ from mantidimaging.test_helpers.start_qapplication import start_qapplication
 
 class SaveDialogTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
-        super(SaveDialogTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_sort_stack_names_order(self):
         stack_list = [

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -80,7 +80,7 @@ class MainWindowView(BaseMainWindowView):
     save_dialogue: Optional[MWSaveDialog] = None
 
     def __init__(self, open_dialogs=True):
-        super(MainWindowView, self).__init__(None, "gui/ui/main_window.ui")
+        super().__init__(None, "gui/ui/main_window.ui")
 
         self.setWindowTitle("Mantid Imaging")
 
@@ -394,7 +394,7 @@ class MainWindowView(BaseMainWindowView):
 
         if should_close:
             # Pass close event to parent
-            super(MainWindowView, self).closeEvent(event)
+            super().closeEvent(event)
 
         else:
             # Ignore the close event, keeping window open

--- a/mantidimaging/gui/windows/nexus_load_dialog/view.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/view.py
@@ -34,7 +34,7 @@ class NexusLoadDialog(QDialog):
     allPushButton: QStackedWidget
 
     def __init__(self, parent):
-        super(NexusLoadDialog, self).__init__(parent)
+        super().__init__(parent)
         compile_ui("gui/ui/nexus_load_dialog.ui", self)
 
         self.parent_view = parent

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -43,7 +43,7 @@ class FilterPreviews(GraphicsLayoutWidget):
     histogram: Optional[PlotItem]
 
     def __init__(self, parent=None, **kwargs):
-        super(FilterPreviews, self).__init__(parent, **kwargs)
+        super().__init__(parent, **kwargs)
 
         widget_location = self.mapToGlobal(QPoint(self.width() // 2, 0))
         # allow the widget to take up to 80% of the desktop's height

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -25,7 +25,7 @@ class FiltersWindowModel(object):
     filter_widget_kwargs: Dict[str, Any]
 
     def __init__(self, presenter: 'FiltersWindowPresenter'):
-        super(FiltersWindowModel, self).__init__()
+        super().__init__()
 
         self.presenter = presenter
         # Update the local filter registry

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -93,7 +93,7 @@ class FiltersWindowPresenter(BasePresenter):
     divider = "------------------------------------"
 
     def __init__(self, view: 'FiltersWindowView', main_window: 'MainWindowView'):
-        super(FiltersWindowPresenter, self).__init__(view)
+        super().__init__(view)
 
         self.model = FiltersWindowModel(self)
         self._main_window = main_window

--- a/mantidimaging/gui/windows/operations/test/test_model.py
+++ b/mantidimaging/gui/windows/operations/test/test_model.py
@@ -18,7 +18,7 @@ class FiltersWindowModelTest(unittest.TestCase):
     ROI_PARAMETER = (4, 3, 2, 1)
 
     def __init__(self, *args, **kwargs):
-        super(FiltersWindowModelTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @classmethod
     def setUpClass(cls):

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -59,7 +59,7 @@ class FiltersWindowView(BaseMainWindowView):
     filterSelector: QComboBox
 
     def __init__(self, main_window: 'MainWindowView'):
-        super(FiltersWindowView, self).__init__(main_window, 'gui/ui/filters_window.ui')
+        super().__init__(main_window, 'gui/ui/filters_window.ui')
 
         self.main_window = main_window
         self.presenter = FiltersWindowPresenter(self, main_window)
@@ -124,7 +124,7 @@ class FiltersWindowView(BaseMainWindowView):
         self.presenter = None
 
     def show(self):
-        super(FiltersWindowView, self).show()
+        super().show()
         self.auto_update_triggered.emit()
 
     def handle_filter_selection(self, filter_name: str):

--- a/mantidimaging/gui/windows/recon/point_table_model.py
+++ b/mantidimaging/gui/windows/recon/point_table_model.py
@@ -30,16 +30,16 @@ class CorTiltPointQtModel(QAbstractTableModel, CorTiltDataModel):
 
     def populate_slice_indices(self, begin, end, count, cor=0.0):
         self.beginResetModel()
-        super(CorTiltPointQtModel, self).populate_slice_indices(begin, end, count, cor)
+        super().populate_slice_indices(begin, end, count, cor)
         self.endResetModel()
 
     def sort_points(self):
         self.layoutAboutToBeChanged.emit()
-        super(CorTiltPointQtModel, self).sort_points()
+        super().sort_points()
         self.layoutChanged.emit()
 
     def set_point(self, idx, slice_idx: int = None, cor: float = None, reset_results=True):
-        super(CorTiltPointQtModel, self).set_point(idx, slice_idx, cor, reset_results)
+        super().set_point(idx, slice_idx, cor, reset_results)
         self.dataChanged.emit(self.index(idx, 0), self.index(idx, 1))
 
     def columnCount(self, parent=None):
@@ -51,7 +51,7 @@ class CorTiltPointQtModel(QAbstractTableModel, CorTiltDataModel):
         return self.num_points
 
     def flags(self, index):
-        flags = super(CorTiltPointQtModel, self).flags(index)
+        flags = super().flags(index)
         flags |= Qt.ItemFlag.ItemIsEditable
         return flags
 

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -50,7 +50,7 @@ class ReconstructWindowPresenter(BasePresenter):
     view: 'ReconstructWindowView'
 
     def __init__(self, view: 'ReconstructWindowView', main_window):
-        super(ReconstructWindowPresenter, self).__init__(view)
+        super().__init__(view)
         self.view = view
         self.model = ReconstructWindowModel(self.view.cor_table_model)
         self.allowed_recon_kwargs: Dict[str, List[str]] = self.model.load_allowed_recon_kwargs()

--- a/mantidimaging/gui/windows/stack_choice/view.py
+++ b/mantidimaging/gui/windows/stack_choice/view.py
@@ -31,7 +31,7 @@ class StackChoiceView(BaseMainWindowView):
 
     def __init__(self, original_stack: Images, new_stack: Images,
                  presenter: Union['StackComparePresenter', 'StackChoicePresenter'], parent: Optional[QMainWindow]):
-        super(StackChoiceView, self).__init__(parent, "gui/ui/stack_choice_window.ui")
+        super().__init__(parent, "gui/ui/stack_choice_window.ui")
 
         self.presenter = presenter
 

--- a/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
+++ b/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
@@ -16,7 +16,7 @@ class MetadataDialog(QDialog):
     Dialog used to show a pretty formatted version of the image metadata.
     """
     def __init__(self, parent: QWidget, images: Images):
-        super(MetadataDialog, self).__init__(parent)
+        super().__init__(parent)
 
         self.setWindowTitle('Image Metadata')
         self.setSizeGripEnabled(True)

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -42,7 +42,7 @@ class StackVisualiserPresenter(BasePresenter):
     view: 'StackVisualiserView'
 
     def __init__(self, view: 'StackVisualiserView', images: Images):
-        super(StackVisualiserPresenter, self).__init__(view)
+        super().__init__(view)
         self.model = SVModel()
         self.images = images
         self._current_image_index = 0

--- a/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
@@ -19,7 +19,7 @@ class StackVisualiserPresenterTest(unittest.TestCase):
     test_data: Images
 
     def __init__(self, *args, **kwargs):
-        super(StackVisualiserPresenterTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def setUp(self):
         self.test_data = th.generate_images()

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -21,7 +21,7 @@ class StackVisualiserViewTest(unittest.TestCase):
     window: MainWindowView
 
     def __init__(self, *args, **kwargs):
-        super(StackVisualiserViewTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def setUp(self):
         with mock.patch("mantidimaging.gui.windows.main.view.WelcomeScreenPresenter"):

--- a/mantidimaging/gui/windows/welcome_screen/presenter.py
+++ b/mantidimaging/gui/windows/welcome_screen/presenter.py
@@ -21,7 +21,7 @@ class WelcomeScreenPresenter(BasePresenter):
         if view is None:
             view = WelcomeScreenView(parent, self)
 
-        super(WelcomeScreenPresenter, self).__init__(view)
+        super().__init__(view)
         self.settings = QSettings()
         self.link_count = 0
 

--- a/mantidimaging/gui/windows/welcome_screen/view.py
+++ b/mantidimaging/gui/windows/welcome_screen/view.py
@@ -10,7 +10,7 @@ from mantidimaging.gui.mvp_base import BaseDialogView
 
 class WelcomeScreenView(BaseDialogView):
     def __init__(self, parent, presenter):
-        super(WelcomeScreenView, self).__init__(parent, "gui/ui/welcome_screen_dialog.ui")
+        super().__init__(parent, "gui/ui/welcome_screen_dialog.ui")
         base_path = finder.ROOT_PATH
 
         bg_image = os.path.join(base_path, "gui/ui/images/welcome_screen_background.png")

--- a/mantidimaging/test_helpers/file_outputting_test_case.py
+++ b/mantidimaging/test_helpers/file_outputting_test_case.py
@@ -8,7 +8,7 @@ import unittest
 
 class FileOutputtingTestCase(unittest.TestCase):
     def __init__(self, *args, **kwargs):
-        super(FileOutputtingTestCase, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.output_directory = None
 


### PR DESCRIPTION
### Issue

Closes #860

### Description

Simplifies calls to `super()` by removing the `classname` and `self` arguments that are no longer required in python 3.

### Testing & Acceptance Criteria 

Ensure that all tests pass

### Documentation

Added to the release notes
