### PR TITLE
Re-enable test_load_180

### DIFF
--- a/mantidimaging/gui/test/test_gui_system_loading.py
+++ b/mantidimaging/gui/test/test_gui_system_loading.py
@@ -4,12 +4,11 @@
 from pathlib import Path
 from unittest import mock
 
-import pytest
-from PyQt5.QtCore import QTimer, QEventLoop
+from PyQt5.QtCore import Qt, QTimer, QEventLoop
 from PyQt5.QtWidgets import QApplication
 
 from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHORT_DELAY, LOAD_SAMPLE
-from mantidimaging.gui.widgets.stack_selector_dialog.stack_selector_dialog import StackSelectorDialog
+from mantidimaging.gui.widgets.dataset_selector_dialog.dataset_selector_dialog import DatasetSelectorDialog
 
 
 class TestGuiSystemLoading(GuiSystemBase):
@@ -32,36 +31,43 @@ class TestGuiSystemLoading(GuiSystemBase):
 
     @classmethod
     def _click_stack_selector(cls):
-        cls._wait_for_widget_visible(StackSelectorDialog)
+        cls._wait_for_widget_visible(DatasetSelectorDialog)
         for widget in cls.app.topLevelWidgets():
-            if isinstance(widget, StackSelectorDialog):
+            if isinstance(widget, DatasetSelectorDialog):
                 for x in range(20):
                     QApplication.processEvents(QEventLoop.ProcessEventsFlag.AllEvents, SHORT_DELAY)
-                    if widget.stack_selector_widget.currentText():
+                    if widget.dataset_selector_widget.currentText():
                         break
                 else:
-                    raise RuntimeError("Timed out waiting for StackSelectorDialog to populate")
+                    raise RuntimeError("Timed out waiting for DatasetSelectorDialog to populate")
 
                 widget.ok_button.click()
 
-    @pytest.mark.xfail(reason="Not yet reimplemented. See #1189")
     @mock.patch("mantidimaging.gui.windows.main.MainWindowView._get_file_name")
     def test_load_180(self, mocked_select_file):
         path_180 = Path(LOAD_SAMPLE).parents[1] / "180deg" / "IMAT_Flower_180deg_000000.tif"
         mocked_select_file.return_value = path_180
         self.assertEqual(len(self.main_window.presenter.get_active_stack_visualisers()), 0)
-        self._load_images()
+        self._load_data_set()
         stacks = self.main_window.presenter.get_active_stack_visualisers()
+        self.assertEqual(len(self.main_window.presenter.get_active_stack_visualisers()), 5)
 
-        self.assertEqual(len(self.main_window.presenter.get_active_stack_visualisers()), 1)
+        # Remove existing 180
+        proj180deg_entry = self.main_window.dataset_tree_widget.findItems("180", Qt.MatchFlag.MatchRecursive)
+        self.assertEqual(len(proj180deg_entry), 1)
+        self.main_window.dataset_tree_widget.setCurrentItem(proj180deg_entry[0])
+        self.main_window._delete_container()
+
         self.assertFalse(stacks[0].presenter.images.has_proj180deg())
+        self.assertEqual(len(self.main_window.presenter.get_active_stack_visualisers()), 4)
 
+        # load new 180
         QTimer.singleShot(SHORT_DELAY, lambda: self._click_stack_selector())
         self.main_window.actionLoad180deg.trigger()
 
-        self._wait_until(lambda: len(self.main_window.presenter.get_active_stack_visualisers()) == 2)
+        self._wait_until(lambda: len(self.main_window.presenter.get_active_stack_visualisers()) == 5)
 
         stacks_after = self.main_window.presenter.get_active_stack_visualisers()
-        self.assertEqual(len(stacks_after), 2)
+        self.assertEqual(len(stacks_after), 5)
         self.assertIn(stacks[0], stacks_after)
         self.assertTrue(stacks[0].presenter.images.has_proj180deg())

--- a/mantidimaging/gui/test/test_gui_system_loading.py
+++ b/mantidimaging/gui/test/test_gui_system_loading.py
@@ -19,12 +19,12 @@ class TestGuiSystemLoading(GuiSystemBase):
     @mock.patch("mantidimaging.gui.windows.main.MainWindowView._get_file_name")
     def _load_images(self, mocked_select_file):
         mocked_select_file.return_value = LOAD_SAMPLE
-        initial_stacks = len(self.main_window.presenter.model.get_active_stack_visualisers())
+        initial_stacks = len(self.main_window.presenter.get_active_stack_visualisers())
 
         self.main_window.actionLoadImages.trigger()
 
         def test_func() -> bool:
-            current_stacks = len(self.main_window.presenter.model.get_active_stack_visualisers())
+            current_stacks = len(self.main_window.presenter.get_active_stack_visualisers())
             return (current_stacks - initial_stacks) >= 1
 
         self._wait_until(test_func, max_retry=600)
@@ -42,6 +42,9 @@ class TestGuiSystemLoading(GuiSystemBase):
                     raise RuntimeError("Timed out waiting for DatasetSelectorDialog to populate")
 
                 widget.ok_button.click()
+
+    def test_load_images(self):
+        self._load_images()
 
     @mock.patch("mantidimaging.gui.windows.main.MainWindowView._get_file_name")
     def test_load_180(self, mocked_select_file):


### PR DESCRIPTION
### Issue

Closes #1264 

### Description

Re-enable with needed changes
* Now need to have loaded a dataset, not just an image stack
* Remove existing 180 from example dataset
* Use DatasetSelectorDialog

### Testing && Acceptance Criteria 

Tests should pass. In the gui system tests the final summery should not have any xfail,
e.g.
`================= 30 passed, 34 warnings in 489.06s (0:08:09) ==================`
not
` ============ 29 passed, 1 xfailed, 44 warnings in 418.41s (0:06:58) ============`


Run single test with:
`pytest -vs -rs --run-system-tests -k test_load_180`
or
`xvfb-run --auto-servernum pytest -vs -rs --run-system-tests -k test_load_180`

### Documentation

Not needed
