### PR TITLE
Fix test timeouts

### DIFF
--- a/mantidimaging/gui/dialogs/async_task/model.py
+++ b/mantidimaging/gui/dialogs/async_task/model.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from logging import getLogger
-from typing import Callable, Optional
+from typing import Callable, Optional, Set
 
 from PyQt5.QtCore import QObject, pyqtSignal
 
@@ -21,6 +21,11 @@ class AsyncTaskDialogModel(QObject):
         self.task.finished.connect(self._on_task_exit)
 
         self.on_complete_function: Optional[Callable] = None
+        self.tracker: Optional[Set] = None
+
+    def set_tracker(self, tracker: Set):
+        self.tracker = tracker
+        self.tracker.add(self)
 
     def do_execute_async(self):
         """
@@ -51,3 +56,9 @@ class AsyncTaskDialogModel(QObject):
             except Exception:
                 log.exception("Failed to run task completion callback")
                 raise
+            finally:
+                if self.tracker is not None:
+                    self.tracker.remove(self)
+        else:
+            if self.tracker is not None:
+                self.tracker.remove(self)

--- a/mantidimaging/gui/dialogs/async_task/presenter.py
+++ b/mantidimaging/gui/dialogs/async_task/presenter.py
@@ -5,7 +5,7 @@ import traceback
 from logging import getLogger
 from enum import Enum
 
-from typing import Callable
+from typing import Callable, Set
 
 from PyQt5.QtCore import QObject, pyqtSignal
 
@@ -46,6 +46,9 @@ class AsyncTaskDialogPresenter(QObject, ProgressHandler):
 
     def set_on_complete(self, f: Callable):
         self.model.on_complete_function = f
+
+    def set_tracker(self, tracker: Set):
+        self.model.set_tracker(tracker)
 
     def do_start_processing(self):
         """

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-from typing import Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Set
 
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.mvp_base import BaseDialogView
@@ -59,7 +59,11 @@ class AsyncTaskDialogView(BaseDialogView):
             self.show()
 
 
-def start_async_task_view(parent: QMainWindow, task: Callable, on_complete: Callable, kwargs: Optional[Dict] = None):
+def start_async_task_view(parent: QMainWindow,
+                          task: Callable,
+                          on_complete: Callable,
+                          kwargs: Optional[Dict] = None,
+                          tracker: Optional[Set[Any]] = None):
     atd = AsyncTaskDialogView(parent, auto_close=True)
     if not kwargs:
         kwargs = {'progress': Progress()}
@@ -70,4 +74,6 @@ def start_async_task_view(parent: QMainWindow, task: Callable, on_complete: Call
     atd.presenter.set_task(task)
     atd.presenter.set_on_complete(on_complete)
     atd.presenter.set_parameters(**kwargs)
+    if tracker is not None:
+        atd.presenter.set_tracker(tracker)
     atd.presenter.do_start_processing()

--- a/mantidimaging/gui/test/test_gui_system_reconstruction.py
+++ b/mantidimaging/gui/test/test_gui_system_reconstruction.py
@@ -23,6 +23,7 @@ class TestGuiSystemReconstruction(GuiSystemBase):
         self._wait_until(lambda: self.recon_window.presenter.model.stack is not None, max_retry=600)
 
     def tearDown(self) -> None:
+        self._wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
         self.recon_window.close()
         assert isinstance(self.main_window.recon, ReconstructWindowView)
         self.assertFalse(self.main_window.recon.isVisible())
@@ -33,9 +34,9 @@ class TestGuiSystemReconstruction(GuiSystemBase):
     def test_correlate(self):
         for _ in range(5):
             QTest.mouseClick(self.recon_window.correlateBtn, Qt.MouseButton.LeftButton)
-
             QTest.qWait(SHORT_DELAY)
             self._wait_until(lambda: self.recon_window.correlateBtn.isEnabled())
+            self._wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
 
     def test_minimise(self):
         for i in range(2, 6):
@@ -44,6 +45,7 @@ class TestGuiSystemReconstruction(GuiSystemBase):
 
             QTest.qWait(SHORT_DELAY)
             self._wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=200)
+            self._wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
             QTest.qWait(SHORT_DELAY)
 
     @classmethod
@@ -80,5 +82,6 @@ class TestGuiSystemReconstruction(GuiSystemBase):
             QTimer.singleShot(SHORT_DELAY, lambda: self._click_cor_inspect())
             QTest.mouseClick(self.recon_window.refineCorBtn, Qt.MouseButton.LeftButton)
             QTest.qWait(SHORT_DELAY * 2)
+            self._wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
 
         QTest.qWait(SHOW_DELAY)

--- a/mantidimaging/gui/test/test_gui_system_windows.py
+++ b/mantidimaging/gui/test/test_gui_system_windows.py
@@ -40,6 +40,7 @@ class TestGuiSystemWindows(GuiSystemBase):
         self.assertIsNotNone(self.main_window.recon)
         self.assertTrue(self.main_window.recon.isVisible())
         QTest.qWait(SHOW_DELAY)
+        self._wait_until(lambda: len(self.main_window.recon.presenter.async_tracker) == 0)
         self.main_window.recon.close()
         QTest.qWait(SHOW_DELAY)
         self._close_stack_tabs()

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -126,16 +126,17 @@ class ReconstructWindowModel(object):
                           recon_params: ReconstructionParameters,
                           progress: Progress = None) -> Optional[Images]:
         # Ensure we have some sample data
-        if self.images is None:
+        images = self.images
+        if images is None:
             return None
 
         # Perform single slice reconstruction
         reconstructor = get_reconstructor_for(recon_params.algorithm)
-        output_shape = (1, self.images.width, self.images.width)
-        recon: Images = Images.create_empty_images(output_shape, self.images.dtype, self.images.metadata)
-        recon.data[0] = reconstructor.single_sino(self.images.sino(slice_idx),
+        output_shape = (1, images.width, images.width)
+        recon: Images = Images.create_empty_images(output_shape, images.dtype, images.metadata)
+        recon.data[0] = reconstructor.single_sino(images.sino(slice_idx),
                                                   cor,
-                                                  self.images.projection_angles(recon_params.max_projection_angle),
+                                                  images.projection_angles(recon_params.max_projection_angle),
                                                   recon_params,
                                                   progress=progress)
         recon = self._apply_pixel_size(recon, recon_params)
@@ -143,12 +144,13 @@ class ReconstructWindowModel(object):
 
     def run_full_recon(self, recon_params: ReconstructionParameters, progress: Progress) -> Optional[Images]:
         # Ensure we have some sample data
-        if self.images is None:
+        images = self.images
+        if images is None:
             return None
         reconstructor = get_reconstructor_for(recon_params.algorithm)
         # get the image height based on the current ROI
-        recon = reconstructor.full(self.images, self.data_model.get_all_cors_from_regression(self.images.height),
-                                   recon_params, progress)
+        recon = reconstructor.full(images, self.data_model.get_all_cors_from_regression(images.height), recon_params,
+                                   progress)
 
         recon = self._apply_pixel_size(recon, recon_params, progress)
         return recon

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -148,9 +148,11 @@ class ReconWindowPresenterTest(unittest.TestCase):
     def test_do_reconstruct_volume(self, mock_async_task):
         self.presenter.do_reconstruct_volume()
         # kind of a pointless test, but at least it might capture some parameter change
-        mock_async_task.assert_called_once_with(self.view, self.presenter.model.run_full_recon,
+        mock_async_task.assert_called_once_with(self.view,
+                                                self.presenter.model.run_full_recon,
                                                 self.presenter._on_volume_recon_done,
-                                                {'recon_params': self.view.recon_params()})
+                                                {'recon_params': self.view.recon_params()},
+                                                tracker=self.presenter.async_tracker)
 
     @mock.patch('mantidimaging.gui.windows.recon.presenter.CORInspectionDialogView')
     def test_do_refine_selected_cor_declined(self, mock_corview):


### PR DESCRIPTION
Another attempt to fix the system test timeouts

### Issue

Closes  #1251

### Description

See #1251 for more analysis of the issue.

Add a set to keep track of running async tasks from the recon window. This allows the tests to wait until any remaining reconstructions have finished before closing the datasets

### Testing && Acceptance Criteria 
Tests should reliably pass now.

### Documentation

release_notes already claim to have fixed the issue, so don't need updating :-)
