### PR TITLE
1273: Move sinograms into dataset

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -20,6 +20,7 @@ New Features
 - #1235 : Improvements to input value defaults and spin box step sizes
 - #1230 : Update CIL to 21.3 reducing memory requirements
 - #1191 : Loading 180 should only show datasets
+- #1273 : Move sinograms into the Dataset
 
 
 Fixes

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -95,6 +95,7 @@ class StrictDataset(BaseDataset):
         self.flat_after = flat_after
         self.dark_before = dark_before
         self.dark_after = dark_after
+        self._sinograms = None
 
         if self.name == "":
             self._name = sample.name
@@ -102,7 +103,8 @@ class StrictDataset(BaseDataset):
     @property
     def all(self) -> List[Images]:
         image_stacks = [
-            self.sample, self.proj180deg, self.flat_before, self.flat_after, self.dark_before, self.dark_after
+            self.sample, self.proj180deg, self.flat_before, self.flat_after, self.dark_before, self.dark_after,
+            self._sinograms
         ]
         return [image_stack for image_stack in image_stacks if image_stack is not None] + self.recons
 
@@ -113,6 +115,14 @@ class StrictDataset(BaseDataset):
     @proj180deg.setter
     def proj180deg(self, _180_deg: Images):
         self.sample.proj180deg = _180_deg
+
+    @property
+    def sinograms(self) -> Images:
+        return self._sinograms
+
+    @sinograms.setter
+    def sinograms(self, sino: Images):
+        self._sinograms = sino
 
     def delete_stack(self, images_id: uuid.UUID):
         if isinstance(self.sample, Images) and self.sample.id == images_id:
@@ -127,6 +137,8 @@ class StrictDataset(BaseDataset):
             self.dark_after = None
         elif isinstance(self.proj180deg, Images) and self.proj180deg.id == images_id:
             self.sample.clear_proj180deg()
+        elif isinstance(self.sinograms, Images) and self.sinograms.id == images_id:
+            self._sinograms = None
         elif images_id in [recon.id for recon in self.recons]:
             for recon in self.recons:
                 if recon.id == images_id:

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -95,7 +95,7 @@ class StrictDataset(BaseDataset):
         self.flat_after = flat_after
         self.dark_before = dark_before
         self.dark_after = dark_after
-        self._sinograms = None
+        self._sinograms: Optional[Images] = None
 
         if self.name == "":
             self._name = sample.name
@@ -117,7 +117,7 @@ class StrictDataset(BaseDataset):
         self.sample.proj180deg = _180_deg
 
     @property
-    def sinograms(self) -> Images:
+    def sinograms(self) -> Optional[Images]:
         return self._sinograms
 
     @sinograms.setter

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -83,6 +83,9 @@ class MixedDataset(BaseDataset):
             if recon.id == images_id:
                 self.recons.remove(recon)
                 return
+        if self.sinograms is not None and self.sinograms.id == images_id:
+            self.sinograms = None
+            return
         raise KeyError(_delete_stack_error_message(images_id))
 
 

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -69,7 +69,10 @@ class MixedDataset(BaseDataset):
 
     @property
     def all(self) -> List[Images]:
-        return self._stacks + self.recons + [self.sinograms]
+        all_images = self._stacks + self.recons
+        if self.sinograms is None:
+            return all_images
+        return all_images + [self.sinograms]
 
     def delete_stack(self, images_id: uuid.UUID):
         for image in self._stacks:

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -212,16 +212,3 @@ class MainWindowModel(object):
                 dataset.recons.append(recon_data)
                 return dataset.id
         self.raise_error_when_parent_dataset_not_found(stack_id)
-
-    def add_sinograms_to_dataset(self, sino_stack: Images, original_stack_id: uuid.UUID) -> uuid.UUID:
-        """
-        Adds a sinogram to a dataset using the sino stack and an ID from one of the stacks in the dataset.
-        :param sino_stack: The sinogram data.
-        :param original_stack_id: The ID of one of the member stacks.
-        :return: The ID of the parent dataset if found.
-        """
-        for dataset in self.datasets.values():
-            if original_stack_id in dataset and isinstance(dataset, StrictDataset):
-                dataset.sinograms = sino_stack
-                return dataset.id
-        self.raise_error_when_parent_dataset_not_found(original_stack_id)

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -186,6 +186,20 @@ class MainWindowModel(object):
                 proj180s.append(dataset.proj180deg)
         return proj180s
 
+    def get_parent_strict_dataset(self, member_id: uuid.UUID) -> uuid.UUID:
+        """
+        Takes the ID of an image stack and returns the ID of its parent strict dataset.
+        :param member_id: The ID of the image stack.
+        :return: The ID of the parent dataset if found.
+        """
+        for dataset in self.datasets.values():
+            if member_id in dataset:
+                if isinstance(dataset, StrictDataset):
+                    return dataset.id
+                else:
+                    break
+        self.raise_error_when_parent_dataset_not_found(member_id)
+
     def add_recon_to_dataset(self, recon_data: Images, stack_id: uuid.UUID) -> uuid.UUID:
         """
         Adds a recon to a dataset using recon data and an ID from one of the stacks in the dataset.

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -125,7 +125,7 @@ class MainWindowModel(object):
         raise RuntimeError(f"Failed to get Images with ID {images_id}")
 
     def raise_error_when_parent_dataset_not_found(self, images_id: uuid.UUID) -> NoReturn:
-        raise RuntimeError(f"Failed to find strict dataset containing Images with ID {images_id}")
+        raise RuntimeError(f"Failed to find dataset containing Images with ID {images_id}")
 
     def add_log_to_sample(self, images_id: uuid.UUID, log_file: str):
         images = self.get_images_by_uuid(images_id)
@@ -186,7 +186,7 @@ class MainWindowModel(object):
                 proj180s.append(dataset.proj180deg)
         return proj180s
 
-    def get_parent_strict_dataset(self, member_id: uuid.UUID) -> uuid.UUID:
+    def get_parent_dataset(self, member_id: uuid.UUID) -> uuid.UUID:
         """
         Takes the ID of an image stack and returns the ID of its parent strict dataset.
         :param member_id: The ID of the image stack.
@@ -194,10 +194,7 @@ class MainWindowModel(object):
         """
         for dataset in self.datasets.values():
             if member_id in dataset:
-                if isinstance(dataset, StrictDataset):
-                    return dataset.id
-                else:
-                    break
+                return dataset.id
         self.raise_error_when_parent_dataset_not_found(member_id)
 
     def add_recon_to_dataset(self, recon_data: Images, stack_id: uuid.UUID) -> uuid.UUID:

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -125,7 +125,7 @@ class MainWindowModel(object):
         raise RuntimeError(f"Failed to get Images with ID {images_id}")
 
     def raise_error_when_parent_dataset_not_found(self, images_id: uuid.UUID) -> NoReturn:
-        raise RuntimeError(f"Failed to find dataset containing Images with ID {images_id}")
+        raise RuntimeError(f"Failed to find strict dataset containing Images with ID {images_id}")
 
     def add_log_to_sample(self, images_id: uuid.UUID, log_file: str):
         images = self.get_images_by_uuid(images_id)

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -127,6 +127,9 @@ class MainWindowModel(object):
     def raise_error_when_parent_dataset_not_found(self, images_id: uuid.UUID) -> NoReturn:
         raise RuntimeError(f"Failed to find dataset containing Images with ID {images_id}")
 
+    def raise_error_when_parent_strict_dataset_not_found(self, images_id: uuid.UUID) -> NoReturn:
+        raise RuntimeError(f"Failed to find strict dataset containing Images with ID {images_id}")
+
     def add_log_to_sample(self, images_id: uuid.UUID, log_file: str):
         images = self.get_images_by_uuid(images_id)
         if images is None:
@@ -208,4 +211,4 @@ class MainWindowModel(object):
             if stack_id in dataset:
                 dataset.recons.append(recon_data)
                 return dataset.id
-        self.raise_error_when_parent_dataset_not_found(stack_id)
+        self.raise_error_when_parent_strict_dataset_not_found(stack_id)

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -124,6 +124,9 @@ class MainWindowModel(object):
     def raise_error_when_images_not_found(self, images_id: uuid.UUID) -> NoReturn:
         raise RuntimeError(f"Failed to get Images with ID {images_id}")
 
+    def raise_error_when_parent_dataset_not_found(self, images_id: uuid.UUID) -> NoReturn:
+        raise RuntimeError(f"Failed to find dataset containing Images with ID {images_id}")
+
     def add_log_to_sample(self, images_id: uuid.UUID, log_file: str):
         images = self.get_images_by_uuid(images_id)
         if images is None:
@@ -194,4 +197,17 @@ class MainWindowModel(object):
             if stack_id in dataset:
                 dataset.recons.append(recon_data)
                 return dataset.id
-        self.raise_error_when_images_not_found(stack_id)
+        self.raise_error_when_parent_dataset_not_found(stack_id)
+
+    def add_sinograms_to_dataset(self, sino_stack: Images, original_stack_id: uuid.UUID) -> uuid.UUID:
+        """
+        Adds a sinogram to a dataset using the sino stack and an ID from one of the stacks in the dataset.
+        :param sino_stack: The sinogram data.
+        :param original_stack_id: The ID of one of the member stacks.
+        :return: The ID of the parent dataset if found.
+        """
+        for dataset in self.datasets.values():
+            if original_stack_id in dataset and isinstance(dataset, StrictDataset):
+                dataset.sinograms = sino_stack
+                return dataset.id
+        self.raise_error_when_parent_dataset_not_found(original_stack_id)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -585,6 +585,10 @@ class MainWindowPresenter(BasePresenter):
         for i in range(top_level_item_count):
             top_level_item = self.view.dataset_tree_widget.topLevelItem(i)
             if top_level_item.id == parent_id:
-                self.view.create_child_tree_item(top_level_item, sino_id, "Sinograms")
+                sinograms_item = self.view.get_sinograms_item(top_level_item)
+                if sinograms_item is None:
+                    self.view.create_child_tree_item(top_level_item, sino_id, self.view.sino_text)
+                else:
+                    sinograms_item._id = sino_id
                 return
         raise RuntimeError(f"Unable to add sinogram item to dataset tree item with ID {parent_id}")

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -561,10 +561,10 @@ class MainWindowPresenter(BasePresenter):
         :param original_stack_id: The ID of a stack in the dataset.
         """
         parent_id = self.model.get_parent_strict_dataset(original_stack_id)
-        prev_sino = self.model.datasets[parent_id].sinograms
+        prev_sino = self.model.datasets[parent_id].sinograms  # type: ignore
         if prev_sino is not None:
             self._delete_stack(prev_sino.id)
-        self.model.datasets[parent_id].sinograms = sino_stack
+        self.model.datasets[parent_id].sinograms = sino_stack  # type: ignore
         self._add_sinograms_to_tree_view(sino_stack.id, parent_id)
         self.create_single_tabbed_images_stack(sino_stack)
         self.view.model_changed.emit()
@@ -573,7 +573,7 @@ class MainWindowPresenter(BasePresenter):
         """
         Adds a sinograms item to the tree view or updates the id of an existing one.
         :param parent_id: The ID of the parent dataset.
-        :param child_id: The ID of the corresponding Images object.
+        :param sino_id: The ID of the corresponding Images object.
         """
         dataset_item = self.view.get_dataset_tree_view_item(parent_id)
         sinograms_item = self.view.get_sinograms_item(dataset_item)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -556,7 +556,7 @@ class MainWindowPresenter(BasePresenter):
 
     def add_sinograms_to_dataset_and_update_view(self, sino_stack: Images, original_stack_id: uuid.UUID):
         """
-        Adds sinograms to a dataset.
+        Adds sinograms to a dataset or replaces an existing one.
         :param sino_stack: The sinogram stack.
         :param original_stack_id: The ID of a stack in the dataset.
         """
@@ -571,7 +571,7 @@ class MainWindowPresenter(BasePresenter):
 
     def _add_sinograms_to_tree_view(self, sino_id: uuid.UUID, parent_id: uuid.UUID):
         """
-        Adds a sinograms item to the tree view.
+        Adds a sinograms item to the tree view or updates the id of an existing one.
         :param parent_id: The ID of the parent dataset.
         :param child_id: The ID of the corresponding Images object.
         """

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -482,13 +482,8 @@ class MainWindowPresenter(BasePresenter):
         :param child_id: The ID of the corresponding Images object.
         :param child_name: The name that should appear in the tree view.
         """
-        top_level_item_count = self.view.dataset_tree_widget.topLevelItemCount()
-        for i in range(top_level_item_count):
-            top_level_item = self.view.dataset_tree_widget.topLevelItem(i)
-            if top_level_item.id == parent_id:
-                self.view.create_child_tree_item(top_level_item, child_id, child_name)
-                return
-        raise RuntimeError(f"Unable to add 180 item to dataset tree item with ID {parent_id}")
+        dataset_item = self.view.get_dataset_tree_view_item(parent_id)
+        self.view.create_child_tree_item(dataset_item, child_id, child_name)
 
     def add_recon_item_to_tree_view(self, parent_id: uuid.UUID, child_id: uuid.UUID, recon_count: int):
         """
@@ -497,19 +492,14 @@ class MainWindowPresenter(BasePresenter):
         :param child_id: The ID of the corresponding Images object.
         :param recon_count: The number of the recon in the dataset. One indicates the first recon that has been added.
         """
-        top_level_item_count = self.view.dataset_tree_widget.topLevelItemCount()
-        for i in range(top_level_item_count):
-            top_level_item = self.view.dataset_tree_widget.topLevelItem(i)
-            if top_level_item.id == parent_id:
-                if recon_count == 1:
-                    recon_group = self.view.add_recon_group(top_level_item)
-                    name = "Recon"
-                else:
-                    recon_group = self.view.get_recon_group(top_level_item)
-                    name = _generate_recon_item_name(recon_count)
-                self.view.create_child_tree_item(recon_group, child_id, name)
-                return
-        raise RuntimeError(f"Unable to add 180 item to dataset tree item with ID {parent_id}")
+        dataset_item = self.view.get_dataset_tree_view_item(parent_id)
+        if recon_count == 1:
+            recon_group = self.view.add_recon_group(dataset_item)
+            name = "Recon"
+        else:
+            recon_group = self.view.get_recon_group(dataset_item)
+            name = _generate_recon_item_name(recon_count)
+        self.view.create_child_tree_item(recon_group, child_id, name)
 
     def add_stack_to_dictionary(self, stack: StackVisualiserView) -> None:
         self.stack_visualisers[stack.id] = stack
@@ -581,14 +571,9 @@ class MainWindowPresenter(BasePresenter):
         :param parent_id: The ID of the parent dataset.
         :param child_id: The ID of the corresponding Images object.
         """
-        top_level_item_count = self.view.dataset_tree_widget.topLevelItemCount()
-        for i in range(top_level_item_count):
-            top_level_item = self.view.dataset_tree_widget.topLevelItem(i)
-            if top_level_item.id == parent_id:
-                sinograms_item = self.view.get_sinograms_item(top_level_item)
-                if sinograms_item is None:
-                    self.view.create_child_tree_item(top_level_item, sino_id, self.view.sino_text)
-                else:
-                    sinograms_item._id = sino_id
-                return
-        raise RuntimeError(f"Unable to add sinogram item to dataset tree item with ID {parent_id}")
+        dataset_item = self.view.find_dataset_tree_view_item(parent_id)
+        sinograms_item = self.view.get_sinograms_item(dataset_item)
+        if sinograms_item is None:
+            self.view.create_child_tree_item(dataset_item, sino_id, self.view.sino_text)
+        else:
+            sinograms_item._id = sino_id

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -560,11 +560,11 @@ class MainWindowPresenter(BasePresenter):
         :param sino_stack: The sinogram stack.
         :param original_stack_id: The ID of a stack in the dataset.
         """
-        parent_id = self.model.get_parent_strict_dataset(original_stack_id)
-        prev_sino = self.model.datasets[parent_id].sinograms  # type: ignore
+        parent_id = self.model.get_parent_dataset(original_stack_id)
+        prev_sino = self.model.datasets[parent_id].sinograms
         if prev_sino is not None:
             self._delete_stack(prev_sino.id)
-        self.model.datasets[parent_id].sinograms = sino_stack  # type: ignore
+        self.model.datasets[parent_id].sinograms = sino_stack
         self._add_sinograms_to_tree_view(sino_stack.id, parent_id)
         self.create_single_tabbed_images_stack(sino_stack)
         self.view.model_changed.emit()

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -571,7 +571,7 @@ class MainWindowPresenter(BasePresenter):
         :param parent_id: The ID of the parent dataset.
         :param child_id: The ID of the corresponding Images object.
         """
-        dataset_item = self.view.find_dataset_tree_view_item(parent_id)
+        dataset_item = self.view.get_dataset_tree_view_item(parent_id)
         sinograms_item = self.view.get_sinograms_item(dataset_item)
         if sinograms_item is None:
             self.view.create_child_tree_item(dataset_item, sino_id, self.view.sino_text)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -560,7 +560,11 @@ class MainWindowPresenter(BasePresenter):
         :param sino_stack: The sinogram stack.
         :param original_stack_id: The ID of a stack in the dataset.
         """
-        parent_id = self.model.add_sinograms_to_dataset(sino_stack, original_stack_id)
+        parent_id = self.model.get_parent_strict_dataset(original_stack_id)
+        prev_sino = self.model.datasets[parent_id].sinograms
+        if prev_sino is not None:
+            self._delete_stack(prev_sino.id)
+        self.model.datasets[parent_id].sinograms = sino_stack
         self._add_sinograms_to_tree_view(sino_stack.id, parent_id)
         self.create_single_tabbed_images_stack(sino_stack)
         self.view.model_changed.emit()

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -563,3 +563,28 @@ class MainWindowPresenter(BasePresenter):
         self.view.create_new_stack(recon_data)
         self.add_recon_item_to_tree_view(parent_id, recon_data.id, len(self.model.datasets[parent_id].recons))
         self.view.model_changed.emit()
+
+    def add_sinograms_to_dataset_and_update_view(self, sino_stack: Images, original_stack_id: uuid.UUID):
+        """
+        Adds sinograms to a dataset.
+        :param sino_stack: The sinogram stack.
+        :param original_stack_id: The ID of a stack in the dataset.
+        """
+        parent_id = self.model.add_sinograms_to_dataset(sino_stack, original_stack_id)
+        self._add_sinograms_to_tree_view(sino_stack.id, parent_id)
+        self.create_single_tabbed_images_stack(sino_stack)
+        self.view.model_changed.emit()
+
+    def _add_sinograms_to_tree_view(self, sino_id: uuid.UUID, parent_id: uuid.UUID):
+        """
+        Adds a sinograms item to the tree view.
+        :param parent_id: The ID of the parent dataset.
+        :param child_id: The ID of the corresponding Images object.
+        """
+        top_level_item_count = self.view.dataset_tree_widget.topLevelItemCount()
+        for i in range(top_level_item_count):
+            top_level_item = self.view.dataset_tree_widget.topLevelItem(i)
+            if top_level_item.id == parent_id:
+                self.view.create_child_tree_item(top_level_item, sino_id, "Sinograms")
+                return
+        raise RuntimeError(f"Unable to add sinogram item to dataset tree item with ID {parent_id}")

--- a/mantidimaging/gui/windows/main/test/dataset_test.py
+++ b/mantidimaging/gui/windows/main/test/dataset_test.py
@@ -126,3 +126,7 @@ class DatasetTest(unittest.TestCase):
         self.dataset.delete_stack(_180.id)
         self.assertIsNone(self.dataset.proj180deg)
         self.assertIsNone(self.dataset.sample.proj180deg)
+
+    def test_sinograms(self):
+        self.dataset.sinograms = sinograms = generate_images()
+        self.assertIs(self.dataset.sinograms, sinograms)

--- a/mantidimaging/gui/windows/main/test/dataset_test.py
+++ b/mantidimaging/gui/windows/main/test/dataset_test.py
@@ -130,3 +130,8 @@ class DatasetTest(unittest.TestCase):
     def test_sinograms(self):
         self.dataset.sinograms = sinograms = generate_images()
         self.assertIs(self.dataset.sinograms, sinograms)
+
+    def test_delete_sinograms(self):
+        self.dataset.sinograms = sinograms = generate_images()
+        self.dataset.delete_stack(sinograms.id)
+        self.assertIsNone(self.dataset.sinograms)

--- a/mantidimaging/gui/windows/main/test/dataset_test.py
+++ b/mantidimaging/gui/windows/main/test/dataset_test.py
@@ -5,7 +5,7 @@ import unittest
 
 from numpy import array_equal
 
-from mantidimaging.core.data.dataset import StrictDataset, _delete_stack_error_message
+from mantidimaging.core.data.dataset import StrictDataset, _delete_stack_error_message, MixedDataset
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
 
@@ -17,11 +17,12 @@ def test_delete_stack_error_message():
 class DatasetTest(unittest.TestCase):
     def setUp(self) -> None:
         self.images = [generate_images() for _ in range(5)]
-        self.dataset = StrictDataset(sample=self.images[0],
-                                     flat_before=self.images[1],
-                                     flat_after=self.images[2],
-                                     dark_before=self.images[3],
-                                     dark_after=self.images[4])
+        self.strict_dataset = StrictDataset(sample=self.images[0],
+                                            flat_before=self.images[1],
+                                            flat_after=self.images[2],
+                                            dark_before=self.images[3],
+                                            dark_after=self.images[4])
+        self.mixed_dataset = MixedDataset([generate_images()])
 
     def test_attribute_not_set_returns_none(self):
         sample = generate_images()
@@ -35,103 +36,108 @@ class DatasetTest(unittest.TestCase):
     def test_replace_success(self):
         sample_id = self.images[0].id
         new_sample_data = generate_images().data
-        self.dataset.replace(sample_id, new_sample_data)
-        assert array_equal(self.dataset.sample.data, new_sample_data)
+        self.strict_dataset.replace(sample_id, new_sample_data)
+        assert array_equal(self.strict_dataset.sample.data, new_sample_data)
 
     def test_replace_failure(self):
         with self.assertRaises(KeyError):
-            self.dataset.replace("nonexistent-id", generate_images().data)
+            self.strict_dataset.replace("nonexistent-id", generate_images().data)
 
     def test_cant_change_dataset_id(self):
         with self.assertRaises(Exception):
-            self.dataset.id = "id"
+            self.strict_dataset.id = "id"
 
     def test_set_flat_before(self):
         flat_before = generate_images()
-        self.dataset.flat_before = flat_before
-        assert flat_before is self.dataset.flat_before
+        self.strict_dataset.flat_before = flat_before
+        assert flat_before is self.strict_dataset.flat_before
 
     def test_set_flat_after(self):
         flat_after = generate_images()
-        self.dataset.flat_after = flat_after
-        assert flat_after is self.dataset.flat_after
+        self.strict_dataset.flat_after = flat_after
+        assert flat_after is self.strict_dataset.flat_after
 
     def test_set_dark_before(self):
         dark_before = generate_images()
-        self.dataset.dark_before = dark_before
-        assert dark_before is self.dataset.dark_before
+        self.strict_dataset.dark_before = dark_before
+        assert dark_before is self.strict_dataset.dark_before
 
     def test_set_dark_after(self):
         dark_after = generate_images()
-        self.dataset.dark_after = dark_after
-        assert dark_after is self.dataset.dark_after
+        self.strict_dataset.dark_after = dark_after
+        assert dark_after is self.strict_dataset.dark_after
 
     def test_all(self):
-        self.assertListEqual(self.dataset.all, self.images)
+        self.assertListEqual(self.strict_dataset.all, self.images)
 
     def test_all_images_ids(self):
-        self.assertListEqual(self.dataset.all_image_ids, [images.id for images in self.images])
+        self.assertListEqual(self.strict_dataset.all_image_ids, [images.id for images in self.images])
 
     def test_contains_returns_true(self):
-        assert self.images[2].id in self.dataset
+        assert self.images[2].id in self.strict_dataset
 
     def test_contains_returns_false(self):
-        assert not generate_images().id in self.dataset
+        assert not generate_images().id in self.strict_dataset
 
     def test_delete_sample(self):
-        self.dataset.delete_stack(self.images[0].id)
-        self.assertIsNone(self.dataset.sample)
+        self.strict_dataset.delete_stack(self.images[0].id)
+        self.assertIsNone(self.strict_dataset.sample)
 
     def test_delete_flat_before(self):
-        self.dataset.delete_stack(self.images[1].id)
-        self.assertIsNone(self.dataset.flat_before)
+        self.strict_dataset.delete_stack(self.images[1].id)
+        self.assertIsNone(self.strict_dataset.flat_before)
 
     def test_delete_flat_after(self):
-        self.dataset.delete_stack(self.images[2].id)
-        self.assertIsNone(self.dataset.flat_after)
+        self.strict_dataset.delete_stack(self.images[2].id)
+        self.assertIsNone(self.strict_dataset.flat_after)
 
     def test_delete_dark_before(self):
-        self.dataset.delete_stack(self.images[3].id)
-        self.assertIsNone(self.dataset.dark_before)
+        self.strict_dataset.delete_stack(self.images[3].id)
+        self.assertIsNone(self.strict_dataset.dark_before)
 
     def test_delete_dark_after(self):
-        self.dataset.delete_stack(self.images[4].id)
-        self.assertIsNone(self.dataset.dark_after)
+        self.strict_dataset.delete_stack(self.images[4].id)
+        self.assertIsNone(self.strict_dataset.dark_after)
 
     def test_delete_recon(self):
         recons = [generate_images() for _ in range(2)]
-        self.dataset.recons = recons.copy()
+        self.strict_dataset.recons = recons.copy()
 
         id_to_remove = recons[-1].id
-        self.dataset.delete_stack(id_to_remove)
-        self.assertNotIn(recons[-1], self.dataset.all)
+        self.strict_dataset.delete_stack(id_to_remove)
+        self.assertNotIn(recons[-1], self.strict_dataset.all)
 
     def test_delete_failure(self):
         with self.assertRaises(KeyError):
-            self.dataset.delete_stack("nonexistent-id")
+            self.strict_dataset.delete_stack("nonexistent-id")
 
     def test_name(self):
-        self.dataset.name = dataset_name = "name"
-        assert self.dataset.name == dataset_name
+        self.strict_dataset.name = dataset_name = "name"
+        assert self.strict_dataset.name == dataset_name
 
     def test_set_180(self):
         _180 = generate_images((1, 200, 200))
-        self.dataset.proj180deg = _180
-        assert self.dataset.proj180deg is _180
-        assert self.dataset.sample.proj180deg is _180
+        self.strict_dataset.proj180deg = _180
+        assert self.strict_dataset.proj180deg is _180
+        assert self.strict_dataset.sample.proj180deg is _180
 
     def test_remove_180(self):
         _180 = generate_images((1, 200, 200))
-        self.dataset.proj180deg = _180
-        self.dataset.delete_stack(_180.id)
-        self.assertIsNone(self.dataset.proj180deg)
-        self.assertIsNone(self.dataset.sample.proj180deg)
+        self.strict_dataset.proj180deg = _180
+        self.strict_dataset.delete_stack(_180.id)
+        self.assertIsNone(self.strict_dataset.proj180deg)
+        self.assertIsNone(self.strict_dataset.sample.proj180deg)
 
     def test_sinograms(self):
-        self.dataset.sinograms = sinograms = generate_images()
-        self.assertIs(self.dataset.sinograms, sinograms)
+        self.strict_dataset.sinograms = sinograms = generate_images()
+        self.assertIs(self.strict_dataset.sinograms, sinograms)
 
     def test_delete_sinograms(self):
-        self.dataset.sinograms = sinograms = generate_images()
-        self.dataset.delete_stack(sinograms.id)
-        self.assertIsNone(self.dataset.sinograms)
+        self.strict_dataset.sinograms = sinograms = generate_images()
+        self.strict_dataset.delete_stack(sinograms.id)
+        self.assertIsNone(self.strict_dataset.sinograms)
+
+    def test_sinograms_in_mixed_dataset_all(self):
+        self.assertListEqual(self.mixed_dataset._stacks, self.mixed_dataset.all)
+        self.mixed_dataset.sinograms = sinograms = generate_images()
+        self.assertListEqual(self.mixed_dataset._stacks + [sinograms], self.mixed_dataset.all)

--- a/mantidimaging/gui/windows/main/test/mixeddataset_test.py
+++ b/mantidimaging/gui/windows/main/test/mixeddataset_test.py
@@ -10,27 +10,37 @@ from mantidimaging.test_helpers.unit_test_helper import generate_images
 class MixedDatasetTest(unittest.TestCase):
     def setUp(self) -> None:
         self.image_stacks = [generate_images() for _ in range(3)]
-        self.stack_dataset = MixedDataset(self.image_stacks)
+        self.mixed_dataset = MixedDataset(self.image_stacks)
 
     def test_all(self):
-        self.assertListEqual(self.stack_dataset.all, self.image_stacks)
+        self.assertListEqual(self.mixed_dataset.all, self.image_stacks)
 
     def test_delete_stack_from_stacks_list(self):
         prev_stacks = self.image_stacks.copy()
-        self.stack_dataset.delete_stack(self.image_stacks[-1].id)
-        self.assertListEqual(self.stack_dataset.all, prev_stacks[:-1])
+        self.mixed_dataset.delete_stack(self.image_stacks[-1].id)
+        self.assertListEqual(self.mixed_dataset.all, prev_stacks[:-1])
 
     def test_delete_stack_from_recons_list(self):
         recons = [generate_images() for _ in range(2)]
-        self.stack_dataset.recons = recons.copy()
+        self.mixed_dataset.recons = recons.copy()
 
         id_to_remove = recons[-1].id
-        self.stack_dataset.delete_stack(id_to_remove)
-        self.assertNotIn(recons[-1], self.stack_dataset.all)
+        self.mixed_dataset.delete_stack(id_to_remove)
+        self.assertNotIn(recons[-1], self.mixed_dataset.all)
 
     def test_delete_stack_failure(self):
         with self.assertRaises(KeyError):
-            self.stack_dataset.delete_stack("nonexistent-id")
+            self.mixed_dataset.delete_stack("nonexistent-id")
 
     def test_all_ids(self):
-        self.assertListEqual(self.stack_dataset.all_image_ids, [image_stack.id for image_stack in self.image_stacks])
+        self.assertListEqual(self.mixed_dataset.all_image_ids, [image_stack.id for image_stack in self.image_stacks])
+
+    def test_sinograms_in_all(self):
+        self.assertListEqual(self.mixed_dataset._stacks, self.mixed_dataset.all)
+        self.mixed_dataset.sinograms = sinograms = generate_images()
+        self.assertListEqual(self.mixed_dataset._stacks + [sinograms], self.mixed_dataset.all)
+
+    def test_delete_sinograms(self):
+        self.mixed_dataset.sinograms = sinograms = generate_images()
+        self.mixed_dataset.delete_stack(sinograms.id)
+        self.assertNotIn(sinograms, self.mixed_dataset.all)

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -382,3 +382,11 @@ class MainWindowModelTest(unittest.TestCase):
         self.model.add_dataset_to_model(ds3)
 
         self.assertListEqual(self.model.proj180s, proj180s)
+
+    def test_exception_when_dataset_for_sinograms_not_found(self):
+        with self.assertRaises(RuntimeError):
+            self.model.add_sinograms_to_dataset(generate_images(), "bad-id")
+
+    def test_exception_when_dataset_for_recons_not_found(self):
+        with self.assertRaises(RuntimeError):
+            self.model.add_recon_to_dataset(generate_images(), "bad-id")

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -364,8 +364,9 @@ class MainWindowModelTest(unittest.TestCase):
 
         recon = generate_images()
         self.model.add_dataset_to_model(ds)
-        self.model.add_recon_to_dataset(recon, sample_id)
+        parent_id = self.model.add_recon_to_dataset(recon, sample_id)
         self.assertIn(recon, ds.all)
+        assert parent_id == ds.id
 
     def test_proj180s(self):
 

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -390,3 +390,11 @@ class MainWindowModelTest(unittest.TestCase):
     def test_exception_when_dataset_for_recons_not_found(self):
         with self.assertRaises(RuntimeError):
             self.model.add_recon_to_dataset(generate_images(), "bad-id")
+
+    def test_add_sinograms_to_dataset(self):
+        sinograms = generate_images()
+        ds = StrictDataset(generate_images())
+        self.model.add_dataset_to_model(ds)
+
+        self.model.add_sinograms_to_dataset(sinograms, ds.sample.id)
+        self.assertIs(sinograms, ds.sinograms)

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -387,3 +387,20 @@ class MainWindowModelTest(unittest.TestCase):
     def test_exception_when_dataset_for_recons_not_found(self):
         with self.assertRaises(RuntimeError):
             self.model.add_recon_to_dataset(generate_images(), "bad-id")
+
+    def test_get_parent_strict_dataset_success(self):
+        ds = StrictDataset(generate_images())
+        self.model.add_dataset_to_model(ds)
+        self.assertIs(self.model.get_parent_strict_dataset(ds.sample.id), ds.id)
+
+    def test_get_parent_strict_dataset_finds_stack_in_mixed_dataset(self):
+        ds = MixedDataset([generate_images()])
+        self.model.add_dataset_to_model(ds)
+        with self.assertRaises(RuntimeError):
+            self.model.get_parent_strict_dataset(ds.all[0].id)
+
+    def test_get_parent_strict_dataset_doesnt_find_any_parent(self):
+        ds = StrictDataset(generate_images())
+        self.model.add_dataset_to_model(ds)
+        with self.assertRaises(RuntimeError):
+            self.model.get_parent_strict_dataset("unrecognised-id")

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -391,16 +391,10 @@ class MainWindowModelTest(unittest.TestCase):
     def test_get_parent_strict_dataset_success(self):
         ds = StrictDataset(generate_images())
         self.model.add_dataset_to_model(ds)
-        self.assertIs(self.model.get_parent_strict_dataset(ds.sample.id), ds.id)
+        self.assertIs(self.model.get_parent_dataset(ds.sample.id), ds.id)
 
-    def test_get_parent_strict_dataset_finds_stack_in_mixed_dataset(self):
-        ds = MixedDataset([generate_images()])
-        self.model.add_dataset_to_model(ds)
-        with self.assertRaises(RuntimeError):
-            self.model.get_parent_strict_dataset(ds.all[0].id)
-
-    def test_get_parent_strict_dataset_doesnt_find_any_parent(self):
+    def test_get_parent_dataset_doesnt_find_any_parent(self):
         ds = StrictDataset(generate_images())
         self.model.add_dataset_to_model(ds)
         with self.assertRaises(RuntimeError):
-            self.model.get_parent_strict_dataset("unrecognised-id")
+            self.model.get_parent_dataset("unrecognised-id")

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -384,19 +384,6 @@ class MainWindowModelTest(unittest.TestCase):
 
         self.assertListEqual(self.model.proj180s, proj180s)
 
-    def test_exception_when_dataset_for_sinograms_not_found(self):
-        with self.assertRaises(RuntimeError):
-            self.model.add_sinograms_to_dataset(generate_images(), "bad-id")
-
     def test_exception_when_dataset_for_recons_not_found(self):
         with self.assertRaises(RuntimeError):
             self.model.add_recon_to_dataset(generate_images(), "bad-id")
-
-    def test_add_sinograms_to_dataset(self):
-        sinograms = generate_images()
-        ds = StrictDataset(generate_images())
-        self.model.add_dataset_to_model(ds)
-
-        parent_id = self.model.add_sinograms_to_dataset(sinograms, ds.sample.id)
-        self.assertIs(sinograms, ds.sinograms)
-        assert parent_id == ds.id

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -396,5 +396,6 @@ class MainWindowModelTest(unittest.TestCase):
         ds = StrictDataset(generate_images())
         self.model.add_dataset_to_model(ds)
 
-        self.model.add_sinograms_to_dataset(sinograms, ds.sample.id)
+        parent_id = self.model.add_sinograms_to_dataset(sinograms, ds.sample.id)
         self.assertIs(sinograms, ds.sinograms)
+        assert parent_id == ds.id

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -637,7 +637,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         ds = StrictDataset(generate_images())
         self.model.datasets = dict()
         self.model.datasets[ds.id] = ds
-        self.model.get_parent_strict_dataset.return_value = ds.id
+        self.model.get_parent_dataset.return_value = ds.id
 
         dataset_item_mock = self.view.get_dataset_tree_view_item.return_value
         dataset_item_mock.id = ds.id
@@ -646,7 +646,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter._delete_stack = mock.Mock()
 
         self.presenter.add_sinograms_to_dataset_and_update_view(sinograms, ds.sample.id)
-        self.model.get_parent_strict_dataset.assert_called_once_with(ds.sample.id)
+        self.model.get_parent_dataset.assert_called_once_with(ds.sample.id)
         self.presenter._delete_stack.assert_not_called()
         self.assertIs(ds.sinograms, sinograms)
         self.view.get_dataset_tree_view_item.assert_called_once_with(ds.id)
@@ -660,7 +660,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         ds = StrictDataset(generate_images())
         self.model.datasets = dict()
         self.model.datasets[ds.id] = ds
-        self.model.get_parent_strict_dataset.return_value = ds.id
+        self.model.get_parent_dataset.return_value = ds.id
         ds.sinograms = existing_sinograms = generate_images()
 
         dataset_item_mock = self.view.get_dataset_tree_view_item.return_value

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -49,6 +49,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.create_stack_window.return_value = dock_mock = mock.Mock()
         self.view.model_changed = mock.Mock()
         self.view.dataset_tree_widget = mock.Mock()
+        self.view.get_dataset_tree_view_item = mock.Mock()
 
         def stack_id():
             return uuid.uuid4()
@@ -502,23 +503,14 @@ class MainWindowPresenterTest(unittest.TestCase):
         dataset_list = self.presenter.dataset_list
         assert len(dataset_list) == 2
 
-    def test_add_child_item_to_tree_view_success(self):
-        self.view.dataset_tree_widget.topLevelItemCount.return_value = 1
-        top_level_item_mock = self.view.dataset_tree_widget.topLevelItem.return_value
-        top_level_item_mock.id = dataset_id = "dataset-id"
+    def test_add_child_item_to_tree_view(self):
+        dataset_item_mock = self.view.get_dataset_tree_view_item.return_value
+        dataset_item_mock.id = dataset_id = "dataset-id"
 
         child_id = "child-id"
         child_name = "180"
         self.presenter.add_child_item_to_tree_view(dataset_id, child_id, child_name)
-        self.view.create_child_tree_item.assert_called_once_with(top_level_item_mock, child_id, child_name)
-
-    def test_add_child_item_to_tree_view_failure(self):
-        self.view.dataset_tree_widget.topLevelItemCount.return_value = 1
-        top_level_item_mock = self.view.dataset_tree_widget.topLevelItem.return_value
-        top_level_item_mock.id = "different-id"
-
-        with self.assertRaises(RuntimeError):
-            self.presenter.add_child_item_to_tree_view("nonexistent-id", "child-id", "180")
+        self.view.create_child_tree_item.assert_called_once_with(dataset_item_mock, child_id, child_name)
 
     @mock.patch("mantidimaging.gui.windows.main.presenter.MainWindowPresenter.create_mixed_dataset_tree_view_items")
     def test_on_stack_load_done_success(self, _):
@@ -591,26 +583,25 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.add_item_to_tree_view.assert_called_once_with(dataset_tree_item_mock)
 
     def test_add_first_recon_item_to_tree_view(self):
-        self.view.dataset_tree_widget.topLevelItemCount.return_value = 1
-        top_level_item_mock = self.view.dataset_tree_widget.topLevelItem.return_value
-        top_level_item_mock.id = parent_id = "parent-id"
+        dataset_item_mock = self.view.get_dataset_tree_view_item.return_value
+        dataset_item_mock.id = parent_id = "parent-id"
         child_id = "child-id"
         recon_group_mock = self.view.add_recon_group.return_value
 
         self.presenter.add_recon_item_to_tree_view(parent_id, child_id, 1)
-        self.view.add_recon_group.assert_called_once_with(top_level_item_mock)
+        self.view.get_dataset_tree_view_item.assert_called_once_with(parent_id)
+        self.view.add_recon_group.assert_called_once_with(dataset_item_mock)
         self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, "Recon")
 
     def test_add_additional_recon_item_to_tree_view(self):
         parent_id = "parent-id"
-        self.view.find_dataset_tree_view_item = mock.Mock()
-        dataset_item_mock = self.view.find_dataset_tree_view_item.return_value
+        dataset_item_mock = self.view.get_dataset_tree_view_item.return_value
         child_id = "child-id"
         recon_group_mock = self.view.get_recon_group.return_value
         recon_count = 2
 
         self.presenter.add_recon_item_to_tree_view(parent_id, child_id, recon_count)
-        self.view.find_dataset_tree_view_item.assert_called_once_with(parent_id)
+        self.view.get_dataset_tree_view_item.assert_called_once_with(parent_id)
         self.view.get_recon_group.assert_called_once_with(dataset_item_mock)
         self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, "Recon 2")
 

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -602,23 +602,17 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, "Recon")
 
     def test_add_additional_recon_item_to_tree_view(self):
-        self.view.dataset_tree_widget.topLevelItemCount.return_value = 1
-        top_level_item_mock = self.view.dataset_tree_widget.topLevelItem.return_value
-        top_level_item_mock.id = parent_id = "parent-id"
+        parent_id = "parent-id"
+        self.view.find_dataset_tree_view_item = mock.Mock()
+        dataset_item_mock = self.view.find_dataset_tree_view_item.return_value
         child_id = "child-id"
         recon_group_mock = self.view.get_recon_group.return_value
         recon_count = 2
 
         self.presenter.add_recon_item_to_tree_view(parent_id, child_id, recon_count)
-        self.view.get_recon_group.assert_called_once_with(top_level_item_mock)
+        self.view.find_dataset_tree_view_item.assert_called_once_with(parent_id)
+        self.view.get_recon_group.assert_called_once_with(dataset_item_mock)
         self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, "Recon 2")
-
-    def test_add_recon_item_to_tree_view_failed(self):
-        self.view.dataset_tree_widget.topLevelItemCount.return_value = 1
-        top_level_item_mock = self.view.dataset_tree_widget.topLevelItem.return_value
-        top_level_item_mock.id = "different-id"
-        with self.assertRaises(RuntimeError):
-            self.presenter.add_recon_item_to_tree_view("parent-id", "child-id", 0)
 
     def test_created_mixed_dataset_tree_view_items(self):
         n_images = 3

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -647,6 +647,27 @@ class MainWindowPresenterTest(unittest.TestCase):
         stack_mock.setVisible.assert_not_called()
         stack_mock._raise.assert_not_called()
 
+    def test_add_sinograms_to_dataset_with_no_sinograms_and_update_view(self):
+        sinograms = generate_images()
+        ds = StrictDataset(generate_images())
+        self.model.datasets = dict()
+        self.model.datasets[ds.id] = ds
+        self.model.add_sinograms_to_dataset.return_value = ds.id
+
+        self.view.dataset_tree_widget.topLevelItemCount.return_value = 1
+        dataset_tree_widget_item = self.view.dataset_tree_widget.topLevelItem.return_value
+        dataset_tree_widget_item.id = ds.id
+        self.view.get_sinograms_item.return_value = None
+        self.presenter.create_single_tabbed_images_stack = mock.Mock()
+
+        self.presenter.add_sinograms_to_dataset_and_update_view(sinograms, ds.sample.id)
+        self.model.add_sinograms_to_dataset.assert_called_once_with(sinograms, ds.sample.id)
+        self.view.get_sinograms_item.assert_called_once_with(dataset_tree_widget_item)
+        self.view.create_child_tree_item.assert_called_once_with(dataset_tree_widget_item, sinograms.id,
+                                                                 self.view.sino_text)
+        self.presenter.create_single_tabbed_images_stack.assert_called_once_with(sinograms)
+        self.view.model_changed.emit.assert_called_once()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -639,17 +639,36 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.model.datasets[ds.id] = ds
         self.model.add_sinograms_to_dataset.return_value = ds.id
 
-        self.view.dataset_tree_widget.topLevelItemCount.return_value = 1
-        dataset_tree_widget_item = self.view.dataset_tree_widget.topLevelItem.return_value
-        dataset_tree_widget_item.id = ds.id
+        dataset_item_mock = self.view.get_dataset_tree_view_item.return_value
+        dataset_item_mock.id = ds.id
         self.view.get_sinograms_item.return_value = None
         self.presenter.create_single_tabbed_images_stack = mock.Mock()
 
         self.presenter.add_sinograms_to_dataset_and_update_view(sinograms, ds.sample.id)
         self.model.add_sinograms_to_dataset.assert_called_once_with(sinograms, ds.sample.id)
-        self.view.get_sinograms_item.assert_called_once_with(dataset_tree_widget_item)
-        self.view.create_child_tree_item.assert_called_once_with(dataset_tree_widget_item, sinograms.id,
-                                                                 self.view.sino_text)
+        self.view.get_dataset_tree_view_item.assert_called_once_with(ds.id)
+        self.view.get_sinograms_item.assert_called_once_with(dataset_item_mock)
+        self.view.create_child_tree_item.assert_called_once_with(dataset_item_mock, sinograms.id, self.view.sino_text)
+        self.presenter.create_single_tabbed_images_stack.assert_called_once_with(sinograms)
+        self.view.model_changed.emit.assert_called_once()
+
+    def test_add_sinograms_to_dataset_with_existing_sinograms(self):
+        sinograms = generate_images()
+        ds = StrictDataset(generate_images())
+        self.model.datasets = dict()
+        self.model.datasets[ds.id] = ds
+        self.model.add_sinograms_to_dataset.return_value = ds.id
+
+        dataset_item_mock = self.view.get_dataset_tree_view_item.return_value
+        dataset_item_mock.id = ds.id
+        sinograms_item_mock = self.view.get_sinograms_item.return_value
+        self.presenter.create_single_tabbed_images_stack = mock.Mock()
+
+        self.presenter.add_sinograms_to_dataset_and_update_view(sinograms, ds.sample.id)
+        self.model.add_sinograms_to_dataset.assert_called_once_with(sinograms, ds.sample.id)
+        self.view.get_dataset_tree_view_item.assert_called_once_with(ds.id)
+        self.view.get_sinograms_item.assert_called_once_with(dataset_item_mock)
+        assert sinograms_item_mock._id == sinograms.id
         self.presenter.create_single_tabbed_images_stack.assert_called_once_with(sinograms)
         self.view.model_changed.emit.assert_called_once()
 

--- a/mantidimaging/gui/windows/main/test/strictdataset_test.py
+++ b/mantidimaging/gui/windows/main/test/strictdataset_test.py
@@ -5,7 +5,7 @@ import unittest
 
 from numpy import array_equal
 
-from mantidimaging.core.data.dataset import StrictDataset, _delete_stack_error_message, MixedDataset
+from mantidimaging.core.data.dataset import StrictDataset, _delete_stack_error_message
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
 
@@ -14,7 +14,7 @@ def test_delete_stack_error_message():
                                                       " dataset."
 
 
-class DatasetTest(unittest.TestCase):
+class StrictDatasetTest(unittest.TestCase):
     def setUp(self) -> None:
         self.images = [generate_images() for _ in range(5)]
         self.strict_dataset = StrictDataset(sample=self.images[0],
@@ -22,7 +22,6 @@ class DatasetTest(unittest.TestCase):
                                             flat_after=self.images[2],
                                             dark_before=self.images[3],
                                             dark_after=self.images[4])
-        self.mixed_dataset = MixedDataset([generate_images()])
 
     def test_attribute_not_set_returns_none(self):
         sample = generate_images()
@@ -136,8 +135,3 @@ class DatasetTest(unittest.TestCase):
         self.strict_dataset.sinograms = sinograms = generate_images()
         self.strict_dataset.delete_stack(sinograms.id)
         self.assertIsNone(self.strict_dataset.sinograms)
-
-    def test_sinograms_in_mixed_dataset_all(self):
-        self.assertListEqual(self.mixed_dataset._stacks, self.mixed_dataset.all)
-        self.mixed_dataset.sinograms = sinograms = generate_images()
-        self.assertListEqual(self.mixed_dataset._stacks + [sinograms], self.mixed_dataset.all)

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -12,7 +12,7 @@ from PyQt5.QtWidgets import QDialog
 from mantidimaging.core.utility.data_containers import ProjectionAngles
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.main.presenter import Notification as PresNotification
-from mantidimaging.gui.windows.main.view import RECON_GROUP_TEXT, RECON_ID
+from mantidimaging.gui.windows.main.view import RECON_GROUP_TEXT, RECON_ID, SINO_TEXT
 from mantidimaging.test_helpers import start_qapplication
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
@@ -421,3 +421,15 @@ class MainWindowViewTest(unittest.TestCase):
 
     def test_get_all_180_projections(self):
         self.assertIs(self.view.get_all_180_projections(), self.presenter.get_all_180_projections.return_value)
+
+    def test_get_sinograms_item(self):
+        n_children = 3
+        children = [mock.Mock() for _ in range(n_children)]
+        children[0].text.return_value = children[1].text.return_value = "Not Sinograms"
+        children[2].text.return_value = SINO_TEXT
+
+        parent_mock = mock.Mock()
+        parent_mock.childCount.return_value = n_children
+        parent_mock.child.side_effect = children
+
+        self.assertIs(self.view.get_sinograms_item(parent_mock), children[2])

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -435,6 +435,17 @@ class MainWindowViewTest(unittest.TestCase):
 
         self.assertIs(self.view.get_sinograms_item(parent_mock), children[2])
 
+    def test_get_sinograms_item_returns_none(self):
+        n_children = 3
+        children = [mock.Mock() for _ in range(n_children)]
+        children[0].text.return_value = children[1].text.return_value = children[2].text.return_value = "Not Sinograms"
+
+        parent_mock = mock.Mock()
+        parent_mock.childCount.return_value = n_children
+        parent_mock.child.side_effect = children
+
+        self.assertIsNone(self.view.get_sinograms_item(parent_mock))
+
     def test_get_dataset_tree_view_item_success(self):
         self.dataset_tree_widget.topLevelItemCount.return_value = 1
         dataset_tree_view_item_mock = self.dataset_tree_widget.topLevelItem.return_value

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -32,6 +32,7 @@ class MainWindowViewTest(unittest.TestCase):
                 self.view = MainWindowView()
         self.presenter = mock.MagicMock()
         self.view.presenter = self.presenter
+        self.view.dataset_tree_widget = self.dataset_tree_widget = mock.Mock()
 
     def test_execute_save(self):
         self.view.execute_save()
@@ -433,3 +434,14 @@ class MainWindowViewTest(unittest.TestCase):
         parent_mock.child.side_effect = children
 
         self.assertIs(self.view.get_sinograms_item(parent_mock), children[2])
+
+    def test_get_dataset_tree_view_item_success(self):
+        self.dataset_tree_widget.topLevelItemCount.return_value = 1
+        dataset_tree_view_item_mock = self.dataset_tree_widget.topLevelItem.return_value
+        dataset_tree_view_item_mock.id = dataset_id = "dataset-id"
+        self.assertIs(dataset_tree_view_item_mock, self.view.get_dataset_tree_view_item(dataset_id))
+
+    def test_get_dataset_tree_view_item_failure(self):
+        self.dataset_tree_widget.topLevelItemCount.return_value = 1
+        with self.assertRaises(RuntimeError):
+            self.view.get_dataset_tree_view_item("bad-dataset-id")

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -469,10 +469,22 @@ class MainWindowView(BaseMainWindowView):
         return dataset_tree_item
 
     @staticmethod
-    def create_child_tree_item(parent: QTreeDatasetWidgetItem, dataset_id: UUID, name: str):
+    def create_child_tree_item(parent: QTreeDatasetWidgetItem, dataset_id: uuid.UUID, name: str):
         child = QTreeDatasetWidgetItem(parent, dataset_id)
         child.setText(0, name)
         parent.addChild(child)
+
+    @staticmethod
+    def get_sinograms_item(parent: QTreeDatasetWidgetItem) -> Optional[QTreeDatasetWidgetItem]:
+        """
+        Tries to look for a sinograms entry in a dataset tree view item.
+        :return: The sinograms entry if found, None otherwise.
+        """
+        for i in range(parent.childCount()):
+            child = parent.child(i)
+            if child.text(0) == SINO_TEXT:
+                return child
+        return None
 
     def add_item_to_tree_view(self, item: QTreeWidgetItem):
         self.dataset_tree_widget.insertTopLevelItem(self.dataset_tree_widget.topLevelItemCount(), item)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -36,6 +36,7 @@ from mantidimaging.gui.windows.welcome_screen.presenter import WelcomeScreenPres
 from mantidimaging.gui.windows.wizard.presenter import WizardPresenter
 
 RECON_GROUP_TEXT = "Recons"
+SINO_TEXT = "Sinograms"
 RECON_ID = uuid.uuid4()
 
 LOG = getLogger(__file__)
@@ -550,3 +551,10 @@ class MainWindowView(BaseMainWindowView):
         :return: The recon group ID.
         """
         return RECON_ID
+
+    @property
+    def sino_text(self) -> str:
+        """
+        :return: The sinogram entry text. Used to avoid circular imports.
+        """
+        return SINO_TEXT

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -543,6 +543,19 @@ class MainWindowView(BaseMainWindowView):
                 return dataset_item.child(i)
         raise RuntimeError(f"Unable to find recon group in dataset tree item for dataset {dataset_item.id}")
 
+    def get_dataset_tree_view_item(self, dataset_id: uuid.UUID) -> QTreeDatasetWidgetItem:
+        """
+        Looks for the dataset tree view item matching a given ID.
+        :param dataset_id: The dataset ID.
+        :return: The tree view item if found.
+        """
+        top_level_item_count = self.dataset_tree_widget.topLevelItemCount()
+        for i in range(top_level_item_count):
+            top_level_item = self.dataset_tree_widget.topLevelItem(i)
+            if top_level_item.id == dataset_id:
+                return top_level_item
+        raise RuntimeError(f"Unable to find dataset with ID {dataset_id}")
+
     @property
     def recon_groups_id(self) -> uuid.UUID:
         """

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -105,7 +105,7 @@ class StackVisualiserPresenter(BasePresenter):
             new_stack = self.images.copy(flip_axes=True)
             new_stack.name = self.images.name + "_sino"
             new_stack.record_operation(const.OPERATION_NAME_AXES_SWAP, display_name="Axes Swapped")
-            self.add_singograms_to_model_and_update_view(new_stack)
+            self.add_sinograms_to_model_and_update_view(new_stack)
 
     def dupe_stack(self):
         with operation_in_progress("Copying data, this may take a while",
@@ -138,5 +138,5 @@ class StackVisualiserPresenter(BasePresenter):
                 return index
         return len(self.images.projection_angles().value)
 
-    def add_singograms_to_model_and_update_view(self, new_stack: Images):
+    def add_sinograms_to_model_and_update_view(self, new_stack: Images):
         self.view._main_window.presenter.add_sinograms_to_dataset_and_update_view(new_stack, self.images.id)

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -105,7 +105,7 @@ class StackVisualiserPresenter(BasePresenter):
             new_stack = self.images.copy(flip_axes=True)
             new_stack.name = self.images.name + "_sino"
             new_stack.record_operation(const.OPERATION_NAME_AXES_SWAP, display_name="Axes Swapped")
-            self.add_mixed_dataset_to_model_and_update_view(new_stack)
+            self.add_singograms_to_model_and_update_view(new_stack)
 
     def dupe_stack(self):
         with operation_in_progress("Copying data, this may take a while",
@@ -137,3 +137,6 @@ class StackVisualiserPresenter(BasePresenter):
             if angle >= selected_angle:
                 return index
         return len(self.images.projection_angles().value)
+
+    def add_singograms_to_model_and_update_view(self, new_stack: Images):
+        self.view._main_window.presenter.add_sinograms_to_dataset_and_update_view(new_stack, self.images.id)

--- a/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
@@ -24,6 +24,7 @@ class StackVisualiserPresenterTest(unittest.TestCase):
         self.view = mock.create_autospec(StackVisualiserView)
         self.presenter = StackVisualiserPresenter(self.view, self.test_data)
         self.presenter.model = mock.Mock()
+        self.view._main_window = mock.Mock()
 
     def test_get_image(self):
         index = 3
@@ -107,6 +108,12 @@ class StackVisualiserPresenterTest(unittest.TestCase):
     def test_get_parameter_value_raises_value_error(self):
         with self.assertRaises(ValueError):
             self.presenter.get_parameter_value(7)
+
+    def test_add_sinograms_to_model_and_update_view(self):
+        sinograms = th.generate_images()
+        self.presenter.add_sinograms_to_model_and_update_view(sinograms)
+        self.view._main_window.presenter.add_sinograms_to_dataset_and_update_view.assert_called_once_with(
+            sinograms, self.presenter.images.id)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Issue

Closes #1273

### Description

Gives the datasets a sinogram attribute. The sinogram also has an entry in the tree view. Datasets can have one sinogram so the previous one is replaced when the method is called again. Sinograms can also be deleted with the tree view.

### Testing 

Wrote some tests for main window model/presenter/view and dataset.

### Acceptance Criteria 

Check that the tests pass. Check that creating a sinogram updates the tree view. Check that double-clicking item on tree view changes stack. Check that creating another set of sinograms replaces the previous one.

### Documentation

Updated release notes.
