### PR TITLE
Github Actions: Add cache for mamba packages

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+          echo "::set-output name=date::$(/bin/date -u "+%Y%V")"
         shell: bash
 
       - name: Cache Mambaforge and Pip packages
@@ -35,7 +35,7 @@ jobs:
             ~/conda_pkgs_dir
             ~/.cache/pip
           key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{hashFiles('environment-dev.yml') }}
+            ${{runner.os}}-condapkg-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml')}}
 
       - name: Cache Mambaforge environment
         uses: actions/cache@v2

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -20,12 +20,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cache Mambaforge
+      - name: Cache Mambaforge and Pip packages
         uses: actions/cache@v2
         env:
           CACHE_NUMBER: 0
         with:
-          path: ~/conda_pkgs_dir
+          path: |
+            ~/conda_pkgs_dir
+            ~/.cache/pip
           key:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{hashFiles('environment-dev.yml') }}
 

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -20,6 +20,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        shell: bash
+
       - name: Cache Mambaforge and Pip packages
         uses: actions/cache@v2
         env:
@@ -31,6 +37,16 @@ jobs:
           key:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{hashFiles('environment-dev.yml') }}
 
+      - name: Cache Mambaforge environment
+        uses: actions/cache@v2
+        id: cache-mambaforge-environment
+        env:
+          CACHE_NUMBER: 0
+        with:
+          path: /usr/share/miniconda3/envs/mantidimaging-dev.cache
+          key:
+            ${{runner.os}}-condaenv-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml')}}
+
       - name: Setup Mambaforge
         uses: conda-incubator/setup-miniconda@v2.1.1
         with:
@@ -38,13 +54,21 @@ jobs:
           miniforge-variant: Mambaforge
           activate-environment: mantidimaging-dev
           auto-activate-base: false
-          use-only-tar-bz2: true # Need for cache
+          use-mamba: true
 
       - name: Mantid Imaging developer dependencies
+        if: steps.cache-mambaforge-environment.outputs.cache-hit != 'true'
         shell: bash -l {0}
         run: |
           conda deactivate
           python3 ./setup.py create_dev_env
+          cp -Ta /usr/share/miniconda3/envs/mantidimaging-dev /usr/share/miniconda3/envs/mantidimaging-dev.cache
+
+      - name: Mantid Imaging developer dependencies - from cache
+        if: steps.cache-mambaforge-environment.outputs.cache-hit == 'true'
+        shell: bash -l {0}
+        run: |
+          cp -Ta /usr/share/miniconda3/envs/mantidimaging-dev.cache /usr/share/miniconda3/envs/mantidimaging-dev
 
       - name: Other dependencies
         shell: bash -l {0}
@@ -55,6 +79,7 @@ jobs:
       - name: List versions
         shell: bash -l {0}
         run: |
+          mamba env list
           python --version; conda list ; pip list
 
       - name: Yapf

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -20,6 +20,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Cache Mambaforge
+        uses: actions/cache@v2
+        env:
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{hashFiles('environment-dev.yml') }}
+
       - name: Setup Mambaforge
         uses: conda-incubator/setup-miniconda@v2.1.1
         with:
@@ -28,6 +37,7 @@ jobs:
           environment-file: environment-dev.yml
           activate-environment: mantidimaging-dev
           auto-activate-base: false
+          use-only-tar-bz2: true # Need for cache
 
       - name: Mantid Imaging developer dependencies
         shell: bash -l {0}

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -36,7 +36,6 @@ jobs:
         with:
           miniforge-version: latest
           miniforge-variant: Mambaforge
-          environment-file: environment-dev.yml
           activate-environment: mantidimaging-dev
           auto-activate-base: false
           use-only-tar-bz2: true # Need for cache


### PR DESCRIPTION
### Issue

Closes #1337 

### Description

Add caches for mamba and pip packages to reduce download time.

Cache the installed mantidimaging-dev environment

Using the cache in-place as described at https://github.com/conda-incubator/setup-miniconda#caching-packages does not give a working environment. Instead cache a copy of the folder, and copy back on cache hit.

Cache key uses has of the environment-dev.yml and conda/meta.yaml, as well as the year and week number. So should be refreshed on any relevant changes and also at the start of each week.

Previous mean set up time in seconds
'Setup Mambaforge' 243
'Mantid Imaging developer dependencies' 49
Total: 292s ~ 5 min

Now - 2 example runs  on this PR 
Cache Mambaforge and Pip packages 16s, 16s
Cache Mambaforge environment 36, 31
Setup Mambaforge 25, 28
Mantid Imaging developer dependencies - from cache 56, 50
Total: 130s, 125s ~ 2 mins

### Testing 
Tests should still pass

### Documentation

Not needed.