### PR TITLE
UI improvements to various input default settings

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -17,6 +17,7 @@ New Features
 - #1197 : Dataset Tree View: Delete image stack
 - #1197 : Dataset Tree View : Show tab from treeview
 - #1200 : Default save option set to float32
+- #1235 : Improvements to input value defaults and spin box step sizes
 
 Fixes
 -----

--- a/mantidimaging/core/operations/arithmetic/arithmetic.py
+++ b/mantidimaging/core/operations/arithmetic/arithmetic.py
@@ -86,18 +86,18 @@ class ArithmeticFilter(BaseFilter):
                                                    on_change=on_change,
                                                    default_value=0.0,
                                                    valid_values=(-MAX_SPIN_BOX, MAX_SPIN_BOX),
-                                                   tooltip="The add value.")
+                                                   tooltip="The add value.",
+                                                   single_step_size=1e-6)
         _, sub_input_widget = add_property_to_form('Subtract',
                                                    Type.FLOAT,
                                                    form=form,
                                                    on_change=on_change,
                                                    default_value=0.0,
                                                    valid_values=(-MAX_SPIN_BOX, MAX_SPIN_BOX),
-                                                   tooltip="The subtract value.")
+                                                   tooltip="The subtract value.",
+                                                   single_step_size=1e-6)
 
-        add_input_widget.setSingleStep(1e-6)
         add_input_widget.setDecimals(6)
-        sub_input_widget.setSingleStep(1e-6)
         sub_input_widget.setDecimals(6)
 
         return {

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -74,7 +74,7 @@ class OutliersFilter(BaseFilter):
         _, diff_field = add_property_to_form('Difference',
                                              'float',
                                              1000,
-                                             valid_values=(0, 1000),
+                                             valid_values=(0, 10000),
                                              form=form,
                                              on_change=on_change,
                                              tooltip="Difference between pixels that will be used to spot outliers.\n"

--- a/mantidimaging/core/operations/outliers/test/outliers_test.py
+++ b/mantidimaging/core/operations/outliers/test/outliers_test.py
@@ -67,6 +67,11 @@ class OutliersTest(unittest.TestCase):
 
         self.assertEqual(0, gui_dict["diff_field"].minimum())
 
+    def test_gui_diff_spin_box_max_is_10000(self):
+        gui_dict = OutliersFilter.register_gui(mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
+
+        self.assertEqual(10000, gui_dict["diff_field"].maximum())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -74,8 +74,8 @@ class RebinFilter(BaseFilter):
                                          0.5, (0.0, 1.0),
                                          on_change=on_change,
                                          tooltip="Factor by which the data will be rebinned, "
-                                         "e.g. 0.5 is 50% reduced size")
-        factor.setSingleStep(0.05)
+                                         "e.g. 0.5 is 50% reduced size",
+                                         single_step_size=0.05)
 
         # Rebin to target shape options
         shape_range = (0, 9999)

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -20,7 +20,7 @@ from mantidimaging.gui.widgets.stack_selector import StackSelectorWidgetView
 
 
 def modes() -> List[str]:
-    return ['Preserve Max', 'Stack Average', 'Flat Field']
+    return ['Stack Average', 'Preserve Max', 'Flat Field']
 
 
 class RoiNormalisationFilter(BaseFilter):

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -362,13 +362,13 @@
                     <bool>false</bool>
                    </property>
                    <property name="decimals">
-                    <number>3</number>
+                    <number>4</number>
                    </property>
                    <property name="minimum">
                     <double>-99.989999999999995</double>
                    </property>
                    <property name="singleStep">
-                    <double>0.100000000000000</double>
+                    <double>0.010000000000000</double>
                    </property>
                   </widget>
                  </item>
@@ -385,13 +385,13 @@
                     <bool>false</bool>
                    </property>
                    <property name="decimals">
-                    <number>3</number>
+                    <number>4</number>
                    </property>
                    <property name="minimum">
                     <double>-99.989999999999995</double>
                    </property>
                    <property name="singleStep">
-                    <double>0.100000000000000</double>
+                    <double>0.010000000000000</double>
                    </property>
                   </widget>
                  </item>
@@ -415,13 +415,13 @@
                     <bool>false</bool>
                    </property>
                    <property name="decimals">
-                    <number>3</number>
+                    <number>4</number>
                    </property>
                    <property name="minimum">
                     <double>-99.989999999999995</double>
                    </property>
                    <property name="singleStep">
-                    <double>0.100000000000000</double>
+                    <double>0.010000000000000</double>
                    </property>
                   </widget>
                  </item>
@@ -431,13 +431,13 @@
                     <bool>false</bool>
                    </property>
                    <property name="decimals">
-                    <number>3</number>
+                    <number>4</number>
                    </property>
                    <property name="minimum">
                     <double>-99.989999999999995</double>
                    </property>
                    <property name="singleStep">
-                    <double>0.100000000000000</double>
+                    <double>0.010000000000000</double>
                    </property>
                   </widget>
                  </item>

--- a/mantidimaging/gui/utility/qt_helpers.py
+++ b/mantidimaging/gui/utility/qt_helpers.py
@@ -98,7 +98,8 @@ def add_property_to_form(label: str,
                          on_change=None,
                          form=None,
                          filters_view=None,
-                         run_on_press=None) -> Tuple[Union[QLabel, QLineEdit], Any]:
+                         run_on_press=None,
+                         single_step_size=None) -> Tuple[Union[QLabel, QLineEdit], Any]:
     """
     Adds a property to the algorithm dialog.
 
@@ -114,6 +115,7 @@ def add_property_to_form(label: str,
     :param form: Form layout to optionally add the new widgets to
     :param filters_view: The Filter window view - passed to connect Type.STACK to the stack change events
     :param run_on_press: Run this function on press, specialisation for button.
+    :param single_step_size: Optionally provide a step size for a SpinBox widget.
     """
     # By default assume the left hand side widget will be a label
     left_widget = QLabel(label)
@@ -136,6 +138,12 @@ def add_property_to_form(label: str,
 
         if default_value:
             box.setValue(cast_func(default_value))
+
+        if single_step_size is not None:
+            box.setSingleStep(single_step_size)
+        elif cast_func == float:
+            # Override the default step size for QDoubleSpinBox
+            box.setSingleStep(0.1)
 
     if dtype in ['str', Type.STR, 'tuple', Type.TUPLE, 'NoneType', Type.NONETYPE, 'list', Type.LIST]:
         # TODO for tuple with numbers add N combo boxes, N = number of tuple members


### PR DESCRIPTION
### Issue

Closes #1235

### Description

Changes to a few input settings and defaults, as described on the issue. In particular, `float` spin boxes in the Operations window will now default to a step size of 0.1 unless specified otherwise, which I think was the suggestion on the issue. I've implemented it so that `int` spin boxes could now also have a step size specified, but this isn't currently in use and the default will be the `QSpinBox` default.

The Difference spin box for the Remove Outliers filter now has a range of 0 - 10000. The spin boxes are actually set to render with this range by default, but I've continued passing it in as a parameter as I took from the issue that this range was needed specifically here.

### Testing & Acceptance Criteria 

Ensure that all tests pass.
Check the following in the UI:

_Operations window_
1)  Remove Outliers -> Difference field: range is 0 - 10000
2) ROI Normalisation -> Normalisation mode field: default selection is Stack Average
3) For all filters the spin box step sizes are 0.1 for float and 1 for int, other than those that are set differently (the different ones will be Arithmetic `Add` and `Subtract`, Rebin `Factor` and Median `Kernel Size`). Please shout if there are any where the step size seems like it will no longer be appropriate.

_Recon window_
1) BHC tab inputs all have 4 decimal places and step size is 0.01

### Documentation

Issue details added to release notes
