### PR TITLE
Update CIL to 21.3

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -33,9 +33,9 @@ requirements:
     - h5py=3.4.*
     - sarepy=2020.07
     - psutil=5.8.*
-    - cil=21.2.*
-    - cil-astra=21.2.*
-    - ccpi-regulariser=20.9
+    - cil=21.3.*
+    - cil-astra=21.3.*
+    - ccpi-regulariser=21.0.*
 
 build:
   number: 1

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -18,6 +18,8 @@ New Features
 - #1197 : Dataset Tree View : Show tab from treeview
 - #1200 : Default save option set to float32
 - #1235 : Improvements to input value defaults and spin box step sizes
+- #1230 : Update CIL to 21.3 reducing memory requirements
+
 
 Fixes
 -----

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -6,6 +6,7 @@ channels:
   - conda-forge
   - ccpi
   - algotom
+  - intel
 dependencies:
   - mantidimaging
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ channels:
   - conda-forge
   - ccpi
   - algotom
+  - intel
 # Dependencies that can be installed with conda should be in conda/meta.yaml
 dependencies:
   - mantidimaging

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -148,7 +148,7 @@ class CILRecon(BaseRecon):
         projection_size = full_size_KB(images.data.shape, images.dtype)
         recon_volume_shape = images.data.shape[2], images.data.shape[2], images.data.shape[1]
         recon_volume_size = full_size_KB(recon_volume_shape, images.dtype)
-        estimated_mem_required = 5 * projection_size + 25 * recon_volume_size
+        estimated_mem_required = 5 * projection_size + 13 * recon_volume_size
         free_mem = system_free_memory().kb()
 
         if (estimated_mem_required > free_mem):


### PR DESCRIPTION
Waiting on #1233 

### Issue
Closes #1224 

### Description

Update CIL to 21.3
Add intel channel for Integrated Performance Primitives
Adjust memory limit it CILRecon
No API changes needed.

### Testing & Acceptance Criteria

Test a reconstruction with CIL


### Documentation
release_notes
