### PR TITLE
Fix auto colour dialog in compare images

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -40,6 +40,7 @@ Fixes
 - #1248 : Rebin operations not working for small image dimensions
 - #1190 : Add recon item to right part of tree view
 - #1239 : 180 warning when applying ring removal to recon
+- #1297 : Auto colour dialog not working in compare images
 
 
 Developer Changes

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -251,5 +251,5 @@ class MIImageView(ImageView, BadDataOverlay):
         """
         Opens the Palette Changer window when the "Auto" option has been clicked.
         """
-        change_colour_palette = PaletteChangerView(parent=None, main_hist=self.ui.histogram.item, image=self.image)
+        change_colour_palette = PaletteChangerView(parent=self, main_hist=self.ui.histogram.item, image=self.image)
         change_colour_palette.show()


### PR DESCRIPTION
### Issue

Closes #1297

### Description

Changing the parent of the `PaletteChangerView` made the auto colour dialog operable when opened from the compare images window.

I spent a bit of time looking into whether we could add a test for this bug. I couldn't easily find a way because of the nature of the dialog, however if we think it's important to have a test I could spend more time looking into this.

### Testing & Acceptance Criteria 

The dialog is fully operable when opened from the Compare Images window (see steps on original issue).
Also double check the equivalent dialog is working in other places in MI where it can be opened.

### Documentation

Issue number added to release notes.
