### PR TITLE
Restore metadata when choosing original

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -53,6 +53,7 @@ Fixes
 - #1311 : Operation applied to 180 twice
 - #1310 : Disable Auto color menu item when no image shown
 - #1295 : Failed recon still increments recon counter
+- #1313 : Restore metadata when choosing original
 
 
 Developer Changes

--- a/mantidimaging/gui/windows/stack_choice/presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/presenter.py
@@ -70,6 +70,7 @@ class StackChoicePresenter(StackChoicePresenterMixin):
 
     def do_reapply_original_data(self):
         self.new_stack.data = self.original_stack.data
+        self.new_stack.metadata = self.original_stack.metadata
         self._clean_up_original_images_stack()
         self.view.choice_made = True
         self.close_view()

--- a/mantidimaging/gui/windows/stack_choice/presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/presenter.py
@@ -32,10 +32,10 @@ class StackChoicePresenter(StackChoicePresenterMixin):
         if view is None:
             # Check if multiple stacks to choose from
             if isinstance(original_stack, list):
-                self.stack = _get_stack_from_uuid(original_stack, stack_uuid)
+                self.original_stack = _get_stack_from_uuid(original_stack, stack_uuid)
             else:
-                self.stack = original_stack
-            view = StackChoiceView(self.stack, new_stack, self, parent=operations_presenter.view)
+                self.original_stack = original_stack
+            view = StackChoiceView(self.original_stack, new_stack, self, parent=operations_presenter.view)
 
         self.view = view
         self.stack_uuid = stack_uuid
@@ -68,7 +68,7 @@ class StackChoicePresenter(StackChoicePresenterMixin):
             self.operations_presenter.original_images_stack = None
 
     def do_reapply_original_data(self):
-        self.operations_presenter.main_window.presenter.set_images_in_stack(self.stack_uuid, self.stack)
+        self.operations_presenter.main_window.presenter.set_images_in_stack(self.stack_uuid, self.original_stack)
         self._clean_up_original_images_stack()
         self.view.choice_made = True
         self.close_view()
@@ -80,7 +80,7 @@ class StackChoicePresenter(StackChoicePresenterMixin):
 
     def close_view(self):
         self.view.close()
-        self.stack = None
+        self.original_stack = None
         self.done = True
 
     def enable_nonpositive_check(self):

--- a/mantidimaging/gui/windows/stack_choice/presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/presenter.py
@@ -38,6 +38,7 @@ class StackChoicePresenter(StackChoicePresenterMixin):
             view = StackChoiceView(self.original_stack, new_stack, self, parent=operations_presenter.view)
 
         self.view = view
+        self.new_stack = new_stack
         self.stack_uuid = stack_uuid
         self.done = False
         self.use_new_data = False
@@ -68,7 +69,7 @@ class StackChoicePresenter(StackChoicePresenterMixin):
             self.operations_presenter.original_images_stack = None
 
     def do_reapply_original_data(self):
-        self.operations_presenter.main_window.presenter.set_images_in_stack(self.stack_uuid, self.original_stack)
+        self.new_stack.data = self.original_stack.data
         self._clean_up_original_images_stack()
         self.view.choice_made = True
         self.close_view()

--- a/mantidimaging/gui/windows/stack_choice/tests/test_presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/test_presenter.py
@@ -81,13 +81,16 @@ class StackChoicePresenterTest(unittest.TestCase):
         self.p._clean_up_original_images_stack = mock.MagicMock()
         self.p.close_view = mock.MagicMock()
         img1 = Images(np.zeros((3, 3, 3)) + 1)
+        img1.metadata = {"name": 1}
         img2 = Images(np.zeros((3, 3, 3)) + 2)
+        img2.metadata = {"name": 2}
         self.p.original_stack = img1
         self.p.new_stack = img2
 
         self.p.do_reapply_original_data()
 
         self.assertEqual(self.p.new_stack.data[0, 0, 0], 1)
+        self.assertEqual(self.p.new_stack.metadata["name"], 1)
         self.p._clean_up_original_images_stack.assert_called_once()
         self.assertTrue(self.v.choice_made)
         self.p.close_view.assert_called_once()

--- a/mantidimaging/gui/windows/stack_choice/tests/test_presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/test_presenter.py
@@ -6,9 +6,12 @@ from unittest import mock
 from unittest.mock import DEFAULT, MagicMock, Mock, patch
 from uuid import uuid4
 
+import numpy as np
+
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.gui.windows.stack_choice.presenter import StackChoicePresenter
 from mantidimaging.gui.windows.stack_choice.view import Notification
+from mantidimaging.core.data.images import Images
 
 
 class StackChoicePresenterTest(unittest.TestCase):
@@ -77,11 +80,14 @@ class StackChoicePresenterTest(unittest.TestCase):
     def test_do_reapply_original_data(self):
         self.p._clean_up_original_images_stack = mock.MagicMock()
         self.p.close_view = mock.MagicMock()
-        self.p.original_stack = 1
+        img1 = Images(np.zeros((3, 3, 3)) + 1)
+        img2 = Images(np.zeros((3, 3, 3)) + 2)
+        self.p.original_stack = img1
+        self.p.new_stack = img2
 
         self.p.do_reapply_original_data()
 
-        self.op_p.main_window.presenter.set_images_in_stack.assert_called_once_with(self.uuid, 1)
+        self.assertEqual(self.p.new_stack.data[0, 0, 0], 1)
         self.p._clean_up_original_images_stack.assert_called_once()
         self.assertTrue(self.v.choice_made)
         self.p.close_view.assert_called_once()

--- a/mantidimaging/gui/windows/stack_choice/tests/test_presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/test_presenter.py
@@ -77,7 +77,7 @@ class StackChoicePresenterTest(unittest.TestCase):
     def test_do_reapply_original_data(self):
         self.p._clean_up_original_images_stack = mock.MagicMock()
         self.p.close_view = mock.MagicMock()
-        self.p.stack = 1
+        self.p.original_stack = 1
 
         self.p.do_reapply_original_data()
 
@@ -87,7 +87,7 @@ class StackChoicePresenterTest(unittest.TestCase):
         self.p.close_view.assert_called_once()
 
     def test_do_clean_up_original_data(self):
-        self.p.stack = mock.MagicMock()
+        self.p.original_stack = mock.MagicMock()
         self.p._clean_up_original_images_stack = mock.MagicMock()
         self.p.close_view = mock.MagicMock()
 


### PR DESCRIPTION
### Issue

Closes #1313

### Description

Simplify do_reapply_original_data by avoiding calling into set_images_in_stack. Inline the actual work.

Restore the metadata here too.

### Testing & Acceptance Criteria 

Follow steps on #1313

### Documentation

release notes
