### PR TITLE
Prevent loading 180 projections to MixedDataset stacks

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -48,6 +48,7 @@ Fixes
 - #1299 : CIL: when reconstructing from sinograms use right dimensions and ordering
 - #1305 : Delete recon group from tree view
 - #1285 : Error when load two 180 stacks
+- #1278 : It should not be possible to attempt loading 180 projections to a MixedDataset
 
 
 Developer Changes

--- a/mantidimaging/gui/widgets/dataset_selector/view.py
+++ b/mantidimaging/gui/widgets/dataset_selector/view.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import uuid
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union, Tuple
 
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QComboBox
@@ -27,10 +27,12 @@ class DatasetSelectorWidgetView(QComboBox):
 
     main_window: 'MainWindowView'
 
-    def __init__(self, parent, show_stacks=False):
+    def __init__(self, parent, show_stacks=False, relevant_dataset_types: Union[type, Tuple[type]] = None):
         super().__init__(parent)
 
-        self.presenter = DatasetSelectorWidgetPresenter(self, show_stacks=show_stacks)
+        self.presenter = DatasetSelectorWidgetPresenter(self,
+                                                        show_stacks=show_stacks,
+                                                        relevant_dataset_types=relevant_dataset_types)
         self.currentIndexChanged[int].connect(self.presenter.handle_selection)
 
     def subscribe_to_main_window(self, main_window: 'MainWindowView'):

--- a/mantidimaging/gui/widgets/dataset_selector/view.py
+++ b/mantidimaging/gui/widgets/dataset_selector/view.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import uuid
-from typing import TYPE_CHECKING, Optional, Union, Tuple
+from typing import TYPE_CHECKING, Optional, Union, Tuple, List
 
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QComboBox
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView
 
 
-def _string_contains_all_parts(string: str, parts: list) -> bool:
+def _string_contains_all_parts(string: str, parts: List[str]) -> bool:
     for part in parts:
         if part.lower() not in string:
             return False
@@ -27,7 +27,7 @@ class DatasetSelectorWidgetView(QComboBox):
 
     main_window: 'MainWindowView'
 
-    def __init__(self, parent, show_stacks=False, relevant_dataset_types: Union[type, Tuple[type]] = None):
+    def __init__(self, parent, show_stacks: bool = False, relevant_dataset_types: Union[type, Tuple[type]] = None):
         super().__init__(parent)
 
         self.presenter = DatasetSelectorWidgetPresenter(self,
@@ -35,7 +35,7 @@ class DatasetSelectorWidgetView(QComboBox):
                                                         relevant_dataset_types=relevant_dataset_types)
         self.currentIndexChanged[int].connect(self.presenter.handle_selection)
 
-    def subscribe_to_main_window(self, main_window: 'MainWindowView'):
+    def subscribe_to_main_window(self, main_window: 'MainWindowView') -> None:
         self.main_window = main_window
 
         # Initial population of dataset list
@@ -44,7 +44,7 @@ class DatasetSelectorWidgetView(QComboBox):
         # Connect signal for auto update on stack change
         self.main_window.model_changed.connect(self._handle_loaded_datasets_changed)
 
-    def unsubscribe_from_main_window(self):
+    def unsubscribe_from_main_window(self) -> None:
         """
         Removes connections to main window.
 
@@ -54,7 +54,7 @@ class DatasetSelectorWidgetView(QComboBox):
             # Disconnect signal
             self.main_window.model_changed.disconnect(self._handle_loaded_datasets_changed)
 
-    def _handle_loaded_datasets_changed(self):
+    def _handle_loaded_datasets_changed(self) -> None:
         """
         Handle a change in loaded stacks.
         """
@@ -72,5 +72,5 @@ class DatasetSelectorWidgetView(QComboBox):
                 self.setCurrentIndex(i)
                 break
 
-    def select_eligible_stack(self):
+    def select_eligible_stack(self) -> None:
         self.presenter.notify(Notification.SELECT_ELIGIBLE_STACK)

--- a/mantidimaging/gui/widgets/dataset_selector_dialog/dataset_selector_dialog.py
+++ b/mantidimaging/gui/widgets/dataset_selector_dialog/dataset_selector_dialog.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Optional
 
 from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QHBoxLayout, QPushButton
 
+from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.gui.widgets.dataset_selector.view import DatasetSelectorWidgetView
 
 if TYPE_CHECKING:
@@ -26,7 +27,7 @@ class DatasetSelectorDialog(QDialog):
         self.vertical_layout.addWidget(QLabel("What dataset is the 180 projection being loaded for?", self))
 
         # Dataset selector
-        self.dataset_selector_widget = DatasetSelectorWidgetView(self)
+        self.dataset_selector_widget = DatasetSelectorWidgetView(self, relevant_dataset_types=StrictDataset)
         self.dataset_selector_widget.subscribe_to_main_window(main_window)  # type: ignore
         self.vertical_layout.addWidget(self.dataset_selector_widget)
 

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -14,6 +14,7 @@ from PyQt5.QtWidgets import QAction, QDialog, QLabel, QMessageBox, QMenu, QFileD
     QTreeWidgetItem, QTreeWidget
 
 from mantidimaging.core.data import Images
+from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.core.utility import finder
 from mantidimaging.core.utility.command_line_arguments import CommandLineArguments
 from mantidimaging.core.utility.projection_angle_parser import ProjectionAngleFileParser
@@ -181,13 +182,15 @@ class MainWindowView(BaseMainWindowView):
         return None
 
     def update_shortcuts(self):
-        enabled = len(self.presenter.stack_visualisers.values()) > 0
-        self.actionSave.setEnabled(enabled)
-        self.actionSampleLoadLog.setEnabled(enabled)
-        self.actionLoad180deg.setEnabled(enabled)
-        self.actionLoadProjectionAngles.setEnabled(enabled)
-        self.menuWorkflow.setEnabled(enabled)
-        self.menuImage.setEnabled(enabled)
+        has_datasets = len(self.presenter.datasets) > 0
+        has_strict_datasets = any(isinstance(dataset, StrictDataset) for dataset in self.presenter.datasets)
+
+        self.actionSave.setEnabled(has_datasets)
+        self.actionSampleLoadLog.setEnabled(has_datasets)
+        self.actionLoad180deg.setEnabled(has_strict_datasets)
+        self.actionLoadProjectionAngles.setEnabled(has_datasets)
+        self.menuWorkflow.setEnabled(has_datasets)
+        self.menuImage.setEnabled(has_datasets)
 
     @staticmethod
     def open_online_documentation():


### PR DESCRIPTION
### Issue

Closes #1278

### Description

The `File -> Load 180 deg projection` menu option is only enabled if there is at least one `StrictDataset` loaded. Once enabled, only datasets of type `StrictDataset` are available to select from the dialog drop-down.

I also reviewed the Mypy coverage of the `gui/widgets/dataset_selector` folder and added some annotations to the `presenter.py` and `view.py` files to improve the coverage statistic in the report. This was done in it's own commit, so the PR could be reviewed per commit if it would help to split out the functional changes from the Mypy updates.

### Testing & Acceptance Criteria 

Run through a few sequences/combinations of loading and deleting datasets, images and NeXus files to confirm that:
- The File menu options enable and disable correctly based on the types of stacks that are loaded - `Load 180 deg projection` should only be enabled if there is one or more StrictDataset loaded (i.e. one or more stack loaded via Load dataset or Load NeXus file).
- The stack selectors in all areas of the application other than the load 180 dialog should always contain all loaded stacks, regardless of dataset type.
- When it's possible to open the load 180 dialog from the File menu, only stacks of type `StrictDataset` (those loaded via Load dataset or Load NeXus file) should be available to select from the dialog drop-down.

### Documentation

Issue number added to release notes.