### PR TITLE
Change operations to raise errors for invalid parameters

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -33,6 +33,7 @@ Fixes
 - #1161 : Remove run_ring_removal argument from Ring Removal operation and always run filter
 - #1226 : AttributeError when trying to open reconstruction auto colour dialog
 - #1236 : Aspect ratio not preserved in COR inspector or operations window
+- #1162 : Raise exceptions when invalid parameter values are passed to filter functions
 
 
 Developer Changes

--- a/mantidimaging/core/operations/arithmetic/arithmetic.py
+++ b/mantidimaging/core/operations/arithmetic/arithmetic.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-import logging
 from functools import partial
 from typing import Callable, Dict, Optional
 
@@ -57,11 +56,10 @@ class ArithmeticFilter(BaseFilter):
         :param progress: The Progress object isn't used.
         :return: The processed Images object.
         """
-        if div_val != 0 and mult_val != 0:
-            _execute(images.data, div_val, mult_val, add_val, sub_val, cores, progress)
-        else:
-            logging.getLogger(__name__).error("Unable to proceed with operation because division/multiplication value "
-                                              "is zero.")
+        if div_val == 0 or mult_val == 0:
+            raise ValueError("Unable to proceed with operation because division/multiplication value is zero.")
+
+        _execute(images.data, div_val, mult_val, add_val, sub_val, cores, progress)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/arithmetic/test/arithmetic_test.py
+++ b/mantidimaging/core/operations/arithmetic/test/arithmetic_test.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-import logging
 import unittest
 
 import numpy.testing as npt
@@ -13,10 +12,6 @@ class ArithmeticTest(unittest.TestCase):
     """
     Test arithmetic filter.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.logger = logging.getLogger("mantidimaging.core.operations.arithmetic.arithmetic")
-
     def test_div_only(self):
         images = th.generate_images()
 
@@ -34,18 +29,12 @@ class ArithmeticTest(unittest.TestCase):
     def test_cant_multiply_by_zero(self):
         images = th.generate_images()
 
-        with self.assertLogs(self.logger, level="ERROR") as log_mock:
-            result = ArithmeticFilter().filter_func(images.copy(), mult_val=0.0)
-        self.assertIn("Unable to proceed with operation", log_mock.output[0])
-        npt.assert_array_equal(images.data, result.data)
+        self.assertRaises(ValueError, ArithmeticFilter.filter_func, images, mult_val=0.0)
 
     def test_cant_divide_by_zero(self):
         images = th.generate_images()
 
-        with self.assertLogs(self.logger, level="ERROR") as log_mock:
-            result = ArithmeticFilter().filter_func(images.copy(), div_val=0.0)
-        self.assertIn("Unable to proceed with operation", log_mock.output[0])
-        npt.assert_array_equal(images.data, result.data)
+        self.assertRaises(ValueError, ArithmeticFilter.filter_func, images, div_val=0.0)
 
     def test_add_only(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/circular_mask/circular_mask.py
+++ b/mantidimaging/core/operations/circular_mask/circular_mask.py
@@ -38,11 +38,10 @@ class CircularMaskFilter(BaseFilter):
 
         :return: The processed 3D numpy.ndarray
         """
-        progress = Progress.ensure_instance(progress, num_steps=1, task_name='Circular Mask')
-
         if not circular_mask_ratio or not circular_mask_ratio < 1:
             raise ValueError(f'circular_mask_ratio must be > 0 and < 1. Value provided was {circular_mask_ratio}')
 
+        progress = Progress.ensure_instance(progress, num_steps=1, task_name='Circular Mask')
         tomopy = importer.do_importing('tomopy')
 
         with progress:

--- a/mantidimaging/core/operations/circular_mask/circular_mask.py
+++ b/mantidimaging/core/operations/circular_mask/circular_mask.py
@@ -40,15 +40,17 @@ class CircularMaskFilter(BaseFilter):
         """
         progress = Progress.ensure_instance(progress, num_steps=1, task_name='Circular Mask')
 
-        if circular_mask_ratio and 0 < circular_mask_ratio < 1:
-            tomopy = importer.do_importing('tomopy')
+        if not circular_mask_ratio or not circular_mask_ratio < 1:
+            raise ValueError(f'circular_mask_ratio must be > 0 and < 1. Value provided was {circular_mask_ratio}')
 
-            with progress:
-                progress.update(msg="Applying circular mask")
+        tomopy = importer.do_importing('tomopy')
 
-                # for some reason this doesn't like the ncore param, even though
-                # it's in the official tomopy docs
-                tomopy.circ_mask(arr=data.data, axis=0, ratio=circular_mask_ratio, val=circular_mask_value, ncore=cores)
+        with progress:
+            progress.update(msg="Applying circular mask")
+
+            # for some reason this doesn't like the ncore param, even though
+            # it's in the official tomopy docs
+            tomopy.circ_mask(arr=data.data, axis=0, ratio=circular_mask_ratio, val=circular_mask_value, ncore=cores)
 
         return data
 
@@ -58,7 +60,7 @@ class CircularMaskFilter(BaseFilter):
 
         _, radius_field = add_property_to_form('Radius',
                                                Type.FLOAT,
-                                               0.95, (0.0, 1.0),
+                                               0.95, (0.01, 0.99),
                                                form=form,
                                                on_change=on_change,
                                                tooltip="Radius [0, 1] of image that should be left untouched.")

--- a/mantidimaging/core/operations/circular_mask/test/circular_mask_test.py
+++ b/mantidimaging/core/operations/circular_mask/test/circular_mask_test.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
+from parameterized import parameterized
 import unittest
 from unittest import mock
 
@@ -14,6 +15,12 @@ class CircularMaskTest(unittest.TestCase):
 
     Tests return value and in-place modified data.
     """
+    @parameterized.expand([("None", None), ("0", 0), ("1", 1)])
+    def test_exception_raised_for_invalid_ratio(self, _, ratio):
+        images = th.generate_images()
+
+        self.assertRaises(ValueError, CircularMaskFilter.filter_func, images, ratio)
+
     def test_executed(self):
         images = th.generate_images()
 
@@ -31,7 +38,7 @@ class CircularMaskTest(unittest.TestCase):
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
         """
         radius_field = mock.Mock()
-        radius_field.value = mock.Mock(return_value=0)
+        radius_field.value = mock.Mock(return_value=0.95)
         value_field = mock.Mock()
         value_field.value = mock.Mock(return_value=0)
         execute_func = CircularMaskFilter.execute_wrapper(radius_field, value_field)

--- a/mantidimaging/core/operations/clip_values/clip_values.py
+++ b/mantidimaging/core/operations/clip_values/clip_values.py
@@ -48,27 +48,27 @@ class ClipValuesFilter(BaseFilter):
 
         :return: The processed 3D numpy.ndarray.
         """
+        # We're using is None because 0.0 is a valid value
+        if clip_min is None and clip_max is None:
+            raise ValueError('At least one of clip_min or clip_max must be supplied')
+
         progress = Progress.ensure_instance(progress, num_steps=2, task_name='Clipping Values.')
+        with progress:
+            sample = data.data
+            progress.update(msg="Determining clip min and clip max")
+            clip_min = clip_min if clip_min is not None else sample.min()
+            clip_max = clip_max if clip_max is not None else sample.max()
 
-        # we're using is not None because if the value specified is 0.0 that
-        # evaluates to false
-        if clip_min is not None or clip_max is not None:
-            with progress:
-                sample = data.data
-                progress.update(msg="Determining clip min and clip max")
-                clip_min = clip_min if clip_min is not None else sample.min()
-                clip_max = clip_max if clip_max is not None else sample.max()
+            clip_min_new_value = clip_min_new_value if clip_min_new_value is not None else clip_min
 
-                clip_min_new_value = clip_min_new_value if clip_min_new_value is not None else clip_min
+            clip_max_new_value = clip_max_new_value if clip_max_new_value is not None else clip_max
 
-                clip_max_new_value = clip_max_new_value if clip_max_new_value is not None else clip_max
+            progress.update(msg=f"Clipping data with values min {clip_min} and max {clip_max}")
 
-                progress.update(msg=f"Clipping data with values min {clip_min} and max {clip_max}")
-
-                # this is the fastest way to clip the values, np.clip does not do
-                # the clipping in place and ends up copying the data
-                sample[sample < clip_min] = clip_min_new_value
-                sample[sample > clip_max] = clip_max_new_value
+            # this is the fastest way to clip the values, np.clip does not do
+            # the clipping in place and ends up copying the data
+            sample[sample < clip_min] = clip_min_new_value
+            sample[sample > clip_max] = clip_max_new_value
 
         return data
 

--- a/mantidimaging/core/operations/clip_values/test/clip_values_test.py
+++ b/mantidimaging/core/operations/clip_values/test/clip_values_test.py
@@ -16,6 +16,14 @@ class ClipValuesFilterTest(unittest.TestCase):
 
     Tests return value and in-place modified data.
     """
+    def test_exception_raised_for_no_min_or_max(self):
+        images = th.generate_images()
+
+        clip_min = None
+        clip_max = None
+
+        self.assertRaises(ValueError, ClipValuesFilter.filter_func, images, clip_min, clip_max)
+
     def test_execute_min_only(self):
         images = th.generate_images()
 

--- a/mantidimaging/core/operations/divide/divide.py
+++ b/mantidimaging/core/operations/divide/divide.py
@@ -28,12 +28,14 @@ class DivideFilter(BaseFilter):
 
     @staticmethod
     def filter_func(images: Images, value: Union[int, float] = 0, unit="micron", progress=None) -> Images:
+        h.check_data_stack(images)
+        if not value:
+            raise ValueError('value parameter must not equal 0 or None')
+
         if unit == "micron":
             value *= 1e-4
 
-        h.check_data_stack(images)
-        if value != 0:
-            images.data /= value
+        images.data /= value
         return images
 
     @staticmethod
@@ -42,6 +44,8 @@ class DivideFilter(BaseFilter):
 
         _, value_widget = add_property_to_form("Divide by",
                                                Type.FLOAT,
+                                               default_value=1,
+                                               valid_values=[1e-7, 10000],
                                                form=form,
                                                on_change=on_change,
                                                tooltip="Value the data will be divided by")

--- a/mantidimaging/core/operations/divide/test/divide_test.py
+++ b/mantidimaging/core/operations/divide/test/divide_test.py
@@ -1,10 +1,10 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
+from parameterized import parameterized
 import unittest
 from unittest import mock
 import numpy as np
-import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.data import Images
@@ -12,13 +12,11 @@ from mantidimaging.core.operations.divide import DivideFilter
 
 
 class DivideTest(unittest.TestCase):
-    def test_divide_with_zero_does_nothing(self):
+    @parameterized.expand([("None", None), ("0", 0.00)])
+    def test_divide_with_invalid_value_raises_exception(self, _, value):
         images = th.generate_images()
-        copy = np.copy(images.data)
 
-        result = self.do_divide(images, 0.00)
-
-        npt.assert_equal(result.data, copy)
+        self.assertRaises(ValueError, self.do_divide, images, value)
 
     def test_divide(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
+++ b/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
+from parameterized import parameterized
 import unittest
 from typing import Tuple
 from unittest import mock
@@ -27,6 +28,12 @@ class FlatFieldingTest(unittest.TestCase):
         flat_after = th.generate_images()
         dark_after = th.generate_images()
         return images, flat_before, dark_before, flat_after, dark_after
+
+    @parameterized.expand([("None", None), ("Invalid", "invalid")])
+    def test_raises_exception_for_invalid_method(self, _, method):
+        images = th.generate_images()
+
+        self.assertRaises(ValueError, FlatFieldFilter.filter_func, images, selected_flat_fielding=method)
 
     def test_real_result_before_only(self):
         # the calculation here was designed on purpose to have a value

--- a/mantidimaging/core/operations/gaussian/gaussian.py
+++ b/mantidimaging/core/operations/gaussian/gaussian.py
@@ -50,7 +50,7 @@ class GaussianFilter(BaseFilter):
         h.check_data_stack(data)
 
         if not size or not size > 1:
-            raise ValueError(f'Size parameter must be greater than 1, but value provided was {0}', size)
+            raise ValueError(f'Size parameter must be greater than 1, but value provided was {size}')
 
         _execute(data.data, size, mode, order, cores, progress)
         h.check_data_stack(data)

--- a/mantidimaging/core/operations/gaussian/gaussian.py
+++ b/mantidimaging/core/operations/gaussian/gaussian.py
@@ -31,7 +31,7 @@ class GaussianFilter(BaseFilter):
         """
         :param data: Input data as a 3D numpy.ndarray
         :param size: Size of the kernel
-        :param mode: The mode with which to handle the endges.
+        :param mode: The mode with which to handle the edges.
                      One of [reflect, constant, nearest, mirror, wrap].
                      Modes are described in the `SciPy documentation
                      <https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.gaussian_filter.html>`_.
@@ -49,8 +49,10 @@ class GaussianFilter(BaseFilter):
         """
         h.check_data_stack(data)
 
-        if size and size > 1:
-            _execute(data.data, size, mode, order, cores, progress)
+        if not size or not size > 1:
+            raise ValueError(f'Size parameter must be greater than 1, but value provided was {0}', size)
+
+        _execute(data.data, size, mode, order, cores, progress)
         h.check_data_stack(data)
         return data
 

--- a/mantidimaging/core/operations/gaussian/test/gaussian_test.py
+++ b/mantidimaging/core/operations/gaussian/test/gaussian_test.py
@@ -6,7 +6,6 @@ import unittest
 from unittest import mock
 
 import numpy as np
-import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.gaussian import GaussianFilter
@@ -31,7 +30,7 @@ class GaussianTest(unittest.TestCase):
         mode = None
         order = None
 
-        npt.assert_raises(ValueError, GaussianFilter.filter_func, images, size, mode, order)
+        self.assertRaises(ValueError, GaussianFilter.filter_func, images, size, mode, order)
 
     def test_executed_parallel(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/gaussian/test/gaussian_test.py
+++ b/mantidimaging/core/operations/gaussian/test/gaussian_test.py
@@ -5,6 +5,7 @@ import unittest
 from unittest import mock
 
 import numpy as np
+import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.gaussian import GaussianFilter
@@ -22,16 +23,14 @@ class GaussianTest(unittest.TestCase):
     This does not scale and parallel execution is always faster on any
     reasonably sized data (e.g. 143,512,512)
     """
-    def test_not_executed(self):
+    def test_exception_raised_for_invalid_size(self):
         images = th.generate_images()
 
         size = None
         mode = None
         order = None
 
-        original = np.copy(images.data[0])
-        result = GaussianFilter.filter_func(images, size, mode, order)
-        th.assert_not_equals(result.data, original)
+        npt.assert_raises(ValueError, GaussianFilter.filter_func, images, size, mode, order)
 
     def test_executed_parallel(self):
         images = th.generate_images()

--- a/mantidimaging/core/operations/gaussian/test/gaussian_test.py
+++ b/mantidimaging/core/operations/gaussian/test/gaussian_test.py
@@ -8,7 +8,7 @@ import numpy as np
 import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
-from mantidimaging.core.operations.gaussian import GaussianFilter
+from mantidimaging.core.operations.gaussian import GaussianFilter, modes
 
 
 class GaussianTest(unittest.TestCase):
@@ -36,7 +36,7 @@ class GaussianTest(unittest.TestCase):
         images = th.generate_images()
 
         size = 3
-        mode = 'reflect'
+        mode = modes()[0]
         order = 1
 
         original = np.copy(images.data[0])
@@ -49,9 +49,9 @@ class GaussianTest(unittest.TestCase):
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
         """
         size_field = mock.Mock()
-        size_field.value = mock.Mock(return_value=0)
+        size_field.value = mock.Mock(return_value=2)
         mode_field = mock.Mock()
-        mode_field.currentText = mock.Mock(return_value=0)
+        mode_field.currentText = mock.Mock(return_value=modes()[0])
         order_field = mock.Mock()
         order_field.value = mock.Mock(return_value=0)
         execute_func = GaussianFilter.execute_wrapper(size_field, order_field, mode_field)

--- a/mantidimaging/core/operations/gaussian/test/gaussian_test.py
+++ b/mantidimaging/core/operations/gaussian/test/gaussian_test.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
+from parameterized import parameterized
 import unittest
 from unittest import mock
 
@@ -23,10 +24,10 @@ class GaussianTest(unittest.TestCase):
     This does not scale and parallel execution is always faster on any
     reasonably sized data (e.g. 143,512,512)
     """
-    def test_exception_raised_for_invalid_size(self):
+    @parameterized.expand([("None", None), ("1", 1)])
+    def test_exception_raised_for_invalid_size(self, _, size):
         images = th.generate_images()
 
-        size = None
         mode = None
         order = None
 

--- a/mantidimaging/core/operations/gaussian/test/gaussian_test.py
+++ b/mantidimaging/core/operations/gaussian/test/gaussian_test.py
@@ -8,7 +8,7 @@ import numpy as np
 import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
-from mantidimaging.core.operations.gaussian import GaussianFilter, modes
+from mantidimaging.core.operations.gaussian import GaussianFilter
 
 
 class GaussianTest(unittest.TestCase):
@@ -36,7 +36,7 @@ class GaussianTest(unittest.TestCase):
         images = th.generate_images()
 
         size = 3
-        mode = modes()[0]
+        mode = 'reflect'
         order = 1
 
         original = np.copy(images.data[0])
@@ -51,7 +51,7 @@ class GaussianTest(unittest.TestCase):
         size_field = mock.Mock()
         size_field.value = mock.Mock(return_value=2)
         mode_field = mock.Mock()
-        mode_field.currentText = mock.Mock(return_value=modes()[0])
+        mode_field.currentText = mock.Mock(return_value='reflect')
         order_field = mock.Mock()
         order_field.value = mock.Mock(return_value=0)
         execute_func = GaussianFilter.execute_wrapper(size_field, order_field, mode_field)

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -85,11 +85,13 @@ class MedianFilter(BaseFilter):
         """
         h.check_data_stack(data)
 
-        if size and size > 1:
-            if not force_cpu:
-                data = _execute_gpu(data.data, size, mode, progress)
-            else:
-                _execute(data.data, size, mode, cores, chunksize, progress)
+        if not size or not size > 1:
+            raise ValueError(f'Size parameter must be greater than 1, but value provided was {0}', size)
+
+        if not force_cpu:
+            data = _execute_gpu(data.data, size, mode, progress)
+        else:
+            _execute(data.data, size, mode, cores, chunksize, progress)
 
         h.check_data_stack(data)
         return data

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -86,7 +86,7 @@ class MedianFilter(BaseFilter):
         h.check_data_stack(data)
 
         if not size or not size > 1:
-            raise ValueError(f'Size parameter must be greater than 1, but value provided was {0}', size)
+            raise ValueError(f'Size parameter must be greater than 1, but value provided was {size}')
 
         if not force_cpu:
             data = _execute_gpu(data.data, size, mode, progress)

--- a/mantidimaging/core/operations/median_filter/test/median_filter_test.py
+++ b/mantidimaging/core/operations/median_filter/test/median_filter_test.py
@@ -22,16 +22,13 @@ class MedianTest(unittest.TestCase):
 
     Tests return value and in-place modified data.
     """
-    def test_not_executed(self):
+    @parameterized.expand([("None", None), ("1", 1)])
+    def test_exception_raised_for_invalid_size(self, _, size):
         images = th.generate_images()
 
-        size = None
         mode = None
 
-        original = np.copy(images.data[0])
-        result = MedianFilter.filter_func(images, size, mode)
-
-        th.assert_not_equals(result.data, original)
+        npt.assert_raises(ValueError, MedianFilter.filter_func, images, size, mode)
 
     def test_executed_no_helper_parallel(self):
         images = th.generate_images()
@@ -75,9 +72,9 @@ class MedianTest(unittest.TestCase):
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
         """
         size_field = mock.Mock()
-        size_field.value = mock.Mock(return_value=0)
+        size_field.value = mock.Mock(return_value=3)
         mode_field = mock.Mock()
-        mode_field.currentText = mock.Mock(return_value=0)
+        mode_field.currentText = mock.Mock(return_value='reflect')
         use_gpu_field = mock.Mock()
         use_gpu_field.isChecked = mock.Mock(return_value=False)
         execute_func = MedianFilter.execute_wrapper(size_field, mode_field, use_gpu_field)

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -33,7 +33,8 @@ class MonitorNormalisation(BaseFilter):
         if images.num_projections == 1:
             # we can't really compute the preview as the image stack copy
             # passed in doesn't have the logfile in it
-            return images
+            raise RuntimeError("No logfile available for this stack.")
+
         counts = images.counts()
 
         if counts is None:

--- a/mantidimaging/core/operations/monitor_normalisation/test/monitor_normalisation_test.py
+++ b/mantidimaging/core/operations/monitor_normalisation/test/monitor_normalisation_test.py
@@ -11,16 +11,18 @@ from mantidimaging.test_helpers.unit_test_helper import generate_images, assert_
 from ..monitor_normalisation import MonitorNormalisation
 
 
+def test_one_projection():
+    images = generate_images((1, 1, 1))
+    images._log_file = mock.Mock()
+    images._log_file.counts = mock.Mock(return_value=Counts(np.sin(np.linspace(0, 1, images.num_projections))))
+    npt.assert_raises(RuntimeError, MonitorNormalisation.filter_func, images)
+
+
 def test_no_counts():
-    images = generate_images()
-    original = images.copy()
-    filter_threw = False
-    try:
-        MonitorNormalisation.filter_func(images)
-    except RuntimeError:
-        filter_threw = True
-    assert filter_threw
-    npt.assert_equal(original.data, images.data)
+    images = generate_images((2, 2, 2))
+    images._log_file = mock.Mock()
+    images._log_file.counts = mock.Mock(return_value=None)
+    npt.assert_raises(RuntimeError, MonitorNormalisation.filter_func, images)
 
 
 def test_execute():

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -60,13 +60,18 @@ class OutliersFilter(BaseFilter):
 
         :return: The processed 3D numpy.ndarray
         """
-        if diff and radius and diff > 0 and radius > 0:
-            func = ps.create_partial(OutliersFilter._execute, ps.return_to_self, diff=diff, radius=radius, mode=mode)
-            ps.shared_list = [images.data]
-            ps.execute(func,
-                       images.num_projections,
-                       progress=progress,
-                       msg=f"Outliers with threshold {diff} and kernel {radius}")
+        if not diff or not diff > 0:
+            raise ValueError(f'diff parameter must be greater than 0. Value provided was {diff}')
+
+        if not radius or not radius > 0:
+            raise ValueError(f'radius parameter must be greater than 0. Value provided was {radius}')
+
+        func = ps.create_partial(OutliersFilter._execute, ps.return_to_self, diff=diff, radius=radius, mode=mode)
+        ps.shared_list = [images.data]
+        ps.execute(func,
+                   images.num_projections,
+                   progress=progress,
+                   msg=f"Outliers with threshold {diff} and kernel {radius}")
         return images
 
     @staticmethod
@@ -74,7 +79,7 @@ class OutliersFilter(BaseFilter):
         _, diff_field = add_property_to_form('Difference',
                                              'float',
                                              1000,
-                                             valid_values=(0, 10000),
+                                             valid_values=(1e-7, 10000),
                                              form=form,
                                              on_change=on_change,
                                              tooltip="Difference between pixels that will be used to spot outliers.\n"
@@ -84,7 +89,7 @@ class OutliersFilter(BaseFilter):
 
         _, size_field = add_property_to_form('Median kernel',
                                              Type.INT,
-                                             3, (0, 1000),
+                                             3, (1, 1000),
                                              form=form,
                                              on_change=on_change,
                                              tooltip="The size of the median filter kernel used to find outliers.")

--- a/mantidimaging/core/operations/outliers/test/outliers_test.py
+++ b/mantidimaging/core/operations/outliers/test/outliers_test.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
+from parameterized import parameterized
 import unittest
 from unittest import mock
 
@@ -20,6 +21,22 @@ class OutliersTest(unittest.TestCase):
 
     Tests return value only.
     """
+    @parameterized.expand([("None", None), ("0", 0)])
+    def test_raises_exception_for_invalid_diff(self, _, diff):
+        images = th.generate_images()
+
+        radius = 3
+
+        self.assertRaises(ValueError, OutliersFilter.filter_func, images, diff, radius)
+
+    @parameterized.expand([("None", None), ("0", 0)])
+    def test_raises_exception_for_invalid_radius(self, _, radius):
+        images = th.generate_images()
+
+        diff = 1
+
+        self.assertRaises(ValueError, OutliersFilter.filter_func, images, diff, radius)
+
     def test_executed(self):
         images = th.generate_images()
 
@@ -36,9 +53,9 @@ class OutliersTest(unittest.TestCase):
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
         """
         diff_field = mock.Mock()
-        diff_field.value = mock.Mock(return_value=0)
+        diff_field.value = mock.Mock(return_value=1)
         size_field = mock.Mock()
-        size_field.value = mock.Mock(return_value=0)
+        size_field.value = mock.Mock(return_value=1)
         mode_field = mock.Mock()
         mode_field.currentText = mock.Mock(return_value=OUTLIERS_BRIGHT)
         execute_func = OutliersFilter.execute_wrapper(diff_field, size_field, mode_field)
@@ -59,10 +76,10 @@ class OutliersTest(unittest.TestCase):
         # use sets because dictionary order isn't guaranteed in Python 3
         self.assertEqual({'diff_field', 'size_field', 'mode_field'}, set(gui_dict.keys()))
 
-    def test_gui_diff_spin_box_min_is_0(self):
+    def test_gui_diff_spin_box_min_is_correct(self):
         gui_dict = OutliersFilter.register_gui(mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
 
-        self.assertEqual(0, gui_dict["diff_field"].minimum())
+        self.assertEqual(1e-7, gui_dict["diff_field"].minimum())
 
     def test_gui_diff_spin_box_max_is_10000(self):
         gui_dict = OutliersFilter.register_gui(mock.MagicMock(), mock.MagicMock(), mock.MagicMock())

--- a/mantidimaging/core/operations/rebin/test/rebin_test.py
+++ b/mantidimaging/core/operations/rebin/test/rebin_test.py
@@ -6,9 +6,18 @@ from unittest import mock
 
 import numpy as np
 import numpy.testing as npt
+import pytest
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.rebin import RebinFilter
+
+
+@pytest.mark.parametrize('val', [0, -1, (0, 1), (1, 0), (-1, 1), (1, -1)])
+def test_exception_raised_for_invalid_rebin_param(val):
+    images = th.generate_images()
+    mode = 'reflect'
+
+    npt.assert_raises(ValueError, RebinFilter.filter_func, images, val, mode)
 
 
 class RebinTest(unittest.TestCase):
@@ -17,26 +26,6 @@ class RebinTest(unittest.TestCase):
 
     Tests return value only.
     """
-    def test_not_executed_rebin_negative(self):
-        images = th.generate_images()
-
-        mode = 'reflect'
-        val = -1
-
-        result = RebinFilter.filter_func(images, val, mode)
-
-        npt.assert_equal(result, images)
-
-    def test_not_executed_rebin_zero(self):
-        images = th.generate_images()
-
-        mode = 'reflect'
-        val = 0
-
-        result = RebinFilter.filter_func(images, val, mode)
-
-        npt.assert_equal(result, images)
-
     def test_executed_uniform_par_2(self):
         self.do_execute_uniform(2.0)
 
@@ -116,9 +105,9 @@ class RebinTest(unittest.TestCase):
         rebin_by_factor_radio = mock.Mock()
         rebin_by_factor_radio.isChecked = mock.Mock(return_value=True)
         factor = mock.Mock()
-        factor.value = mock.Mock(return_value=0)
+        factor.value = mock.Mock(return_value=0.5)
         mode_field = mock.Mock()
-        mode_field.currentText = mock.Mock(return_value=0)
+        mode_field.currentText = mock.Mock(return_value='reflect')
         execute_func = RebinFilter.execute_wrapper(rebin_to_dimensions_radio=rebin_to_dimensions_radio,
                                                    rebin_by_factor_radio=rebin_by_factor_radio,
                                                    factor=factor,

--- a/mantidimaging/core/operations/rebin/test/rebin_test.py
+++ b/mantidimaging/core/operations/rebin/test/rebin_test.py
@@ -1,23 +1,15 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
+from parameterized import parameterized
 import unittest
 from unittest import mock
 
 import numpy as np
 import numpy.testing as npt
-import pytest
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.rebin import RebinFilter
-
-
-@pytest.mark.parametrize('val', [0, -1, (0, 1), (1, 0), (-1, 1), (1, -1)])
-def test_exception_raised_for_invalid_rebin_param(val):
-    images = th.generate_images()
-    mode = 'reflect'
-
-    npt.assert_raises(ValueError, RebinFilter.filter_func, images, val, mode)
 
 
 class RebinTest(unittest.TestCase):
@@ -26,6 +18,14 @@ class RebinTest(unittest.TestCase):
 
     Tests return value only.
     """
+    @parameterized.expand([("Zero", 0), ("Negative", -1), ("0,1", (0, 1)), ("1,0", (1, 0)), ("-1,1", (-1, 1)),
+                           ("1,-1", (1, -1))])
+    def test_exception_raised_for_invalid_rebin_param(self, _, val):
+        images = th.generate_images()
+        mode = 'reflect'
+
+        npt.assert_raises(ValueError, RebinFilter.filter_func, images, val, mode)
+
     def test_executed_uniform_par_2(self):
         self.do_execute_uniform(2.0)
 

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -80,17 +80,19 @@ class RoiNormalisationFilter(BaseFilter):
         if normalisation_mode == "Flat Field" and flat_field is None:
             raise ValueError('flat_field must provided if using normalisation_mode of "Flat Field"')
 
+        h.check_data_stack(images)
+
+        if not region_of_interest:
+            raise ValueError('region_of_interest must be provided')
+
         if flat_field is not None:
             flat_field_data = flat_field.data
         else:
             flat_field_data = None
 
-        h.check_data_stack(images)
-
         # just get data reference
-        if region_of_interest:
-            progress = Progress.ensure_instance(progress, task_name='ROI Normalisation')
-            _execute(images.data, region_of_interest, normalisation_mode, flat_field_data, cores, chunksize, progress)
+        progress = Progress.ensure_instance(progress, task_name='ROI Normalisation')
+        _execute(images.data, region_of_interest, normalisation_mode, flat_field_data, cores, chunksize, progress)
         h.check_data_stack(images)
         return images
 

--- a/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
@@ -19,14 +19,12 @@ class ROINormalisationTest(unittest.TestCase):
 
     Tests return value and in-place modified data.
     """
-    def test_not_executed_empty_params(self):
+    def test_exception_raised_for_empty_roi_param(self):
         images = th.generate_images()
 
         air = None
 
-        original = np.copy(images.data[0])
-        result = RoiNormalisationFilter.filter_func(images, air)
-        npt.assert_equal(result.data[0], original)
+        npt.assert_raises(ValueError, RoiNormalisationFilter.filter_func, images, air)
 
     def test_not_executed_invalid_shape(self):
         images = np.arange(100).reshape(10, 10)

--- a/mantidimaging/core/operations/rotate_stack/rotate_stack.py
+++ b/mantidimaging/core/operations/rotate_stack/rotate_stack.py
@@ -42,7 +42,11 @@ class RotateFilter(BaseFilter):
         """
         h.check_data_stack(data)
 
-        if angle:
+        if angle is None:
+            raise ValueError('Value must be provided for angle parameter')
+
+        # No need to run the filter for an angle of 0 as it won't have any effect
+        if not angle == 0:
             _execute(data.data, angle, cores, chunksize, progress)
 
         return data

--- a/mantidimaging/core/operations/rotate_stack/test/rotate_stack_test.py
+++ b/mantidimaging/core/operations/rotate_stack/test/rotate_stack_test.py
@@ -16,6 +16,13 @@ class RotateStackTest(unittest.TestCase):
 
     Tests return value and in-place modified data.
     """
+    def test_raise_exception_for_none_angle(self):
+        images = th.generate_images()
+
+        rotation = None
+
+        self.assertRaises(ValueError, RotateFilter.filter_func, images, rotation)
+
     def test_executed_par(self):
         self.do_execute()
 


### PR DESCRIPTION
### Issue

Closes #1162

### Description

Changes various filter operations so that they will throw an exception instead of silently doing nothing when supplied with invalid parameters. Where possible, I've also changed min/max input ranges and default values to prevent the user being able to trigger these exceptions via the GUI.

The only filter where an exception could be encountered via the GUI should be the arithmetic filter, where entering 0 for the divide or multiply parameters will trigger an exception. This couldn't be avoided because the input needs to allow both positive and negative values. The change in this PR unfortunately surfaces the bug described in this issue #1256, which I wasn't able to find a solution for. A user is unlikely to encounter the problem in normal use, though, and can workaround it easily, so it still seemed OK to go ahead with the change to the filter.

### Testing 

I've tried to ensure we have unit tests for the different scenarios that we expect to cause an exception. There are already unit tests checking that the filters run successfully, so I ran these through as well as manually checking that the filters were working as expected in the application.

### Acceptance Criteria 

Ensure all tests pass.
Test a selection of the filters that have been changed to ensure they are still functioning as expected.

### Documentation

Release notes updated with issue number.
