### PR TITLE
Updates to the github actions scripts

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,6 +1,14 @@
 name: Testing with conda
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - 'main'
+    - 'release-*'
+  pull_request:
+    branches:
+      - 'main'
+      - 'release-*'
 
 jobs:
   test:

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -109,7 +109,7 @@ jobs:
           coveralls
 
       - name: publish 'unstable' package
-        if: github.ref == 'refs/heads/main'
+        if: ${{ github.event_name == 'push' }}  && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release'))
         uses: ./.github/actions/publish-package
         with:
           label: unstable

--- a/.github/workflows/cos7_testing.yml
+++ b/.github/workflows/cos7_testing.yml
@@ -2,7 +2,15 @@
 
 name: Testing with CentOS 7 docker
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - 'main'
+    - 'release-*'
+  pull_request:
+    branches:
+      - 'main'
+      - 'release-*'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/u18_testing.yml
+++ b/.github/workflows/u18_testing.yml
@@ -2,7 +2,15 @@
 
 name: Testing with Ubuntu 18 docker
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - 'main'
+    - 'release-*'
+  pull_request:
+    branches:
+      - 'main'
+      - 'release-*'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
### Description
Tweaks to the actions scripts

Prevent push trigger happening push to to PR branches as these are already triggered for the pull request. (This should have an effect on the PR, reducing the number of jobs run).

Run the `publish 'unstable' package` step on release branches. (This wont be visible until release time. Should allow us to use automatically built packages for release).


