### PR TITLE
Make bad data overlay visible even with only a few pixels

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -54,6 +54,7 @@ Fixes
 - #1310 : Disable Auto color menu item when no image shown
 - #1295 : Failed recon still increments recon counter
 - #1313 : Restore metadata when choosing original
+- #1324 : Bad data overlay not showing with large files
 
 
 Developer Changes

--- a/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
+++ b/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
@@ -32,7 +32,7 @@ class BadDataCheck:
         # cast any_bad to python bool to prevent DeprecationWarning
         self.indicator.setVisible(bool(any_bad))
 
-        self.overlay.setImage(bad_data)
+        self.overlay.setImage(bad_data, autoLevels=False)
 
     def setup_overlay(self):
         color = np.array([[0, 0, 0, 0], self.color], dtype=np.ubyte)
@@ -41,6 +41,7 @@ class BadDataCheck:
         lut = color_map.getLookupTable(0, 1, 2)
         self.overlay.setLookupTable(lut)
         self.overlay.setZValue(11)
+        self.overlay.setLevels([0, 1])
 
     def clear(self):
         self.overlay.getViewBox().removeItem(self.indicator)


### PR DESCRIPTION
Disable autolevels which uses sub-sampling and can therefore miss a few individual pixels in a large image.

The levels are always 0-1.

### Issue

Closes #1324 

### Description

Disable autolevels and manually set the levels to 0-1

### Testing & Acceptance Criteria 
See #1324

Bad pixels should new be visable

### Documentation

Release notes
