### PR TITLE
Disable Auto color menu item when no image shown

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -50,6 +50,7 @@ Fixes
 - #1285 : Error when load two 180 stacks
 - #1278 : It should not be possible to attempt loading 180 projections to a MixedDataset
 - #1311 : Operation applied to 180 twice
+- #1310 : Disable Auto color menu item when no image shown
 
 
 Developer Changes

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -8,7 +8,6 @@ from typing import Optional
 import numpy as np
 from PyQt5.QtCore import QPoint, QRect
 from PyQt5.QtGui import QGuiApplication, QResizeEvent
-from PyQt5.QtWidgets import QAction
 from pyqtgraph import ColorMap, GraphicsLayoutWidget, ImageItem, LegendItem, PlotItem
 from pyqtgraph.graphicsItems.GraphicsLayout import GraphicsLayout
 from pyqtgraph.graphicsItems.HistogramLUTItem import HistogramLUTItem
@@ -92,10 +91,9 @@ class FilterPreviews(GraphicsLayoutWidget):
         # Work around for https://github.com/mantidproject/mantidimaging/issues/565
         self.scene().contextMenu = [item for item in self.scene().contextMenu if "export" not in item.text().lower()]
 
-        self.auto_colour_actions = []
-        self._add_auto_colour_action(self.image_before_hist, self.image_before)
-        self._add_auto_colour_action(self.image_after_hist, self.image_after)
-        self._add_auto_colour_action(self.image_difference_hist, self.image_difference)
+        self._add_auto_colour_action(self.imageview_before)
+        self._add_auto_colour_action(self.imageview_after)
+        self._add_auto_colour_action(self.imageview_difference)
 
         self.imageview_before.link_sibling_axis()
 
@@ -202,18 +200,13 @@ class FilterPreviews(GraphicsLayoutWidget):
         set_histogram_log_scale(self.image_before_hist)
         set_histogram_log_scale(self.image_after_hist)
 
-    def _add_auto_colour_action(self, histogram: HistogramLUTItem, image: ImageItem):
+    def _add_auto_colour_action(self, img_view: MIMiniImageView):
         """
         Adds an "Auto" action to the histogram right-click menu.
-        :param histogram: The HistogramLUTItem
-        :param image: The ImageItem to have the Jenks/Otsu algorithm performed on it.
         """
-        self.auto_colour_actions.append(QAction("Auto"))
-        self.auto_colour_actions[-1].triggered.connect(lambda: self._on_change_colour_palette(histogram, image))
 
-        action = histogram.gradient.menu.actions()[12]
-        histogram.gradient.menu.insertAction(action, self.auto_colour_actions[-1])
-        histogram.gradient.menu.insertSeparator(self.auto_colour_actions[-1])
+        action = img_view.add_auto_color_action()
+        action.triggered.connect(lambda: self._on_change_colour_palette(img_view.hist, img_view.im))
 
     def _on_change_colour_palette(self, main_histogram: HistogramLUTItem, image: ImageItem):
         """

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -7,8 +7,7 @@ from uuid import UUID
 
 import numpy
 from PyQt5.QtWidgets import (QAbstractItemView, QComboBox, QDoubleSpinBox, QInputDialog, QPushButton, QSpinBox,
-                             QVBoxLayout, QWidget, QMessageBox, QAction, QTextEdit, QLabel, QApplication, QStyle,
-                             QCheckBox)
+                             QVBoxLayout, QWidget, QMessageBox, QTextEdit, QLabel, QApplication, QStyle, QCheckBox)
 from PyQt5.QtCore import QSignalBlocker
 
 from mantidimaging.core.data import Images
@@ -187,12 +186,8 @@ class ReconstructWindowView(BaseMainWindowView):
         self.updatePreviewButton.clicked.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_USER_CLICK))
 
         # Preparing the auto change colour map UI
-        self.auto_colour_action = QAction("Auto")
+        self.auto_colour_action = self.image_view.imageview_recon.add_auto_color_action()
         self.auto_colour_action.triggered.connect(self.on_change_colour_palette)
-
-        action = self.image_view.recon_hist.gradient.menu.actions()[12]
-        self.image_view.recon_hist.gradient.menu.insertAction(action, self.auto_colour_action)
-        self.image_view.recon_hist.gradient.menu.insertSeparator(self.auto_colour_action)
 
         for spinbox in [self.lbhc_a0, self.lbhc_a1, self.lbhc_a2, self.lbhc_a3]:
             spinbox.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))


### PR DESCRIPTION
### Issue

Closes #1310

### Description

Disable the Auto option when there is no image displayed in the image view.

Moved some of the code in to `MIMiniImageView`, so that the `setImage()` and `clear()` can enable and disable the action

There is further code deduplication possible but not urgent now #1317

### Testing & Acceptance Criteria 
Follow steps on #1310

The Auto menu item should be disabled when there is no image. Switch back and forth between operations to check that it re-enables

### Documentation

Release notes
