### PR TITLE
Use DatasetSelector in Reconstruction window

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -58,5 +58,5 @@ Developer Changes
 - #1245 : Remove empty init methods from test classes
 - #1251 : System tests: test_correlate ValueError
 - #1259 : Update license year in code files and add pre-commit check
-- #1243 : Stack selector based on datasets
+- #1243  #1276 : Stack selector based on datasets
 - #1184 : Make more use of QTest in gui testing

--- a/mantidimaging/eyes_tests/test_reconstruct_window.py
+++ b/mantidimaging/eyes_tests/test_reconstruct_window.py
@@ -5,6 +5,7 @@ from PyQt5.QtWidgets import QApplication
 
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
 from mantidimaging.test_helpers.unit_test_helper import generate_images
+from mantidimaging.core.data.dataset import MixedDataset
 
 
 class ReconstructionWindowTest(BaseEyesTest):
@@ -44,6 +45,8 @@ class ReconstructionWindowTest(BaseEyesTest):
     def test_negative_nan_overlay(self):
         images = generate_images(seed=10)
         images.name = "bad_data"
+        ds = MixedDataset([images])
+        self.imaging.presenter.model.add_dataset_to_model(ds)
         self.imaging.presenter.create_single_tabbed_images_stack(images)
         QApplication.sendPostedEvents()
 

--- a/mantidimaging/gui/test/test_gui_system_reconstruction.py
+++ b/mantidimaging/gui/test/test_gui_system_reconstruction.py
@@ -20,7 +20,7 @@ class TestGuiSystemReconstruction(GuiSystemBase):
         assert isinstance(self.main_window.recon, ReconstructWindowView)  # for yapf
         self.assertTrue(self.main_window.recon.isVisible())
         self.recon_window = self.main_window.recon
-        self._wait_until(lambda: self.recon_window.presenter.model.stack is not None, max_retry=600)
+        self._wait_until(lambda: self.recon_window.presenter.model.images is not None, max_retry=600)
 
     def tearDown(self) -> None:
         self._wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -66,7 +66,7 @@
               </property>
               <layout class="QFormLayout" name="formLayout">
                <item row="0" column="0" colspan="2">
-                <widget class="StackSelectorWidgetView" name="stackSelector"/>
+                <widget class="DatasetSelectorWidgetView" name="stackSelector"/>
                </item>
               </layout>
              </widget>
@@ -820,9 +820,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>StackSelectorWidgetView</class>
+   <class>DatasetSelectorWidgetView</class>
    <extends>QComboBox</extends>
-   <header>mantidimaging.gui.widgets.stack_selector</header>
+   <header>mantidimaging.gui.widgets.dataset_selector</header>
   </customwidget>
   <customwidget>
    <class>RemovableRowTableView</class>

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -17,7 +17,6 @@ from mantidimaging.core.utility.cuda_check import CudaChecker
 from mantidimaging.core.utility.data_containers import (Degrees, ReconstructionParameters, ScalarCoR, Slope)
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.windows.recon.point_table_model import CorTiltPointQtModel
-from mantidimaging.gui.windows.stack_visualiser import StackVisualiserView
 
 if TYPE_CHECKING:
     import uuid
@@ -27,7 +26,7 @@ LOG = getLogger(__name__)
 
 class ReconstructWindowModel(object):
     def __init__(self, data_model: CorTiltPointQtModel):
-        self.stack: Optional['StackVisualiserView'] = None
+        self._images: Optional[Images] = None
         self._preview_projection_idx = 0
         self._preview_slice_idx = 0
         self._selected_row = 0
@@ -84,16 +83,16 @@ class ReconstructWindowModel(object):
 
     @property
     def images(self):
-        return self.stack.presenter.images if self.stack else None
+        return self._images
 
     @property
     def num_points(self):
         return self.data_model.num_points
 
-    def initial_select_data(self, stack: 'StackVisualiserView'):
+    def initial_select_data(self, images: 'Images'):
         self.data_model.clear_results()
 
-        self.stack = stack
+        self._images = images
         slice_idx, cor = self.find_initial_cor()
         self.last_cor = cor
         self.preview_projection_idx = 0

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from logging import getLogger
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
 
@@ -18,6 +18,9 @@ from mantidimaging.core.utility.data_containers import (Degrees, ReconstructionP
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.windows.recon.point_table_model import CorTiltPointQtModel
 from mantidimaging.gui.windows.stack_visualiser import StackVisualiserView
+
+if TYPE_CHECKING:
+    import uuid
 
 LOG = getLogger(__name__)
 
@@ -106,7 +109,7 @@ class ReconstructWindowModel(object):
 
     def do_fit(self):
         # Ensure we have some sample data
-        if self.stack is None:
+        if self.images is None:
             raise ValueError('No image stack is provided')
 
         self.data_model.linear_regression()
@@ -217,8 +220,8 @@ class ReconstructWindowModel(object):
         self.data_model.set_precalculated(cor, tilt)
         self.last_result = self.data_model.stack_properties
 
-    def is_current_stack(self, stack):
-        return self.stack == stack
+    def is_current_stack(self, uuid: "uuid.UUID"):
+        return self.stack_id == uuid
 
     def get_slice_indices(self, num_cors: int) -> Tuple[int, Union[np.ndarray, Tuple[np.ndarray, Optional[float]]]]:
         # used to crop off 20% off the top and bottom, which is usually noise/empty
@@ -277,6 +280,6 @@ class ReconstructWindowModel(object):
 
     @property
     def stack_id(self):
-        if isinstance(self.stack, StackVisualiserView):
-            return self.stack.id
+        if self.images is not None:
+            return self.images.id
         return None

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -15,7 +15,6 @@ from mantidimaging.gui.dialogs.cor_inspection.view import CORInspectionDialogVie
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.utility.qt_helpers import BlockQtSignals
 from mantidimaging.gui.windows.recon.model import ReconstructWindowModel
-from mantidimaging.gui.windows.stack_visualiser import StackVisualiserView
 
 LOG = getLogger(__name__)
 
@@ -117,7 +116,7 @@ class ReconstructWindowPresenter(BasePresenter):
 
     def set_stack_uuid(self, uuid):
         stack = self.view.get_stack_visualiser(uuid)
-        if self.model.is_current_stack(stack):
+        if self.model.is_current_stack(uuid):
             return
 
         self.view.reset_image_recon_preview()
@@ -236,7 +235,7 @@ class ReconstructWindowPresenter(BasePresenter):
         images: Images = task.result
         slice_idx = self._get_slice_index(None)
         if images is not None:
-            assert isinstance(self.model.stack, StackVisualiserView)
+            assert self.model.images is not None
             images.name = "Recon"
             self.view.show_recon_volume(images, self.model.stack_id)
             images.record_operation('AstraRecon.single_sino',
@@ -289,7 +288,7 @@ class ReconstructWindowPresenter(BasePresenter):
             self.view.show_error_dialog(f"Encountered error while trying to reconstruct: {str(task.error)}")
             return
 
-        assert isinstance(self.model.stack, StackVisualiserView)
+        assert self.model.images is not None
         task.result.name = "Recon"
         self.view.show_recon_volume(task.result, self.model.stack_id)
         self.view.recon_applied.emit()

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -115,18 +115,18 @@ class ReconstructWindowPresenter(BasePresenter):
         self.view.change_refine_iterations()
 
     def set_stack_uuid(self, uuid):
-        stack = self.view.get_stack_visualiser(uuid)
+        images = self.view.get_stack(uuid)
         if self.model.is_current_stack(uuid):
             return
 
         self.view.reset_image_recon_preview()
         self.view.clear_cor_table()
-        self.model.initial_select_data(stack)
+        self.model.initial_select_data(images)
         self.view.rotation_centre = self.model.last_cor.value
         self.view.pixel_size = self.get_pixel_size_from_images()
         self.do_update_projection()
         self.view.update_recon_hist_needed = True
-        if stack is None:
+        if images is None:
             return
         self.do_preview_reconstruct_slice()
         self._do_nan_zero_negative_check()

--- a/mantidimaging/gui/windows/recon/test/model_test.py
+++ b/mantidimaging/gui/windows/recon/test/model_test.py
@@ -14,7 +14,6 @@ from mantidimaging.core.reconstruct.cil_recon import allowed_recon_kwargs as cil
 from mantidimaging.core.rotation.data_model import Point
 from mantidimaging.core.utility.data_containers import Degrees, ScalarCoR, ReconstructionParameters
 from mantidimaging.gui.windows.recon import (ReconstructWindowModel, CorTiltPointQtModel)
-from mantidimaging.gui.windows.stack_visualiser import (StackVisualiserView, StackVisualiserPresenter)
 from mantidimaging.test_helpers.unit_test_helper import assert_called_once_with, generate_images
 
 
@@ -22,16 +21,12 @@ class ReconWindowModelTest(unittest.TestCase):
     def setUp(self):
         self.model = ReconstructWindowModel(CorTiltPointQtModel())
 
-        # Mock stack
-        self.stack = mock.create_autospec(StackVisualiserView)
-        data = Images(data=np.ndarray(shape=(10, 128, 256), dtype=np.float32))
-        self.stack.presenter = StackVisualiserPresenter(self.stack, data)
-
-        self.model.initial_select_data(self.stack)
+        self.data = Images(data=np.ndarray(shape=(10, 128, 256), dtype=np.float32))
+        self.model.initial_select_data(self.data)
 
     def test_empty_init(self):
         m = ReconstructWindowModel(CorTiltPointQtModel())
-        self.assertIsNone(m.stack)
+        self.assertIsNone(m.images)
         self.assertIsNone(m.last_result)
 
     def test_find_initial_cor_returns_0_0_without_data(self):
@@ -41,7 +36,7 @@ class ReconWindowModelTest(unittest.TestCase):
         self.assertEqual(initial_cor.value, 0)
 
     def test_find_initial_cor_returns_middle_with_data(self):
-        self.model.initial_select_data(self.stack)
+        self.model.initial_select_data(self.data)
         first_slice, initial_cor = self.model.find_initial_cor()
         self.assertEqual(first_slice, 64)
         self.assertEqual(initial_cor.value, 128)
@@ -83,7 +78,7 @@ class ReconWindowModelTest(unittest.TestCase):
         self.model.preview_slice_idx = 150
         self.model.set_precalculated(test_cor, test_tilt)
 
-        self.model.initial_select_data(self.stack)
+        self.model.initial_select_data(self.data)
 
         self.assertNotEqual(test_cor, self.model.last_cor)
         self.assertNotEqual(test_tilt, self.model.tilt_angle)

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -33,8 +33,7 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.presenter.model.initial_select_data(self.sv_view)
         self.view.get_stack_visualiser = mock.Mock(return_value=self.sv_view)
 
-        import uuid
-        self.uuid = uuid.uuid4()
+        self.uuid = data.id
 
     def make_view(self):
         self.view = mock.create_autospec(ReconstructWindowView)

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -257,15 +257,15 @@ class ReconstructWindowViewTest(unittest.TestCase):
         self.view.show_recon_volume(data, stack_id)
         add_to_dataset_mock.assert_called_once_with(data, stack_id)
 
-    def test_get_stack_visualiser_when_uuid_is_none(self):
-        assert self.view.get_stack_visualiser(None) is None
+    def test_get_stack_when_uuid_is_none(self):
+        assert self.view.get_stack(None) is None
 
-    def test_get_stack_visualiser_when_uuid_is_not_none(self):
+    def test_get_stack_when_uuid_is_not_none(self):
         uuid = mock.Mock()
-        self.main_window.get_stack_visualiser = mock.Mock()
+        self.main_window.get_stack = mock.Mock()
 
-        assert self.view.get_stack_visualiser(uuid) == self.main_window.get_stack_visualiser.return_value
-        self.main_window.get_stack_visualiser.assert_called_once_with(uuid)
+        assert self.view.get_stack(uuid) == self.main_window.get_stack.return_value
+        self.main_window.get_stack.assert_called_once_with(uuid)
 
     def test_hide_tilt(self):
         self.view.hide_tilt()

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -18,7 +18,7 @@ from mantidimaging.core.utility.data_containers import Degrees, ReconstructionPa
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.widgets import RemovableRowTableView
 from mantidimaging.gui.widgets.palette_changer.view import PaletteChangerView
-from mantidimaging.gui.widgets.stack_selector import StackSelectorWidgetView
+from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
 from mantidimaging.gui.windows.recon.image_view import ReconImagesView
 from mantidimaging.gui.windows.recon.point_table_model import Column, CorTiltPointQtModel
 from mantidimaging.gui.windows.recon.presenter import AutoCorMethod
@@ -77,7 +77,7 @@ class ReconstructWindowView(BaseMainWindowView):
     changeColourPaletteButton: QPushButton
     change_colour_palette_dialog: Optional[PaletteChangerView] = None
 
-    stackSelector: StackSelectorWidgetView
+    stackSelector: DatasetSelectorWidgetView
 
     recon_applied = pyqtSignal()
 
@@ -95,6 +95,7 @@ class ReconstructWindowView(BaseMainWindowView):
             self.algorithmName.setEnabled(True)
 
         self.update_recon_hist_needed = False
+        self.stackSelector.presenter.show_stacks = True
         self.stackSelector.stack_selected_uuid.connect(self.presenter.set_stack_uuid)
 
         # Handle preview image selection

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -27,7 +27,6 @@ from mantidimaging.gui.windows.recon.presenter import ReconstructWindowPresenter
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
-    from mantidimaging.gui.windows.stack_visualiser.view import StackVisualiserView  # pragma: no cover
 
 LOG = getLogger(__name__)
 
@@ -419,9 +418,9 @@ class ReconstructWindowView(BaseMainWindowView):
     def show_recon_volume(self, data: Images, stack_id: uuid.UUID):
         self.main_window.add_recon_to_dataset(data, stack_id)
 
-    def get_stack_visualiser(self, uuid) -> Optional['StackVisualiserView']:
+    def get_stack(self, uuid) -> Optional['Images']:
         if uuid is not None:
-            return self.main_window.get_stack_visualiser(uuid)
+            return self.main_window.get_stack(uuid)
         return None
 
     def hide_tilt(self):


### PR DESCRIPTION
### Issue
Closes  #1269

Also fixes #1231

### Description

~~Note currently based on #1274 to minimise conflicts. Needs rebasing before merging~~

Switch the recon window to use DatasetSelectorWidget. See #1266

### Testing & Acceptance Criteria 

1) Load a dataset
Check that it the stacks are shown in the Recon window
Check that Recon run successfully

2) Load a dataset
Close the tabs (but not the data in the sidebar)
Check that it the stacks are still shown in the Recon window
Check that Recon run successfully

Steps on #1231

### Documentation

release notes
