### PR TITLE
Shorten name used in tree-view for loaded images

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -23,6 +23,7 @@ New Features
 - #1279 : Add auto update checkbox option to turn off live reconstruction
 - #1273 : Move sinograms into the Dataset
 - #1220 : Make reconstruction window side bar scrollable for smaller screens
+- #1280 : Don't display full file path for loaded images in the tree view
 
 
 Fixes

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -67,7 +67,7 @@ class BaseDataset:
 
 
 class MixedDataset(BaseDataset):
-    def __init__(self, stacks: List[Images] = [], name=""):
+    def __init__(self, stacks: List[Images] = [], name: str = ""):
         super().__init__(name=name)
         self._stacks = stacks
 

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -66,7 +66,7 @@ class MainWindowModel(object):
 
     def load_images(self, file_path: str, progress) -> MixedDataset:
         images = loader.load_stack(file_path, progress)
-        sd = MixedDataset([images])
+        sd = MixedDataset([images], images.name)
         self.datasets[sd.id] = sd
         return sd
 

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 import uuid
 from logging import getLogger
-from typing import Dict, Optional, List, Union, NoReturn
+from typing import Dict, Optional, List, Union, NoReturn, TYPE_CHECKING
 
 import numpy as np
 
@@ -10,6 +10,9 @@ from mantidimaging.core.data import Images
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
 from mantidimaging.core.io import loader, saver
 from mantidimaging.core.utility.data_containers import LoadingParameters, ProjectionAngles
+
+if TYPE_CHECKING:
+    from mantidimaging.core.utility.progress_reporting import Progress
 
 logger = getLogger(__name__)
 
@@ -64,7 +67,7 @@ class MainWindowModel(object):
         self.datasets[ds.id] = ds
         return ds
 
-    def load_images(self, file_path: str, progress) -> MixedDataset:
+    def load_images(self, file_path: str, progress: 'Progress') -> MixedDataset:
         images = loader.load_stack(file_path, progress)
         sd = MixedDataset([images], images.name)
         self.datasets[sd.id] = sd

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-import os
 import traceback
 import uuid
 from enum import Enum, auto
@@ -140,7 +139,6 @@ class MainWindowPresenter(BasePresenter):
         log = getLogger(__name__)
 
         if task.was_successful():
-            task.result.name = os.path.splitext(task.kwargs['file_path'])[0]
             self.create_mixed_dataset_tree_view_items(task.result)
             self.create_mixed_dataset_stack_windows(task.result)
             self.view.model_changed.emit()


### PR DESCRIPTION
### Issue

Closes #1280

### Description

To be consistent with the approach we're using when loading datasets and NeXus files, I have set this to use the stack name for the loaded images rather than the file path:

![Capture](https://user-images.githubusercontent.com/38210467/154291772-f65681c9-f66f-402c-b7b7-658513368591.PNG)

I spent a bit of time looking at the differences between how we're handling naming of stacks in the current version of MI compared to the previous stable release. Previously if you didn't click on the first image when loading (either via a dataset or load images) the whole stack was still loaded but the stack was given the name of the image that was clicked on. The current version of MI uses the name of the first image in the stack, regardless of which was clicked on originally. This seems fine to me, but it may be worth taking time at some stage to review the differences in stack display names in the tree view compared to their names in the visualiser windows and stack selector drop-downs. When stacks with duplicate names are loaded, the unique names assigned by MI aren't currently reflected in the tree view, which may confuse some users. Additionally, we don't assign unique names if duplicate datasets are loaded. If these things are worth addressing then I thought that was probably best done under a separate issue, though.

### Testing & Acceptance Criteria 

1) Load a stack of images using `File -> Load images`.
2) Check that the dataset name that appears in the tree-view is just the stack name and not the full file path.

### Documentation

Issue number added to release notes.
