### PR TITLE
1305: Delete entire recon group with tree view

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -45,6 +45,7 @@ Fixes
 - #1292 : Attribute error if apply filter after closing and re-opening Operations window
 - #1294 : Dataset Tree View: Allow for deleting recons
 - #1289 : Trigger recon redraws when stack is modified
+- #1305 : Delete recon group from tree view
 
 
 Developer Changes

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -73,7 +73,7 @@ class MixedDataset(BaseDataset):
 
     @property
     def all(self) -> List[Images]:
-        all_images = self._stacks + self.recons.data
+        all_images = self._stacks + self.recons.stacks
         if self.sinograms is None:
             return all_images
         return all_images + [self.sinograms]
@@ -124,7 +124,7 @@ class StrictDataset(BaseDataset):
             self.sample, self.proj180deg, self.flat_before, self.flat_after, self.dark_before, self.dark_after,
             self.sinograms
         ]
-        return [image_stack for image_stack in image_stacks if image_stack is not None] + self.recons.data
+        return [image_stack for image_stack in image_stacks if image_stack is not None] + self.recons.stacks
 
     @property
     def proj180deg(self):

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -7,6 +7,7 @@ from typing import Optional, List
 import numpy as np
 
 from mantidimaging.core.data import Images
+from mantidimaging.core.data.reconlist import ReconList
 
 
 def _delete_stack_error_message(images_id: uuid.UUID) -> str:
@@ -16,7 +17,7 @@ def _delete_stack_error_message(images_id: uuid.UUID) -> str:
 class BaseDataset:
     def __init__(self, name: str = ""):
         self._id: uuid.UUID = uuid.uuid4()
-        self.recons: List[Images] = []
+        self.recons = ReconList()
         self._name = name
         self._sinograms: Optional[Images] = None
 
@@ -79,6 +80,9 @@ class MixedDataset(BaseDataset):
             if image.id == images_id:
                 self._stacks.remove(image)
                 return
+        if images_id == self.recons.id:
+            self.recons.clear()
+            return
         for recon in self.recons:
             if recon.id == images_id:
                 self.recons.remove(recon)
@@ -145,6 +149,8 @@ class StrictDataset(BaseDataset):
             self.sample.clear_proj180deg()
         elif isinstance(self.sinograms, Images) and self.sinograms.id == images_id:
             self.sinograms = None
+        elif images_id == self.recons.id:
+            self.recons.clear()
         elif images_id in [recon.id for recon in self.recons]:
             for recon in self.recons:
                 if recon.id == images_id:

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -124,7 +124,7 @@ class StrictDataset(BaseDataset):
             self.sample, self.proj180deg, self.flat_before, self.flat_after, self.dark_before, self.dark_after,
             self.sinograms
         ]
-        return [image_stack for image_stack in image_stacks if image_stack is not None] + self.recons
+        return [image_stack for image_stack in image_stacks if image_stack is not None] + self.recons.data
 
     @property
     def proj180deg(self):

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -62,6 +62,9 @@ class BaseDataset:
     def all_image_ids(self) -> List[uuid.UUID]:
         return [image_stack.id for image_stack in self.all if image_stack is not None]
 
+    def delete_recons(self):
+        self.recons.clear()
+
 
 class MixedDataset(BaseDataset):
     def __init__(self, stacks: List[Images] = [], name=""):
@@ -80,9 +83,6 @@ class MixedDataset(BaseDataset):
             if image.id == images_id:
                 self._stacks.remove(image)
                 return
-        if images_id == self.recons.id:
-            self.recons.clear()
-            return
         for recon in self.recons:
             if recon.id == images_id:
                 self.recons.remove(recon)
@@ -149,9 +149,7 @@ class StrictDataset(BaseDataset):
             self.sample.clear_proj180deg()
         elif isinstance(self.sinograms, Images) and self.sinograms.id == images_id:
             self.sinograms = None
-        elif images_id == self.recons.id:
-            self.recons.clear()
-        elif images_id in [recon.id for recon in self.recons]:
+        elif images_id in self.recons.ids:
             for recon in self.recons:
                 if recon.id == images_id:
                     self.recons.remove(recon)

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -73,7 +73,7 @@ class MixedDataset(BaseDataset):
 
     @property
     def all(self) -> List[Images]:
-        all_images = self._stacks + self.recons
+        all_images = self._stacks + self.recons.data
         if self.sinograms is None:
             return all_images
         return all_images + [self.sinograms]

--- a/mantidimaging/core/data/reconlist.py
+++ b/mantidimaging/core/data/reconlist.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+import uuid
+
+
+class ReconList(list):
+    def __init__(self):
+        super().__init__()
+        self._id: uuid.UUID = uuid.UUID
+
+    @property
+    def id(self) -> uuid.UUID:
+        return self._id

--- a/mantidimaging/core/data/reconlist.py
+++ b/mantidimaging/core/data/reconlist.py
@@ -11,7 +11,7 @@ from mantidimaging.core.data import Images
 class ReconList(UserList):
     def __init__(self, data: List[Images] = []):
         super().__init__(data)
-        self._id: uuid.UUID = uuid.UUID
+        self._id: uuid.UUID = uuid.uuid4()
 
     @property
     def id(self) -> uuid.UUID:

--- a/mantidimaging/core/data/reconlist.py
+++ b/mantidimaging/core/data/reconlist.py
@@ -20,3 +20,7 @@ class ReconList(UserList):
     @property
     def ids(self) -> List[uuid.UUID]:
         return [recon.id for recon in self.data]
+
+    @property
+    def stacks(self) -> List[Images]:
+        return self.data

--- a/mantidimaging/core/data/reconlist.py
+++ b/mantidimaging/core/data/reconlist.py
@@ -2,9 +2,11 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import uuid
+from collections import UserList
+from typing import List
 
 
-class ReconList(list):
+class ReconList(UserList):
     def __init__(self):
         super().__init__()
         self._id: uuid.UUID = uuid.UUID
@@ -12,3 +14,7 @@ class ReconList(list):
     @property
     def id(self) -> uuid.UUID:
         return self._id
+
+    @property
+    def ids(self) -> List[uuid.UUID]:
+        return [recon.id for recon in self.data]

--- a/mantidimaging/core/data/reconlist.py
+++ b/mantidimaging/core/data/reconlist.py
@@ -5,10 +5,12 @@ import uuid
 from collections import UserList
 from typing import List
 
+from mantidimaging.core.data import Images
+
 
 class ReconList(UserList):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, data: List[Images] = []):
+        super().__init__(data)
         self._id: uuid.UUID = uuid.UUID
 
     @property

--- a/mantidimaging/core/data/test/reconlist_test.py
+++ b/mantidimaging/core/data/test/reconlist_test.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+import unittest
+import uuid
+
+from mantidimaging.core.data.reconlist import ReconList
+from mantidimaging.test_helpers.unit_test_helper import generate_images
+
+
+class ReconListTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.recon_list = ReconList([generate_images() for _ in range(3)])
+
+    def test_recon_list_id(self):
+        self.assertIsInstance(self.recon_list.id, uuid.UUID)
+
+    def test_recon_list_ids(self):
+        ids = [recon.id for recon in self.recon_list.data]
+        self.assertListEqual(self.recon_list.ids, ids)

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -161,6 +161,10 @@ class MainWindowModel(object):
                 if container_id in dataset:
                     dataset.delete_stack(container_id)
                     return [container_id]
+                if container_id == dataset.recons.id:
+                    ids_to_remove = dataset.recons.ids
+                    dataset.delete_recons()
+                    return ids_to_remove
         self.raise_error_when_images_not_found(container_id)
         return None
 

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -216,3 +216,7 @@ class MainWindowModel(object):
                 dataset.recons.append(recon_data)
                 return dataset.id
         self.raise_error_when_parent_strict_dataset_not_found(stack_id)
+
+    @property
+    def recon_ids(self):
+        return [dataset.recons.id for dataset in self.datasets.values()]

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -220,3 +220,6 @@ class MainWindowModel(object):
     @property
     def recon_ids(self):
         return [dataset.recons.id for dataset in self.datasets.values()]
+
+    def get_recons_id(self, parent_id: uuid.UUID) -> uuid.UUID:
+        return self.datasets[parent_id].recons.id

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -218,8 +218,8 @@ class MainWindowModel(object):
         self.raise_error_when_parent_strict_dataset_not_found(stack_id)
 
     @property
-    def recon_ids(self):
+    def recon_list_ids(self):
         return [dataset.recons.id for dataset in self.datasets.values()]
 
-    def get_recons_id(self, parent_id: uuid.UUID) -> uuid.UUID:
+    def get_recon_list_id(self, parent_id: uuid.UUID) -> uuid.UUID:
         return self.datasets[parent_id].recons.id

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -145,7 +145,7 @@ class MainWindowModel(object):
         """
         del self.datasets[dataset_id]
 
-    def remove_container(self, container_id: uuid.UUID) -> Optional[List[uuid.UUID]]:
+    def remove_container(self, container_id: uuid.UUID) -> List[uuid.UUID]:
         """
         Removes a container from the model.
         :param container_id: The ID of the dataset or image stack.
@@ -166,7 +166,6 @@ class MainWindowModel(object):
                     dataset.delete_recons()
                     return ids_to_remove
         self.raise_error_when_images_not_found(container_id)
-        return None
 
     def add_dataset_to_model(self, dataset: Union[StrictDataset, MixedDataset]) -> None:
         self.datasets[dataset.id] = dataset

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -516,7 +516,7 @@ class MainWindowPresenter(BasePresenter):
         """
         dataset_item = self.view.get_dataset_tree_view_item(parent_id)
         if recon_count == 1:
-            recon_group = self.view.add_recon_group(dataset_item, self.model.datasets[parent_id].recons.id)
+            recon_group = self.view.add_recon_group(dataset_item, self.model.get_recons_id(parent_id))
             name = "Recon"
         else:
             recon_group = self.view.get_recon_group(dataset_item)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -474,7 +474,7 @@ class MainWindowPresenter(BasePresenter):
                 if child_item.id == uuid_remove:
                     top_level_item.takeChild(j)
                     return
-                if child_item.id == self.view.recon_groups_id:
+                if child_item.childCount() > 0:
                     if self._remove_recon_item_from_tree_view(child_item, uuid_remove):
                         if child_item.childCount() == 0:
                             # Delete recon group when last recon item has been removed
@@ -516,7 +516,7 @@ class MainWindowPresenter(BasePresenter):
         """
         dataset_item = self.view.get_dataset_tree_view_item(parent_id)
         if recon_count == 1:
-            recon_group = self.view.add_recon_group(dataset_item)
+            recon_group = self.view.add_recon_group(dataset_item, self.model.datasets[parent_id].recons.id)
             name = "Recon"
         else:
             recon_group = self.view.get_recon_group(dataset_item)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -516,7 +516,7 @@ class MainWindowPresenter(BasePresenter):
         """
         dataset_item = self.view.get_dataset_tree_view_item(parent_id)
         if recon_count == 1:
-            recon_group = self.view.add_recon_group(dataset_item, self.model.get_recons_id(parent_id))
+            recon_group = self.view.add_recon_group(dataset_item, self.model.get_recon_list_id(parent_id))
             name = "Recon"
         else:
             recon_group = self.view.get_recon_group(dataset_item)
@@ -557,7 +557,7 @@ class MainWindowPresenter(BasePresenter):
         """
         if stack_id in self.model.datasets:
             return
-        if stack_id in self.model.recon_ids:
+        if stack_id in self.model.recon_list_ids:
             return
         if stack_id in self.model.image_ids:
             self.stack_visualisers[stack_id].setVisible(True)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -532,8 +532,6 @@ class MainWindowPresenter(BasePresenter):
         :param container_id: The ID of the container to delete.
         """
         ids_to_remove = self.model.remove_container(container_id)
-        if ids_to_remove is None:
-            return
         for stack_id in ids_to_remove:
             if stack_id in self.stack_visualisers:
                 self._delete_stack(stack_id)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -557,8 +557,8 @@ class MainWindowPresenter(BasePresenter):
         """
         if stack_id in self.model.datasets:
             return
-        # if stack_id is self.view.recon_groups_id:
-        #     return
+        if stack_id in self.model.recon_ids:
+            return
         if stack_id in self.model.image_ids:
             self.stack_visualisers[stack_id].setVisible(True)
             self.stack_visualisers[stack_id].raise_()

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -557,8 +557,8 @@ class MainWindowPresenter(BasePresenter):
         """
         if stack_id in self.model.datasets:
             return
-        if stack_id is self.view.recon_groups_id:
-            return
+        # if stack_id is self.view.recon_groups_id:
+        #     return
         if stack_id in self.model.image_ids:
             self.stack_visualisers[stack_id].setVisible(True)
             self.stack_visualisers[stack_id].raise_()

--- a/mantidimaging/gui/windows/main/test/mixeddataset_test.py
+++ b/mantidimaging/gui/windows/main/test/mixeddataset_test.py
@@ -4,6 +4,7 @@
 import unittest
 
 from mantidimaging.core.data.dataset import MixedDataset
+from mantidimaging.core.data.reconlist import ReconList
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
 
@@ -21,7 +22,7 @@ class MixedDatasetTest(unittest.TestCase):
         self.assertListEqual(self.mixed_dataset.all, prev_stacks[:-1])
 
     def test_delete_stack_from_recons_list(self):
-        recons = [generate_images() for _ in range(2)]
+        recons = ReconList([generate_images() for _ in range(2)])
         self.mixed_dataset.recons = recons.copy()
 
         id_to_remove = recons[-1].id

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -408,3 +408,18 @@ class MainWindowModelTest(unittest.TestCase):
 
         self.assertListEqual(self.model.remove_container(ds.recons.id), recon_ids)
         self.assertListEqual(ds.recons.data, [])
+
+    def test_get_all_recons_ids(self):
+        ds1 = MixedDataset()
+        ds2 = MixedDataset()
+
+        self.model.add_dataset_to_model(ds1)
+        self.model.add_dataset_to_model(ds2)
+
+        self.assertListEqual(self.model.recon_ids, [ds1.recons.id, ds2.recons.id])
+
+    def test_get_recons_id(self):
+        ds = MixedDataset()
+        self.model.add_dataset_to_model(ds)
+
+        assert self.model.get_recons_id(ds.id) == ds.recons.id

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -407,7 +407,7 @@ class MainWindowModelTest(unittest.TestCase):
         self.model.add_dataset_to_model(ds)
 
         self.assertListEqual(self.model.remove_container(ds.recons.id), recon_ids)
-        self.assertListEqual(ds.recons.data, [])
+        self.assertListEqual(ds.recons.stacks, [])
 
     def test_get_all_recon_list_ids(self):
         ds1 = MixedDataset()

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -409,17 +409,17 @@ class MainWindowModelTest(unittest.TestCase):
         self.assertListEqual(self.model.remove_container(ds.recons.id), recon_ids)
         self.assertListEqual(ds.recons.data, [])
 
-    def test_get_all_recons_ids(self):
+    def test_get_all_recon_list_ids(self):
         ds1 = MixedDataset()
         ds2 = MixedDataset()
 
         self.model.add_dataset_to_model(ds1)
         self.model.add_dataset_to_model(ds2)
 
-        self.assertListEqual(self.model.recon_ids, [ds1.recons.id, ds2.recons.id])
+        self.assertListEqual(self.model.recon_list_ids, [ds1.recons.id, ds2.recons.id])
 
-    def test_get_recons_id(self):
+    def test_get_recon_list_id(self):
         ds = MixedDataset()
         self.model.add_dataset_to_model(ds)
 
-        assert self.model.get_recons_id(ds.id) == ds.recons.id
+        assert self.model.get_recon_list_id(ds.id) == ds.recons.id

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -10,6 +10,7 @@ from numpy.testing import assert_array_equal
 
 from mantidimaging.core.data import Images
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
+from mantidimaging.core.data.reconlist import ReconList
 from mantidimaging.core.utility.data_containers import LoadingParameters, ProjectionAngles
 from mantidimaging.gui.windows.main import MainWindowModel
 from mantidimaging.gui.windows.main.model import _matching_dataset_attribute
@@ -398,3 +399,12 @@ class MainWindowModelTest(unittest.TestCase):
         self.model.add_dataset_to_model(ds)
         with self.assertRaises(RuntimeError):
             self.model.get_parent_dataset("unrecognised-id")
+
+    def test_delete_all_recons_in_dataset(self):
+        ds = StrictDataset(generate_images())
+        ds.recons = ReconList([generate_images() for _ in range(3)])
+        recon_ids = ds.recons.ids
+        self.model.add_dataset_to_model(ds)
+
+        self.assertListEqual(self.model.remove_container(ds.recons.id), recon_ids)
+        self.assertListEqual(ds.recons.data, [])

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -588,7 +588,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         dataset_item_mock.id = parent_id = "parent-id"
         child_id = "child-id"
         recon_group_mock = self.view.add_recon_group.return_value
-        self.model.get_recons_id.return_value = recons_id = "recons-id"
+        self.model.get_recon_list_id.return_value = recons_id = "recons-id"
 
         self.presenter.add_recon_item_to_tree_view(parent_id, child_id, 1)
         self.view.get_dataset_tree_view_item.assert_called_once_with(parent_id)
@@ -629,7 +629,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.model.datasets = []
         self.presenter.stack_visualisers["stack-id"] = stack_mock = mock.Mock()
         recons_id = "recons-id"
-        self.model.recon_ids = [recons_id]
+        self.model.recon_list_ids = [recons_id]
 
         self.presenter._restore_and_focus_tab(recons_id)
         stack_mock.setVisible.assert_not_called()

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -453,11 +453,6 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.remove_item_from_tree_view.assert_called_once_with(dataset_id)
         self.view.model_changed.emit.assert_called_once()
 
-    def test_delete_fails_then_presenter_does_nothing(self):
-        self.model.remove_container = mock.Mock(return_value=None)
-        self.presenter._delete_container("bad-id")
-        self.view.model_changed.emit.assert_not_called()
-
     def test_focus_tab_with_id_not_found(self):
         self.model.image_ids = []
         self.model.datasets = []

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -45,6 +45,7 @@ class MainWindowPresenterTest(unittest.TestCase):
                                      dark_before=self.images[3],
                                      dark_after=self.images[4])
         self.presenter.model = self.model = mock.Mock()
+        self.model.get_recons_id = mock.Mock()
 
         self.view.create_stack_window.return_value = dock_mock = mock.Mock()
         self.view.model_changed = mock.Mock()
@@ -587,10 +588,11 @@ class MainWindowPresenterTest(unittest.TestCase):
         dataset_item_mock.id = parent_id = "parent-id"
         child_id = "child-id"
         recon_group_mock = self.view.add_recon_group.return_value
+        self.model.get_recons_id.return_value = recons_id = "recons-id"
 
         self.presenter.add_recon_item_to_tree_view(parent_id, child_id, 1)
         self.view.get_dataset_tree_view_item.assert_called_once_with(parent_id)
-        self.view.add_recon_group.assert_called_once_with(dataset_item_mock)
+        self.view.add_recon_group.assert_called_once_with(dataset_item_mock, recons_id)
         self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, "Recon")
 
     def test_add_additional_recon_item_to_tree_view(self):
@@ -626,9 +628,10 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.stack_visualisers = dict()
         self.model.datasets = []
         self.presenter.stack_visualisers["stack-id"] = stack_mock = mock.Mock()
-        self.view.recon_groups_id = recon_id = "recon-id"
+        recons_id = "recons-id"
+        self.model.recon_ids = [recons_id]
 
-        self.presenter._restore_and_focus_tab(recon_id)
+        self.presenter._restore_and_focus_tab(recons_id)
         stack_mock.setVisible.assert_not_called()
         stack_mock._raise.assert_not_called()
 
@@ -684,9 +687,8 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.dataset_tree_widget.topLevelItem.return_value = top_level_item_mock
         top_level_item_mock.childCount.return_value = 1
         top_level_item_mock.child.return_value = recon_group_mock = mock.Mock()
-        recon_group_mock.id = self.view.recon_groups_id
 
-        recon_group_mock.childCount.side_effect = [2, 1]
+        recon_group_mock.childCount.side_effect = [2, 2, 1]
         recon_to_delete = mock.Mock()
         recon_to_delete.id = recon_to_delete_id = "recon-to-delete-id"
         recon_group_mock.child.side_effect = [mock.Mock(), recon_to_delete]
@@ -701,9 +703,8 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.dataset_tree_widget.topLevelItem.return_value = top_level_item_mock
         top_level_item_mock.childCount.return_value = 1
         top_level_item_mock.child.return_value = recon_group_mock = mock.Mock()
-        recon_group_mock.id = self.view.recon_groups_id
 
-        recon_group_mock.childCount.side_effect = [1, 0]
+        recon_group_mock.childCount.side_effect = [1, 1, 0]
         recon_group_mock.child.return_value = recon_to_delete = mock.Mock()
         recon_to_delete.id = recon_to_delete_id = "recon-to-delete-id"
 
@@ -720,7 +721,6 @@ class MainWindowPresenterTest(unittest.TestCase):
         other_data_mock = mock.Mock()
         other_data_mock.id = item_to_delete_id = "item-to-delete-id"
         top_level_item_mock.child.side_effect = [recon_group_mock, other_data_mock]
-        recon_group_mock.id = self.view.recon_groups_id
 
         recon_group_mock.childCount.return_value = 1
         recon_group_mock.child.return_value = mock.Mock()

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -587,6 +587,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         self.presenter.add_recon_item_to_tree_view(parent_id, child_id, 1)
         self.view.get_dataset_tree_view_item.assert_called_once_with(parent_id)
+        self.model.get_recon_list_id.assert_called_once_with(parent_id)
         self.view.add_recon_group.assert_called_once_with(dataset_item_mock, recons_id)
         self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, "Recon")
 

--- a/mantidimaging/gui/windows/main/test/strictdataset_test.py
+++ b/mantidimaging/gui/windows/main/test/strictdataset_test.py
@@ -136,3 +136,8 @@ class StrictDatasetTest(unittest.TestCase):
         self.strict_dataset.sinograms = sinograms = generate_images()
         self.strict_dataset.delete_stack(sinograms.id)
         self.assertIsNone(self.strict_dataset.sinograms)
+
+    def test_delete_all_recons(self):
+        self.strict_dataset.recons = ReconList([generate_images() for _ in range(2)])
+        self.strict_dataset.delete_recons()
+        self.assertListEqual(self.strict_dataset.recons.data, [])

--- a/mantidimaging/gui/windows/main/test/strictdataset_test.py
+++ b/mantidimaging/gui/windows/main/test/strictdataset_test.py
@@ -140,4 +140,4 @@ class StrictDatasetTest(unittest.TestCase):
     def test_delete_all_recons(self):
         self.strict_dataset.recons = ReconList([generate_images() for _ in range(2)])
         self.strict_dataset.delete_recons()
-        self.assertListEqual(self.strict_dataset.recons.data, [])
+        self.assertListEqual(self.strict_dataset.recons.stacks, [])

--- a/mantidimaging/gui/windows/main/test/strictdataset_test.py
+++ b/mantidimaging/gui/windows/main/test/strictdataset_test.py
@@ -6,6 +6,7 @@ import unittest
 from numpy import array_equal
 
 from mantidimaging.core.data.dataset import StrictDataset, _delete_stack_error_message
+from mantidimaging.core.data.reconlist import ReconList
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
 
@@ -99,7 +100,7 @@ class StrictDatasetTest(unittest.TestCase):
         self.assertIsNone(self.strict_dataset.dark_after)
 
     def test_delete_recon(self):
-        recons = [generate_images() for _ in range(2)]
+        recons = ReconList([generate_images() for _ in range(2)])
         self.strict_dataset.recons = recons.copy()
 
         id_to_remove = recons[-1].id

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -12,7 +12,7 @@ from PyQt5.QtWidgets import QDialog
 from mantidimaging.core.utility.data_containers import ProjectionAngles
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.main.presenter import Notification as PresNotification
-from mantidimaging.gui.windows.main.view import RECON_GROUP_TEXT, RECON_ID, SINO_TEXT
+from mantidimaging.gui.windows.main.view import RECON_GROUP_TEXT, SINO_TEXT
 from mantidimaging.test_helpers import start_qapplication
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
@@ -389,9 +389,10 @@ class MainWindowViewTest(unittest.TestCase):
     @mock.patch("mantidimaging.gui.windows.main.view.QTreeDatasetWidgetItem")
     def test_add_recon_group(self, dataset_widget_item_mock):
         dataset_item_mock = mock.Mock()
+        recons_id = "recon-id"
 
-        recon_group_mock = self.view.add_recon_group(dataset_item_mock)
-        dataset_widget_item_mock.assert_called_once_with(dataset_item_mock, RECON_ID)
+        recon_group_mock = self.view.add_recon_group(dataset_item_mock, recons_id)
+        dataset_widget_item_mock.assert_called_once_with(dataset_item_mock, recons_id)
         recon_group_mock.setText.assert_called_once_with(0, RECON_GROUP_TEXT)
         dataset_item_mock.addChild.assert_called_once_with(recon_group_mock)
 

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -37,7 +37,6 @@ from mantidimaging.gui.windows.wizard.presenter import WizardPresenter
 
 RECON_GROUP_TEXT = "Recons"
 SINO_TEXT = "Sinograms"
-RECON_ID = uuid.uuid4()
 
 LOG = getLogger(__file__)
 
@@ -519,13 +518,13 @@ class MainWindowView(BaseMainWindowView):
         self.presenter.notify(PresNotification.ADD_RECON, recon_data=recon_data, stack_id=stack_id)
 
     @staticmethod
-    def add_recon_group(dataset_item: QTreeDatasetWidgetItem) -> QTreeDatasetWidgetItem:
+    def add_recon_group(dataset_item: QTreeDatasetWidgetItem, recon_id: uuid.UUID) -> QTreeDatasetWidgetItem:
         """
         Adds a recon group to a dataset item in the tree view.
         :param dataset_item: The dataset item.
         :return: The recon group that was added.
         """
-        recon_group = QTreeDatasetWidgetItem(dataset_item, RECON_ID)
+        recon_group = QTreeDatasetWidgetItem(dataset_item, recon_id)
         recon_group.setText(0, RECON_GROUP_TEXT)
         dataset_item.addChild(recon_group)
         recon_group.setExpanded(True)
@@ -555,15 +554,6 @@ class MainWindowView(BaseMainWindowView):
             if top_level_item.id == dataset_id:
                 return top_level_item
         raise RuntimeError(f"Unable to find dataset with ID {dataset_id}")
-
-    @property
-    def recon_groups_id(self) -> uuid.UUID:
-        """
-        Returns the ID given to all the recon group headers in the dataset tree view. Used so that double-clicks are
-        ignored.
-        :return: The recon group ID.
-        """
-        return RECON_ID
 
     @property
     def sino_text(self) -> str:


### PR DESCRIPTION
### Issue

Closes #1305

### Description

Makes it possible to delete all the recons in one go from the tree view.

### Testing 

Added tests for `ReconList` class. Changed/added to `Dataset`, `MainWindowPresenter` and `MainWindowView` tests.

### Acceptance Criteria 

Check that the tests pass. Add a group of recons and delete them all by using the recon group header.

### Documentation

Updated release notes.
