### PR TITLE
Make treeview items for load images

### DIFF
--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -519,10 +519,8 @@ class MainWindowPresenter(BasePresenter):
         ids_to_remove = self.model.remove_container(container_id)
         if ids_to_remove is None:
             return
-        if len(ids_to_remove) == 1:
-            self._delete_stack(container_id)
-        else:
-            for stack_id in ids_to_remove:
+        for stack_id in ids_to_remove:
+            if stack_id in self.stack_visualisers:
                 self._delete_stack(stack_id)
         self.remove_item_from_tree_view(container_id)
         self.view.model_changed.emit()

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -141,6 +141,7 @@ class MainWindowPresenter(BasePresenter):
 
         if task.was_successful():
             task.result.name = os.path.splitext(task.kwargs['file_path'])[0]
+            self.create_mixed_dataset_tree_view_items(task.result)
             self.create_mixed_dataset_stack_windows(task.result)
             self.view.model_changed.emit()
             task.result = None

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -520,7 +520,8 @@ class MainWindowPresenterTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.presenter.add_child_item_to_tree_view("nonexistent-id", "child-id", "180")
 
-    def test_on_stack_load_done_success(self):
+    @mock.patch("mantidimaging.gui.windows.main.presenter.MainWindowPresenter.create_mixed_dataset_tree_view_items")
+    def test_on_stack_load_done_success(self, _):
         task = mock.Mock()
         task.result = result_mock = mock.Mock()
         task.was_successful.return_value = True


### PR DESCRIPTION
### Issue

Closes #1282 

### Description

Note needs rebasing.

Make treeview items for load images

Allow deleting a dataset with a single item

### Testing & Acceptance Criteria 

File->Load Images
Should create a tab, and entry in the tree view.
Should be selectable in the Operations window.
Should be possible to close the tab, and reopen by double clicking in the side bar.
Should be deletable

### Documentation

Not needed
