### PR TITLE
Fix call to prepare_sinogram

### DIFF
--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -180,7 +180,7 @@ class CILRecon(BaseRecon):
 
             # stick it into an AcquisitionData
             data = ag.allocate(None)
-            data.fill(BaseRecon.prepare_sinogram(images, recon_params))
+            data.fill(BaseRecon.prepare_sinogram(images.data, recon_params))
             data.reorder('astra')
 
             alpha = recon_params.alpha

--- a/mantidimaging/core/reconstruct/tomopy_recon.py
+++ b/mantidimaging/core/reconstruct/tomopy_recon.py
@@ -63,7 +63,7 @@ class TomopyRecon(BaseRecon):
 
         kwargs = {
             'ncore': ncores,
-            'tomo': BaseRecon.prepare_sinogram(images, recon_params),
+            'tomo': BaseRecon.prepare_sinogram(images.data, recon_params),
             'sinogram_order': images._is_sinograms,
             'theta': images.projection_angles(recon_params.max_projection_angle).value,
             'center': [cor.value for cor in cors],


### PR DESCRIPTION
Fix CIL reconstruction.

### Issue

Closes #1232

### Description

In 40a6e61261c0ec0987b9d01fc58784a6c388399f the argument was accidentally changed from `images.data` to `images`. Change it back.

### Testing & Acceptance Criteria 

Follow steps on #1232 to do a reconstruction with CIL

### Documentation

Fixes a recent regression so does not need to be on release notes.