### PR TITLE
1294: Delete recon item/group from tree view

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -46,7 +46,6 @@ Fixes
 - #1294 : Dataset Tree View: Allow for deleting recons
 
 
-
 Developer Changes
 -----------------
 

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -42,6 +42,7 @@ Fixes
 - #1190 : Add recon item to right part of tree view
 - #1239 : 180 warning when applying ring removal to recon
 - #1297 : Auto colour dialog not working in compare images
+- #1294 : Dataset Tree View: Allow for deleting recons
 
 
 Developer Changes

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -475,7 +475,10 @@ class MainWindowPresenter(BasePresenter):
                     top_level_item.takeChild(j)
                     return
                 if child_item.id == self.view.recon_groups_id:
-                    self._remove_recon_item_from_tree_view(child_item)
+                    if self._remove_recon_item_from_tree_view(child_item, uuid_remove):
+                        if child_item.childCount() == 0:
+                            top_level_item.takeChild(j)
+                        return
 
     @staticmethod
     def _remove_recon_item_from_tree_view(recon_group, uuid_remove: uuid.UUID) -> None:
@@ -484,7 +487,8 @@ class MainWindowPresenter(BasePresenter):
             recon_item = recon_group.child(i)
             if recon_item.id == uuid_remove:
                 recon_group.takeChild(i)
-                return
+                return True
+        return False
 
     def add_child_item_to_tree_view(self, parent_id: uuid.UUID, child_id: uuid.UUID, child_name: str):
         """

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -477,11 +477,18 @@ class MainWindowPresenter(BasePresenter):
                 if child_item.id == self.view.recon_groups_id:
                     if self._remove_recon_item_from_tree_view(child_item, uuid_remove):
                         if child_item.childCount() == 0:
+                            # Delete recon group when last recon item has been removed
                             top_level_item.takeChild(j)
                         return
 
     @staticmethod
-    def _remove_recon_item_from_tree_view(recon_group, uuid_remove: uuid.UUID) -> None:
+    def _remove_recon_item_from_tree_view(recon_group, uuid_remove: uuid.UUID) -> bool:
+        """
+        Removes a recon item from the recon group in the tree view.
+        :param recon_group: The recon group.
+        :param uuid_remove: The ID of the recon data to remove.
+        :return: True if a recon with a matching ID was removed, False otherwise.
+        """
         recon_count = recon_group.childCount()
         for i in range(recon_count):
             recon_item = recon_group.child(i)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -474,6 +474,17 @@ class MainWindowPresenter(BasePresenter):
                 if child_item.id == uuid_remove:
                     top_level_item.takeChild(j)
                     return
+                if child_item.id == self.view.recon_groups_id:
+                    self._remove_recon_item_from_tree_view(child_item)
+
+    @staticmethod
+    def _remove_recon_item_from_tree_view(recon_group, uuid_remove: uuid.UUID) -> None:
+        recon_count = recon_group.childCount()
+        for i in range(recon_count):
+            recon_item = recon_group.child(i)
+            if recon_item.id == uuid_remove:
+                recon_group.takeChild(i)
+                return
 
     def add_child_item_to_tree_view(self, parent_id: uuid.UUID, child_id: uuid.UUID, child_name: str):
         """

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -678,6 +678,39 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.create_single_tabbed_images_stack.assert_called_once_with(new_sinograms)
         self.view.model_changed.emit.assert_called_once()
 
+    def test_remove_item_from_recon_group_but_keep_group(self):
+        top_level_item_mock = mock.Mock()
+        self.view.dataset_tree_widget.topLevelItemCount.return_value = 1
+        self.view.dataset_tree_widget.topLevelItem.return_value = top_level_item_mock
+        top_level_item_mock.childCount.return_value = 1
+        top_level_item_mock.child.return_value = recon_group_mock = mock.Mock()
+        recon_group_mock.id = self.view.recon_groups_id
+
+        recon_group_mock.childCount.side_effect = [2, 1]
+        recon_to_delete = mock.Mock()
+        recon_to_delete.id = recon_to_delete_id = "recon-to-delete-id"
+        recon_group_mock.child.side_effect = [mock.Mock(), recon_to_delete]
+
+        self.presenter.remove_item_from_tree_view(recon_to_delete_id)
+        recon_group_mock.takeChild.assert_called_once_with(1)
+        top_level_item_mock.takeChild.assert_not_called()
+
+    def test_remove_item_from_recon_group_and_remove_group(self):
+        top_level_item_mock = mock.Mock()
+        self.view.dataset_tree_widget.topLevelItemCount.return_value = 1
+        self.view.dataset_tree_widget.topLevelItem.return_value = top_level_item_mock
+        top_level_item_mock.childCount.return_value = 1
+        top_level_item_mock.child.return_value = recon_group_mock = mock.Mock()
+        recon_group_mock.id = self.view.recon_groups_id
+
+        recon_group_mock.childCount.side_effect = [1, 0]
+        recon_group_mock.child.return_value = recon_to_delete = mock.Mock()
+        recon_to_delete.id = recon_to_delete_id = "recon-to-delete-id"
+
+        self.presenter.remove_item_from_tree_view(recon_to_delete_id)
+        recon_group_mock.takeChild.assert_called_once_with(0)
+        top_level_item_mock.takeChild.assert_called_once_with(0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -711,6 +711,24 @@ class MainWindowPresenterTest(unittest.TestCase):
         recon_group_mock.takeChild.assert_called_once_with(0)
         top_level_item_mock.takeChild.assert_called_once_with(0)
 
+    def test_nothing_removed_from_recon_group(self):
+        top_level_item_mock = mock.Mock()
+        self.view.dataset_tree_widget.topLevelItemCount.return_value = 1
+        self.view.dataset_tree_widget.topLevelItem.return_value = top_level_item_mock
+        top_level_item_mock.childCount.return_value = 2
+        recon_group_mock = mock.Mock()
+        other_data_mock = mock.Mock()
+        other_data_mock.id = item_to_delete_id = "item-to-delete-id"
+        top_level_item_mock.child.side_effect = [recon_group_mock, other_data_mock]
+        recon_group_mock.id = self.view.recon_groups_id
+
+        recon_group_mock.childCount.return_value = 1
+        recon_group_mock.child.return_value = mock.Mock()
+
+        self.presenter.remove_item_from_tree_view(item_to_delete_id)
+        recon_group_mock.takeChild.assert_not_called()
+        top_level_item_mock.takeChild.assert_called_once_with(1)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Issue

Closes #1294 

### Description

Deletes the recon item/group from the tree view when the recon data has been deleted.

### Testing 

Wrote some more `MainWindowPresenter` tests.

### Acceptance Criteria 

Add some recons to a dataset and delete them. Check that individual recon items are removed from the tree view and that the recon group is removed when the number of recons reaches zero.

### Documentation

Updated release notes.