### PR TITLE
1295: Failed recon increments counter

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -50,6 +50,7 @@ Fixes
 - #1285 : Error when load two 180 stacks
 - #1278 : It should not be possible to attempt loading 180 projections to a MixedDataset
 - #1311 : Operation applied to 180 twice
+- #1295 : Failed recon still increments recon counter
 
 
 Developer Changes

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -6,6 +6,7 @@ from enum import Enum, auto
 from logging import getLogger
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Callable, Set
 
+import numpy as np
 from PyQt5.QtWidgets import QWidget
 
 from mantidimaging.core.data import Images
@@ -253,6 +254,8 @@ class ReconstructWindowPresenter(BasePresenter):
         if images is not None:
             assert self.model.images is not None
             images.name = "Recon"
+
+            self._replace_inf_nan(images)
             self.view.show_recon_volume(images, self.model.stack_id)
             images.record_operation('AstraRecon.single_sino',
                                     'Slice Reconstruction',
@@ -304,6 +307,7 @@ class ReconstructWindowPresenter(BasePresenter):
             self.view.show_error_dialog(f"Encountered error while trying to reconstruct: {str(task.error)}")
             return
 
+        self._replace_inf_nan(task.result)
         assert self.model.images is not None
         task.result.name = "Recon"
         self.view.show_recon_volume(task.result, self.model.stack_id)
@@ -410,3 +414,12 @@ class ReconstructWindowPresenter(BasePresenter):
         else:
             msg_list.insert(0, "Warning:")
             self.view.show_status_message(" ".join(msg_list))
+
+    @staticmethod
+    def _replace_inf_nan(images: Images):
+        """
+        Replaces infinity values in a data array with NaNs.
+        :param images: The Images object.
+        """
+        images.data[np.isinf(images.data)] = np.nan
+        images.data[np.isneginf(images.data)] = np.nan

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -254,7 +254,6 @@ class ReconstructWindowPresenter(BasePresenter):
         if images is not None:
             assert self.model.images is not None
             images.name = "Recon"
-
             self._replace_inf_nan(images)
             self.view.show_recon_volume(images, self.model.stack_id)
             images.record_operation('AstraRecon.single_sino',

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -348,3 +348,19 @@ class ReconWindowPresenterTest(unittest.TestCase):
 
         self.presenter._do_nan_zero_negative_check()
         self.view.show_status_message.assert_called_once_with("")
+
+    def test_infs_removed_from_recon_volume(self):
+        task = mock.Mock()
+        task.error = None
+        task.result.data = np.array([np.inf, -np.inf])
+
+        self.presenter._on_volume_recon_done(task)
+        assert not np.isinf(self.view.show_recon_volume.call_args[0][0].data).any()
+
+    def test_infs_removed_from_recon_slice(self):
+        task = mock.Mock()
+        task.error = None
+        task.result.data = np.array([np.inf, -np.inf])
+
+        self.presenter._on_stack_reconstruct_slice_done(task)
+        assert not np.isinf(self.view.show_recon_volume.call_args[0][0].data).any()


### PR DESCRIPTION
### Issue

Closes #1295

### Description

Replaces infs with NaNs in recons. This prevents the error caused by inf arguments to the pyqtgraph histogram.

### Testing 

Added tests that check the add data to view method is called with data that doesn't contain infs.

### Acceptance Criteria 

Check that the tests pass. Check that the error mentioned in #1295 doesn't happen.

### Documentation

Updated release notes.
