### PR TITLE
1239: 180 warning when applying ring removal to recon

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -37,6 +37,7 @@ Fixes
 - #1162 : Raise exceptions when invalid parameter values are passed to filter functions
 - #1248 : Rebin operations not working for small image dimensions
 - #1190 : Add recon item to right part of tree view
+- #1239 : 180 warning when applying ring removal to recon
 
 
 Developer Changes

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -12,6 +12,7 @@ from PyQt5.QtGui import QFont
 from PyQt5.QtWidgets import QMainWindow, QMenu, QWidget, QApplication
 from applitools.common import MatchLevel
 
+from mantidimaging.core.data import Images
 from mantidimaging.core.io.loader import loader
 from mantidimaging.eyes_tests.eyes_manager import EyesManager
 from mantidimaging.test_helpers.start_qapplication import start_qapplication
@@ -92,11 +93,16 @@ class BaseEyesTest(unittest.TestCase):
         menu_location = widget.menuBar().rect().bottomLeft()
         menu.popup(widget.mapFromGlobal(menu_location))
 
-    def _load_data_set(self):
+    def _load_data_set(self, set_180: bool = False):
         dataset = loader.load(file_names=[LOAD_SAMPLE])
         dataset.sample.name = "Stack 1"
         vis = self.imaging.presenter.create_strict_dataset_stack_windows(dataset)
         self.imaging.presenter.create_strict_dataset_tree_view_items(dataset)
+
+        if set_180:
+            dataset.sample.proj180deg = _180_proj = Images(dataset.sample.data[0:1])
+            self.imaging.presenter.create_single_tabbed_images_stack(_180_proj)
+
         self.imaging.presenter.model.add_dataset_to_model(dataset)
 
         QApplication.sendPostedEvents()

--- a/mantidimaging/eyes_tests/test_operations_window.py
+++ b/mantidimaging/eyes_tests/test_operations_window.py
@@ -25,7 +25,7 @@ class OperationsWindowTest(BaseEyesTest):
         self.check_target(widget=self.imaging.filters)
 
     def test_operation_window_after_data_was_processed(self):
-        self._load_data_set()
+        self._load_data_set(set_180=True)
 
         self.imaging.show_filters_window()
         self.imaging.filters.ask_confirmation = mock.MagicMock(return_value=True)

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -175,6 +175,13 @@ class MainWindowModel(object):
             images += dataset.all
         return images
 
+    @property
+    def recons(self) -> List[Images]:
+        recons = []
+        for dataset in self.datasets.values():
+            recons += dataset.recons
+        return recons
+
     def add_recon_to_dataset(self, recon_data: Images, stack_id: uuid.UUID) -> uuid.UUID:
         """
         Adds a recon to a dataset using recon data and an ID from one of the stacks in the dataset.

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -176,13 +176,6 @@ class MainWindowModel(object):
         return images
 
     @property
-    def recons(self) -> List[Images]:
-        recons = []
-        for dataset in self.datasets.values():
-            recons += dataset.recons
-        return recons
-
-    @property
     def proj180s(self) -> List[Images]:
         proj180s = []
         for dataset in self.datasets.values():

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -182,6 +182,14 @@ class MainWindowModel(object):
             recons += dataset.recons
         return recons
 
+    @property
+    def proj180s(self) -> List[Images]:
+        proj180s = []
+        for dataset in self.datasets.values():
+            if dataset.proj180deg is not None:
+                proj180s.append(dataset.proj180deg)
+        return proj180s
+
     def add_recon_to_dataset(self, recon_data: Images, stack_id: uuid.UUID) -> uuid.UUID:
         """
         Adds a recon to a dataset using recon data and an ID from one of the stacks in the dataset.

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -179,7 +179,7 @@ class MainWindowModel(object):
     def proj180s(self) -> List[Images]:
         proj180s = []
         for dataset in self.datasets.values():
-            if dataset.proj180deg is not None:
+            if isinstance(dataset, StrictDataset) and dataset.proj180deg is not None:
                 proj180s.append(dataset.proj180deg)
         return proj180s
 

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -191,6 +191,9 @@ class MainWindowPresenter(BasePresenter):
     def get_all_recons(self) -> List[Images]:
         return self.model.recons
 
+    def get_all_180_projections(self) -> List[Images]:
+        return self.model.proj180s
+
     def add_alternative_180_if_required(self, dataset: StrictDataset):
         """
         Checks if the dataset has a 180 projection and tries to find an alternative if one is missing.

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -188,6 +188,9 @@ class MainWindowPresenter(BasePresenter):
     def get_all_stacks(self) -> List[Images]:
         return self.model.images
 
+    def get_all_recons(self) -> List[Images]:
+        return self.model.recons
+
     def add_alternative_180_if_required(self, dataset: StrictDataset):
         """
         Checks if the dataset has a 180 projection and tries to find an alternative if one is missing.

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -188,9 +188,6 @@ class MainWindowPresenter(BasePresenter):
     def get_all_stacks(self) -> List[Images]:
         return self.model.images
 
-    def get_all_recons(self) -> List[Images]:
-        return self.model.recons
-
     def get_all_180_projections(self) -> List[Images]:
         return self.model.proj180s
 

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -8,7 +8,7 @@ from unittest import mock
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from mantidimaging.core.data.dataset import StrictDataset
+from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
 from mantidimaging.core.utility.data_containers import LoadingParameters, ProjectionAngles
 from mantidimaging.gui.windows.main import MainWindowModel
 from mantidimaging.gui.windows.main.model import _matching_dataset_attribute
@@ -365,3 +365,16 @@ class MainWindowModelTest(unittest.TestCase):
         self.model.add_dataset_to_model(ds)
         self.model.add_recon_to_dataset(recon, sample_id)
         self.assertIn(recon, ds.all)
+
+    def test_recons(self):
+        recons = [generate_images() for _ in range(2)]
+
+        mixed_ds = MixedDataset([generate_images()])
+        mixed_ds.recons.append(recons[0])
+        strict_ds = StrictDataset(generate_images())
+        strict_ds.recons.append(recons[1])
+
+        self.model.add_dataset_to_model(mixed_ds)
+        self.model.add_dataset_to_model(strict_ds)
+
+        self.assertListEqual(self.model.recons, recons)

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -8,7 +8,8 @@ from unittest import mock
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
+from mantidimaging.core.data import Images
+from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.core.utility.data_containers import LoadingParameters, ProjectionAngles
 from mantidimaging.gui.windows.main import MainWindowModel
 from mantidimaging.gui.windows.main.model import _matching_dataset_attribute
@@ -366,15 +367,16 @@ class MainWindowModelTest(unittest.TestCase):
         self.model.add_recon_to_dataset(recon, sample_id)
         self.assertIn(recon, ds.all)
 
-    def test_recons(self):
-        recons = [generate_images() for _ in range(2)]
+    def test_proj180s(self):
 
-        mixed_ds = MixedDataset([generate_images()])
-        mixed_ds.recons.append(recons[0])
-        strict_ds = StrictDataset(generate_images())
-        strict_ds.recons.append(recons[1])
+        ds1 = StrictDataset(generate_images())
+        ds2 = StrictDataset(generate_images())
 
-        self.model.add_dataset_to_model(mixed_ds)
-        self.model.add_dataset_to_model(strict_ds)
+        proj180s = [Images(ds1.sample.data[0]), Images(ds2.sample.data[0])]
+        ds1.proj180deg = proj180s[0]
+        ds2.proj180deg = proj180s[1]
 
-        self.assertListEqual(self.model.recons, recons)
+        self.model.add_dataset_to_model(ds1)
+        self.model.add_dataset_to_model(ds2)
+
+        self.assertListEqual(self.model.proj180s, proj180s)

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from mantidimaging.core.data import Images
-from mantidimaging.core.data.dataset import StrictDataset
+from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
 from mantidimaging.core.utility.data_containers import LoadingParameters, ProjectionAngles
 from mantidimaging.gui.windows.main import MainWindowModel
 from mantidimaging.gui.windows.main.model import _matching_dataset_attribute
@@ -371,6 +371,7 @@ class MainWindowModelTest(unittest.TestCase):
 
         ds1 = StrictDataset(generate_images())
         ds2 = StrictDataset(generate_images())
+        ds3 = MixedDataset([generate_images()])
 
         proj180s = [Images(ds1.sample.data[0]), Images(ds2.sample.data[0])]
         ds1.proj180deg = proj180s[0]
@@ -378,5 +379,6 @@ class MainWindowModelTest(unittest.TestCase):
 
         self.model.add_dataset_to_model(ds1)
         self.model.add_dataset_to_model(ds2)
+        self.model.add_dataset_to_model(ds3)
 
         self.assertListEqual(self.model.proj180s, proj180s)

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -418,7 +418,3 @@ class MainWindowViewTest(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             self.view.get_recon_group(dataset_item_mock)
-
-    def test_get_all_recons(self):
-        self.view.get_all_recons()
-        self.presenter.get_all_recons.assert_called_once()

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -418,3 +418,6 @@ class MainWindowViewTest(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             self.view.get_recon_group(dataset_item_mock)
+
+    def test_get_all_180_projections(self):
+        self.assertIs(self.view.get_all_180_projections(), self.presenter.get_all_180_projections.return_value)

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -418,3 +418,7 @@ class MainWindowViewTest(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             self.view.get_recon_group(dataset_item_mock)
+
+    def test_get_all_recons(self):
+        self.view.get_all_recons()
+        self.presenter.get_all_recons.assert_called_once()

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -351,6 +351,9 @@ class MainWindowView(BaseMainWindowView):
     def get_all_recons(self) -> List[Images]:
         return self.presenter.get_all_recons()
 
+    def get_all_180_projections(self):
+        return self.presenter.get_all_180_projections()
+
     def get_all_stack_visualisers_with_180deg_proj(self):
         return self.presenter.get_all_stack_visualisers_with_180deg_proj()
 

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -348,9 +348,6 @@ class MainWindowView(BaseMainWindowView):
     def get_all_stacks(self) -> List[Images]:
         return self.presenter.get_all_stacks()
 
-    def get_all_recons(self) -> List[Images]:
-        return self.presenter.get_all_recons()
-
     def get_all_180_projections(self):
         return self.presenter.get_all_180_projections()
 

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -348,6 +348,9 @@ class MainWindowView(BaseMainWindowView):
     def get_all_stacks(self) -> List[Images]:
         return self.presenter.get_all_stacks()
 
+    def get_all_recons(self) -> List[Images]:
+        return self.presenter.get_all_recons()
+
     def get_all_stack_visualisers_with_180deg_proj(self):
         return self.presenter.get_all_stack_visualisers_with_180deg_proj()
 

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -242,19 +242,7 @@ class FiltersWindowPresenter(BasePresenter):
         return stack_choice.use_new_data
 
     def is_a_proj180deg(self, stack_to_check: Images):
-        if stack_to_check.has_proj180deg():
-            return False
-        if stack_to_check in self.main_window.get_all_recons():
-            return False
-        stacks = self.main_window.get_all_stacks()
-        for stack in stacks:
-            if stack.proj180deg is not None:
-                stack_proj180deg = stack.proj180deg
-            else:
-                stack_proj180deg = stack
-            if stack_proj180deg == stack_to_check:
-                return True
-        return False
+        return stack_to_check in self.main_window.get_all_180_projections()
 
     def _post_filter(self, updated_stacks: List[Images], task):
         try:

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -244,6 +244,8 @@ class FiltersWindowPresenter(BasePresenter):
     def is_a_proj180deg(self, stack_to_check: Images):
         if stack_to_check.has_proj180deg():
             return False
+        if stack_to_check in self.main_window.get_all_recons():
+            return False
         stacks = self.main_window.get_all_stacks()
         for stack in stacks:
             if stack.proj180deg is not None:

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -531,3 +531,12 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         slices = [i for i in range(8)] + [i for i in range(10, 15)]
         ranges = _group_consecutive_values(slices)
         self.assertListEqual(ranges, ["0-7", "10-14"])
+
+    def test_is_a_proj180deg_returns_true(self):
+        _180_images = generate_images()
+        self.main_window.get_all_180_projections.return_value = [_180_images]
+        assert self.presenter.is_a_proj180deg(_180_images)
+
+    def test_is_a_proj180deg_returns_false(self):
+        self.main_window.get_all_180_projections.return_value = [generate_images() for _ in range(5)]
+        assert not self.presenter.is_a_proj180deg(generate_images())


### PR DESCRIPTION
### Issue

Closes #1239

### Description

Changed the method for checking if a stack is a 180 projection by using the information from the StrictDataset class.

### Testing 

Added tests for the new methods.

### Acceptance Criteria 

Check that the message no longer appears when applying filters to the recon images.

### Documentation

Updated release notes.
