### PR TITLE
Make more use of QTest in GUI tests

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -58,3 +58,4 @@ Developer Changes
 - #1251 : System tests: test_correlate ValueError
 - #1259 : Update license year in code files and add pre-commit check
 - #1243 : Stack selector based on datasets
+- #1184 : Make more use of QTest in gui testing

--- a/mantidimaging/eyes_tests/eyes_manager.py
+++ b/mantidimaging/eyes_tests/eyes_manager.py
@@ -4,11 +4,11 @@
 import inspect
 import os
 from tempfile import mkdtemp
-import time
 from unittest import mock
 from uuid import uuid4
 
 from PyQt5.QtWidgets import QWidget, QApplication
+from PyQt5.QtTest import QTest
 from applitools.common import BatchInfo, MatchLevel
 from applitools.images import Eyes
 
@@ -87,7 +87,7 @@ class EyesManager:
         if not isinstance(widget, QWidget):
             raise ValueError("widget is not a QWidget")
 
-        time.sleep(0.2)
+        QTest.qWaitForWindowExposed(widget)
         QApplication.processEvents()
         window_image = widget.grab()
 

--- a/mantidimaging/gui/test/test_gui_system_loading.py
+++ b/mantidimaging/gui/test/test_gui_system_loading.py
@@ -90,4 +90,6 @@ class TestGuiSystemLoading(GuiSystemBase):
             QTest.mouseClick(ok_button, Qt.LeftButton)
 
             QApplication.processEvents()
+            self._wait_until(lambda: mock_save.call_count == 1)
+            # Confirm that save has been called only once
             mock_save.assert_called_once()

--- a/mantidimaging/gui/test/test_gui_system_operations.py
+++ b/mantidimaging/gui/test/test_gui_system_operations.py
@@ -13,7 +13,6 @@ from PyQt5.QtWidgets import QFormLayout, QLabel, QWidget
 from mantidimaging.gui.windows.stack_choice.presenter import StackChoicePresenter
 from mantidimaging.core.data import Images
 from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHOW_DELAY, SHORT_DELAY
-from mantidimaging.gui.windows.stack_choice.view import StackChoiceView
 from mantidimaging.gui.windows.operations.view import FiltersWindowView
 
 OP_LIST = [
@@ -72,17 +71,6 @@ class TestGuiSystemOperations(GuiSystemBase):
                     return widget_item.widget()
 
         raise ValueError(f"Could not find '{param_name}' in form")
-
-    @classmethod
-    def _click_stack_selector(cls, keep_new: bool):
-        cls._wait_for_widget_visible(StackChoiceView)
-        QTest.qWait(SHOW_DELAY)
-        for widget in cls.app.topLevelWidgets():
-            if isinstance(widget, StackChoiceView):
-                if keep_new:
-                    QTest.mouseClick(widget.newDataButton, Qt.MouseButton.LeftButton)
-                else:
-                    QTest.mouseClick(widget.originalDataButton, Qt.MouseButton.LeftButton)
 
     @parameterized.expand(OP_LIST)
     def test_run_operation_stack(self, op_name, params):


### PR DESCRIPTION
### Issue

Closes #1184

### Description

I was able to switch  `time.sleep()` to `qWaitForWindowExposed` in the Applitools tests. Interestingly it wasn't possible to use `qWaitForWindowActive` as the condition didn't seem to be satisfied.

I haven't made any changes to the GUI System Tests. Unfortunately the `qWaitFor` method hasn't been made available in PyQt version 5.15, so we can't use that to replace the `_wait_until` method in GuiSystemBase. For `_wait_for_widget_visible`, I did some testing with `qWaitForWindowExposed` and `qWaitForWindowActive` using various approaches in the code, but conditions were not satisfied consistently (particularly in the recon tests) and so either slowed things down or required timeouts that basically meant they were doing an equivalent thing to what was already there. I concluded the current approach was the best for now.

In this PR I've also removed an unused method in test_gui_system_operations.py and added a wait to try and help improve the reliability of `test_save_images`, which has been having intermittent timing problems.

### Testing & Acceptance Criteria 

All tests pass.

### Documentation

Issue number added to release notes.
