### PR TITLE
StrictDataset.proj180deg return None if no sample

### DIFF
--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -128,7 +128,10 @@ class StrictDataset(BaseDataset):
 
     @property
     def proj180deg(self):
-        return self.sample.proj180deg
+        if self.sample is not None:
+            return self.sample.proj180deg
+        else:
+            return None
 
     @proj180deg.setter
     def proj180deg(self, _180_deg: Images):

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -335,6 +335,17 @@ class MainWindowModelTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.model.remove_container(uuid.uuid4())
 
+    def test_remove_empty_dataset_from_model(self):
+        sample = generate_images()
+        ds = StrictDataset(sample)
+        self.model.datasets[ds.id] = ds
+
+        self.model.remove_container(sample.id)
+        self.assertEqual(len(ds.all), 0)
+
+        self.model.remove_container(ds.id)
+        self.assertEqual(len(self.model.datasets), 0)
+
     def test_remove_images_from_dataset(self):
         images = [generate_images() for _ in range(2)]
         ds = StrictDataset(*images)


### PR DESCRIPTION
Prevents an error if no sample.

### Issue

Closes #1326

### Description

If there is no sample then there is no 180 projection. So match the behaviour of other stacks of being None when not set.

I'm not 100% sure this is the best solution, but it works for now. The type annotations suggest that `sample` is always set and not optional. But it is possible to delete the sample from a dataset. There is a bit more UI to think about if we wanted it not to be possible to delete the sample.

### Testing & Acceptance Criteria 
Follow steps on #1326
Should be possible to delete all the stacks, and then the dataset, without error.

### Documentation

Not needed.
