### PR TITLE
Add checkbox to allow optional live reconstruction

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -20,6 +20,7 @@ New Features
 - #1235 : Improvements to input value defaults and spin box step sizes
 - #1230 : Update CIL to 21.3 reducing memory requirements
 - #1191 : Loading 180 should only show datasets
+- #1279 : Add auto update checkbox option to turn off live reconstruction
 
 
 Fixes

--- a/mantidimaging/gui/test/test_gui_system_operations.py
+++ b/mantidimaging/gui/test/test_gui_system_operations.py
@@ -137,3 +137,10 @@ class TestGuiSystemOperations(GuiSystemBase):
             self._wait_until(lambda: self.op_window.presenter.filter_is_running is False)
             self.main_window.filters.close()
             QTest.qWait(SHOW_DELAY)
+
+    @mock.patch("mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter.do_update_previews")
+    def test_selecting_auto_update_triggers_preview(self, mock_do_update_previews):
+        self.op_window.previewAutoUpdate.setCheckState(Qt.CheckState.Unchecked)
+
+        QTest.mouseClick(self.op_window.previewAutoUpdate, Qt.MouseButton.LeftButton)
+        self._wait_until(lambda: mock_do_update_previews.call_count == 1)

--- a/mantidimaging/gui/test/test_gui_system_operations.py
+++ b/mantidimaging/gui/test/test_gui_system_operations.py
@@ -144,3 +144,10 @@ class TestGuiSystemOperations(GuiSystemBase):
 
         QTest.mouseClick(self.op_window.previewAutoUpdate, Qt.MouseButton.LeftButton)
         self._wait_until(lambda: mock_do_update_previews.call_count == 1)
+
+    @mock.patch("mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter.do_update_previews")
+    def test_clicking_update_now_btn_triggers_preview(self, mock_do_update_previews):
+        self.op_window.previewAutoUpdate.setCheckState(Qt.CheckState.Unchecked)
+
+        QTest.mouseClick(self.op_window.updatePreviewButton, Qt.MouseButton.LeftButton)
+        self._wait_until(lambda: mock_do_update_previews.call_count == 1)

--- a/mantidimaging/gui/test/test_gui_system_reconstruction.py
+++ b/mantidimaging/gui/test/test_gui_system_reconstruction.py
@@ -93,3 +93,10 @@ class TestGuiSystemReconstruction(GuiSystemBase):
 
         QTest.mouseClick(self.recon_window.previewAutoUpdate, Qt.MouseButton.LeftButton)
         self._wait_until(lambda: mock_do_preview_reconstruct_slice.call_count == 1)
+
+    @mock.patch("mantidimaging.gui.windows.recon.presenter.ReconstructWindowPresenter._get_reconstruct_slice")
+    def test_clicking_update_now_btn_triggers_preview(self, mock_get_reconstruct_slice):
+        self.recon_window.previewAutoUpdate.setCheckState(Qt.CheckState.Unchecked)
+
+        QTest.mouseClick(self.recon_window.updatePreviewButton, Qt.MouseButton.LeftButton)
+        self._wait_until(lambda: mock_get_reconstruct_slice.call_count == 1)

--- a/mantidimaging/gui/test/test_gui_system_reconstruction.py
+++ b/mantidimaging/gui/test/test_gui_system_reconstruction.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from unittest import mock
 
 from PyQt5.QtTest import QTest
 from PyQt5.QtCore import Qt, QTimer
@@ -85,3 +86,10 @@ class TestGuiSystemReconstruction(GuiSystemBase):
             self._wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
 
         QTest.qWait(SHOW_DELAY)
+
+    @mock.patch("mantidimaging.gui.windows.recon.presenter.ReconstructWindowPresenter.do_preview_reconstruct_slice")
+    def test_selecting_auto_update_triggers_preview(self, mock_do_preview_reconstruct_slice):
+        self.recon_window.previewAutoUpdate.setCheckState(Qt.CheckState.Unchecked)
+
+        QTest.mouseClick(self.recon_window.previewAutoUpdate, Qt.MouseButton.LeftButton)
+        self._wait_until(lambda: mock_do_preview_reconstruct_slice.call_count == 1)

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -736,6 +736,13 @@
              </property>
             </widget>
            </item>
+           <item row="0" column="1">
+            <widget class="QPushButton" name="updatePreviewButton">
+             <property name="text">
+              <string>Update Now</string>
+             </property>
+            </widget>
+           </item>
           </layout>
          </widget>
         </item>

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -686,7 +686,7 @@
            <string>Preview</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_2">
-           <item row="1" column="0">
+           <item row="2" column="0">
             <widget class="QLabel" name="previewSliceIndexLabel">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -699,21 +699,21 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
+           <item row="1" column="1">
             <widget class="QSpinBox" name="previewProjectionIndex">
              <property name="maximum">
               <number>99999</number>
              </property>
             </widget>
            </item>
-           <item row="1" column="1">
+           <item row="2" column="1">
             <widget class="QSpinBox" name="previewSliceIndex">
              <property name="maximum">
               <number>99999</number>
              </property>
             </widget>
            </item>
-           <item row="0" column="0">
+           <item row="1" column="0">
             <widget class="QLabel" name="previewProjectionIndexLabel">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -723,6 +723,16 @@
              </property>
              <property name="text">
               <string>Projection index:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QCheckBox" name="previewAutoUpdate">
+             <property name="text">
+              <string>Auto Update</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
              </property>
             </widget>
            </item>

--- a/mantidimaging/gui/windows/operations/test/test_view.py
+++ b/mantidimaging/gui/windows/operations/test/test_view.py
@@ -31,3 +31,25 @@ class OperationsWindowsViewTest(unittest.TestCase):
         self.assertEqual(">>", self.window.collapseToggleButton.text())
         # check that left column is 0 as expected as it has been collapsed
         self.assertEqual(0, self.window.splitter.sizes()[0])
+
+    def test_on_auto_update_triggered_with_auto_selected(self):
+        self.window.previewAutoUpdate = mock.Mock()
+        self.window.previewAutoUpdate.isChecked.return_value = True
+        self.window.isVisible = mock.Mock()
+        self.window.isVisible.return_value = True
+
+        with mock.patch("mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter.do_update_previews")\
+                as mock_do_update_previews:
+            self.window.on_auto_update_triggered()
+            mock_do_update_previews.assert_called_once()
+
+    def test_on_auto_update_triggered_with_auto_not_selected(self):
+        self.window.previewAutoUpdate = mock.Mock()
+        self.window.previewAutoUpdate.isChecked.return_value = False
+        self.window.isVisible = mock.Mock()
+        self.window.isVisible.return_value = True
+
+        with mock.patch("mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter.do_update_previews")\
+                as mock_do_update_previews:
+            self.window.on_auto_update_triggered()
+            mock_do_update_previews.assert_not_called()

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -98,6 +98,7 @@ class FiltersWindowView(BaseMainWindowView):
 
         # Preview update triggers
         self.auto_update_triggered.connect(self.on_auto_update_triggered)
+        self.previewAutoUpdate.stateChanged.connect(self.handle_auto_update_preview_selection)
         self.updatePreviewButton.clicked.connect(lambda: self.presenter.notify(PresNotification.UPDATE_PREVIEWS))
 
         self.stackSelector.subscribe_to_main_window(main_window)
@@ -165,6 +166,10 @@ class FiltersWindowView(BaseMainWindowView):
 
         # Enable the spinbox widget once the preview has been created
         self.previewImageIndex.setEnabled(True)
+
+    def handle_auto_update_preview_selection(self):
+        if self.previewAutoUpdate.isChecked():
+            self.presenter.notify(PresNotification.UPDATE_PREVIEWS)
 
     def clear_previews(self, clear_before: bool = True):
         self.previews.clear_items(clear_before=clear_before)

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -212,7 +212,8 @@ class ReconstructWindowPresenter(BasePresenter):
 
         slice_idx = self._get_slice_index(slice_idx)
         self.view.update_sinogram(self.model.images.sino(slice_idx))
-        self._get_reconstruct_slice(cor, slice_idx, self._on_preview_reconstruct_slice_done)
+        if self.view.is_auto_update_preview():
+            self._get_reconstruct_slice(cor, slice_idx, self._on_preview_reconstruct_slice_done)
 
     def _on_preview_reconstruct_slice_done(self, task: TaskWorkerThread):
         if task.error is not None:

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -30,6 +30,7 @@ class AutoCorMethod(Enum):
 class Notifications(Enum):
     RECONSTRUCT_VOLUME = auto()
     RECONSTRUCT_PREVIEW_SLICE = auto()
+    RECONSTRUCT_PREVIEW_USER_CLICK = auto()
     RECONSTRUCT_STACK_SLICE = auto()
     RECONSTRUCT_USER_CLICK = auto()
     COR_FIT = auto()
@@ -70,6 +71,8 @@ class ReconstructWindowPresenter(BasePresenter):
                 self.do_reconstruct_volume()
             elif notification == Notifications.RECONSTRUCT_PREVIEW_SLICE:
                 self.do_preview_reconstruct_slice()
+            elif notification == Notifications.RECONSTRUCT_PREVIEW_USER_CLICK:
+                self.do_preview_reconstruct_slice(force_update=True)
             elif notification == Notifications.RECONSTRUCT_STACK_SLICE:
                 self.do_stack_reconstruct_slice()
             elif notification == Notifications.RECONSTRUCT_USER_CLICK:
@@ -206,13 +209,13 @@ class ReconstructWindowPresenter(BasePresenter):
             self.model.preview_slice_idx = slice_idx
         return slice_idx
 
-    def do_preview_reconstruct_slice(self, cor=None, slice_idx: Optional[int] = None):
+    def do_preview_reconstruct_slice(self, cor=None, slice_idx: Optional[int] = None, force_update: bool = False):
         if self.model.images is None:
             return
 
         slice_idx = self._get_slice_index(slice_idx)
         self.view.update_sinogram(self.model.images.sino(slice_idx))
-        if self.view.is_auto_update_preview():
+        if self.view.is_auto_update_preview() or force_update:
             self._get_reconstruct_slice(cor, slice_idx, self._on_preview_reconstruct_slice_done)
 
     def _on_preview_reconstruct_slice_done(self, task: TaskWorkerThread):

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -120,6 +120,16 @@ class ReconWindowPresenterTest(unittest.TestCase):
         mock_start_async_task_view.assert_called_once()
         self.view.recon_params.assert_called_once()
 
+    @mock.patch('mantidimaging.gui.windows.recon.presenter.ReconstructWindowPresenter._get_reconstruct_slice')
+    def test_do_preview_reconstruct_slice_no_auto_update(self, mock_get_reconstruct_slice):
+        self.view.is_auto_update_preview.return_value = False
+        self.presenter.model.preview_slice_idx = 0
+
+        self.presenter.do_preview_reconstruct_slice()
+
+        self.view.update_sinogram.assert_called_once()
+        mock_get_reconstruct_slice.assert_not_called()
+
     def test_do_preview_reconstruct_slice_done(self):
         image_mock = mock.Mock()
         result_mock = mock.Mock(data=[image_mock])

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -186,6 +186,7 @@ class ReconstructWindowView(BaseMainWindowView):
         self.corHelpButton.clicked.connect(lambda: self.open_help_webpage("reconstructions/center_of_rotation"))
 
         self.previewAutoUpdate.stateChanged.connect(self.handle_auto_update_preview_selection)
+        self.updatePreviewButton.clicked.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_USER_CLICK))
 
         # Preparing the auto change colour map UI
         self.auto_colour_action = QAction("Auto")

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -185,6 +185,8 @@ class ReconstructWindowView(BaseMainWindowView):
         self.reconHelpButton.clicked.connect(lambda: self.open_help_webpage("reconstructions/index"))
         self.corHelpButton.clicked.connect(lambda: self.open_help_webpage("reconstructions/center_of_rotation"))
 
+        self.previewAutoUpdate.stateChanged.connect(self.handle_auto_update_preview_selection)
+
         # Preparing the auto change colour map UI
         self.auto_colour_action = QAction("Auto")
         self.auto_colour_action.triggered.connect(self.on_change_colour_palette)
@@ -278,6 +280,13 @@ class ReconstructWindowView(BaseMainWindowView):
 
     def update_sinogram(self, image_data):
         self.image_view.update_sinogram(image_data)
+
+    def is_auto_update_preview(self) -> bool:
+        return self.previewAutoUpdate.isChecked()
+
+    def handle_auto_update_preview_selection(self):
+        if self.previewAutoUpdate.isChecked():
+            self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE)
 
     def update_recon_preview(self, image_data: numpy.ndarray):
         """


### PR DESCRIPTION
### Issue

Closes #1279

### Description

Adds an auto-update checkbox to the recon window to allow the user to control whether or not a live reconstruction preview is provided. Unchecking the checkbox stops the live preview. Checking the checkbox triggers a preview to bring things up to date and, while the box remains checked, further parameter changes are previewed live.

Also adds an Update Now button, as described in the comments.

Screenshot of checkbox and button on the recon window:

![ReconAutoUpdate](https://user-images.githubusercontent.com/38210467/152129396-87fee79a-2171-47bc-b0d9-3f1f9bda113d.png)


### Testing & Acceptance Criteria 

All tests pass (a couple of new tests have been added for the functionality).

Load a dataset and open the reconstruction window. The checkbox should be checked by default and any parameter changes should be previewed live.
Uncheck the checkbox and make further changes to parameters - the preview should not be updated, but any sinogram changes should render.
Check the checkbox - the preview should update straight away. Further changes to parameters should also now preview live.

Test Update Now button refreshes the preview when auto update is disabled.

### Documentation

Issue added to release notes.
