### PR TITLE
Change default save format to float32

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -16,6 +16,7 @@ New Features
 - #1205 : Linearisation correction for beam hardening
 - #1197 : Dataset Tree View: Delete image stack
 - #1197 : Dataset Tree View : Show tab from treeview
+- #1200 : Default save option set to float32
 
 Fixes
 -----

--- a/mantidimaging/eyes_tests/test_main_window.py
+++ b/mantidimaging/eyes_tests/test_main_window.py
@@ -26,7 +26,7 @@ class MainWindowTest(BaseEyesTest):
 
     def test_main_window_file_menu_image_loaded(self):
         self.imaging.presenter = mock.MagicMock()
-        self.imaging.presenter.stack_names = [""]
+        self.imaging.presenter.stacks = {"": ""}
         self.imaging.update_shortcuts()
 
         self.show_menu(self.imaging, self.imaging.menuFile)

--- a/mantidimaging/eyes_tests/test_save_dialog.py
+++ b/mantidimaging/eyes_tests/test_save_dialog.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from unittest import mock
+
+from collections import namedtuple
+from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
+
+
+class SaveDialogTest(BaseEyesTest):
+    def test_save_dialog_opens_with_no_dataset(self):
+        self.imaging.actionSave.trigger()
+
+        self.check_target(widget=self.imaging.save_dialogue)
+
+    def test_save_dialog_opens_with_dataset(self):
+        TestTuple = namedtuple('TestTuple', ['id', 'name'])
+        type(self.imaging).stack_list = mock.PropertyMock(return_value=[TestTuple('', 'Test Stack')])
+        self.imaging.actionSave.trigger()
+
+        self.check_target(widget=self.imaging.save_dialogue)

--- a/mantidimaging/gui/ui/save_dialog.ui
+++ b/mantidimaging/gui/ui/save_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>406</width>
-    <height>216</height>
+    <width>444</width>
+    <height>229</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -49,12 +49,12 @@
        </property>
        <item>
         <property name="text">
-         <string>int16</string>
+         <string>float32</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>float32</string>
+         <string>int16</string>
         </property>
        </item>
       </widget>


### PR DESCRIPTION
### Issue

Closes #1200

### Description

Changes the order of the options in the pixel bit depth dropdown so that float32 is at index 0 (the default selection). I changed the option order rather than the default index so that the dropdown menu will still open downwards if clicked.
Note that changing the option order seems to have automatically changed the dialog's width and height settings.

I've also added a couple of new screenshot tests for the save dialog - one for opening the dialog without any images selected (not actually possible via the UI I don't think, but the code tries to handle this scenario just in case). The second test is for opening with images selected, which worked either with mocking or by actually loading data, so I've gone for the first option here but happy to change if actually loading the data is preferred.

### Testing & Acceptance Criteria 

All tests pass.
Loading a dataset and then opening the save dialog shows the float32 option selected by default in the pixel bit depth dropdown.
Saving using either option applies the correct pixel bit depth to the saved images.

### Documentation

Issue number added to release notes.
