### PR TITLE
Version check update command uses mamba if available

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -44,3 +44,4 @@ Developer Changes
 - #1182 : Handle exception in _post_filter
 - #1173 : Sometimes tests open many operations windows
 - #860  : Clean up super calls to use python 3 syntax
+- #1181 : Version check update command uses mamba if available


### PR DESCRIPTION
In CheckVersion use mamba for checking installed version and in the suggested update command if it is available

### Issue

Closes #1181 

### Description
Check if path has mamba, if not fall back to conda. Use in the installed version check and suggested command.

### Testing 

Added test for choosing between conda and mamba

### Acceptance Criteria 

You can trigger the update message in the terminal by uncommenting line 37 in mantidimaging/core/utility/version_check.py

### Documentation

release_notes
