### PR TITLE
Remove run_ring_removal argument from RingRemovalFilter.filter_func

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -30,6 +30,7 @@ Fixes
 - #1117 : Median operation preserves NaNs
 - #1151 : IndexError with sinograms and stripe tools
 - #1174 : TypeError in link_before_after_histogram_scales
+- #1161 : Remove run_ring_removal argument from Ring Removal operation and always run filter
 
 
 Developer Changes

--- a/mantidimaging/core/operations/ring_removal/test/ring_removal_test.py
+++ b/mantidimaging/core/operations/ring_removal/test/ring_removal_test.py
@@ -4,9 +4,6 @@
 import unittest
 from unittest.mock import Mock
 
-import numpy as np
-import numpy.testing as npt
-
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.ring_removal import RingRemovalFilter
 
@@ -19,16 +16,6 @@ class RingRemovalTest(unittest.TestCase):
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-    def test_not_executed(self):
-        images = th.generate_images()
-
-        # invalid threshold
-        run_ring_removal = False
-
-        original = np.copy(images.data[0])
-        result = RingRemovalFilter.filter_func(images, run_ring_removal, cores=1)
-        npt.assert_equal(result.data[0], original)
 
     def test_execute_wrapper_return_is_runnable(self):
         """


### PR DESCRIPTION
### Issue

Closes #1161 

### Description

Removes the run_ring_removal argument from `RingRemovalFilter.filter_func` and deletes the unit test for checking its functionality.

### Testing & Acceptance Criteria 

All tests pass and the ring removal filter operation still works as expected.

### Documentation

Added issue number to release notes.
The Ring Removal operation is documented in the user guide here: 

> https://mantidproject.github.io/mantidimaging/user_guide/operations/index.html#ring-removal

However, it looks like this documentation should update automatically.
