### PR TITLE
Fix attribute errors when applying filters after closing and re-opening ops window

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -42,6 +42,7 @@ Fixes
 - #1190 : Add recon item to right part of tree view
 - #1239 : 180 warning when applying ring removal to recon
 - #1297 : Auto colour dialog not working in compare images
+- #1292 : Attribute error if apply filter after closing and re-opening Operations window
 
 
 Developer Changes

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -104,8 +104,6 @@ class FiltersWindowPresenter(BasePresenter):
 
         self.prev_apply_single_state = True
         self.prev_apply_all_state = True
-        self.main_window.filter_applied.connect(
-            lambda: self._set_apply_buttons_enabled(self.prev_apply_single_state, self.prev_apply_all_state))
 
     @property
     def main_window(self) -> 'MainWindowView':
@@ -294,6 +292,7 @@ class FiltersWindowPresenter(BasePresenter):
 
         finally:
             self.view.filter_applied.emit()
+            self._set_apply_buttons_enabled(self.prev_apply_single_state, self.prev_apply_all_state)
             self.filter_is_running = False
 
     def _do_apply_filter(self, apply_to: List[Images]):

--- a/mantidimaging/gui/windows/operations/test/test_presenter.py
+++ b/mantidimaging/gui/windows/operations/test/test_presenter.py
@@ -24,7 +24,6 @@ from mantidimaging.core.data import Images
 class FiltersWindowPresenterTest(unittest.TestCase):
     def setUp(self) -> None:
         self.main_window = mock.create_autospec(MainWindowView)
-        self.main_window.filter_applied.connect = mock.Mock()
         self.view = mock.MagicMock()
         self.presenter = FiltersWindowPresenter(self.view, self.main_window)
         self.presenter.model.filter_widget_kwargs = {"roi_field": None}


### PR DESCRIPTION
### Issue

Closes #1292

### Description

The attribute error was because method `_set_apply_buttons_enabled` was being triggered by a signal from the main window (which itself was triggered because of the call to `self.view.filter_applied.emit()` in the presenter's `_post_filter` method). When the Operations window was closed this connection between the old presenter and the main window wasn't getting cleaned up, so subsequent filters were still triggering calls to the old presenter, which no longer had a view associated with it.

As both the `_post_filter` and `_set_apply_buttons_enabled` methods are located in the presenter, I've refactored so that we now call `_set_apply_buttons_enabled` directly from `_post_filter` rather than using signals.

### Testing & Acceptance Criteria 

Following the steps described on the issue results in filters being applied without any errors.

### Documentation

Issue number added to release notes.
