### PR TITLE
1219: When loading files like NAME_001.tif NAME_002.tif don't include NAME_180deg.tif

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -9,7 +9,9 @@ New Features
 Fixes
 -----
 
+- #1219 : When loading files like NAME_001.tif NAME_002.tif don't include NAME_180deg.tif
+
 Developer Changes
 -----------------
 
-- #1272: Consistent test class filenames
+- #1272 : Consistent test class filenames

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -113,12 +113,13 @@ def load_log(log_file: str) -> IMATLogFile:
         return IMATLogFile(f.readlines(), log_file)
 
 
-def load_p(parameters: ImageParameters, dtype: 'npt.DTypeLike', progress: Progress) -> Images:
+def load_p(parameters: ImageParameters, dtype: 'npt.DTypeLike', progress: Progress, ignore_substring: str) -> Images:
     return load(input_path=parameters.input_path,
                 in_prefix=parameters.prefix,
                 in_format=parameters.format,
                 indices=parameters.indices,
                 dtype=dtype,
+                ignore_substring=ignore_substring,
                 progress=progress).sample
 
 
@@ -137,6 +138,7 @@ def load(input_path: Optional[str] = None,
          input_path_dark_after: Optional[str] = None,
          in_prefix: str = '',
          in_format: str = DEFAULT_IO_FILE_FORMAT,
+         ignore_substring: str = '',
          dtype: 'npt.DTypeLike' = np.float32,
          file_names: Optional[List[str]] = None,
          indices: Optional[Union[List[int], Indices]] = None,
@@ -169,7 +171,7 @@ def load(input_path: Optional[str] = None,
         raise ValueError("Indices at this point MUST have 3 elements: [start, stop, step]!")
 
     if not file_names:
-        input_file_names = get_file_names(input_path, in_format, in_prefix)
+        input_file_names = get_file_names(input_path, in_format, ignore_substring, in_prefix)
     else:
         input_file_names = file_names
 

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -113,7 +113,10 @@ def load_log(log_file: str) -> IMATLogFile:
         return IMATLogFile(f.readlines(), log_file)
 
 
-def load_p(parameters: ImageParameters, dtype: 'npt.DTypeLike', progress: Progress, ignore_substring: str) -> Images:
+def load_p(parameters: ImageParameters,
+           dtype: 'npt.DTypeLike',
+           progress: Progress,
+           ignore_substring: str = "deg") -> Images:
     return load(input_path=parameters.input_path,
                 in_prefix=parameters.prefix,
                 in_format=parameters.format,

--- a/mantidimaging/core/io/test/utility_test.py
+++ b/mantidimaging/core/io/test/utility_test.py
@@ -35,6 +35,22 @@ class UtilityTest(FileOutputtingTestCase):
         # Expect to find the .tiff file
         self.assertEqual([tiff_filename], found_files)
 
+    def test_exclude_substring_filenames(self):
+        # Create test files
+        exclude_substring = "exclude-this"
+        tiff_filename = os.path.join(self.output_directory, 'test.tiff')
+        exclude_filename = os.path.join(self.output_directory, f'test-{exclude_substring}.tiff')
+
+        for test_filename in [tiff_filename, exclude_filename]:
+            with open(test_filename, 'wb') as tf:
+                tf.write(b'\0')
+
+        # Search for files with .tif extension
+        found_files = utility.get_file_names(self.output_directory, 'tif', ignore_substring=exclude_substring)
+
+        # Expect to find the .tiff file but not the excluded file
+        self.assertEqual([tiff_filename], found_files)
+
     def test_find_log(self):
         with open(os.path.join(self.output_directory, "../sample_log.txt"), 'w') as f:
             f.write("sample logs")

--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -58,6 +58,7 @@ def get_candidate_file_extensions(ext: str) -> List[str]:
 def get_file_names(path: Optional[Union[Path, str]],
                    img_format: str,
                    prefix: str = '',
+                   ignore_substring: str = '',
                    essential: bool = True) -> List[str]:
     """
     Get all file names in a directory with a specific format.
@@ -89,6 +90,9 @@ def get_file_names(path: Optional[Union[Path, str]],
 
     if len(files_match) == 0 and essential:
         raise RuntimeError(f"Could not find any image files in '{path}' with extensions: {extensions}")
+
+    if ignore_substring:
+        files_match = list(filter(lambda filename: ignore_substring not in filename, files_match))
 
     # This is a necessary step, otherwise the file order is not guaranteed to
     # be sequential and we get randomly ordered stack of names

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -34,7 +34,7 @@ class MainWindowModel(object):
         return None
 
     def do_load_dataset(self, parameters: LoadingParameters, progress) -> StrictDataset:
-        sample = loader.load_p(parameters.sample, parameters.dtype, progress, "deg")
+        sample = loader.load_p(parameters.sample, parameters.dtype, progress)
         ds = StrictDataset(sample)
 
         sample._is_sinograms = parameters.sinograms
@@ -62,7 +62,7 @@ class MainWindowModel(object):
             ds.dark_after = dark_after
 
         if parameters.proj_180deg:
-            sample.proj180deg = loader.load_p(parameters.proj_180deg, parameters.dtype, progress)
+            sample.proj180deg = loader.load_p(parameters.proj_180deg, parameters.dtype, progress, "")
 
         self.datasets[ds.id] = ds
         return ds

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -34,7 +34,7 @@ class MainWindowModel(object):
         return None
 
     def do_load_dataset(self, parameters: LoadingParameters, progress) -> StrictDataset:
-        sample = loader.load_p(parameters.sample, parameters.dtype, progress)
+        sample = loader.load_p(parameters.sample, parameters.dtype, progress, "deg")
         ds = StrictDataset(sample)
 
         sample._is_sinograms = parameters.sinograms

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -172,7 +172,7 @@ class MainWindowModelTest(unittest.TestCase):
             mock.call(flat_after_mock, lp.dtype, progress_mock),
             mock.call(dark_before_mock, lp.dtype, progress_mock),
             mock.call(dark_after_mock, lp.dtype, progress_mock),
-            mock.call(proj_180deg_mock, lp.dtype, progress_mock)
+            mock.call(proj_180deg_mock, lp.dtype, progress_mock, "")
         ])
 
         load_log_mock.assert_has_calls([


### PR DESCRIPTION
### Issue

Closes #1219 

### Description

Adds an `ignore_substring` argument to the load file methods. When "deg" is given the 180deg files are ignored.

### Testing 

Wrote a test for the change to `get_file_names`.

### Acceptance Criteria 

Check that the deg files are now ignored when loading the sample files.

### Documentation

Updated release notes.
