### PR TITLE
When using a slice from stack as 180, make sidebar entry and tabs

### DIFF
--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -202,6 +202,10 @@ class MainWindowPresenter(BasePresenter):
                 dataset.proj180deg = Images(np.reshape(closest_projection, (1, ) + closest_projection.shape),
                                             name=f"{dataset.name}_180")
 
+                self.add_child_item_to_tree_view(dataset.id, dataset.proj180deg.id, "180")
+                sample_vis = self.get_stack_visualiser(dataset.sample.id)
+                self._create_and_tabify_stack_window(dataset.proj180deg, sample_vis)
+
     def create_strict_dataset_stack_windows(self, dataset: StrictDataset) -> StackVisualiserView:
         """
         Creates the stack widgets for the strict dataset.
@@ -371,7 +375,7 @@ class MainWindowPresenter(BasePresenter):
         return [widget.windowTitle() for widget in self.stack_visualisers.values()]
 
     def get_stack_visualiser(self, stack_id: uuid.UUID) -> StackVisualiserView:
-        return self.active_stacks[stack_id]
+        return self.stack_visualisers[stack_id]
 
     def get_stack(self, stack_id: uuid.UUID) -> Images:
         images = self.model.get_images_by_uuid(stack_id)

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -185,7 +185,9 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         self.assertEqual(6, len(self.presenter.stack_visualisers))
 
-    def test_create_new_stack_dataset_and_use_threshold_180(self):
+    @mock.patch("mantidimaging.gui.windows.main.presenter.MainWindowPresenter.add_child_item_to_tree_view")
+    @mock.patch("mantidimaging.gui.windows.main.presenter.MainWindowPresenter.get_stack_visualiser")
+    def test_create_new_stack_dataset_and_use_threshold_180(self, mock_get_stack, mock_add_child):
         self.dataset.sample.set_projection_angles(
             ProjectionAngles(np.linspace(0, np.pi, self.dataset.sample.num_images)))
 
@@ -226,7 +228,8 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.wizard_action_show_reconstruction()
         self.view.show_recon_window.assert_called_once()
 
-    def test_nexus_load_success_calls_show_information(self):
+    @mock.patch("mantidimaging.gui.windows.main.presenter.MainWindowPresenter.add_alternative_180_if_required")
+    def test_nexus_load_success_calls_show_information(self, _):
         self.view.nexus_load_dialog = mock.Mock()
         data_title = "data tile"
         self.view.nexus_load_dialog.presenter.get_dataset.return_value = self.dataset, data_title


### PR DESCRIPTION
### Issue
Closes  #1283

### Description

In add_alternative_180_if_required() the new stack should be added to the dataset treeview and have a tab created.

Let get_stack_visualiser() search all visualiser, not just visible ones.

Add some mocking in the tests as these reach quite a way into the view.

### Testing & Acceptance Criteria 

Steps on #1283

### Documentation
Fix for a recent so does not need to be on release notes.
