### PR TITLE
Trigger conda builds on release events

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - 'main'
       - 'release-*'
+  release:
 
 jobs:
   test:
@@ -108,8 +109,9 @@ jobs:
         run: |
           coveralls
 
+      # Always label as unstable. Builds of stable releases can be manually labeled to 'main' once tested
       - name: publish 'unstable' package
-        if: github.event_name == 'push'  && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release'))
+        if: github.event_name == 'release' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release')))
         uses: ./.github/actions/publish-package
         with:
           label: unstable


### PR DESCRIPTION

### Issue

For the current release we had to push a commit to the release branch to trigger a build. Add a trigger on release so this is not necessary. 

They will still trigger on pushes to the release branch. But it is a manual decision to give them a "main" label on conda.org.

### Description

Add a `release` item to the `on` rule

### Testing 

Hard to test. We'll find out when we do the next release.
