### PR TITLE
Trigger recon redraws when stack is modified

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -44,6 +44,7 @@ Fixes
 - #1297 : Auto colour dialog not working in compare images
 - #1292 : Attribute error if apply filter after closing and re-opening Operations window
 - #1294 : Dataset Tree View: Allow for deleting recons
+- #1289 : Trigger recon redraws when stack is modified
 
 
 Developer Changes

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -56,9 +56,10 @@ class MainWindowView(BaseMainWindowView):
     NOT_THE_LATEST_VERSION = "This is not the latest version"
     UNCAUGHT_EXCEPTION = "Uncaught exception"
 
+    # Emitted when a new stack is created or an existing one deleted
     model_changed = pyqtSignal()
-    filter_applied = pyqtSignal()
-    recon_applied = pyqtSignal()
+    # Emitted when an existing stack is changed
+    stack_changed = pyqtSignal()
     backend_message = pyqtSignal(bytes)
 
     menuFile: QMenu
@@ -306,7 +307,6 @@ class MainWindowView(BaseMainWindowView):
     def show_recon_window(self):
         if not self.recon:
             self.recon = ReconstructWindowView(self)
-            self.recon.recon_applied.connect(self.recon_applied.emit)
             self.recon.show()
         else:
             self.recon.activateWindow()
@@ -316,7 +316,7 @@ class MainWindowView(BaseMainWindowView):
     def show_filters_window(self):
         if not self.filters:
             self.filters = FiltersWindowView(self)
-            self.filters.filter_applied.connect(self.filter_applied.emit)
+            self.filters.filter_applied.connect(self.stack_changed.emit)
             self.filters.show()
         else:
             self.filters.activateWindow()

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -90,9 +90,12 @@ class ReconstructWindowModel(object):
         return self.data_model.num_points
 
     def initial_select_data(self, images: 'Images'):
+        self._images = images
+        self.reset_cor_model()
+
+    def reset_cor_model(self):
         self.data_model.clear_results()
 
-        self._images = images
         slice_idx, cor = self.find_initial_cor()
         self.last_cor = cor
         self.preview_projection_idx = 0

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -295,7 +295,6 @@ class ReconstructWindowPresenter(BasePresenter):
         assert self.model.images is not None
         task.result.name = "Recon"
         self.view.show_recon_volume(task.result, self.model.stack_id)
-        self.view.recon_applied.emit()
 
     def do_clear_all_cors(self):
         self.view.clear_cor_table()

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -164,6 +164,7 @@ class ReconstructWindowPresenter(BasePresenter):
 
     def handle_stack_changed(self):
         if self.view.isVisible():
+            self.model.reset_cor_model()
             self.do_update_projection()
             self.do_preview_reconstruct_slice()
         else:

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -19,7 +19,7 @@ class ReconWindowPresenterTest(unittest.TestCase):
     def setUp(self):
         self.make_view()
 
-        self.presenter = ReconstructWindowPresenter(self.view, None)
+        self.presenter = ReconstructWindowPresenter(self.view, mock.Mock())
 
         self.data = Images(data=np.ndarray(shape=(128, 10, 128), dtype=np.float32))
         self.data.pixel_size = TEST_PIXEL_SIZE

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -199,6 +199,11 @@ class ReconstructWindowView(BaseMainWindowView):
             self.lbhc_enabled.toggled.connect(spinbox.setEnabled)
         self.lbhc_enabled.toggled.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
 
+    def showEvent(self, e):
+        if self.presenter.stack_changed_pending:
+            self.presenter.handle_stack_changed()
+            self.presenter.stack_changed_pending = False
+
     def closeEvent(self, e):
         if self.presenter.recon_is_running:
             e.ignore()

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -9,7 +9,7 @@ import numpy
 from PyQt5.QtWidgets import (QAbstractItemView, QComboBox, QDoubleSpinBox, QInputDialog, QPushButton, QSpinBox,
                              QVBoxLayout, QWidget, QMessageBox, QAction, QTextEdit, QLabel, QApplication, QStyle,
                              QCheckBox)
-from PyQt5.QtCore import pyqtSignal, QSignalBlocker
+from PyQt5.QtCore import QSignalBlocker
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.net.help_pages import SECTION_USER_GUIDE, open_help_webpage
@@ -77,8 +77,6 @@ class ReconstructWindowView(BaseMainWindowView):
     change_colour_palette_dialog: Optional[PaletteChangerView] = None
 
     stackSelector: DatasetSelectorWidgetView
-
-    recon_applied = pyqtSignal()
 
     def __init__(self, main_window: 'MainWindowView'):
         super().__init__(main_window, 'gui/ui/recon_window.ui')

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -193,6 +193,7 @@ class StackVisualiserView(QDockWidget):
                                               ["projections", "sinograms"], current)
         if accepted:
             self.presenter.images._is_sinograms = False if item == "projections" else True
+            self._main_window.stack_changed.emit()
 
     def ask_confirmation(self, msg: str):
         response = QMessageBox.question(self, "Confirm action", msg, QMessageBox.Ok | QMessageBox.Cancel)  # type:ignore

--- a/mantidimaging/gui/windows/wizard/presenter.py
+++ b/mantidimaging/gui/windows/wizard/presenter.py
@@ -21,8 +21,7 @@ class WizardPresenter(BasePresenter):
         self.wizard_data = yaml.safe_load(wizard_data_file.open())
         self.populate()
         parent.model_changed.connect(self.handle_stack_change)
-        parent.filter_applied.connect(self.handle_stack_change)
-        parent.recon_applied.connect(self.handle_stack_change)
+        parent.stack_changed.connect(self.handle_stack_change)
         self.handle_stack_change()
         self.show()
 


### PR DESCRIPTION
### Issue

Closes #1289

### Description

If a stack is modified while the reconstruction window is open, then the views and preview should be updated.

This covers the case for marking a stack as sinograms/projections and also the common case of applying operations to a stack.

### Testing & Acceptance Criteria 

Steps in the report.

Also, try opening the recon window, and then in the operations window applying a operation such as guassian.

### Documentation

release notes
