### PR TITLE
Fix SaveDialogTest mocking

### DIFF
--- a/mantidimaging/eyes_tests/test_save_dialog.py
+++ b/mantidimaging/eyes_tests/test_save_dialog.py
@@ -14,7 +14,10 @@ class SaveDialogTest(BaseEyesTest):
 
     def test_save_dialog_opens_with_dataset(self):
         TestTuple = namedtuple('TestTuple', ['id', 'name'])
-        type(self.imaging).stack_list = mock.PropertyMock(return_value=[TestTuple('', 'Test Stack')])
-        self.imaging.actionSave.trigger()
+        stack_list = [TestTuple('', 'Test Stack')]
+        with mock.patch("mantidimaging.gui.windows.main.MainWindowView.stack_list",
+                        new_callable=mock.PropertyMock) as mock_stack_list:
+            mock_stack_list.return_value = stack_list
+            self.imaging.actionSave.trigger()
 
         self.check_target(widget=self.imaging.save_dialogue)


### PR DESCRIPTION
### Issue

Closes #1260 

### Description

Stop test_save_dialog_opens_with_dataset from permanently modifying MainWindowView.

Before this test_save_dialog_opens_with_no_dataset was showing a stack in the drop down, if test_save_dialog_opens_with_dataset ran first.

### Testing & Acceptance Criteria 

Eyes tests should pass

### Documentation

Small test fix so no release note
