### PR TITLE
Consistent names for reconstructions

### DIFF
--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -495,13 +495,13 @@ class MainWindowPresenter(BasePresenter):
         Adds a recon item to the tree view.
         :param parent_id: The ID of the parent dataset.
         :param child_id: The ID of the corresponding Images object.
-        :param recon_count: The number of the recon in the dataset. Zero indicates the first recon that has been added.
+        :param recon_count: The number of the recon in the dataset. One indicates the first recon that has been added.
         """
         top_level_item_count = self.view.dataset_tree_widget.topLevelItemCount()
         for i in range(top_level_item_count):
             top_level_item = self.view.dataset_tree_widget.topLevelItem(i)
             if top_level_item.id == parent_id:
-                if recon_count == 0:
+                if recon_count == 1:
                     recon_group = self.view.add_recon_group(top_level_item)
                     name = "Recon"
                 else:
@@ -561,5 +561,5 @@ class MainWindowPresenter(BasePresenter):
         """
         parent_id = self.model.add_recon_to_dataset(recon_data, stack_id)
         self.view.create_new_stack(recon_data)
-        self.add_recon_item_to_tree_view(parent_id, recon_data.id, len(self.model.datasets[parent_id].recons) - 1)
+        self.add_recon_item_to_tree_view(parent_id, recon_data.id, len(self.model.datasets[parent_id].recons))
         self.view.model_changed.emit()

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -486,7 +486,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         self.presenter.notify(Notification.ADD_RECON, recon_data=recon, stack_id=stack_id)
         self.model.add_recon_to_dataset.assert_called_once_with(recon, stack_id)
-        self.presenter.add_recon_item_to_tree_view.assert_called_with(parent_id, recon.id, 0)
+        self.presenter.add_recon_item_to_tree_view.assert_called_with(parent_id, recon.id, 1)
         self.view.create_new_stack.assert_called_once_with(recon)
         self.view.model_changed.emit.assert_called_once()
 
@@ -597,7 +597,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         child_id = "child-id"
         recon_group_mock = self.view.add_recon_group.return_value
 
-        self.presenter.add_recon_item_to_tree_view(parent_id, child_id, 0)
+        self.presenter.add_recon_item_to_tree_view(parent_id, child_id, 1)
         self.view.add_recon_group.assert_called_once_with(top_level_item_mock)
         self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, "Recon")
 
@@ -607,11 +607,11 @@ class MainWindowPresenterTest(unittest.TestCase):
         top_level_item_mock.id = parent_id = "parent-id"
         child_id = "child-id"
         recon_group_mock = self.view.get_recon_group.return_value
-        recon_count = 1
+        recon_count = 2
 
         self.presenter.add_recon_item_to_tree_view(parent_id, child_id, recon_count)
         self.view.get_recon_group.assert_called_once_with(top_level_item_mock)
-        self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, "Recon 1")
+        self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, "Recon 2")
 
     def test_add_recon_item_to_tree_view_failed(self):
         self.view.dataset_tree_widget.topLevelItemCount.return_value = 1

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -515,6 +515,7 @@ class MainWindowView(BaseMainWindowView):
         recon_group = QTreeDatasetWidgetItem(dataset_item, RECON_ID)
         recon_group.setText(0, RECON_GROUP_TEXT)
         dataset_item.addChild(recon_group)
+        recon_group.setExpanded(True)
         return recon_group
 
     @staticmethod


### PR DESCRIPTION
### Issue

Closes #1281 

### Description

Change naming of recons in treeview

    Recon
    Recon 2
    Recon 3

(Note, that if there are multiple datasets open, then the treeview counting is per dataset, but tabs count globally. This is something to think about in the future.)

### Testing & Acceptance Criteria 

Open a dataset
Make several reconstructions
Check that numbering is constistent between the treeview and tabs

### Documentation

Not needed
