### PR TITLE
Handle case where disconnect called with no signal connected

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -25,6 +25,7 @@ Fixes
 - #1178 : --operation argument sometimes opens wrong operation
 - #1117 : Median operation preserves NaNs
 - #1151 : IndexError with sinograms and stripe tools
+- #1174 : TypeError in link_before_after_histogram_scales
 
 
 Developer Changes

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -124,7 +124,11 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay):
     def unlink_sibling_histogram(self):
         for img_view in chain([self], self.histogram_siblings):
             img_view.hist.vb.linkView(ViewBox.YAxis, None)
-            img_view.hist.sigLevelChangeFinished.disconnect()
+            try:
+                img_view.hist.sigLevelChangeFinished.disconnect()
+            except TypeError:
+                # This is expected if there are slots currently connected
+                pass
 
     def update_sibling_histograms(self):
         hist_range = self.hist.getLevels()


### PR DESCRIPTION
Will happen when switching between 2 filters that both have histograms unlinked.

### Issue
Closes #1174 

### Description

Use try accept to catch this case.

https://www.riverbankcomputing.com/static/Docs/PyQt5/signals_slots.html#disconnect

### Testing & Acceptance Criteria 
Should be no exception when following steps on #1174

(Not that error shows in terminal not in GUI)

### Documentation

release_notes
