### PR TITLE
Add more diagnostic to GuiSystemBase._click_messageBox

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -52,3 +52,4 @@ Developer Changes
 - #1181 : Version check update command uses mamba if available
 - #1212 : Model Change: Put everything in datasets
 - #1245 : Remove empty init methods from test classes
+- #1251 : System tests: test_correlate ValueError

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -53,7 +53,8 @@ class GuiSystemBase(unittest.TestCase):
                         QTest.mouseClick(button, Qt.LeftButton)
                         return
                 button_texts = [button.text() for button in widget.buttons()]
-                raise ValueError(f"Could not find button '{button_text}' in {button_texts}")
+                raise ValueError(f"Could not find button '{button_text}' in {button_texts}.\n"
+                                 f"Message box: {widget.windowTitle()} {widget.text()}")
 
     @classmethod
     def _click_InputDialog(cls, set_int: Optional[int] = None):

--- a/mantidimaging/gui/test/test_gui_system_reconstruction.py
+++ b/mantidimaging/gui/test/test_gui_system_reconstruction.py
@@ -20,6 +20,7 @@ class TestGuiSystemReconstruction(GuiSystemBase):
         assert isinstance(self.main_window.recon, ReconstructWindowView)  # for yapf
         self.assertTrue(self.main_window.recon.isVisible())
         self.recon_window = self.main_window.recon
+        self._wait_until(lambda: self.recon_window.presenter.model.stack is not None, max_retry=600)
 
     def tearDown(self) -> None:
         self.recon_window.close()


### PR DESCRIPTION
### Issue

Closes #1251 

### Description

The Recon window is not ready to work until the stack selector widget has found the list of current stacks and settled to one. This cause the `stack` attribute in the ReconstructWindowModel to be set.

### Testing & Acceptance Criteria 

Tests should pass

### Documentation

release_notes
