### PR TITLE
Update cudatoolkit and cupy

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -26,9 +26,9 @@ requirements:
     - numpy=1.18.*
     - algotom=1.0.*
     - tomopy=1.10.*
-    - cudatoolkit=9.2*
-    - cupy=9.4.*
-    - astra-toolbox=1.9.9.dev4
+    - cudatoolkit=10.2*
+    - cupy=10.2.*
+    - astra-toolbox=1.9.9*
     - requests=2.26.*
     - h5py=3.4.*
     - sarepy=2020.07

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -15,3 +15,4 @@ Developer Changes
 -----------------
 
 - #1272: Consistent test class filenames
+- #1352 : Update astra-toolbox and cudatoolkit to allow windows installation


### PR DESCRIPTION
### Issue
Closes #1352 

### Description
Update cudatoolkit and cupy
Also slacken the astra-toolbox requirement

### Testing & Acceptance Criteria 

`python ./setup.py create_dev_env`

Should successfully create an environment, and mantidimaging should launch in that environment 

### Documentation

Release notes
