### PR TITLE
CIL: when reconstructing from sino use right dimensions and ordering

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -45,6 +45,7 @@ Fixes
 - #1292 : Attribute error if apply filter after closing and re-opening Operations window
 - #1294 : Dataset Tree View: Allow for deleting recons
 - #1289 : Trigger recon redraws when stack is modified
+- #1299 : CIL: when reconstructing from sinograms use right dimensions and ordering
 
 
 Developer Changes


### PR DESCRIPTION
### Issue

Closes #1299

### Description

When working with a stack in sinogram ordering the correct dimensions much be used for height and width and the ASTRA ordering should be used.

### Testing & Acceptance Criteria 

Steps on #1299 should run without error

### Documentation

Release notes
