### PR TITLE
Move names into Images

### DIFF
--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -20,7 +20,7 @@ from mantidimaging.core.utility.sensible_roi import SensibleROI
 
 class Images:
     NO_FILENAME_IMAGE_TITLE_STRING = "Image: {}"
-    name: Optional[str]
+    name: str
 
     def __init__(self,
                  data: np.ndarray,

--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -305,3 +305,13 @@ class Images:
 
     def clear_proj180deg(self):
         self._proj180deg = None
+
+    def make_name_unique(self, existing_names: List[str]):
+        name = self.name
+        num = 1
+        while self.name in existing_names:
+            num += 1
+            self.name = f"{name}_{num}"
+
+            if num > 1000:
+                raise ValueError(f"Could not make unique name for: {name}")

--- a/mantidimaging/core/data/images.py
+++ b/mantidimaging/core/data/images.py
@@ -3,6 +3,7 @@
 
 import datetime
 import json
+import os.path
 import uuid
 from copy import deepcopy
 from typing import List, Optional, Any, Dict, Union, TextIO
@@ -19,19 +20,22 @@ from mantidimaging.core.utility.sensible_roi import SensibleROI
 
 class Images:
     NO_FILENAME_IMAGE_TITLE_STRING = "Image: {}"
+    name: Optional[str]
 
     def __init__(self,
                  data: np.ndarray,
                  filenames: Optional[List[str]] = None,
                  indices: Union[List[int], Indices, None] = None,
                  metadata: Optional[Dict[str, Any]] = None,
-                 sinograms: bool = False):
+                 sinograms: bool = False,
+                 name: Optional[str] = None):
         """
 
         :param data: Images of the Sample/Projection data
         :param filenames: All filenames that were matched for loading
         :param indices: Indices that were actually loaded
         :param metadata: Properties to copy when creating a new stack from an existing one
+        :param name: A name for the stack
         """
 
         self._data = data
@@ -46,6 +50,14 @@ class Images:
         self._proj180deg: Optional[Images] = None
         self._log_file: Optional[IMATLogFile] = None
         self._projection_angles: Optional[ProjectionAngles] = None
+
+        if name is None:
+            if filenames is not None:
+                self.name = os.path.splitext(os.path.basename(filenames[0]))[0]
+            else:
+                self.name = "untitled"
+        else:
+            self.name = name
 
     def __eq__(self, other):
         if isinstance(other, Images):

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -215,3 +215,17 @@ class ImagesTest(unittest.TestCase):
     def test_cant_change_id(self):
         with self.assertRaises(Exception):
             generate_images().id = "id"
+
+    def test_default_name(self):
+        imgs = Images(np.asarray([1]))
+        self.assertEqual(imgs.name, "untitled")
+
+    def test_name_from_filenames(self):
+        filenames = ["/path/tomo_0000.tiff", "/path/tomo_0001.tiff"]
+        imgs = Images(np.asarray([1]), filenames=filenames)
+        self.assertEqual(imgs.name, "tomo_0000")
+
+    def test_name_from_argument(self):
+        filenames = ["/path/tomo_0000.tiff", "/path/tomo_0001.tiff"]
+        imgs = Images(np.asarray([1]), filenames=filenames, name="given")
+        self.assertEqual(imgs.name, "given")

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -229,3 +229,15 @@ class ImagesTest(unittest.TestCase):
         filenames = ["/path/tomo_0000.tiff", "/path/tomo_0001.tiff"]
         imgs = Images(np.asarray([1]), filenames=filenames, name="given")
         self.assertEqual(imgs.name, "given")
+
+    def test_name_unique_new(self):
+        existing = []
+        imgs = Images(np.asarray([1]), name="tomo")
+        imgs.make_name_unique(existing)
+        self.assertEqual(imgs.name, "tomo")
+
+    def test_name_unique_exists(self):
+        existing = ["tomo"]
+        imgs = Images(np.asarray([1]), name="tomo")
+        imgs.make_name_unique(existing)
+        self.assertEqual(imgs.name, "tomo_2")

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -95,7 +95,7 @@ class BaseEyesTest(unittest.TestCase):
     def _load_data_set(self):
         dataset = loader.load(file_names=[LOAD_SAMPLE])
         dataset.sample.name = "Stack 1"
-        vis = self.imaging.presenter.create_new_stack(dataset, "Stack 1")
+        vis = self.imaging.presenter.create_new_stack(dataset)
 
         QApplication.sendPostedEvents()
 

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -94,6 +94,7 @@ class BaseEyesTest(unittest.TestCase):
 
     def _load_data_set(self):
         dataset = loader.load(file_names=[LOAD_SAMPLE])
+        dataset.sample.name = "Stack 1"
         vis = self.imaging.presenter.create_new_stack(dataset, "Stack 1")
 
         QApplication.sendPostedEvents()

--- a/mantidimaging/eyes_tests/test_reconstruct_window.py
+++ b/mantidimaging/eyes_tests/test_reconstruct_window.py
@@ -43,6 +43,7 @@ class ReconstructionWindowTest(BaseEyesTest):
 
     def test_negative_nan_overlay(self):
         images = generate_images(seed=10)
+        images.name = "bad_data"
         self.imaging.presenter.create_new_stack(images, "bad_data")
         QApplication.sendPostedEvents()
 

--- a/mantidimaging/eyes_tests/test_reconstruct_window.py
+++ b/mantidimaging/eyes_tests/test_reconstruct_window.py
@@ -44,7 +44,7 @@ class ReconstructionWindowTest(BaseEyesTest):
     def test_negative_nan_overlay(self):
         images = generate_images(seed=10)
         images.name = "bad_data"
-        self.imaging.presenter.create_new_stack(images, "bad_data")
+        self.imaging.presenter.create_new_stack(images)
         QApplication.sendPostedEvents()
 
         images.data[0:, 7:] = 0

--- a/mantidimaging/gui/dialogs/op_history_copy/presenter.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/presenter.py
@@ -49,7 +49,7 @@ class OpHistoryCopyDialogPresenter(BasePresenter):
             history = self.history_with_new_ops(selected_ops)
             result.metadata = history
         if self.view.copy:
-            self.main_window.create_new_stack(result, "Result")
+            self.main_window.create_new_stack(result)
 
     def history_with_new_ops(self, applied_ops: Iterable[ImageOperation]) -> Dict[str, Any]:
         history = self.model.images.metadata.copy() if self.model.images.metadata else {}

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -151,9 +151,8 @@ class MainWindowPresenter(BasePresenter):
     def get_active_stack_visualisers(self) -> List[StackVisualiserView]:
         return [stack for stack in self.active_stacks.values()]  # type:ignore
 
-    def create_new_180_stack(self, container: Images, title: str):
-        title = self.create_stack_name(title)
-        _180_stack_vis = self.view.create_stack_window(container, title)
+    def create_new_180_stack(self, container: Images):
+        _180_stack_vis = self.view.create_stack_window(container)
 
         current_stack_visualisers = self.get_active_stack_visualisers()
         if len(current_stack_visualisers) > 1:
@@ -303,22 +302,6 @@ class MainWindowPresenter(BasePresenter):
         if stack_id is None:
             raise RuntimeError(f"Failed to get stack with name {stack_name}")
         return self.model.add_180_deg_to_dataset(stack_id, _180_deg_file)  # todo: assumes the stack is the sample?
-
-    def create_stack_name(self, filename: str) -> str:
-        """
-        Creates a suitable name for a newly loaded stack.
-        """
-        # Avoid file extensions in names
-        filename = os.path.splitext(filename)[0]
-
-        # Avoid duplicate names
-        name = filename
-        num = 1
-        while name in self.stack_names:
-            num += 1
-            name = f"{filename}_{num}"
-
-        return name
 
     def add_projection_angles_to_sample(self, stack_name: str, proj_angles: ProjectionAngles):
         stack_id = self.get_stack_id_by_name(stack_name)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -144,9 +144,8 @@ class MainWindowPresenter(BasePresenter):
         log.error(msg)
         self.show_error(msg, traceback.format_exc())
 
-    def _add_stack(self, images: Images, filename: str, sample_dock):
-        name = self.create_stack_name(os.path.basename(filename))
-        stack_visualiser = self.view.create_stack_window(images, title=f"{name}")
+    def _add_stack(self, images: Images, sample_dock):
+        stack_visualiser = self.view.create_stack_window(images)
         self.view.tabifyDockWidget(sample_dock, stack_visualiser)
         self.stacks[images.id] = stack_visualiser
 
@@ -173,40 +172,38 @@ class MainWindowPresenter(BasePresenter):
         return _180_stack_vis
 
     def create_new_stack(self, container: Union[Images, Dataset], title: str):
-        title = self.create_stack_name(title)
 
         if isinstance(container, Images):
             sample = container
         else:
             sample = container.sample
 
-        sample_stack_vis = self.view.create_stack_window(sample, title)
+        sample_stack_vis = self.view.create_stack_window(sample)
         self.stacks[sample_stack_vis.id] = sample_stack_vis
 
         current_stack_visualisers = self.get_active_stack_visualisers()
         if len(current_stack_visualisers) > 0:
             self.view.tabifyDockWidget(current_stack_visualisers[0], sample_stack_vis)
 
-        dataset_tree_item = self.view.create_dataset_tree_widget_item(title, container.id)
+        dataset_tree_item = self.view.create_dataset_tree_widget_item(sample.name, container.id)
 
         if isinstance(container, Dataset):
             self.view.create_child_tree_item(dataset_tree_item, container.sample.id, "Projections")
             if container.flat_before and container.flat_before.filenames:
-                self._add_stack(container.flat_before, container.flat_before.filenames[0], sample_stack_vis)
+                self._add_stack(container.flat_before, sample_stack_vis)
                 self.view.create_child_tree_item(dataset_tree_item, container.flat_before.id, "Flat Before")
             if container.flat_after and container.flat_after.filenames:
-                self._add_stack(container.flat_after, container.flat_after.filenames[0], sample_stack_vis)
+                self._add_stack(container.flat_after, sample_stack_vis)
                 self.view.create_child_tree_item(dataset_tree_item, container.flat_after.id, "Flat After")
             if container.dark_before and container.dark_before.filenames:
-                self._add_stack(container.dark_before, container.dark_before.filenames[0], sample_stack_vis)
+                self._add_stack(container.dark_before, sample_stack_vis)
                 self.view.create_child_tree_item(dataset_tree_item, container.dark_before.id, "Dark Before")
             if container.dark_after and container.dark_after.filenames:
-                self._add_stack(container.dark_after, container.dark_after.filenames[0], sample_stack_vis)
+                self._add_stack(container.dark_after, sample_stack_vis)
                 self.view.create_child_tree_item(dataset_tree_item, container.dark_after.id, "Dark After")
             if container.sample.has_proj180deg() and container.sample.proj180deg.filenames:  # type: ignore
                 self._add_stack(
                     container.sample.proj180deg,  # type: ignore
-                    container.sample.proj180deg.filenames[0],  # type: ignore
                     sample_stack_vis)
                 self.view.create_child_tree_item(
                     dataset_tree_item,
@@ -219,7 +216,7 @@ class MainWindowPresenter(BasePresenter):
                     container.sample.proj180deg = Images(np.reshape(closest_projection,
                                                                     (1, ) + closest_projection.shape),
                                                          name=f"{title}_180")
-                    self._add_stack(container.sample.proj180deg, f"{title}_180", sample_stack_vis)
+                    self._add_stack(container.sample.proj180deg, sample_stack_vis)
                     self.view.create_child_tree_item(dataset_tree_item, container.sample.proj180deg.id, "180")
 
         if len(current_stack_visualisers) > 1:

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -123,6 +123,7 @@ class MainWindowPresenter(BasePresenter):
         log = getLogger(__name__)
 
         if task.was_successful():
+            task.result.name = os.path.splitext(task.kwargs['file_path'])[0]
             self.create_new_stack(task.result, self.create_stack_name(task.kwargs['file_path']))
             task.result = None
         else:
@@ -215,8 +216,9 @@ class MainWindowPresenter(BasePresenter):
                 closest_projection, diff = find_projection_closest_to_180(sample.projections,
                                                                           sample.projection_angles().value)
                 if diff <= THRESHOLD_180 or self.view.ask_to_use_closest_to_180(diff):
-                    container.sample.proj180deg = Images(
-                        np.reshape(closest_projection, (1, ) + closest_projection.shape))
+                    container.sample.proj180deg = Images(np.reshape(closest_projection,
+                                                                    (1, ) + closest_projection.shape),
+                                                         name=f"{title}_180")
                     self._add_stack(container.sample.proj180deg, f"{title}_180", sample_stack_vis)
                     self.view.create_child_tree_item(dataset_tree_item, container.sample.proj180deg.id, "180")
 

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -114,7 +114,7 @@ class MainWindowPresenter(BasePresenter):
     def load_nexus_file(self):
         dataset, title = self.view.nexus_load_dialog.presenter.get_dataset()
         self.model.add_dataset_to_model(dataset)
-        self.create_new_stack(dataset, title)
+        self.create_new_stack(dataset)
 
     def load_image_stack(self, file_path: str):
         start_async_task_view(self.view, self.model.load_images, self._on_stack_load_done, {'file_path': file_path})
@@ -124,7 +124,7 @@ class MainWindowPresenter(BasePresenter):
 
         if task.was_successful():
             task.result.name = os.path.splitext(task.kwargs['file_path'])[0]
-            self.create_new_stack(task.result, self.create_stack_name(task.kwargs['file_path']))
+            self.create_new_stack(task.result)
             task.result = None
         else:
             self._handle_task_error(self.LOAD_ERROR_STRING, log, task)
@@ -133,8 +133,7 @@ class MainWindowPresenter(BasePresenter):
         log = getLogger(__name__)
 
         if task.was_successful():
-            title = task.kwargs['parameters'].name
-            self.create_new_stack(task.result, title)
+            self.create_new_stack(task.result)
             task.result = None
         else:
             self._handle_task_error(self.LOAD_ERROR_STRING, log, task)
@@ -171,7 +170,7 @@ class MainWindowPresenter(BasePresenter):
 
         return _180_stack_vis
 
-    def create_new_stack(self, container: Union[Images, Dataset], title: str):
+    def create_new_stack(self, container: Union[Images, Dataset]):
 
         if isinstance(container, Images):
             sample = container
@@ -215,7 +214,7 @@ class MainWindowPresenter(BasePresenter):
                 if diff <= THRESHOLD_180 or self.view.ask_to_use_closest_to_180(diff):
                     container.sample.proj180deg = Images(np.reshape(closest_projection,
                                                                     (1, ) + closest_projection.shape),
-                                                         name=f"{title}_180")
+                                                         name=f"{sample.name}_180")
                     self._add_stack(container.sample.proj180deg, sample_stack_vis)
                     self.view.create_child_tree_item(dataset_tree_item, container.sample.proj180deg.id, "180")
 

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -155,7 +155,7 @@ class MainWindowPresenterTest(unittest.TestCase):
     def test_create_new_stack_images(self):
         self.view.model_changed.emit = mock.Mock()
         images = generate_images()
-        self.presenter.create_new_stack(images, "My title")
+        self.presenter.create_new_stack(images)
         self.assertEqual(1, len(self.presenter.stacks))
         self.view.model_changed.emit.assert_called_once()
 
@@ -173,11 +173,11 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.create_stack_window.side_effect = [first_stack_window, second_stack_window]
 
         self.view.model_changed.emit = mock.Mock()
-        self.presenter.create_new_stack(first_images, "My title")
+        self.presenter.create_new_stack(first_images)
         self.assertEqual(1, len(self.presenter.stacks))
         self.view.model_changed.emit.assert_called_once()
 
-        self.presenter.create_new_stack(second_images, "My title")
+        self.presenter.create_new_stack(second_images)
         assert self.view.tabifyDockWidget.call_count == 2
         assert self.view.findChild.call_count == 1
         mock_tab_bar = self.view.findChild.return_value
@@ -200,7 +200,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.dataset.flat_after.filenames = ["filename"] * 10
         self.dataset.dark_after.filenames = ["filename"] * 10
 
-        self.presenter.create_new_stack(self.dataset, "My title")
+        self.presenter.create_new_stack(self.dataset)
 
         self.assertEqual(6, len(self.presenter.stacks))
         self.view.model_changed.emit.assert_called_once()
@@ -222,7 +222,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         self.view.ask_to_use_closest_to_180.return_value = False
 
-        self.presenter.create_new_stack(self.dataset, "My title")
+        self.presenter.create_new_stack(self.dataset)
 
         self.assertEqual(6, len(self.presenter.stacks))
         self.view.model_changed.emit.assert_called_once()
@@ -242,7 +242,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         self.view.ask_to_use_closest_to_180.return_value = False
 
-        self.presenter.create_new_stack(self.dataset, "My title")
+        self.presenter.create_new_stack(self.dataset)
 
         self.assertEqual(5, len(self.presenter.stacks))
         self.view.model_changed.emit.assert_called_once()
@@ -262,7 +262,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         self.view.ask_to_use_closest_to_180.return_value = True
 
-        self.presenter.create_new_stack(self.dataset, "My title")
+        self.presenter.create_new_stack(self.dataset)
 
         self.assertEqual(6, len(self.presenter.stacks))
         self.view.model_changed.emit.assert_called_once()
@@ -287,7 +287,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.nexus_load_dialog.presenter.get_dataset.return_value = self.dataset, data_title
         self.presenter.create_new_stack = mock.Mock()
         self.presenter.load_nexus_file()
-        self.presenter.create_new_stack.assert_called_once_with(self.dataset, data_title)
+        self.presenter.create_new_stack.assert_called_once_with(self.dataset)
 
     def test_get_stack_widget_by_name_success(self):
         stack_window = mock.Mock()

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -51,23 +51,8 @@ class MainWindowPresenterTest(unittest.TestCase):
             stacks[uuid.uuid4()] = stack_mock
         self.presenter.stacks = stacks
 
-    def test_create_unique_name(self):
-        self.assertEqual("apple", self.presenter.create_stack_name("apple"))
-
-    def test_create_name_one_duplicate_stack_loaded(self):
-        self.create_mock_stacks_with_names(["test"])
-        self.assertEqual(self.presenter.create_stack_name("test"), "test_2")
-
-    def test_create_name_multiple_duplicate_stacks_loaded(self):
-        stack_names = ["test", "test_2", "test_3"]
-        self.create_mock_stacks_with_names(stack_names)
-        self.assertEqual(self.presenter.create_stack_name("test"), "test_4")
-
     def test_initial_stack_list(self):
         self.assertEqual(self.presenter.stack_names, [])
-
-    def test_create_name_strips_extension(self):
-        self.assertEqual(self.presenter.create_stack_name("test.tif"), "test")
 
     def test_failed_attempt_to_load_shows_error(self):
         # Create a filed load async task
@@ -348,9 +333,8 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.findChild.return_value = tab_bar_mock = mock.Mock()
 
         images_180 = generate_images()
-        title = "180-images"
 
-        self.assertIs(self.presenter.create_new_180_stack(images_180, title), stack_vis_180)
+        self.assertIs(self.presenter.create_new_180_stack(images_180), stack_vis_180)
         self.view.tabifyDockWidget.assert_called_once()
         self.view.model_changed.emit.assert_called_once()
         tab_bar_mock.setCurrentIndex.assert_called_once_with(2)
@@ -366,9 +350,8 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.create_stack_window.return_value = stack_vis_180 = mock.Mock()
 
         images_180 = generate_images()
-        title = "180-images"
 
-        self.assertIs(self.presenter.create_new_180_stack(images_180, title), stack_vis_180)
+        self.assertIs(self.presenter.create_new_180_stack(images_180), stack_vis_180)
         self.view.tabifyDockWidget.assert_not_called()
         self.view.model_changed.emit.assert_called_once()
         self.view.findChild.assert_not_called()

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -129,7 +129,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         dock_mock.widget.return_value = stack_visualiser_mock
         self.view.create_stack_window.return_value = dock_mock
 
-        self.presenter._add_stack(images, "myfilename", sample_dock_mock)
+        self.presenter._add_stack(images, sample_dock_mock)
 
         self.assertEqual(1, len(self.presenter.stack_list))
         self.view.tabifyDockWidget.assert_called_once_with(sample_dock_mock, dock_mock)
@@ -145,8 +145,8 @@ class MainWindowPresenterTest(unittest.TestCase):
         dock_mock.widget.return_value = stack_visualiser_mock
         self.view.create_stack_window.return_value = dock_mock
 
-        self.presenter._add_stack(images, "myfilename", sample_dock_mock)
-        self.presenter._add_stack(images2, "myfilename2", sample_dock_mock)
+        self.presenter._add_stack(images, sample_dock_mock)
+        self.presenter._add_stack(images2, sample_dock_mock)
 
         self.assertEqual(2, self.view.create_stack_window.call_count)
         self.view.tabifyDockWidget.assert_called_with(sample_dock_mock, dock_mock)

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -171,15 +171,14 @@ class MainWindowViewTest(unittest.TestCase):
                                  setCentralWidget: Mock = Mock(),
                                  addDockWidget: Mock = Mock()):
         images = generate_images()
-        title = "test_title"
         position = "test_position"
         floating = False
 
         self.view.splitter = splitter_mock = mock.Mock()
 
-        self.view.create_stack_window(images, title, position=position, floating=floating)
+        self.view.create_stack_window(images, position=position, floating=floating)
 
-        mock_sv.assert_called_once_with(self.view, title, images)
+        mock_sv.assert_called_once_with(self.view, images)
         dock = mock_sv.return_value
         setCentralWidget.assert_called_once_with(splitter_mock)
         addDockWidget.assert_called_once_with(position, dock)

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -57,8 +57,6 @@ class MainWindowViewTest(unittest.TestCase):
         _180_dataset = mock.MagicMock()
         self.presenter.add_180_deg_to_dataset.return_value = _180_dataset
         self.view.create_new_180_stack = mock.MagicMock()  # type: ignore
-        selected_filename = "selected_file.tif"
-        self.presenter.create_stack_name = mock.MagicMock(return_value=selected_filename)
 
         self.view.load_180_deg_dialog()
 
@@ -71,8 +69,7 @@ class MainWindowViewTest(unittest.TestCase):
                                                    initialFilter="Image File (*.tif *.tiff)")
         self.presenter.add_180_deg_to_dataset.assert_called_once_with(stack_name=selected_stack,
                                                                       _180_deg_file=selected_file)
-        self.presenter.create_stack_name.assert_called_once_with(selected_file)
-        self.view.create_new_180_stack.assert_called_once_with(_180_dataset, selected_filename)
+        self.view.create_new_180_stack.assert_called_once_with(_180_dataset)
 
     def test_execute_load(self):
         self.view.execute_load()

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -127,9 +127,9 @@ class MainWindowViewTest(unittest.TestCase):
 
     def test_create_new_stack(self):
         images = generate_images()
-        self.view.create_new_stack(images, "Test Title")
+        self.view.create_new_stack(images)
 
-        self.presenter.create_new_stack.assert_called_once_with(images, "Test Title")
+        self.presenter.create_new_stack.assert_called_once_with(images)
 
     def test_update_stack_with_images(self):
         images = generate_images()

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -360,6 +360,7 @@ class MainWindowView(BaseMainWindowView):
                             title: str,
                             position=Qt.DockWidgetArea.RightDockWidgetArea,
                             floating=False) -> StackVisualiserView:
+        stack.make_name_unique(self.stack_names)
         stack_vis = StackVisualiserView(self, title, stack)
 
         # this puts the new stack window into the centre of the window

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -343,8 +343,8 @@ class MainWindowView(BaseMainWindowView):
     def get_stack_history(self, stack_uuid):
         return self.presenter.get_stack_history(stack_uuid)
 
-    def create_new_stack(self, images: Images, title: str):
-        self.presenter.create_new_stack(images, title)
+    def create_new_stack(self, images: Images):
+        self.presenter.create_new_stack(images)
 
     def create_new_180_stack(self, images: Images, title: str):
         self.presenter.create_new_180_stack(images, title)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -261,7 +261,7 @@ class MainWindowView(BaseMainWindowView):
 
         _180_images = self.presenter.add_180_deg_to_dataset(stack_name=stack_to_add_180_deg_to,
                                                             _180_deg_file=selected_file)
-        self.create_new_180_stack(_180_images, self.presenter.create_stack_name(selected_file))
+        self.create_new_180_stack(_180_images)
 
     LOAD_PROJECTION_ANGLES_DIALOG_MESSAGE = "Which stack are the projection angles in DEGREES being loaded for?"
     LOAD_PROJECTION_ANGLES_FILE_DIALOG_CAPTION = "File with projection angles in DEGREES"
@@ -346,8 +346,8 @@ class MainWindowView(BaseMainWindowView):
     def create_new_stack(self, images: Images):
         self.presenter.create_new_stack(images)
 
-    def create_new_180_stack(self, images: Images, title: str):
-        self.presenter.create_new_180_stack(images, title)
+    def create_new_180_stack(self, images: Images):
+        self.presenter.create_new_180_stack(images)
 
     def update_stack_with_images(self, images: Images):
         self.presenter.update_stack_with_images(images)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -357,11 +357,10 @@ class MainWindowView(BaseMainWindowView):
 
     def create_stack_window(self,
                             stack: Images,
-                            title: str,
-                            position=Qt.DockWidgetArea.RightDockWidgetArea,
-                            floating=False) -> StackVisualiserView:
+                            position: Qt.DockWidgetArea = Qt.DockWidgetArea.RightDockWidgetArea,
+                            floating: bool = False) -> StackVisualiserView:
         stack.make_name_unique(self.stack_names)
-        stack_vis = StackVisualiserView(self, title, stack)
+        stack_vis = StackVisualiserView(self, stack)
 
         # this puts the new stack window into the centre of the window
         self.splitter.addWidget(stack_vis)

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -243,6 +243,7 @@ class NexusLoadPresenter:
         :return: A tuple containing the Dataset and the data title string.
         """
         sample_images = self._create_sample_images()
+        sample_images.name = self.title
         return Dataset(sample=sample_images,
                        flat_before=self._create_images_if_required(self.flat_before_array, "Flat Before"),
                        flat_after=self._create_images_if_required(self.flat_after_array, "Flat After"),

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -231,6 +231,7 @@ class ReconstructWindowPresenter(BasePresenter):
         slice_idx = self._get_slice_index(None)
         if images is not None:
             assert isinstance(self.model.stack, StackVisualiserView)
+            images.name = "Recon"
             self.view.show_recon_volume(images, self.model.stack_id)
             images.record_operation('AstraRecon.single_sino',
                                     'Slice Reconstruction',
@@ -283,6 +284,7 @@ class ReconstructWindowPresenter(BasePresenter):
             return
 
         assert isinstance(self.model.stack, StackVisualiserView)
+        task.result.name = "Recon"
         self.view.show_recon_volume(task.result, self.model.stack_id)
         self.view.recon_applied.emit()
 

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -256,7 +256,7 @@ class ReconstructWindowViewTest(unittest.TestCase):
         self.main_window.add_recon_to_dataset = add_to_dataset_mock = mock.Mock()
         stack_id = "id"
         self.view.show_recon_volume(data, stack_id)
-        create_new_stack_mock.assert_called_once_with(data, "Recon")
+        create_new_stack_mock.assert_called_once_with(data)
         add_to_dataset_mock.assert_called_once_with(data, stack_id)
 
     def test_get_stack_visualiser_when_uuid_is_none(self):

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -417,7 +417,7 @@ class ReconstructWindowView(BaseMainWindowView):
 
     def show_recon_volume(self, data: Images, stack_id: uuid.UUID):
         self.main_window.add_recon_to_dataset(data, stack_id)
-        self.main_window.create_new_stack(data, "Recon")
+        self.main_window.create_new_stack(data)
 
     def get_stack_visualiser(self, uuid) -> Optional['StackVisualiserView']:
         if uuid is not None:

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -102,6 +102,7 @@ class StackVisualiserPresenter(BasePresenter):
         with operation_in_progress("Creating sinograms, copying data, this may take a while",
                                    "The data is being copied, this may take a while.", self.view):
             new_stack = self.images.copy(flip_axes=True)
+            new_stack.name = self.images.name + "_sino"
             new_stack.record_operation(const.OPERATION_NAME_AXES_SWAP, display_name="Axes Swapped")
             self.view.parent_create_stack(new_stack, f"{self.view.name}_sino")
 
@@ -109,12 +110,14 @@ class StackVisualiserPresenter(BasePresenter):
         with operation_in_progress("Copying data, this may take a while",
                                    "The data is being copied, this may take a while.", self.view):
             new_images = self.images.copy(flip_axes=False)
+            new_images.name = self.images.name
             self.view.parent_create_stack(new_images, self.view.name)
 
     def dupe_stack_roi(self):
         with operation_in_progress("Copying data, this may take a while",
                                    "The data is being copied, this may take a while.", self.view):
             new_images = self.images.copy_roi(SensibleROI.from_points(*self.view.image_view.get_roi()))
+            new_images.name = self.images.name
             self.view.parent_create_stack(new_images, self.view.name)
 
     def get_num_images(self) -> int:

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -27,6 +27,7 @@ class StackVisualiserViewTest(unittest.TestCase):
 
     def _add_stack_visualiser(self) -> Tuple[StackVisualiserView, Images]:
         test_data = th.generate_images()
+        test_data.name = "Test Data"
         self.window.create_new_stack(test_data, "Test Data")
         view = self.window.get_stack_with_images(test_data)
         return view, test_data

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -28,7 +28,7 @@ class StackVisualiserViewTest(unittest.TestCase):
     def _add_stack_visualiser(self) -> Tuple[StackVisualiserView, Images]:
         test_data = th.generate_images()
         test_data.name = "Test Data"
-        self.window.create_new_stack(test_data, "Test Data")
+        self.window.create_new_stack(test_data)
         view = self.window.get_stack_with_images(test_data)
         return view, test_data
 

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -39,6 +39,10 @@ class StackVisualiserView(QDockWidget):
         # dock is set as a parent the window will be an independent floating
         # window
         super().__init__(title, parent)
+        if title != images.name:
+            # confirm that we are not causing changes before removing title
+            raise ValueError(f"StackVisualiserView: {title=} does not match {images.name=}")
+
         self.central_widget = QWidget(self)
         self.layout = QVBoxLayout()
         self.central_widget.setLayout(self.layout)

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -29,7 +29,7 @@ class StackVisualiserView(QDockWidget):
     presenter: StackVisualiserPresenter
     layout: QVBoxLayout
 
-    def __init__(self, parent: 'MainWindowView', title: str, images: Images):
+    def __init__(self, parent: 'MainWindowView', images: Images):
         # enforce not showing a single image
         assert images.data.ndim == 3, \
             "Data does NOT have 3 dimensions! Dimensions found: {0}".format(images.data.ndim)
@@ -38,10 +38,7 @@ class StackVisualiserView(QDockWidget):
         # having no parent, the window will be inside the QDockWidget. If the
         # dock is set as a parent the window will be an independent floating
         # window
-        super().__init__(title, parent)
-        if title != images.name:
-            # confirm that we are not causing changes before removing title
-            raise ValueError(f"StackVisualiserView: {title=} does not match {images.name=}")
+        super().__init__(images.name, parent)
 
         self.central_widget = QWidget(self)
         self.layout = QVBoxLayout()


### PR DESCRIPTION
### Issue

Progresses #1243

### Description

StackSelectorWidget needs to be able to get a list of stacks from the list of DataSets in the the main window model, instead of the open tags. This means that the names must be stored in the Images class. This PR is just for moving the names.

Add name to Images.

Ensure that this is set to the value that the StackVisualiserView would previously be given.

Remove title argument from StackVisualiserView

Propagate argument removal

### Testing &  Acceptance Criteria 

Test loading a dataset from tiffs and nexus. Loading a plain image stack. Doing a reconstruction. Duplicating a stack.

Tabs should be given sensible names and not left as "untitled".

### Documentation

release_notes
