### PR TITLE
Remove obsolete __init__ methods from test classes

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -49,3 +49,4 @@ Developer Changes
 - #860  : Clean up super calls to use python 3 syntax
 - #1181 : Version check update command uses mamba if available
 - #1212 : Model Change: Put everything in datasets
+- #1245 : Remove empty init methods from test classes

--- a/mantidimaging/core/gpu/test/gpu_test.py
+++ b/mantidimaging/core/gpu/test/gpu_test.py
@@ -21,9 +21,6 @@ class GPUTest(unittest.TestCase):
 
     Tests return value and in-place modified data.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     @unittest.skipIf(GPU_NOT_AVAIL, reason=GPU_SKIP_REASON)
     def test_numpy_pad_modes_match_scipy_median_modes(self):
         """

--- a/mantidimaging/core/operations/circular_mask/test/circular_mask_test.py
+++ b/mantidimaging/core/operations/circular_mask/test/circular_mask_test.py
@@ -14,9 +14,6 @@ class CircularMaskTest(unittest.TestCase):
 
     Tests return value and in-place modified data.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_executed(self):
         images = th.generate_images()
 

--- a/mantidimaging/core/operations/clip_values/test/clip_values_test.py
+++ b/mantidimaging/core/operations/clip_values/test/clip_values_test.py
@@ -16,9 +16,6 @@ class ClipValuesFilterTest(unittest.TestCase):
 
     Tests return value and in-place modified data.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_execute_min_only(self):
         images = th.generate_images()
 

--- a/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
+++ b/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
@@ -17,9 +17,6 @@ class CropCoordsTest(unittest.TestCase):
 
     Tests return value only.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_executed_only_volume(self):
         # Check that the filter is  executed when:
         #   - valid Region of Interest is provided

--- a/mantidimaging/core/operations/divide/test/divide_test.py
+++ b/mantidimaging/core/operations/divide/test/divide_test.py
@@ -12,9 +12,6 @@ from mantidimaging.core.operations.divide import DivideFilter
 
 
 class DivideTest(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_divide_with_zero_does_nothing(self):
         images = th.generate_images()
         copy = np.copy(images.data)

--- a/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
+++ b/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
@@ -20,9 +20,6 @@ class FlatFieldingTest(unittest.TestCase):
 
     Tests return value and in-place modified data.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def _make_images(self) -> Tuple[Images, Images, Images, Images, Images]:
         images = th.generate_images()
         flat_before = th.generate_images()

--- a/mantidimaging/core/operations/gaussian/test/gaussian_test.py
+++ b/mantidimaging/core/operations/gaussian/test/gaussian_test.py
@@ -22,9 +22,6 @@ class GaussianTest(unittest.TestCase):
     This does not scale and parallel execution is always faster on any
     reasonably sized data (e.g. 143,512,512)
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_not_executed(self):
         images = th.generate_images()
 

--- a/mantidimaging/core/operations/median_filter/test/median_filter_test.py
+++ b/mantidimaging/core/operations/median_filter/test/median_filter_test.py
@@ -22,9 +22,6 @@ class MedianTest(unittest.TestCase):
 
     Tests return value and in-place modified data.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_not_executed(self):
         images = th.generate_images()
 

--- a/mantidimaging/core/operations/nan_removal/test/nan_removal_test.py
+++ b/mantidimaging/core/operations/nan_removal/test/nan_removal_test.py
@@ -11,9 +11,6 @@ from mantidimaging.core.operations.nan_removal import NaNRemovalFilter
 
 
 class NaNRemovalFilterTest(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_replace_nans(self):
         images = th.generate_images()
         images.data[::, 0] = np.nan

--- a/mantidimaging/core/operations/outliers/test/outliers_test.py
+++ b/mantidimaging/core/operations/outliers/test/outliers_test.py
@@ -20,9 +20,6 @@ class OutliersTest(unittest.TestCase):
 
     Tests return value only.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_executed(self):
         images = th.generate_images()
 

--- a/mantidimaging/core/operations/rebin/test/rebin_test.py
+++ b/mantidimaging/core/operations/rebin/test/rebin_test.py
@@ -17,9 +17,6 @@ class RebinTest(unittest.TestCase):
 
     Tests return value only.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_not_executed_rebin_negative(self):
         images = th.generate_images()
 

--- a/mantidimaging/core/operations/remove_all_stripe/test/remove_all_stripe_test.py
+++ b/mantidimaging/core/operations/remove_all_stripe/test/remove_all_stripe_test.py
@@ -14,9 +14,6 @@ class RemoveAllStripesTest(unittest.TestCase):
 
     Tests that it executes and returns a valid object, but does not verify the numerical results.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_executed(self):
         images = th.generate_images()
         control = images.copy()

--- a/mantidimaging/core/operations/remove_dead_stripe/test/remove_dead_stripe_test.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/test/remove_dead_stripe_test.py
@@ -14,9 +14,6 @@ class RemoveDeadStripesTest(unittest.TestCase):
 
     Tests that it executes and returns a valid object, but does not verify the numerical results.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_executed(self):
         images = th.generate_images()
         control = images.copy()

--- a/mantidimaging/core/operations/remove_large_stripe/test/remove_large_stripe_test.py
+++ b/mantidimaging/core/operations/remove_large_stripe/test/remove_large_stripe_test.py
@@ -14,9 +14,6 @@ class RemoveLargeStripesTest(unittest.TestCase):
 
     Tests that it executes and returns a valid object, but does not verify the numerical results.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_executed(self):
         images = th.generate_images()
         control = images.copy()

--- a/mantidimaging/core/operations/remove_stripe/test/stripe_removal_test.py
+++ b/mantidimaging/core/operations/remove_stripe/test/stripe_removal_test.py
@@ -14,9 +14,6 @@ class StripeRemovalTest(unittest.TestCase):
 
     Tests that it executes and returns a valid object, but does not verify the numerical results.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def do_stripe_removal(self, wf=None, ti=None, sf=None):
         images = th.generate_images()
         control = images.copy()

--- a/mantidimaging/core/operations/remove_stripe_filtering/test/remove_stripe_filtering_test.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/test/remove_stripe_filtering_test.py
@@ -14,9 +14,6 @@ class RemoveStripeFilteringTest(unittest.TestCase):
 
     Tests that it executes and returns a valid object, but does not verify the numerical results.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_executed_1d(self):
         images = th.generate_images()
         control = images.copy()

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/test/remove_stripe_sorting_fitting_test.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/test/remove_stripe_sorting_fitting_test.py
@@ -14,9 +14,6 @@ class RemoveStripeSortingFittingTest(unittest.TestCase):
 
     Tests that it executes and returns a valid object, but does not verify the numerical results.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_executed(self):
         images = th.generate_images()
         control = images.copy()

--- a/mantidimaging/core/operations/ring_removal/test/ring_removal_test.py
+++ b/mantidimaging/core/operations/ring_removal/test/ring_removal_test.py
@@ -14,9 +14,6 @@ class RingRemovalTest(unittest.TestCase):
 
     Tests return value and in-place modified data.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_execute_wrapper_return_is_runnable(self):
         """
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)

--- a/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
@@ -19,9 +19,6 @@ class ROINormalisationTest(unittest.TestCase):
 
     Tests return value and in-place modified data.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_not_executed_empty_params(self):
         images = th.generate_images()
 

--- a/mantidimaging/core/operations/rotate_stack/test/rotate_stack_test.py
+++ b/mantidimaging/core/operations/rotate_stack/test/rotate_stack_test.py
@@ -16,9 +16,6 @@ class RotateStackTest(unittest.TestCase):
 
     Tests return value and in-place modified data.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_executed_par(self):
         self.do_execute()
 

--- a/mantidimaging/core/utility/progress_reporting/test/progress_test.py
+++ b/mantidimaging/core/utility/progress_reporting/test/progress_test.py
@@ -10,9 +10,6 @@ from mantidimaging.core.utility.progress_reporting.progress import ProgressHisto
 
 
 class ProgressTest(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_basic_single_step(self):
         p = Progress(num_steps=2)
 

--- a/mantidimaging/core/utility/test/execution_timer_test.py
+++ b/mantidimaging/core/utility/test/execution_timer_test.py
@@ -8,9 +8,6 @@ from mantidimaging.core.utility import ExecutionTimer
 
 
 class ExecutionTimerTest(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_execute(self):
         t = ExecutionTimer()
         self.assertEqual(t.total_seconds, None)

--- a/mantidimaging/core/utility/test/size_calculator_test.py
+++ b/mantidimaging/core/utility/test/size_calculator_test.py
@@ -9,9 +9,6 @@ from mantidimaging.core.utility import size_calculator
 
 
 class SizeCalculatorTest(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_full_size_mb(self):
         shape = (40234079, 1, 13)
         dtype = np.int32

--- a/mantidimaging/gui/windows/load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/load_dialog/test/presenter_test.py
@@ -11,9 +11,6 @@ from mantidimaging.gui.windows.load_dialog.presenter import LoadPresenter, Notif
 
 
 class LoadDialogPresenterTest(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def setUp(self):
         self.v = mock.MagicMock()
         self.p = LoadPresenter(self.v)

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -30,9 +30,6 @@ def test_matching_dataset_attribute_returns_false_for_none():
 
 
 class MainWindowModelTest(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def setUp(self):
         self.model = MainWindowModel()
         self.model_class_name = f"{self.model.__module__}.{self.model.__class__.__name__}"

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -19,9 +19,6 @@ from mantidimaging.test_helpers.unit_test_helper import generate_images
 
 
 class MainWindowPresenterTest(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def setUp(self):
         self.view = mock.create_autospec(MainWindowView)
         self.view.load_dialogue = mock.create_autospec(MWLoadDialog)

--- a/mantidimaging/gui/windows/main/test/save_test.py
+++ b/mantidimaging/gui/windows/main/test/save_test.py
@@ -10,9 +10,6 @@ from mantidimaging.test_helpers.start_qapplication import start_qapplication
 
 
 class SaveDialogTest(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def test_sort_stack_names_order(self):
         stack_list = [
             StackId(uuid.uuid4(), "Stack 1"),

--- a/mantidimaging/gui/windows/operations/test/test_model.py
+++ b/mantidimaging/gui/windows/operations/test/test_model.py
@@ -17,9 +17,6 @@ class FiltersWindowModelTest(unittest.TestCase):
     APPLY_BEFORE_AFTER_MAGIC_NUMBER = 42
     ROI_PARAMETER = (4, 3, 2, 1)
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     @classmethod
     def setUpClass(cls):
         cls.test_data = th.generate_images()

--- a/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
@@ -18,9 +18,6 @@ from mantidimaging.gui.windows.stack_visualiser import StackVisualiserPresenter,
 class StackVisualiserPresenterTest(unittest.TestCase):
     test_data: Images
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def setUp(self):
         self.test_data = th.generate_images()
         # mock the view so it has the same methods

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -20,9 +20,6 @@ class StackVisualiserViewTest(unittest.TestCase):
     test_data: Images
     window: MainWindowView
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def setUp(self):
         with mock.patch("mantidimaging.gui.windows.main.view.WelcomeScreenPresenter"):
             self.window = MainWindowView()


### PR DESCRIPTION
### Issue

Closes #1245

### Description

Removes empty `__init__()` methods from test classes.

### Testing & Acceptance Criteria 

All tests pass

### Documentation

Added issue to release notes
