### PR TITLE
Change ordering of axis linking in MIMiniImageView

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -32,6 +32,7 @@ Fixes
 - #1174 : TypeError in link_before_after_histogram_scales
 - #1161 : Remove run_ring_removal argument from Ring Removal operation and always run filter
 - #1226 : AttributeError when trying to open reconstruction auto colour dialog
+- #1236 : Aspect ratio not preserved in COR inspector or operations window
 
 
 Developer Changes

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -97,7 +97,8 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay):
         image = self.im.image
         if image is not None and pos.y < image.shape[0] and pos.x < image.shape[1]:
             pixel_value = image[pos.y, pos.x]
-            self.details.setText(f"{self.name}: {pixel_value:.6f}")
+            value_string = ("%.6f" % pixel_value)[:8]
+            self.details.setText(f"{self.name}: {value_string}")
 
     def link_sibling_axis(self):
         # Linking multiple viewboxes with locked aspect ratios causes

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -105,8 +105,8 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay):
         # https://github.com/pyqtgraph/pyqtgraph/issues/1348
         self.vb.setAspectLocked(True)
         for view1, view2 in pairwise(chain([self], self.axis_siblings)):
-            view1.vb.linkView(ViewBox.XAxis, view2.vb)
-            view1.vb.linkView(ViewBox.YAxis, view2.vb)
+            view2.vb.linkView(ViewBox.XAxis, view1.vb)
+            view2.vb.linkView(ViewBox.YAxis, view1.vb)
             view2.vb.setAspectLocked(False)
 
     def unlink_sibling_axis(self):


### PR DESCRIPTION
View will pull range from its linked view. Need range to be pulled from the first sibling which has the fixed aspect ratio.

### Issue
Closes #1236 

### Description

9753383 is still needed to prevent run away zooming when resizing linked views.

Fixes is to invert the links.
`vb1.linkView(ViewBox.XAxis, vb2)`
means that v1 will pull the range from vb2. So if vb1 has a fixed aspect but vb2 does not, then vb2 can end up with an odd aspect. 

See https://github.com/pyqtgraph/pyqtgraph/issues/1348

### Testing & Acceptance Criteria 

This might cause tiny changes that trigger applitools.

Check that aspect ratio is preserved in operations, recon, and COR refine (in recon, click `add` then `refine`).

Check that there is no weird zooming behaviour when resizing any of those windows. 

### Documentation

release_notes
