### PR TITLE
Fix import of MWSaveDialog

### DIFF
--- a/mantidimaging/gui/test/test_gui_system_loading.py
+++ b/mantidimaging/gui/test/test_gui_system_loading.py
@@ -5,10 +5,12 @@ from pathlib import Path
 from unittest import mock
 
 from PyQt5.QtCore import Qt, QTimer, QEventLoop
-from PyQt5.QtWidgets import QApplication
+from PyQt5.QtTest import QTest
+from PyQt5.QtWidgets import QApplication, QDialogButtonBox
 
 from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHORT_DELAY, LOAD_SAMPLE
 from mantidimaging.gui.widgets.dataset_selector_dialog.dataset_selector_dialog import DatasetSelectorDialog
+from mantidimaging.gui.windows.main.save_dialog import MWSaveDialog
 
 
 class TestGuiSystemLoading(GuiSystemBase):
@@ -74,3 +76,18 @@ class TestGuiSystemLoading(GuiSystemBase):
         self.assertEqual(len(stacks_after), 5)
         self.assertIn(stacks[0], stacks_after)
         self.assertTrue(stacks[0].presenter.images.has_proj180deg())
+
+    def test_save_images(self):
+        self._load_images()
+
+        self.main_window.show_save_dialogue()
+
+        with mock.patch("mantidimaging.gui.windows.main.MainWindowModel.do_images_saving") as mock_save:
+            self._wait_for_widget_visible(MWSaveDialog)
+            QApplication.processEvents()
+
+            ok_button = self.main_window.save_dialogue.buttonBox.button(QDialogButtonBox.StandardButton.SaveAll)
+            QTest.mouseClick(ok_button, Qt.LeftButton)
+
+            QApplication.processEvents()
+            mock_save.assert_called_once()

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -20,10 +20,10 @@ from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.windows.stack_visualiser.presenter import SVNotification
 from mantidimaging.gui.windows.stack_visualiser.view import StackVisualiserView
 from .model import MainWindowModel
+from mantidimaging.gui.windows.main.save_dialog import MWSaveDialog
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # pragma: no cover
-    from mantidimaging.gui.windows.main.save_dialog import MWSaveDialog
     from mantidimaging.gui.dialogs.async_task.task import TaskWorkerThread
 
 

--- a/mantidimaging/gui/windows/main/save_dialog.py
+++ b/mantidimaging/gui/windows/main/save_dialog.py
@@ -1,17 +1,19 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 import uuid
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from PyQt5.QtWidgets import QDialog, QDialogButtonBox
 
 from mantidimaging.core.io.loader import supported_formats
 from mantidimaging.core.io.utility import DEFAULT_IO_FILE_FORMAT
 from mantidimaging.gui.utility import (compile_ui, select_directory)
-from mantidimaging.gui.windows.main.presenter import StackId
+
+if TYPE_CHECKING:
+    from mantidimaging.gui.windows.main.presenter import StackId
 
 
-def sort_by_tomo_and_recon(stack_id: StackId):
+def sort_by_tomo_and_recon(stack_id: "StackId"):
     if "Recon" in stack_id.name:
         return 1
     elif "Tomo" in stack_id.name:


### PR DESCRIPTION
MWSaveDialog is used at runtime so need a real import

### Issue
Closes #1268 

### Description


Fixes bug introduced by 1079dd8897f5297122793040fd1e94f6498ab550 , MWSaveDialog needs to be properly imported. Also needed change the `StackId` import to avoid a circular import.

Added a system test for saving.

### Testing & Acceptance Criteria 
Open a stack, File -> Save

### Documentation

Fixes a recent regression so no release note needed
