### PR TITLE
stack selector based on datasets

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -57,3 +57,4 @@ Developer Changes
 - #1245 : Remove empty init methods from test classes
 - #1251 : System tests: test_correlate ValueError
 - #1259 : Update license year in code files and add pre-commit check
+- #1243 : Stack selector based on datasets

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -14,13 +14,22 @@ def _delete_stack_error_message(images_id: uuid.UUID) -> str:
 
 
 class BaseDataset:
-    def __init__(self):
+    def __init__(self, name: str = ""):
         self._id: uuid.UUID = uuid.uuid4()
         self.recons: List[Images] = []
+        self._name = name
 
     @property
     def id(self) -> uuid.UUID:
         return self._id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @name.setter
+    def name(self, arg: str):
+        self._name = arg
 
     @property
     def all(self):
@@ -45,8 +54,8 @@ class BaseDataset:
 
 
 class StackDataset(BaseDataset):
-    def __init__(self, stacks: List[Images] = []):
-        super().__init__()
+    def __init__(self, stacks: List[Images] = [], name=""):
+        super().__init__(name=name)
         self._stacks = stacks
 
     @property
@@ -80,16 +89,14 @@ class Dataset(BaseDataset):
                  dark_before: Optional[Images] = None,
                  dark_after: Optional[Images] = None,
                  name: str = ""):
-        super().__init__()
+        super().__init__(name=name)
         self.sample = sample
         self.flat_before = flat_before
         self.flat_after = flat_after
         self.dark_before = dark_before
         self.dark_after = dark_after
 
-        if name:
-            self._name = name
-        else:
+        if self.name == "":
             self._name = sample.name
 
     @property
@@ -98,14 +105,6 @@ class Dataset(BaseDataset):
             self.sample, self.proj180deg, self.flat_before, self.flat_after, self.dark_before, self.dark_after
         ]
         return [image_stack for image_stack in image_stacks if image_stack is not None] + self.recons
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    @name.setter
-    def name(self, arg: str):
-        self._name = arg
 
     @property
     def proj180deg(self):

--- a/mantidimaging/core/operations/base_filter.py
+++ b/mantidimaging/core/operations/base_filter.py
@@ -12,7 +12,7 @@ from mantidimaging.core.data import Images
 if TYPE_CHECKING:
     from PyQt5.QtWidgets import QFormLayout, QWidget  # noqa: F401   # pragma: no cover
     from mantidimaging.gui.mvp_base import BaseMainWindowView  # pragma: no cover
-    from mantidimaging.gui.widgets.stack_selector import StackSelectorWidgetView
+    from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
 
 
 class FilterGroup(Enum):
@@ -88,13 +88,16 @@ class BaseFilter:
         return FilterGroup.NoGroup
 
     @staticmethod
-    def get_images_from_stack(widget: "StackSelectorWidgetView", msg: str) -> Optional[Images]:
+    def get_images_from_stack(widget: "DatasetSelectorWidgetView", msg: str) -> Optional[Images]:
+        stack_uuid = widget.current()
+        if stack_uuid is None:
+            raise ValueError(f"No stack for {msg}")
         try:
-            stack = widget.main_window.get_stack_visualiser(widget.current())
+            stack = widget.main_window.get_stack(stack_uuid)
         except KeyError:
             # Can happen if stack is closed while selected in the form
             raise ValueError(f"Selected stack for {msg} does not exist")
-        return stack.presenter.images
+        return stack
 
 
 def raise_not_implemented(function_name):

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -13,7 +13,7 @@ from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
 from mantidimaging.core.parallel import utility as pu, shared as ps
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.utility.qt_helpers import Type
-from mantidimaging.gui.widgets.stack_selector import StackSelectorWidgetView
+from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
 
 # The smallest and largest allowed pixel value
 MINIMUM_PIXEL_VALUE = 1e-9
@@ -173,25 +173,25 @@ class FlatFieldFilter(BaseFilter):
                                                     on_change=on_change,
                                                     tooltip="Dark images to be used for subtracting the background.")
 
-        assert isinstance(flat_before_widget, StackSelectorWidgetView)
+        assert isinstance(flat_before_widget, DatasetSelectorWidgetView)
         flat_before_widget.setMaximumWidth(375)
         flat_before_widget.subscribe_to_main_window(view.main_window)
         flat_before_widget.try_to_select_relevant_stack("Flat")
         flat_before_widget.try_to_select_relevant_stack("Flat Before")
 
-        assert isinstance(flat_after_widget, StackSelectorWidgetView)
+        assert isinstance(flat_after_widget, DatasetSelectorWidgetView)
         flat_after_widget.setMaximumWidth(375)
         flat_after_widget.subscribe_to_main_window(view.main_window)
         flat_after_widget.try_to_select_relevant_stack("Flat After")
         flat_after_widget.setEnabled(False)
 
-        assert isinstance(dark_before_widget, StackSelectorWidgetView)
+        assert isinstance(dark_before_widget, DatasetSelectorWidgetView)
         dark_before_widget.setMaximumWidth(375)
         dark_before_widget.subscribe_to_main_window(view.main_window)
         dark_before_widget.try_to_select_relevant_stack("Dark")
         dark_before_widget.try_to_select_relevant_stack("Dark Before")
 
-        assert isinstance(dark_after_widget, StackSelectorWidgetView)
+        assert isinstance(dark_after_widget, DatasetSelectorWidgetView)
         dark_after_widget.setMaximumWidth(375)
         dark_after_widget.subscribe_to_main_window(view.main_window)
         dark_after_widget.try_to_select_relevant_stack("Dark After")
@@ -219,8 +219,8 @@ class FlatFieldFilter(BaseFilter):
 
     @staticmethod
     def execute_wrapper(  # type: ignore
-            flat_before_widget: StackSelectorWidgetView, flat_after_widget: StackSelectorWidgetView,
-            dark_before_widget: StackSelectorWidgetView, dark_after_widget: StackSelectorWidgetView,
+            flat_before_widget: DatasetSelectorWidgetView, flat_after_widget: DatasetSelectorWidgetView,
+            dark_before_widget: DatasetSelectorWidgetView, dark_after_widget: DatasetSelectorWidgetView,
             selected_flat_fielding_widget: QComboBox, use_dark_widget: QCheckBox) -> partial:
 
         flat_before_images = BaseFilter.get_images_from_stack(flat_before_widget, "flat before")
@@ -250,10 +250,10 @@ class FlatFieldFilter(BaseFilter):
         if 'flat_before_widget' not in kwargs and 'dark_before_widget' not in kwargs or\
                 'flat_after_widget' not in kwargs and 'dark_after_widget' not in kwargs:
             return False
-        assert isinstance(kwargs["flat_before_widget"], StackSelectorWidgetView)
-        assert isinstance(kwargs["flat_after_widget"], StackSelectorWidgetView)
-        assert isinstance(kwargs["dark_before_widget"], StackSelectorWidgetView)
-        assert isinstance(kwargs["dark_after_widget"], StackSelectorWidgetView)
+        assert isinstance(kwargs["flat_before_widget"], DatasetSelectorWidgetView)
+        assert isinstance(kwargs["flat_after_widget"], DatasetSelectorWidgetView)
+        assert isinstance(kwargs["dark_before_widget"], DatasetSelectorWidgetView)
+        assert isinstance(kwargs["dark_after_widget"], DatasetSelectorWidgetView)
         return True
 
     @staticmethod

--- a/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
+++ b/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
@@ -99,20 +99,15 @@ class FlatFieldingTest(unittest.TestCase):
         """
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)
         """
-        fake_presenter = mock.MagicMock()
-        fake_presenter.presenter.images = th.generate_images()
+        fake_images = th.generate_images()
         flat_before_widget = mock.Mock()
-        flat_before_widget.main_window.get_stack_visualiser = mock.Mock()
-        flat_before_widget.main_window.get_stack_visualiser.return_value = fake_presenter
+        flat_before_widget.main_window.get_stack = mock.Mock(return_value=fake_images)
         flat_after_widget = mock.Mock()
-        flat_after_widget.main_window.get_stack_visualiser = mock.Mock()
-        flat_after_widget.main_window.get_stack_visualiser.return_value = fake_presenter
+        flat_after_widget.main_window.get_stack = mock.Mock(return_value=fake_images)
         dark_before_widget = mock.Mock()
-        dark_before_widget.main_window.get_stack_visualiser = mock.Mock()
-        dark_before_widget.main_window.get_stack_visualiser.return_value = fake_presenter
+        dark_before_widget.main_window.get_stack = mock.Mock(return_value=fake_images)
         dark_after_widget = mock.Mock()
-        dark_after_widget.main_window.get_stack_visualiser = mock.Mock()
-        dark_after_widget.main_window.get_stack_visualiser.return_value = fake_presenter
+        dark_after_widget.main_window.get_stack = mock.Mock(return_value=fake_images)
         selected_flat_fielding_widget = mock.Mock()
         selected_flat_fielding_widget.currentText = mock.Mock(return_value="Only Before")
         use_dark_widget = mock.Mock()

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -16,7 +16,7 @@ from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.utility import add_property_to_form
 from mantidimaging.gui.utility.qt_helpers import Type
-from mantidimaging.gui.widgets.stack_selector import StackSelectorWidgetView
+from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
 
 
 def modes() -> List[str]:
@@ -123,7 +123,7 @@ class RoiNormalisationFilter(BaseFilter):
                                                     on_change=on_change,
                                                     tooltip="Flat images to be used for normalising.")
 
-        assert isinstance(flat_field_widget, StackSelectorWidgetView)
+        assert isinstance(flat_field_widget, DatasetSelectorWidgetView)
         flat_field_widget.setMaximumWidth(375)
         flat_field_widget.subscribe_to_main_window(view.main_window)
         flat_field_widget.try_to_select_relevant_stack("Flat")

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -96,6 +96,7 @@ class BaseEyesTest(unittest.TestCase):
         dataset = loader.load(file_names=[LOAD_SAMPLE])
         dataset.sample.name = "Stack 1"
         vis = self.imaging.presenter.create_new_stack(dataset)
+        self.imaging.presenter.model.add_dataset_to_model(dataset)
 
         QApplication.sendPostedEvents()
 

--- a/mantidimaging/gui/dialogs/async_task/model.py
+++ b/mantidimaging/gui/dialogs/async_task/model.py
@@ -37,6 +37,12 @@ class AsyncTaskDialogModel(QObject):
     def task_is_running(self) -> bool:
         return self.task.isRunning()
 
+    def _cleanup(self):
+        if self.tracker is not None:
+            self.tracker.remove(self)
+        self.on_complete_function = None
+        self.task.task_function = None
+
     def _on_task_exit(self):
         """
         Handler for task thread completion.
@@ -57,8 +63,6 @@ class AsyncTaskDialogModel(QObject):
                 log.exception("Failed to run task completion callback")
                 raise
             finally:
-                if self.tracker is not None:
-                    self.tracker.remove(self)
+                self._cleanup()
         else:
-            if self.tracker is not None:
-                self.tracker.remove(self)
+            self._cleanup()

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -15,7 +15,6 @@ class AsyncTaskDialogView(BaseDialogView):
     def __init__(self, parent: QMainWindow, auto_close: bool = False):
         super().__init__(parent, 'gui/ui/async_task_dialog.ui')
 
-        self.parent_view = parent
         self.presenter = AsyncTaskDialogPresenter(self)
         self.auto_close = auto_close
 
@@ -41,6 +40,8 @@ class AsyncTaskDialogView(BaseDialogView):
         # If auto close is enabled and the task was successful then hide the UI
         if self.auto_close:
             self.hide()
+
+        self.presenter.progress = None
 
     def set_progress(self, progress: float, message: str):
         # Set status message

--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -113,7 +113,7 @@
              </widget>
             </item>
             <item>
-             <widget class="StackSelectorWidgetView" name="stackSelector">
+             <widget class="DatasetSelectorWidgetView" name="stackSelector">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -442,9 +442,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>StackSelectorWidgetView</class>
+   <class>DatasetSelectorWidgetView</class>
    <extends>QComboBox</extends>
-   <header>mantidimaging.gui.widgets.stack_selector</header>
+   <header>mantidimaging.gui.widgets.dataset_selector</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/mantidimaging/gui/utility/qt_helpers.py
+++ b/mantidimaging/gui/utility/qt_helpers.py
@@ -192,8 +192,8 @@ def add_property_to_form(label: str,
             right_widget.currentIndexChanged[int].connect(lambda: on_change())
 
     elif dtype == 'stack' or dtype == Type.STACK:
-        from mantidimaging.gui.widgets.stack_selector import StackSelectorWidgetView
-        right_widget = StackSelectorWidgetView(filters_view)
+        from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
+        right_widget = DatasetSelectorWidgetView(filters_view, show_stacks=True)
         if on_change is not None:
             right_widget.currentIndexChanged[int].connect(lambda: on_change())
 

--- a/mantidimaging/gui/widgets/dataset_selector/__init__.py
+++ b/mantidimaging/gui/widgets/dataset_selector/__init__.py
@@ -1,2 +1,5 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+
+from .view import DatasetSelectorWidgetView  # noqa: F401
+from .presenter import DatasetSelectorWidgetPresenter  # noqa: F401

--- a/mantidimaging/gui/widgets/dataset_selector/presenter.py
+++ b/mantidimaging/gui/widgets/dataset_selector/presenter.py
@@ -21,12 +21,13 @@ class Notification(Enum):
 
 class DatasetSelectorWidgetPresenter(BasePresenter):
     view: 'DatasetSelectorWidgetView'
+    show_stacks: bool
 
-    def __init__(self, view):
+    def __init__(self, view, show_stacks=False):
         super().__init__(view)
 
         self.current_dataset = None
-        self.show_stacks = False
+        self.show_stacks = show_stacks
 
     def notify(self, signal):
         try:
@@ -78,7 +79,10 @@ class DatasetSelectorWidgetPresenter(BasePresenter):
 
     def handle_selection(self, index):
         self.current_dataset = self.view.itemData(index)
-        self.view.dataset_selected_uuid.emit(self.current_dataset)
+        if self.show_stacks:
+            self.view.stack_selected_uuid.emit(self.current_dataset)
+        else:
+            self.view.dataset_selected_uuid.emit(self.current_dataset)
 
     def do_select_eligible_stack(self):
         for i in range(self.view.count()):

--- a/mantidimaging/gui/widgets/dataset_selector/presenter.py
+++ b/mantidimaging/gui/widgets/dataset_selector/presenter.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 class Notification(Enum):
     RELOAD_DATASETS = 0
+    SELECT_ELIGIBLE_STACK = 1
 
 
 class DatasetSelectorWidgetPresenter(BasePresenter):
@@ -31,6 +32,8 @@ class DatasetSelectorWidgetPresenter(BasePresenter):
         try:
             if signal == Notification.RELOAD_DATASETS:
                 self.do_reload_datasets()
+            elif signal == Notification.SELECT_ELIGIBLE_STACK:
+                self.do_select_eligible_stack()
 
         except Exception as e:
             self.show_error(e, traceback.format_exc())
@@ -76,3 +79,10 @@ class DatasetSelectorWidgetPresenter(BasePresenter):
     def handle_selection(self, index):
         self.current_dataset = self.view.itemData(index)
         self.view.dataset_selected_uuid.emit(self.current_dataset)
+
+    def do_select_eligible_stack(self):
+        for i in range(self.view.count()):
+            name = self.view.itemText(i).lower()
+            if "dark" not in name and "flat" not in name and "180deg" not in name:
+                self.view.setCurrentIndex(i)
+                break

--- a/mantidimaging/gui/widgets/dataset_selector/presenter.py
+++ b/mantidimaging/gui/widgets/dataset_selector/presenter.py
@@ -24,7 +24,6 @@ class DatasetSelectorWidgetPresenter(BasePresenter):
     def __init__(self, view):
         super().__init__(view)
 
-        self.dataset_uuids = []
         self.current_dataset = None
 
     def notify(self, signal):
@@ -45,9 +44,10 @@ class DatasetSelectorWidgetPresenter(BasePresenter):
 
             # Get all the new stacks
             dataset_list: List[Tuple[UUID, str]] = self.view.main_window.dataset_list
-            self.dataset_uuids, user_friendly_names = \
-                zip(*dataset_list) if dataset_list else (None, [])
-            self.view.addItems(user_friendly_names)
+            user_friendly_names = [item[1] for item in dataset_list]
+
+            for uuid, name in dataset_list:
+                self.view.addItem(name, uuid)
 
             # If the previously selected window still exists with the same name,
             # reselect it, otherwise default to the first item
@@ -62,6 +62,5 @@ class DatasetSelectorWidgetPresenter(BasePresenter):
         self.handle_selection(new_selected_index)
 
     def handle_selection(self, index):
-        uuid = self.dataset_uuids[index] if self.dataset_uuids else None
-        self.current_dataset = uuid
-        self.view.dataset_selected_uuid.emit(uuid)
+        self.current_dataset = self.view.itemData(index)
+        self.view.dataset_selected_uuid.emit(self.current_dataset)

--- a/mantidimaging/gui/widgets/dataset_selector/presenter.py
+++ b/mantidimaging/gui/widgets/dataset_selector/presenter.py
@@ -25,6 +25,7 @@ class DatasetSelectorWidgetPresenter(BasePresenter):
         super().__init__(view)
 
         self.current_dataset = None
+        self.show_stacks = False
 
     def notify(self, signal):
         try:
@@ -43,7 +44,7 @@ class DatasetSelectorWidgetPresenter(BasePresenter):
             self.view.clear()
 
             # Get all the new stacks
-            dataset_list: List[Tuple[UUID, str]] = self.view.main_window.dataset_list
+            dataset_list: List[Tuple[UUID, str]] = self._get_dataset_list(self.show_stacks)
             user_friendly_names = [item[1] for item in dataset_list]
 
             for uuid, name in dataset_list:
@@ -60,6 +61,17 @@ class DatasetSelectorWidgetPresenter(BasePresenter):
 
         self.view.datasets_updated.emit()
         self.handle_selection(new_selected_index)
+
+    def _get_dataset_list(self, stacks=False) -> List[Tuple[UUID, str]]:
+        result: List[Tuple[UUID, str]] = []
+        for dataset in self.view.main_window.presenter.datasets:
+            if not stacks:
+                result.append((dataset.id, dataset.name))
+            else:
+                for stack in dataset.all:
+                    result.append((stack.id, stack.name))
+
+        return result
 
     def handle_selection(self, index):
         self.current_dataset = self.view.itemData(index)

--- a/mantidimaging/gui/widgets/dataset_selector/test/test_presenter.py
+++ b/mantidimaging/gui/widgets/dataset_selector/test/test_presenter.py
@@ -90,7 +90,7 @@ class DatasetSelectorWidgetPresenterTests(unittest.TestCase):
         self.view.main_window.presenter.datasets = [self.ds1, self.ds2]
         self.presenter.show_stacks = True
         self.view.datasets_updated.emit = mock.Mock()
-        self.view.dataset_selected_uuid.emit = mock.Mock()
+        self.view.stack_selected_uuid.emit = mock.Mock()
 
         self.presenter.do_reload_datasets()
         self.assertEqual(self.view.addItem.call_count, 3)

--- a/mantidimaging/gui/widgets/dataset_selector/test/test_presenter.py
+++ b/mantidimaging/gui/widgets/dataset_selector/test/test_presenter.py
@@ -15,14 +15,15 @@ class DatasetSelectorWidgetPresenterTests(unittest.TestCase):
 
     def test_handle_selection_no_matching_index_found(self):
         self.view.dataset_selected_uuid.emit = mock.Mock()
+        self.view.itemData = mock.Mock(return_value=None)
         self.presenter.handle_selection(1)
         self.view.dataset_selected_uuid.emit.assert_called_with(None)
         self.assertIsNone(self.presenter.current_dataset)
 
     def test_handle_selection_matching_index_found(self):
         matching_uuid = "second-uuid"
-        self.presenter.dataset_uuids = ["first-uuid", matching_uuid]
         self.view.dataset_selected_uuid.emit = mock.Mock()
+        self.view.itemData = mock.Mock(return_value=matching_uuid)
 
         self.presenter.handle_selection(1)
         self.view.dataset_selected_uuid.emit.assert_called_with(matching_uuid)
@@ -37,33 +38,33 @@ class DatasetSelectorWidgetPresenterTests(unittest.TestCase):
         self.view.main_window = mock.Mock()
         self.view.datasets_updated.emit = mock.Mock()
         self.view.dataset_selected_uuid.emit = mock.Mock()
+        self.view.itemData = mock.Mock(return_value="id-2")
         self.view.currentText.return_value = second_dataset_name = "second-dataset-name"
         first_dataset_name = "first-dataset-name"
-        self.view.main_window.dataset_list = [("id-1", first_dataset_name), ("id-1", second_dataset_name)]
+        self.view.main_window.dataset_list = [("id-1", first_dataset_name), ("id-2", second_dataset_name)]
         self.presenter.do_reload_datasets()
 
         self.view.clear.assert_called_once()
-        self.view.addItems.assert_called_once_with((
-            first_dataset_name,
-            second_dataset_name,
-        ))
+        self.view.addItem.assert_any_call(first_dataset_name, "id-1")
+        self.view.addItem.assert_any_call(second_dataset_name, "id-2")
         self.view.setCurrentIndex.assert_called_once_with(1)
         self.view.datasets_updated.emit.assert_called_once()
-        self.view.dataset_selected_uuid.emit.assert_called_once_with(self.presenter.dataset_uuids[1])
-        assert self.presenter.current_dataset == self.presenter.dataset_uuids[1]
+        self.view.dataset_selected_uuid.emit.assert_called_once_with("id-2")
+        assert self.presenter.current_dataset == "id-2"
 
     def test_do_reload_datasets_no_old_selection(self):
         self.view.main_window = mock.Mock()
         self.view.datasets_updated.emit = mock.Mock()
         self.view.dataset_selected_uuid.emit = mock.Mock()
+        self.view.itemData = mock.Mock(return_value="id-1")
         self.view.currentText.return_value = "second-dataset-name"
         first_dataset_name = "first-dataset-name"
         self.view.main_window.dataset_list = [("id-1", first_dataset_name)]
         self.presenter.do_reload_datasets()
 
         self.view.clear.assert_called_once()
-        self.view.addItems.assert_called_once_with((first_dataset_name, ))
+        self.view.addItem.assert_any_call(first_dataset_name, "id-1")
         self.view.setCurrentIndex.assert_called_once_with(0)
         self.view.datasets_updated.emit.assert_called_once()
-        self.view.dataset_selected_uuid.emit.assert_called_once_with(self.presenter.dataset_uuids[0])
-        assert self.presenter.current_dataset == self.presenter.dataset_uuids[0]
+        self.view.dataset_selected_uuid.emit.assert_called_once_with("id-1")
+        assert self.presenter.current_dataset == "id-1"

--- a/mantidimaging/gui/widgets/dataset_selector/test/test_presenter.py
+++ b/mantidimaging/gui/widgets/dataset_selector/test/test_presenter.py
@@ -6,12 +6,29 @@ from unittest import mock
 
 from mantidimaging.gui.widgets.dataset_selector.presenter import DatasetSelectorWidgetPresenter, Notification
 from mantidimaging.gui.widgets.dataset_selector.view import DatasetSelectorWidgetView
+from mantidimaging.core.data.dataset import Dataset
 
 
 class DatasetSelectorWidgetPresenterTests(unittest.TestCase):
     def setUp(self) -> None:
         self.view = mock.create_autospec(DatasetSelectorWidgetView)
         self.presenter = DatasetSelectorWidgetPresenter(self.view)
+
+        self.view.main_window = mock.Mock()
+        self.view.main_window.presenter = mock.Mock()
+
+        self.img1 = mock.Mock(id="img1")
+        self.img1.name = "Image 1"
+        self.img1.proj180deg = None
+        self.img2 = mock.Mock(id="img2")
+        self.img2.name = "Image 2"
+        self.img2.proj180deg = None
+        self.img3 = mock.Mock(id="img3")
+        self.img3.name = "Image 3"
+        self.ds1 = Dataset(sample=self.img1)
+        self.ds1.name = "Dataset 1"
+        self.ds2 = Dataset(sample=self.img2, flat_before=self.img3)
+        self.ds2.name = "Dataset 2"
 
     def test_handle_selection_no_matching_index_found(self):
         self.view.dataset_selected_uuid.emit = mock.Mock()
@@ -35,36 +52,48 @@ class DatasetSelectorWidgetPresenterTests(unittest.TestCase):
         self.presenter.do_reload_datasets.assert_called_once()
 
     def test_do_reload_datasets_keep_old_selection(self):
-        self.view.main_window = mock.Mock()
+        self.view.main_window.presenter.datasets = [self.ds1, self.ds2]
         self.view.datasets_updated.emit = mock.Mock()
         self.view.dataset_selected_uuid.emit = mock.Mock()
-        self.view.itemData = mock.Mock(return_value="id-2")
-        self.view.currentText.return_value = second_dataset_name = "second-dataset-name"
-        first_dataset_name = "first-dataset-name"
-        self.view.main_window.dataset_list = [("id-1", first_dataset_name), ("id-2", second_dataset_name)]
+        self.view.itemData = mock.Mock(return_value=self.ds2.id)
+        self.view.currentText.return_value = self.ds2.name
+
         self.presenter.do_reload_datasets()
 
         self.view.clear.assert_called_once()
-        self.view.addItem.assert_any_call(first_dataset_name, "id-1")
-        self.view.addItem.assert_any_call(second_dataset_name, "id-2")
+        self.assertEqual(self.view.addItem.call_count, 2)
+        self.view.addItem.assert_any_call(self.ds1.name, self.ds1.id)
+        self.view.addItem.assert_any_call(self.ds2.name, self.ds2.id)
         self.view.setCurrentIndex.assert_called_once_with(1)
         self.view.datasets_updated.emit.assert_called_once()
-        self.view.dataset_selected_uuid.emit.assert_called_once_with("id-2")
-        assert self.presenter.current_dataset == "id-2"
+        self.view.dataset_selected_uuid.emit.assert_called_once_with(self.ds2.id)
+        assert self.presenter.current_dataset == self.ds2.id
 
     def test_do_reload_datasets_no_old_selection(self):
-        self.view.main_window = mock.Mock()
+        self.view.main_window.presenter.datasets = [self.ds1]
         self.view.datasets_updated.emit = mock.Mock()
         self.view.dataset_selected_uuid.emit = mock.Mock()
-        self.view.itemData = mock.Mock(return_value="id-1")
-        self.view.currentText.return_value = "second-dataset-name"
-        first_dataset_name = "first-dataset-name"
-        self.view.main_window.dataset_list = [("id-1", first_dataset_name)]
+        self.view.itemData = mock.Mock(return_value=self.ds1.id)
+        self.view.currentText.return_value = self.ds2.name
+
         self.presenter.do_reload_datasets()
 
         self.view.clear.assert_called_once()
-        self.view.addItem.assert_any_call(first_dataset_name, "id-1")
+        self.assertEqual(self.view.addItem.call_count, 1)
+        self.view.addItem.assert_any_call(self.ds1.name, self.ds1.id)
         self.view.setCurrentIndex.assert_called_once_with(0)
         self.view.datasets_updated.emit.assert_called_once()
-        self.view.dataset_selected_uuid.emit.assert_called_once_with("id-1")
-        assert self.presenter.current_dataset == "id-1"
+        self.view.dataset_selected_uuid.emit.assert_called_once_with(self.ds1.id)
+        assert self.presenter.current_dataset == self.ds1.id
+
+    def test_do_reload_datasets_stacks(self):
+        self.view.main_window.presenter.datasets = [self.ds1, self.ds2]
+        self.presenter.show_stacks = True
+        self.view.datasets_updated.emit = mock.Mock()
+        self.view.dataset_selected_uuid.emit = mock.Mock()
+
+        self.presenter.do_reload_datasets()
+        self.assertEqual(self.view.addItem.call_count, 3)
+        self.view.addItem.assert_any_call(self.img1.name, self.img1.id)
+        self.view.addItem.assert_any_call(self.img2.name, self.img2.id)
+        self.view.addItem.assert_any_call(self.img3.name, self.img3.id)

--- a/mantidimaging/gui/widgets/dataset_selector/test/test_view.py
+++ b/mantidimaging/gui/widgets/dataset_selector/test/test_view.py
@@ -37,3 +37,16 @@ class DatasetSelectorWidgetViewTest(unittest.TestCase):
 
     def test_current(self):
         assert self.view.current() is self.presenter.current_dataset
+
+    def _add_items(self):
+        self.view.addItems(["flat_0001", "dark_0001", "tomo_0001"])
+
+    def test_try_to_select_relevant_stack(self):
+        self._add_items()
+        self.view.try_to_select_relevant_stack("dark")
+        self.assertEqual(self.view.currentIndex(), 1)
+        self.assertEqual(self.view.currentText(), "dark_0001")
+
+        self.view.try_to_select_relevant_stack("flat")
+        self.assertEqual(self.view.currentIndex(), 0)
+        self.assertEqual(self.view.currentText(), "flat_0001")

--- a/mantidimaging/gui/widgets/dataset_selector/view.py
+++ b/mantidimaging/gui/widgets/dataset_selector/view.py
@@ -13,6 +13,13 @@ if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView
 
 
+def _string_contains_all_parts(string: str, parts: list) -> bool:
+    for part in parts:
+        if part.lower() not in string:
+            return False
+    return True
+
+
 class DatasetSelectorWidgetView(QComboBox):
     datasets_updated = pyqtSignal()
     dataset_selected_uuid = pyqtSignal('PyQt_PyObject')
@@ -52,3 +59,12 @@ class DatasetSelectorWidgetView(QComboBox):
 
     def current(self) -> Optional[uuid.UUID]:
         return self.presenter.current_dataset
+
+    def try_to_select_relevant_stack(self, name: str) -> None:
+        # Split based on whitespace
+        name_parts = name.split()
+        for i in range(self.count()):
+            # If widget text contains all name parts
+            if _string_contains_all_parts(self.itemText(i).lower(), name_parts):
+                self.setCurrentIndex(i)
+                break

--- a/mantidimaging/gui/widgets/dataset_selector/view.py
+++ b/mantidimaging/gui/widgets/dataset_selector/view.py
@@ -23,13 +23,14 @@ def _string_contains_all_parts(string: str, parts: list) -> bool:
 class DatasetSelectorWidgetView(QComboBox):
     datasets_updated = pyqtSignal()
     dataset_selected_uuid = pyqtSignal('PyQt_PyObject')
+    stack_selected_uuid = pyqtSignal('PyQt_PyObject')
 
     main_window: 'MainWindowView'
 
-    def __init__(self, parent):
+    def __init__(self, parent, show_stacks=False):
         super().__init__(parent)
 
-        self.presenter = DatasetSelectorWidgetPresenter(self)
+        self.presenter = DatasetSelectorWidgetPresenter(self, show_stacks=show_stacks)
         self.currentIndexChanged[int].connect(self.presenter.handle_selection)
 
     def subscribe_to_main_window(self, main_window: 'MainWindowView'):

--- a/mantidimaging/gui/widgets/dataset_selector/view.py
+++ b/mantidimaging/gui/widgets/dataset_selector/view.py
@@ -68,3 +68,6 @@ class DatasetSelectorWidgetView(QComboBox):
             if _string_contains_all_parts(self.itemText(i).lower(), name_parts):
                 self.setCurrentIndex(i)
                 break
+
+    def select_eligible_stack(self):
+        self.presenter.notify(Notification.SELECT_ELIGIBLE_STACK)

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -168,6 +168,13 @@ class MainWindowModel(object):
             images += dataset.all
         return [image.id for image in images if image is not None]
 
+    @property
+    def images(self) -> List[Images]:
+        images = []
+        for dataset in self.datasets.values():
+            images += dataset.all
+        return images
+
     def add_recon_to_dataset(self, recon_data: Images, stack_id: uuid.UUID):
         for dataset in self.datasets.values():
             if stack_id in dataset:

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -163,6 +163,9 @@ class MainWindowPresenter(BasePresenter):
     def get_active_stack_visualisers(self) -> List[StackVisualiserView]:
         return [stack for stack in self.active_stacks.values()]
 
+    def get_all_stacks(self) -> List[Images]:
+        return self.model.images
+
     def create_new_180_stack(self, container: Images) -> StackVisualiserView:
         _180_stack_vis = self.view.create_stack_window(container)
 
@@ -283,6 +286,12 @@ class MainWindowPresenter(BasePresenter):
 
     def get_stack_visualiser(self, stack_id: uuid.UUID) -> StackVisualiserView:
         return self.active_stacks[stack_id]
+
+    def get_stack(self, stack_id: uuid.UUID) -> Images:
+        images = self.model.get_images_by_uuid(stack_id)
+        if images is None:
+            raise RuntimeError(f"Stack not found: {stack_id}")
+        return images
 
     def get_stack_visualiser_history(self, stack_id: uuid.UUID) -> Dict[str, Any]:
         return self.get_stack_visualiser(stack_id).presenter.images.metadata

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -5,13 +5,13 @@ import traceback
 import uuid
 from enum import Enum, auto
 from logging import getLogger, Logger
-from typing import TYPE_CHECKING, Union, Optional, Dict, List, Any, NamedTuple
+from typing import TYPE_CHECKING, Union, Optional, Dict, List, Any, NamedTuple, Iterable
 
 import numpy as np
 from PyQt5.QtWidgets import QTabBar, QApplication
 
 from mantidimaging.core.data import Images
-from mantidimaging.core.data.dataset import Dataset
+from mantidimaging.core.data.dataset import Dataset, StackDataset
 from mantidimaging.core.io.loader.loader import create_loading_parameters_for_file_path
 from mantidimaging.core.io.utility import find_projection_closest_to_180, THRESHOLD_180
 from mantidimaging.core.utility.data_containers import ProjectionAngles, LoadingParameters
@@ -264,6 +264,10 @@ class MainWindowPresenter(BasePresenter):
     def stack_visualiser_list(self) -> List[StackId]:
         stacks = [StackId(stack_id, widget.windowTitle()) for stack_id, widget in self.active_stacks.items()]
         return sorted(stacks, key=lambda x: x.name)
+
+    @property
+    def datasets(self) -> Iterable[Union[StackDataset, Dataset]]:
+        return self.model.datasets.values()
 
     @property
     def dataset_list(self) -> List[DatasetId]:

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -4,7 +4,7 @@
 import os
 import uuid
 from logging import getLogger
-from typing import Optional
+from typing import Optional, List
 from uuid import UUID
 
 import numpy as np
@@ -335,11 +335,17 @@ class MainWindowView(BaseMainWindowView):
     def get_stack_visualiser(self, stack_uuid):
         return self.presenter.get_stack_visualiser(stack_uuid)
 
+    def get_stack(self, stack_uuid: uuid.UUID) -> Images:
+        return self.presenter.get_stack(stack_uuid)
+
     def get_images_from_stack_uuid(self, stack_uuid) -> Images:
         return self.presenter.get_stack_visualiser(stack_uuid).presenter.images
 
     def get_all_stack_visualisers(self):
         return self.presenter.get_active_stack_visualisers()
+
+    def get_all_stacks(self) -> List[Images]:
+        return self.presenter.get_all_stacks()
 
     def get_all_stack_visualisers_with_180deg_proj(self):
         return self.presenter.get_all_stack_visualisers_with_180deg_proj()

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -12,7 +12,7 @@ from mantidimaging.gui.mvp_base import BaseMainWindowView
 if TYPE_CHECKING:
     from PyQt5.QtWidgets import QFormLayout  # noqa: F401  # pragma: no cover
     from mantidimaging.gui.windows.operations import FiltersWindowPresenter  # pragma: no cover
-    from mantidimaging.gui.windows.stack_visualiser import StackVisualiserView  # pragma: no cover
+    from mantidimaging.core.data import Images
 
 
 def ensure_tuple(val):
@@ -100,7 +100,7 @@ class FiltersWindowModel(object):
         self.selected_filter = self.filters[filter_idx]
         self.filter_widget_kwargs = filter_widget_kwargs
 
-    def apply_to_stacks(self, stacks: List['StackVisualiserView'], progress=None):
+    def apply_to_stacks(self, stacks: List['Images'], progress=None):
         """
         Applies the selected filter to a given image stack.
 
@@ -108,7 +108,7 @@ class FiltersWindowModel(object):
         it to the function that actually processes the images.
         """
         for stack in stacks:
-            self.apply_to_images(stack.presenter.images, progress=progress)
+            self.apply_to_images(stack, progress=progress)
 
     def apply_to_images(self, images, progress=None):
         input_kwarg_widgets = self.filter_widget_kwargs.copy()
@@ -128,7 +128,7 @@ class FiltersWindowModel(object):
             *exec_func.args,
             **exec_func.keywords)
 
-    def do_apply_filter(self, stacks: List['StackVisualiserView'], post_filter: Callable[[Any], None]):
+    def do_apply_filter(self, stacks: List['Images'], post_filter: Callable[[Any], None]):
         """
         Applies the selected filter to the selected stack.
         """
@@ -140,7 +140,7 @@ class FiltersWindowModel(object):
         apply_func = partial(self.apply_to_stacks, stacks)
         start_async_task_view(self.presenter.view, apply_func, post_filter)
 
-    def do_apply_filter_sync(self, stacks: List['StackVisualiserView'], post_filter: Callable[[Any], None]):
+    def do_apply_filter_sync(self, stacks: List['Images'], post_filter: Callable[[Any], None]):
         """
         Applies the selected filter to the selected stack in a synchronous manner
         """

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -20,7 +20,7 @@ from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.utility import BlockQtSignals
 from mantidimaging.gui.utility.common import operation_in_progress
 from mantidimaging.gui.windows.stack_choice.presenter import StackChoicePresenter
-from mantidimaging.gui.widgets.stack_selector import StackSelectorWidgetView
+from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
 
 from .model import FiltersWindowModel
 
@@ -151,8 +151,8 @@ class FiltersWindowPresenter(BasePresenter):
 
             for row_id in range(self.view.filterPropertiesLayout.count()):
                 widget = self.view.filterPropertiesLayout.itemAt(row_id).widget()
-                if isinstance(widget, StackSelectorWidgetView):
-                    widget._handle_loaded_stacks_changed()
+                if isinstance(widget, DatasetSelectorWidgetView):
+                    widget._handle_loaded_datasets_changed()
 
         self.do_update_previews()
 

--- a/mantidimaging/gui/windows/operations/test/test_model.py
+++ b/mantidimaging/gui/windows/operations/test/test_model.py
@@ -10,7 +10,8 @@ import numpy as np
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operation_history import const
 from mantidimaging.gui.windows.operations import FiltersWindowModel
-from mantidimaging.gui.windows.stack_visualiser import (StackVisualiserView, StackVisualiserPresenter, SVParameters)
+from mantidimaging.gui.windows.stack_visualiser import SVParameters
+from mantidimaging.core.data import Images
 
 
 class FiltersWindowModelTest(unittest.TestCase):
@@ -22,11 +23,7 @@ class FiltersWindowModelTest(unittest.TestCase):
         cls.test_data = th.generate_images()
 
     def setUp(self):
-        self.sv_view = mock.create_autospec(StackVisualiserView)
-        self.sv_view.current_roi = self.ROI_PARAMETER
-
-        self.sv_presenter = StackVisualiserPresenter(self.sv_view, self.test_data)
-        self.sv_view.presenter = self.sv_presenter
+        self.stack = Images(np.zeros([3, 3, 3]))
 
         self.model = FiltersWindowModel(mock.MagicMock())
 
@@ -74,7 +71,7 @@ class FiltersWindowModelTest(unittest.TestCase):
 
         execute = mock.MagicMock(return_value=partial(self.execute_mock))
         originals = self.setup_mocks(execute)
-        self.model.do_apply_filter([self.sv_view], callback)
+        self.model.do_apply_filter([self.stack], callback)
         self.reset_filter_model(*originals)
 
         execute.assert_called_once()
@@ -92,7 +89,7 @@ class FiltersWindowModelTest(unittest.TestCase):
         execute = mock.MagicMock(return_value=partial(self.execute_mock_with_roi))
         originals = self.setup_mocks(execute)
         self.model.selected_filter.params = lambda: {'roi': SVParameters.ROI}
-        self.model.do_apply_filter([self.sv_view], callback)
+        self.model.do_apply_filter([self.stack], callback)
         self.reset_filter_model(*originals)
 
         execute.assert_called_once()
@@ -101,7 +98,7 @@ class FiltersWindowModelTest(unittest.TestCase):
     @mock.patch("mantidimaging.gui.windows.operations.model.start_async_task_view")
     def test_operation_recorded_in_image_history(self, mocked_start_view):
         mocked_start_view.side_effect = lambda _, task, on_complete: self.run_without_gui(task, on_complete)
-        self.sv_presenter.images.metadata = {}
+        self.stack.metadata = {}
 
         callback_mock = mock.Mock()
 
@@ -113,10 +110,10 @@ class FiltersWindowModelTest(unittest.TestCase):
         execute.keywords = {"kwarg": "kwarg"}
         originals = self.setup_mocks(execute)
 
-        self.model.do_apply_filter([self.sv_view], callback)
+        self.model.do_apply_filter([self.stack], callback)
         self.reset_filter_model(*originals)
 
-        op_history = self.sv_presenter.images.metadata['operation_history']
+        op_history = self.stack.metadata['operation_history']
         self.assertEqual(len(op_history), 1, "One operation should have been recorded")
         self.assertEqual(op_history[0][const.OPERATION_KEYWORD_ARGS], {"kwarg": "kwarg"})
         # Recorded operation should not be a qualified module name.
@@ -125,15 +122,14 @@ class FiltersWindowModelTest(unittest.TestCase):
 
     @mock.patch("mantidimaging.gui.windows.operations.model.FiltersWindowModel.apply_to_images")
     def test_apply_filter_to_stacks(self, apply_to_images_mock: mock.Mock):
-        mock_stack_visualisers = [mock.Mock(), mock.Mock()]
+        mock_stacks = [mock.Mock(), mock.Mock()]
         mock_progress = mock.Mock()
 
-        self.model.apply_to_stacks(mock_stack_visualisers, mock_progress)
+        self.model.apply_to_stacks(mock_stacks, mock_progress)
 
-        apply_to_images_mock.assert_has_calls([
-            mock.call(mock_stack_visualisers[0].presenter.images, progress=mock_progress),
-            mock.call(mock_stack_visualisers[1].presenter.images, progress=mock_progress)
-        ])
+        apply_to_images_mock.assert_has_calls(
+            [mock.call(mock_stacks[0], progress=mock_progress),
+             mock.call(mock_stacks[1], progress=mock_progress)])
 
     def test_apply_filter_to_images(self):
         """

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -120,6 +120,7 @@ class FiltersWindowView(BaseMainWindowView):
         if self.roi_view is not None:
             self.roi_view.close()
             self.roi_view = None
+        self.presenter.set_stack(None)
         self.auto_update_triggered.disconnect()
         self.main_window.filters = None
         self.presenter = None

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -123,6 +123,7 @@ class FiltersWindowView(BaseMainWindowView):
         self.presenter.set_stack(None)
         self.auto_update_triggered.disconnect()
         self.main_window.filters = None
+        self.presenter.view = None
         self.presenter = None
 
     def show(self):

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -13,7 +13,7 @@ from mantidimaging.core.net.help_pages import open_user_operation_docs
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.utility import delete_all_widgets_from_layout
 from mantidimaging.gui.widgets.mi_image_view.view import MIImageView
-from mantidimaging.gui.widgets.stack_selector import StackSelectorWidgetView
+from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
 
 from .filter_previews import FilterPreviews
 from .presenter import FiltersWindowPresenter
@@ -47,7 +47,7 @@ class FiltersWindowView(BaseMainWindowView):
 
     previewsLayout: QVBoxLayout
     previews: FilterPreviews
-    stackSelector: StackSelectorWidgetView
+    stackSelector: DatasetSelectorWidgetView
 
     notification_icon: QLabel
     notification_text: QLabel
@@ -74,6 +74,7 @@ class FiltersWindowView(BaseMainWindowView):
         self.filterSelector.currentTextChanged.connect(self._update_apply_all_button)
 
         # Handle stack selection
+        self.stackSelector.presenter.show_stacks = True
         self.stackSelector.stack_selected_uuid.connect(self.presenter.set_stack_uuid)
         self.stackSelector.stack_selected_uuid.connect(self.auto_update_triggered.emit)
 

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -229,8 +229,8 @@ class FiltersWindowView(BaseMainWindowView):
     def roi_visualiser(self, roi_field):
         # Start the stack visualiser and ensure that it uses the ROI from here in the rest of this
         try:
-            images = self.presenter.stack.presenter.get_image(self.presenter.model.preview_image_idx)
-        except Exception:
+            images = self.presenter.stack.index_as_images(self.presenter.model.preview_image_idx)
+        except IndexError:
             # Happens if nothing has been loaded, so do nothing as nothing can't be visualised
             return
 
@@ -243,7 +243,7 @@ class FiltersWindowView(BaseMainWindowView):
         self.roi_view.setWindowTitle("Select ROI for operation")
 
         def set_averaged_image():
-            averaged_images = np.sum(self.presenter.stack.presenter.images.data, axis=0)
+            averaged_images = np.sum(self.presenter.stack.data, axis=0)
             self.roi_view.setImage(averaged_images.reshape((1, averaged_images.shape[0], averaged_images.shape[1])))
             self.roi_view_averaged = True
 


### PR DESCRIPTION
### Issue

Close #1243

### Description
Update `DatasetSelectorWidgetView` to be able to show the stacks in the datasets. Once migration is complete `StackSelectorWidgetView` can be removed.

Move the operations window over to using DatasetSelectorWidgetView. This involves changing a lot of values from `StackVisualiserView` to `Images`, reducing the amount of passing QWidgets around outside of GUI code.

It was also needed to be more careful about references to Images object being held on to. Cleaned up various places they were being kept alive. 

### Testing & Acceptance Criteria 

Open a dataset, do some operations.

Open a dataset, close the tabs. do some operations

### Documentation

release notes
