### PR TITLE
1285: Error when loading two 180 stacks

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -46,6 +46,7 @@ Fixes
 - #1294 : Dataset Tree View: Allow for deleting recons
 - #1289 : Trigger recon redraws when stack is modified
 - #1299 : CIL: when reconstructing from sinograms use right dimensions and ordering
+- #1285 : Error when load two 180 stacks
 
 
 Developer Changes

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -96,6 +96,21 @@ class MainWindowModel(object):
                 return
         self.raise_error_when_images_not_found(images_id)
 
+    def get_existing_180_id(self, dataset_id: uuid.UUID) -> Optional[uuid.UUID]:
+        """
+        Gets the ID of the 180 projection object in a Dataset.
+        :param dataset_id: The Dataset ID.
+        :return: The 180 ID if found, None otherwise.
+        """
+        if dataset_id in self.datasets and isinstance(self.datasets[dataset_id], StrictDataset):
+            dataset = self.datasets[dataset_id]
+        else:
+            raise RuntimeError(f"Failed to get StrictDataset with ID {dataset_id}")
+
+        if isinstance(dataset.proj180deg, Images):  # type: ignore
+            return dataset.proj180deg.id  # type: ignore
+        return None
+
     def add_180_deg_to_dataset(self, dataset_id: uuid.UUID, _180_deg_file: str) -> Images:
         """
         Loads to 180 projection and adds this to a given Images ID.

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -482,16 +482,14 @@ class MainWindowPresenter(BasePresenter):
         self.view.show_recon_window()
 
     def remove_item_from_tree_view(self, uuid_remove: uuid.UUID) -> None:
-        top_level_item_count = self.view.dataset_tree_widget.topLevelItemCount()
 
-        for i in range(top_level_item_count):
+        for i in range(self.view.dataset_tree_widget.topLevelItemCount()):
             top_level_item = self.view.dataset_tree_widget.topLevelItem(i)
             if top_level_item.id == uuid_remove:
                 self.view.dataset_tree_widget.takeTopLevelItem(i)
                 return
 
-            child_count = top_level_item.childCount()
-            for j in range(child_count):
+            for j in range(top_level_item.childCount()):
                 child_item = top_level_item.child(j)
                 if child_item.id == uuid_remove:
                     top_level_item.takeChild(j)

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -424,30 +424,26 @@ class MainWindowModelTest(unittest.TestCase):
 
         assert self.model.get_recon_list_id(ds.id) == ds.recons.id
 
+    def test_no_dataset_with_180_raises(self):
+        with self.assertRaises(RuntimeError):
+            self.model.get_existing_180_id("bad-id")
 
-def test_no_dataset_with_180_raises(self):
-    with self.assertRaises(RuntimeError):
-        self.model.get_existing_180_id("bad-id")
+    def test_wrong_dataset_type_for_180_raises(self):
+        md = MixedDataset()
+        self.model.add_dataset_to_model(md)
 
+        with self.assertRaises(RuntimeError):
+            self.model.get_existing_180_id(md.id)
 
-def test_wrong_dataset_type_for_180_raises(self):
-    md = MixedDataset()
-    self.model.add_dataset_to_model(md)
+    def test_get_existing_180_id_finds_id(self):
+        sd = StrictDataset(generate_images((5, 20, 20)))
+        sd.proj180deg = _180 = generate_images((1, 20, 20))
+        self.model.add_dataset_to_model(sd)
 
-    with self.assertRaises(RuntimeError):
-        self.model.get_existing_180_id(md.id)
+        assert self.model.get_existing_180_id(sd.id) == _180.id
 
+    def test_get_existing_id_returns_none_for_dataset_without_180(self):
+        sd = StrictDataset(generate_images((5, 20, 20)))
+        self.model.add_dataset_to_model(sd)
 
-def test_get_existing_180_id_finds_id(self):
-    sd = StrictDataset(generate_images((5, 20, 20)))
-    sd.proj180deg = _180 = generate_images((1, 20, 20))
-    self.model.add_dataset_to_model(sd)
-
-    assert self.model.get_existing_180_id(sd.id) == _180.id
-
-
-def test_get_existing_id_returns_none_for_dataset_without_180(self):
-    sd = StrictDataset(generate_images((5, 20, 20)))
-    self.model.add_dataset_to_model(sd)
-
-    self.assertIsNone(self.model.get_existing_180_id(sd.id))
+        self.assertIsNone(self.model.get_existing_180_id(sd.id))

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -398,3 +398,27 @@ class MainWindowModelTest(unittest.TestCase):
         self.model.add_dataset_to_model(ds)
         with self.assertRaises(RuntimeError):
             self.model.get_parent_dataset("unrecognised-id")
+
+    def test_no_dataset_with_180_raises(self):
+        with self.assertRaises(RuntimeError):
+            self.model.get_existing_180_id("bad-id")
+
+    def test_wrong_dataset_type_for_180_raises(self):
+        md = MixedDataset()
+        self.model.add_dataset_to_model(md)
+
+        with self.assertRaises(RuntimeError):
+            self.model.get_existing_180_id(md.id)
+
+    def test_get_existing_180_id_finds_id(self):
+        sd = StrictDataset(generate_images((5, 20, 20)))
+        sd.proj180deg = _180 = generate_images((1, 20, 20))
+        self.model.add_dataset_to_model(sd)
+
+        assert self.model.get_existing_180_id(sd.id) == _180.id
+
+    def test_get_existing_id_returns_none_for_dataset_without_180(self):
+        sd = StrictDataset(generate_images((5, 20, 20)))
+        self.model.add_dataset_to_model(sd)
+
+        self.assertIsNone(self.model.get_existing_180_id(sd.id))

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -328,15 +328,46 @@ class MainWindowPresenterTest(unittest.TestCase):
         mock_stack.image_view.setImage.assert_not_called()
         self.assertEqual(self.presenter.stack_visualisers[old_images.id].presenter.images, old_images)
 
-    def test_add_180_deg_to_dataset_success(self):
+    def test_add_first_180_deg_to_dataset(self):
         dataset_id = "dataset-id"
         filename_for_180 = "path/to/180"
+        self.model.get_existing_180_id.return_value = None
         self.model.add_180_deg_to_dataset.return_value = _180_deg = generate_images((1, 200, 200))
         self.presenter.add_child_item_to_tree_view = mock.Mock()
 
         self.presenter.add_180_deg_file_to_dataset(dataset_id, filename_for_180)
         self.model.add_180_deg_to_dataset.assert_called_once_with(dataset_id, filename_for_180)
         self.presenter.add_child_item_to_tree_view.assert_called_once_with(dataset_id, _180_deg.id, "180")
+        self.view.model_changed.emit.assert_called_once()
+
+    def test_replace_180_deg_in_dataset(self):
+        dataset_id = "dataset-id"
+        filename_for_180 = "path/to/180"
+        self.model.get_existing_180_id.return_value = existing_180_id = "prev-id"
+        self.presenter.stack_visualisers[existing_180_id] = existing_180_stack = mock.Mock()
+        self.model.add_180_deg_to_dataset.return_value = _180_deg = generate_images((1, 200, 200))
+        self.presenter.replace_child_item_id = mock.Mock()
+
+        self.presenter.add_180_deg_file_to_dataset(dataset_id, filename_for_180)
+        self.model.add_180_deg_to_dataset.assert_called_once_with(dataset_id, filename_for_180)
+        self.presenter.replace_child_item_id.assert_called_once_with(dataset_id, existing_180_id, _180_deg.id)
+        self.assertNotIn(existing_180_stack, self.presenter.stack_visualisers)
+        self.view.model_changed.emit.assert_called_once()
+
+    def test_replace_child_item_id_success(self):
+        dataset_tree_item_mock = self.view.get_dataset_tree_view_item.return_value
+        dataset_tree_item_mock.childCount.return_value = 1
+        child_item_mock = dataset_tree_item_mock.child.return_value
+        child_item_mock.id = id_to_replace = "id-to-replace"
+
+        dataset_id = "dataset-id"
+        new_id = "new-id"
+
+        self.presenter.replace_child_item_id(dataset_id, id_to_replace, new_id)
+        self.view.get_dataset_tree_view_item.assert_called_once_with(dataset_id)
+        dataset_tree_item_mock.childCount.assert_called_once()
+        dataset_tree_item_mock.child.assert_called_once_with(0)
+        assert child_item_mock._id == new_id
 
     def test_add_projection_angles_to_stack_success(self):
         mock_stack = mock.Mock()

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -369,6 +369,13 @@ class MainWindowPresenterTest(unittest.TestCase):
         dataset_tree_item_mock.child.assert_called_once_with(0)
         assert child_item_mock._id == new_id
 
+    def test_replace_child_item_id_failure(self):
+        dataset_tree_item_mock = self.view.get_dataset_tree_view_item.return_value
+        dataset_tree_item_mock.childCount.return_value = 1
+
+        with self.assertRaises(RuntimeError):
+            self.presenter.replace_child_item_id("dataset-id", "bad-id", "new-id")
+
     def test_add_projection_angles_to_stack_success(self):
         mock_stack = mock.Mock()
         mock_stack.windowTitle.return_value = window_title = "window title"


### PR DESCRIPTION
### Issue

Closes #1285

### Description

Allows replacing an existing 180 projection.

### Testing 

Added tests for the `MainWindowModel` and `MainWindowPresenter`.

### Acceptance Criteria 

Check that the tests pass. Check that 180 projections can be replaced.

### Documentation

Updated release notes.
