### PR TITLE
1311: Operation applied to 180 twice

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -48,6 +48,7 @@ Fixes
 - #1299 : CIL: when reconstructing from sinograms use right dimensions and ordering
 - #1305 : Delete recon group from tree view
 - #1285 : Error when load two 180 stacks
+- #1311 : Operation applied to 180 twice
 
 
 Developer Changes

--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -238,4 +238,4 @@ def find_projection_closest_to_180(projections: np.ndarray, projection_angles: n
     :return: The 180 projection/the closest non-180 projection and the difference between its angle and 180.
     """
     diff = np.abs(projection_angles - np.pi)
-    return projections[diff.argmin()], np.amin(diff)
+    return projections[diff.argmin()].copy(), np.amin(diff)

--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -238,4 +238,4 @@ def find_projection_closest_to_180(projections: np.ndarray, projection_angles: n
     :return: The 180 projection/the closest non-180 projection and the difference between its angle and 180.
     """
     diff = np.abs(projection_angles - np.pi)
-    return projections[diff.argmin()].copy(), np.amin(diff)
+    return projections[diff.argmin()], np.amin(diff)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -203,7 +203,7 @@ class MainWindowPresenter(BasePresenter):
             closest_projection, diff = find_projection_closest_to_180(dataset.sample.projections,
                                                                       dataset.sample.projection_angles().value)
             if diff <= THRESHOLD_180 or self.view.ask_to_use_closest_to_180(diff):
-                dataset.proj180deg = Images(np.reshape(closest_projection.copy(), (1, ) + closest_projection.shape),
+                dataset.proj180deg = Images(np.reshape(closest_projection, (1, ) + closest_projection.shape),
                                             name=f"{dataset.name}_180")
 
                 self.add_child_item_to_tree_view(dataset.id, dataset.proj180deg.id, "180")

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -203,7 +203,7 @@ class MainWindowPresenter(BasePresenter):
             closest_projection, diff = find_projection_closest_to_180(dataset.sample.projections,
                                                                       dataset.sample.projection_angles().value)
             if diff <= THRESHOLD_180 or self.view.ask_to_use_closest_to_180(diff):
-                dataset.proj180deg = Images(np.reshape(closest_projection, (1, ) + closest_projection.shape),
+                dataset.proj180deg = Images(np.reshape(closest_projection.copy(), (1, ) + closest_projection.shape),
                                             name=f"{dataset.name}_180")
 
                 self.add_child_item_to_tree_view(dataset.id, dataset.proj180deg.id, "180")

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -203,8 +203,8 @@ class MainWindowPresenter(BasePresenter):
             closest_projection, diff = find_projection_closest_to_180(dataset.sample.projections,
                                                                       dataset.sample.projection_angles().value)
             if diff <= THRESHOLD_180 or self.view.ask_to_use_closest_to_180(diff):
-                dataset.proj180deg = Images(np.reshape(closest_projection, (1, ) + closest_projection.shape),
-                                            name=f"{dataset.name}_180")
+                _180_arr = np.reshape(closest_projection, (1, ) + closest_projection.shape).copy()
+                dataset.proj180deg = Images(_180_arr, name=f"{dataset.name}_180")
 
                 self.add_child_item_to_tree_view(dataset.id, dataset.proj180deg.id, "180")
                 sample_vis = self.get_stack_visualiser(dataset.sample.id)

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -202,7 +202,17 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         self.dataset.sample.clear_proj180deg()
         self.presenter.add_alternative_180_if_required(self.dataset)
-        self.assertIsNotNone(self.dataset.proj180deg)
+
+    def test_threshold_180_is_separate_data(self):
+        self.dataset.sample.set_projection_angles(
+            ProjectionAngles(np.linspace(0, np.pi, self.dataset.sample.num_images)))
+
+        self.presenter.get_stack_visualiser = mock.Mock()
+        self.presenter._create_and_tabify_stack_window = mock.Mock()
+        self.dataset.sample.clear_proj180deg()
+        self.presenter.add_alternative_180_if_required(self.dataset)
+
+        self.assertIsNone(self.dataset.proj180deg.data.base)
 
     def test_create_new_stack_dataset_and_reject_180(self):
         self.dataset.flat_before.filenames = ["filename"] * 10


### PR DESCRIPTION
### Issue

Closes #1311

### Description

Makes a copy so that operations don't get applied to 180 twice.

### Testing 

Added a test to check that the `base` attribute of the 180 array is none.

### Acceptance Criteria 

Check that the tests pass. Check that operations are not applied to 180 projections twice.

### Documentation

Updated release notes.
