### PR TITLE
Fix Rebin filter errors

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -34,6 +34,7 @@ Fixes
 - #1161 : Remove run_ring_removal argument from Ring Removal operation and always run filter
 - #1226 : AttributeError when trying to open reconstruction auto colour dialog
 - #1236 : Aspect ratio not preserved in COR inspector or operations window
+- #1248 : Rebin operations not working for small image dimensions
 
 
 Developer Changes

--- a/mantidimaging/gui/widgets/mi_image_view/test/test_view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/test/test_view.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+import numpy as np
+import unittest
+
+from mantidimaging.gui.widgets.mi_image_view.view import MIImageView
+from mantidimaging.test_helpers import start_qapplication
+
+
+@start_qapplication
+class MIImageViewTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.view = MIImageView()
+
+    def test_set_image_creates_tVals_for_small_image_size(self):
+        image = np.zeros((1, 1, 1))
+
+        self.view.setImage(image)
+        self.assertTrue(hasattr(self.view, 'tVals'), 'tVals attribute missing for small image size')

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -127,7 +127,7 @@ class MIImageView(ImageView, BadDataOverlay):
             # For a 3 dimensional image, we need to specify which axes we are providing and their indices in the
             # array's shape attribute
             # If we don't do this then it is interpreted incorrectly for very small images by ImageView.setImage
-            # Note that, for our purposes, the t axes corresponds to angle data
+            # Note that, for our purposes, the t axis corresponds to angle data
             kwargs['axes'] = kwargs.get('axes', {'t': 0, 'x': 2, 'y': 1, 'c': None})
         ImageView.setImage(self, *args, **kwargs)
         self.check_for_bad_data()

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -123,6 +123,12 @@ class MIImageView(ImageView, BadDataOverlay):
         return self.view
 
     def setImage(self, *args, **kwargs):
+        if args[0].ndim == 3:
+            # For a 3 dimensional image, we need to specify which axes we are providing and their indices in the
+            # array's shape attribute
+            # If we don't do this then it is interpreted incorrectly for very small images by ImageView.setImage
+            # Note that, for our purposes, the t axes corresponds to angle data
+            kwargs['axes'] = kwargs.get('axes', {'t': 0, 'x': 2, 'y': 1, 'c': None})
         ImageView.setImage(self, *args, **kwargs)
         self.check_for_bad_data()
 


### PR DESCRIPTION
### Issue

Closes #1248 

### Description

The problem was being caused by some logic in the `setImage` method of the PyQtGraph `ImageView` class, which is called by `MIImageView.setImage`. The logic looks to establish which of four possible axes have been provided in the image data and which image shape indices they correspond to. If this information isn't provided by the caller then some default assumptions are used. For a 3 dimensional image array, the default assumption is that axes t, x and y have been provided if the image width is > 4, otherwise the assumption is that x, y and c have been given. Data for the t axis is required for the `tVals` attribute to be created on the `ImageView` object, so this attribute wasn't being created for images with a width <=4. This would cause an `AttributeError` when we later tried to call it in method `MIImageView._update_roi_region_avg`.

When the original image size is large enough for the `tVals` attribute to be available, we only see this error when using Safe Apply because the dialog for deciding whether to accept the changes uses entirely new `MIImageView` objects. Without Safe Apply, the new data is set on an existing `MIImageView` that already has the `tVals` attribute.

The fix was to specify the axes interpretation that the `ImageView.setImage` method should use for 3 dimensional images to force it to continue to use t, even as image sizes get very small. We know that our data will always include the t axis, which corresponds to angle information in our case.

I've added a new test for the issue.

### Testing & Acceptance Criteria 

Apply rebin operations for various dimensions (including 2 x 2, which was particularly error prone when the bug was originally found) and Safe Apply selected. The operations should succeed without any errors.

### Documentation

Issue number added to release notes.
