### PR TITLE
1340 roi norm preserve max

### DIFF
--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -20,7 +20,7 @@ from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
 
 
 def modes() -> List[str]:
-    return ['Stack Average', 'Preserve Max', 'Flat Field']
+    return ['Stack Average', 'Flat Field']
 
 
 class RoiNormalisationFilter(BaseFilter):
@@ -59,8 +59,6 @@ class RoiNormalisationFilter(BaseFilter):
         region for which grey values are summed up and used for normalisation/scaling.
 
         :param normalisation_mode: Controls what the ROI counts are normalised to.
-            'Preserve Max' : Normalisation is scaled such that the maximum pixel value of the stack is equal before
-                             and after the operation.
             'Stack Average' : The mean value of the air region across all projections is preserved.
             'Flat Field' : The mean value of the air regions in the projections is made equal to the mean value of the
                            air region in the flat field image.
@@ -193,22 +191,7 @@ def _execute(data: np.ndarray,
         ps.shared_list = [data, air_means]
         ps.execute(do_calculate_air_means, data.shape[0], progress, cores=cores)
 
-        if normalisation_mode == 'Preserve Max':
-            air_maxs = pu.create_array((img_num, ), data.dtype)
-            do_calculate_air_max = ps.create_partial(_calc_max, ps.return_to_second_at_i)
-
-            ps.shared_list = [data, air_maxs]
-            ps.execute(do_calculate_air_max, data.shape[0], progress, cores=cores)
-
-            if np.isnan(air_maxs).any():
-                raise ValueError("Image contains invalid (NaN) pixels")
-
-            # calculate the before and after maximum
-            init_max = air_maxs.max()
-            post_max = (air_maxs / air_means).max()
-            air_means *= post_max / init_max
-
-        elif normalisation_mode == 'Stack Average':
+        if normalisation_mode == 'Stack Average':
             air_means /= air_means.mean()
 
         elif normalisation_mode == 'Flat Field' and flat_field is not None:

--- a/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
@@ -53,21 +53,10 @@ class ROINormalisationTest(unittest.TestCase):
         roi_mock = mock.Mock()
         roi_mock.text.return_value = "0, 0, 5, 5"
         mode_mock = mock.Mock()
-        mode_mock.currentText.return_value = "Preserve Max"
+        mode_mock.currentText.return_value = "Stack Average"
         flat_mock = mock.Mock()
         RoiNormalisationFilter.execute_wrapper(roi_mock, mode_mock, flat_mock)(images)
         roi_mock.text.assert_called_once()
-
-    def test_roi_normalisation_preserve_max(self):
-        images = th.generate_images(seed=2021)
-        images_max = images.data.max()
-
-        original = np.copy(images.data[0])
-        air = [3, 3, 4, 4]
-        result = RoiNormalisationFilter.filter_func(images, air, "Preserve Max")
-
-        th.assert_not_equals(result.data[0], original)
-        self.assertAlmostEqual(result.data.max(), images_max, places=6)
 
     def test_roi_normalisation_stack_average(self):
         air = [3, 3, 6, 8]


### PR DESCRIPTION
### Issue

Closes #1340 

### Description

Removed Preserve Max mode from the ROI norm.

### Testing 

Just removed one test and changed another.

### Acceptance Criteria 

Check that the tests still pass. Check that the Preserve Max option doesn't appear on the drop-down list.

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*
