### PR TITLE
Use mixin class for auto colour menu

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -16,3 +16,4 @@ Developer Changes
 
 - #1272: Consistent test class filenames
 - #1352 : Update astra-toolbox and cudatoolkit to allow windows installation
+- #1317 : Unify auto color palette code between MIMiniImageView and MIImageView

--- a/mantidimaging/eyes_tests/reconstruct_window_test.py
+++ b/mantidimaging/eyes_tests/reconstruct_window_test.py
@@ -61,7 +61,7 @@ class ReconstructionWindowTest(BaseEyesTest):
         self._load_data_set()
 
         self.imaging.show_recon_window()
-        self.imaging.recon.image_view.imageview_recon.im.image = np.empty((512, 512))
+        self.imaging.recon.image_view.imageview_recon.setImage(np.zeros((512, 512)))
         self.imaging.recon.changeColourPaletteButton.click()
 
         self.check_target(widget=self.imaging.recon.change_colour_palette_dialog)

--- a/mantidimaging/eyes_tests/reconstruct_window_test.py
+++ b/mantidimaging/eyes_tests/reconstruct_window_test.py
@@ -61,7 +61,7 @@ class ReconstructionWindowTest(BaseEyesTest):
         self._load_data_set()
 
         self.imaging.show_recon_window()
-        self.imaging.recon.image_view.recon.image = np.empty((512, 512))
+        self.imaging.recon.image_view.imageview_recon.im.image = np.empty((512, 512))
         self.imaging.recon.changeColourPaletteButton.click()
 
         self.check_target(widget=self.imaging.recon.change_colour_palette_dialog)

--- a/mantidimaging/gui/widgets/auto_colour_menu/__init__.py
+++ b/mantidimaging/gui/widgets/auto_colour_menu/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/widgets/auto_colour_menu/auto_color_menu.py
+++ b/mantidimaging/gui/widgets/auto_colour_menu/auto_color_menu.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from typing import Optional, TYPE_CHECKING, List
+
+from PyQt5.QtWidgets import QAction
+
+from mantidimaging.gui.widgets.palette_changer.view import PaletteChangerView
+
+if TYPE_CHECKING:
+    from pyqtgraph import HistogramLUTItem
+    import numpy as np
+    from PyQt5.QtWidgets import QWidget
+
+DEFAULT_MENU_POSITION = 12
+
+
+class AutoColorMenu:
+    """
+    Mixin class to be used with MIImageView and MIMiniImageView
+    """
+    def __init__(self) -> None:
+        self.auto_color_action: Optional[QAction] = None
+
+    @property
+    def main_histogram(self) -> 'HistogramLUTItem':
+        raise NotImplementedError('Required main_histogram property not implemented')
+
+    @property
+    def image_data(self) -> 'np.ndarray':
+        raise NotImplementedError('Required image_data property not implemented')
+
+    @property
+    def other_histograms(self) -> 'List[HistogramLUTItem]':
+        raise NotImplementedError('Required other_histograms property not implemented')
+
+    def add_auto_color_menu_action(self,
+                                   parent: 'Optional[QWidget]',
+                                   recon_mode: bool = False,
+                                   index: int = DEFAULT_MENU_POSITION,
+                                   set_enabled: bool = True) -> QAction:
+        self.auto_color_action = QAction("Auto")
+        place = self.main_histogram.gradient.menu.actions()[index]
+
+        self.main_histogram.gradient.menu.insertAction(place, self.auto_color_action)
+        self.main_histogram.gradient.menu.insertSeparator(self.auto_color_action)
+        self.set_auto_color_enabled(set_enabled)
+        self.auto_color_action.triggered.connect(lambda: self._on_colour_change_palette(parent, recon_mode))
+
+        return self.auto_color_action
+
+    def set_auto_color_enabled(self, enabled: bool = True) -> None:
+        if self.auto_color_action is not None:
+            self.auto_color_action.setEnabled(enabled)
+
+    def _on_colour_change_palette(self, parent: 'Optional[QWidget]', recon_mode: bool) -> None:
+        """
+        Opens the Palette Changer window
+        """
+        change_colour_palette = PaletteChangerView(parent=parent,
+                                                   main_hist=self.main_histogram,
+                                                   image=self.image_data,
+                                                   other_hists=self.other_histograms,
+                                                   recon_mode=recon_mode)
+        change_colour_palette.show()

--- a/mantidimaging/gui/widgets/auto_colour_menu/auto_color_menu.py
+++ b/mantidimaging/gui/widgets/auto_colour_menu/auto_color_menu.py
@@ -31,7 +31,7 @@ class AutoColorMenu:
 
     @property
     def other_histograms(self) -> 'List[HistogramLUTItem]':
-        raise NotImplementedError('Required other_histograms property not implemented')
+        return []
 
     def add_auto_color_menu_action(self,
                                    parent: 'Optional[QWidget]',

--- a/mantidimaging/gui/widgets/auto_colour_menu/auto_color_menu.py
+++ b/mantidimaging/gui/widgets/auto_colour_menu/auto_color_menu.py
@@ -22,8 +22,8 @@ class AutoColorMenu:
         self.auto_color_action: Optional[QAction] = None
 
     @property
-    def main_histogram(self) -> 'HistogramLUTItem':
-        raise NotImplementedError('Required main_histogram property not implemented')
+    def histogram(self) -> 'HistogramLUTItem':
+        raise NotImplementedError('Required histogram property not implemented')
 
     @property
     def image_data(self) -> 'np.ndarray':
@@ -39,10 +39,10 @@ class AutoColorMenu:
                                    index: int = DEFAULT_MENU_POSITION,
                                    set_enabled: bool = True) -> QAction:
         self.auto_color_action = QAction("Auto")
-        place = self.main_histogram.gradient.menu.actions()[index]
+        place = self.histogram.gradient.menu.actions()[index]
 
-        self.main_histogram.gradient.menu.insertAction(place, self.auto_color_action)
-        self.main_histogram.gradient.menu.insertSeparator(self.auto_color_action)
+        self.histogram.gradient.menu.insertAction(place, self.auto_color_action)
+        self.histogram.gradient.menu.insertSeparator(self.auto_color_action)
         self.set_auto_color_enabled(set_enabled)
         self.auto_color_action.triggered.connect(lambda: self._on_colour_change_palette(parent, recon_mode))
 
@@ -57,7 +57,7 @@ class AutoColorMenu:
         Opens the Palette Changer window
         """
         change_colour_palette = PaletteChangerView(parent=parent,
-                                                   main_hist=self.main_histogram,
+                                                   main_hist=self.histogram,
                                                    image=self.image_data,
                                                    other_hists=self.other_histograms,
                                                    recon_mode=recon_mode)

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -114,7 +114,7 @@ class MIImageView(ImageView, BadDataOverlay, AutoColorMenu):
         self.scene.contextMenu = [item for item in self.scene.contextMenu if "export" not in item.text().lower()]
 
     @property
-    def main_histogram(self) -> 'HistogramLUTItem':
+    def histogram(self) -> 'HistogramLUTItem':
         return self.ui.histogram.item
 
     @property

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -2,19 +2,23 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from time import sleep
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional, Tuple, TYPE_CHECKING, List
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QApplication, QHBoxLayout, QLabel, QPushButton, QSizePolicy, QAction
+from PyQt5.QtWidgets import QApplication, QHBoxLayout, QLabel, QPushButton, QSizePolicy
 from pyqtgraph import ROI, ImageItem, ImageView, ViewBox
 from pyqtgraph.GraphicsScene.mouseEvents import HoverEvent
 
 from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint
 from mantidimaging.core.utility.histogram import set_histogram_log_scale
 from mantidimaging.core.utility.sensible_roi import SensibleROI
+from mantidimaging.gui.widgets.auto_colour_menu.auto_color_menu import AutoColorMenu
 from mantidimaging.gui.widgets.mi_image_view.presenter import MIImagePresenter
-from mantidimaging.gui.widgets.palette_changer.view import PaletteChangerView
 from mantidimaging.gui.widgets.bad_data_overlay.bad_data_overlay import BadDataOverlay
+
+if TYPE_CHECKING:
+    from pyqtgraph import HistogramLUTItem
+    import numpy as np
 
 
 class UnrotateablePlotROI(ROI):
@@ -31,7 +35,7 @@ class UnrotateablePlotROI(ROI):
 graveyard = []
 
 
-class MIImageView(ImageView, BadDataOverlay):
+class MIImageView(ImageView, BadDataOverlay, AutoColorMenu):
     details: QLabel
     roiString = None
     imageItem: ImageItem
@@ -104,15 +108,22 @@ class MIImageView(ImageView, BadDataOverlay):
         self.imageItem.sigImageChanged.connect(self._refresh_message)
         self.imageItem.sigImageChanged.connect(self.set_log_scale)
 
-        self.auto_colour_action = QAction("Auto")
-        self.auto_colour_action.triggered.connect(self.on_colour_change_palette)
-
-        action = self.ui.histogram.item.gradient.menu.actions()[12]
-        self.ui.histogram.item.gradient.menu.insertAction(action, self.auto_colour_action)
-        self.ui.histogram.item.gradient.menu.insertSeparator(self.auto_colour_action)
+        self.add_auto_color_menu_action(self)
 
         # Work around for https://github.com/mantidproject/mantidimaging/issues/565
         self.scene.contextMenu = [item for item in self.scene.contextMenu if "export" not in item.text().lower()]
+
+    @property
+    def main_histogram(self) -> 'HistogramLUTItem':
+        return self.ui.histogram.item
+
+    @property
+    def image_data(self) -> 'np.ndarray':
+        return self.image
+
+    @property
+    def other_histograms(self) -> 'List[HistogramLUTItem]':
+        return []
 
     @property
     def image_item(self) -> ImageItem:
@@ -246,10 +257,3 @@ class MIImageView(ImageView, BadDataOverlay):
 
     def set_log_scale(self):
         set_histogram_log_scale(self.getHistogramWidget().item)
-
-    def on_colour_change_palette(self):
-        """
-        Opens the Palette Changer window when the "Auto" option has been clicked.
-        """
-        change_colour_palette = PaletteChangerView(parent=self, main_hist=self.ui.histogram.item, image=self.image)
-        change_colour_palette.show()

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from time import sleep
-from typing import Callable, Optional, Tuple, TYPE_CHECKING, List
+from typing import Callable, Optional, Tuple, TYPE_CHECKING
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QApplication, QHBoxLayout, QLabel, QPushButton, QSizePolicy
@@ -120,10 +120,6 @@ class MIImageView(ImageView, BadDataOverlay, AutoColorMenu):
     @property
     def image_data(self) -> 'np.ndarray':
         return self.image
-
-    @property
-    def other_histograms(self) -> 'List[HistogramLUTItem]':
-        return []
 
     @property
     def image_item(self) -> ImageItem:

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -55,7 +55,7 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
         self.histogram_siblings: "WeakSet[MIMiniImageView]" = WeakSet()
 
     @property
-    def main_histogram(self) -> HistogramLUTItem:
+    def histogram(self) -> HistogramLUTItem:
         return self.hist
 
     @property

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from itertools import chain, tee
-from typing import List, Tuple, TYPE_CHECKING, Optional
+from typing import List, TYPE_CHECKING, Optional
 from weakref import WeakSet
 
 from pyqtgraph import ImageItem, ViewBox
@@ -98,9 +98,6 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
 
     def add_hist_sibling(self, sibling: "MIMiniImageView"):
         self.histogram_siblings.add(sibling)
-
-    def get_parts(self) -> Tuple[ImageItem, ViewBox, HistogramLUTItem]:
-        return self.im, self.vb, self.hist
 
     def mouse_over(self, ev):
         # Ignore events triggered by leaving window or right clicking

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -2,17 +2,21 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from itertools import chain, tee
-from typing import List, Optional, Tuple
+from typing import List, Tuple, TYPE_CHECKING, Optional
 from weakref import WeakSet
 
 from pyqtgraph import ImageItem, ViewBox
 from pyqtgraph.graphicsItems.GraphicsLayout import GraphicsLayout
 from pyqtgraph.graphicsItems.HistogramLUTItem import HistogramLUTItem
-from PyQt5.QtWidgets import QAction
 
 from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint
 from mantidimaging.gui.utility.qt_helpers import BlockQtSignals
+from mantidimaging.gui.widgets.auto_colour_menu.auto_color_menu import AutoColorMenu
 from mantidimaging.gui.widgets.bad_data_overlay.bad_data_overlay import BadDataOverlay
+
+if TYPE_CHECKING:
+    import numpy as np
+    from PyQt5.QtWidgets import QAction, QWidget
 
 graveyard = []
 
@@ -26,7 +30,7 @@ def pairwise(iterable):
     return zip(a, b)
 
 
-class MIMiniImageView(GraphicsLayout, BadDataOverlay):
+class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
     def __init__(self, name: str = "MIMiniImageView"):
         super().__init__()
 
@@ -50,7 +54,17 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay):
         self.axis_siblings: "WeakSet[MIMiniImageView]" = WeakSet()
         self.histogram_siblings: "WeakSet[MIMiniImageView]" = WeakSet()
 
-        self.auto_action: Optional[QAction] = None
+    @property
+    def main_histogram(self) -> HistogramLUTItem:
+        return self.hist
+
+    @property
+    def image_data(self) -> 'np.ndarray':
+        return self.im.image
+
+    @property
+    def other_histograms(self) -> List[HistogramLUTItem]:
+        return [axis.hist for axis in self.axis_siblings]
 
     @property
     def image_item(self) -> ImageItem:
@@ -142,16 +156,5 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay):
             with BlockQtSignals(img_view.hist):
                 img_view.hist.setLevels(*hist_range)
 
-    def add_auto_color_action(self) -> QAction:
-        self.auto_action = QAction("Auto", self)
-        place = self.hist.gradient.menu.actions()[12]
-
-        self.hist.gradient.menu.insertAction(place, self.auto_action)
-        self.hist.gradient.menu.insertSeparator(self.auto_action)
-        self.set_auto_color_enabled(False)
-
-        return self.auto_action
-
-    def set_auto_color_enabled(self, enabled: bool = True):
-        if self.auto_action is not None:
-            self.auto_action.setEnabled(enabled)
+    def add_auto_color_action(self, parent: 'Optional[QWidget]', recon_mode: bool = False) -> 'QAction':
+        return self.add_auto_color_menu_action(parent, recon_mode=recon_mode, set_enabled=False)

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -34,9 +34,6 @@ def _data_valid_for_histogram(data):
 
 
 class FilterPreviews(GraphicsLayoutWidget):
-    image_before: ImageItem
-    image_after: ImageItem
-    image_diff: ImageItem
     histogram: Optional[PlotItem]
 
     def __init__(self, parent=None, **kwargs):
@@ -65,16 +62,9 @@ class FilterPreviews(GraphicsLayoutWidget):
         MIMiniImageView.set_siblings(self.all_imageviews, axis=True)
         MIMiniImageView.set_siblings([self.imageview_before, self.imageview_after], hist=True)
 
-        self.image_before, self.image_before_vb, self.image_before_hist = self.imageview_before.get_parts()
-        self.image_after, self.image_after_vb, self.image_after_hist = self.imageview_after.get_parts()
-        self.image_difference, self.image_difference_vb, self.image_difference_hist = \
-            self.imageview_difference.get_parts()
-
-        self.all_histograms = [self.image_before_hist, self.image_after_hist, self.image_difference_hist]
-
         self.image_diff_overlay = ImageItem()
         self.image_diff_overlay.setZValue(10)
-        self.image_after_vb.addItem(self.image_diff_overlay)
+        self.imageview_after.viewbox.addItem(self.image_diff_overlay)
 
         # Ensure images resize equally
         self.image_layout: GraphicsLayout = self.addLayout(colspan=3)
@@ -168,18 +158,18 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.imageview_after.enable_nonpositive_check(False)
 
     def auto_range(self):
-        # This will cause the previews to all show by just causing autorange on self.image_before_vb
-        self.image_before_vb.autoRange()
+        # This will cause the previews to all show by just causing autorange on self.imageview_before.viewbox
+        self.imageview_before.viewbox.autoRange()
 
     def record_histogram_regions(self):
-        self.before_region = self.image_before_hist.region.getRegion()
-        self.diff_region = self.image_difference_hist.region.getRegion()
-        self.after_region = self.image_after_hist.region.getRegion()
+        self.before_region = self.imageview_before.histogram.region.getRegion()
+        self.diff_region = self.imageview_difference.histogram.region.getRegion()
+        self.after_region = self.imageview_after.histogram.region.getRegion()
 
     def restore_histogram_regions(self):
-        self.image_before_hist.region.setRegion(self.before_region)
-        self.image_difference_hist.region.setRegion(self.diff_region)
-        self.image_after_hist.region.setRegion(self.after_region)
+        self.imageview_before.histogram.region.setRegion(self.before_region)
+        self.imageview_difference.histogram.region.setRegion(self.diff_region)
+        self.imageview_after.histogram.region.setRegion(self.after_region)
 
     def link_before_after_histogram_scales(self, create_link: bool):
         """
@@ -195,5 +185,5 @@ class FilterPreviews(GraphicsLayoutWidget):
         """
         Sets the y-values of the before and after histogram plots to a log scale.
         """
-        set_histogram_log_scale(self.image_before_hist)
-        set_histogram_log_scale(self.image_after_hist)
+        set_histogram_log_scale(self.imageview_before.histogram)
+        set_histogram_log_scale(self.imageview_after.histogram)

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -10,10 +10,8 @@ from PyQt5.QtCore import QPoint, QRect
 from PyQt5.QtGui import QGuiApplication, QResizeEvent
 from pyqtgraph import ColorMap, GraphicsLayoutWidget, ImageItem, LegendItem, PlotItem
 from pyqtgraph.graphicsItems.GraphicsLayout import GraphicsLayout
-from pyqtgraph.graphicsItems.HistogramLUTItem import HistogramLUTItem
 
 from mantidimaging.core.utility.histogram import set_histogram_log_scale
-from mantidimaging.gui.widgets.palette_changer.view import PaletteChangerView
 from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
 
 LOG = getLogger(__name__)
@@ -91,9 +89,9 @@ class FilterPreviews(GraphicsLayoutWidget):
         # Work around for https://github.com/mantidproject/mantidimaging/issues/565
         self.scene().contextMenu = [item for item in self.scene().contextMenu if "export" not in item.text().lower()]
 
-        self._add_auto_colour_action(self.imageview_before)
-        self._add_auto_colour_action(self.imageview_after)
-        self._add_auto_colour_action(self.imageview_difference)
+        self.imageview_before.add_auto_color_action(self)
+        self.imageview_after.add_auto_color_action(self)
+        self.imageview_difference.add_auto_color_action(self)
 
         self.imageview_before.link_sibling_axis()
 
@@ -199,22 +197,3 @@ class FilterPreviews(GraphicsLayoutWidget):
         """
         set_histogram_log_scale(self.image_before_hist)
         set_histogram_log_scale(self.image_after_hist)
-
-    def _add_auto_colour_action(self, img_view: MIMiniImageView):
-        """
-        Adds an "Auto" action to the histogram right-click menu.
-        """
-
-        action = img_view.add_auto_color_action()
-        action.triggered.connect(lambda: self._on_change_colour_palette(img_view.hist, img_view.im))
-
-    def _on_change_colour_palette(self, main_histogram: HistogramLUTItem, image: ImageItem):
-        """
-        Creates a Palette Changer window when the "Auto" option has been selected.
-        :param main_histogram: The HistogramLUTItem.
-        :param image: The ImageItem.
-        """
-        other_histograms = self.all_histograms[:]
-        other_histograms.remove(main_histogram)
-        change_colour_palette = PaletteChangerView(self, main_histogram, image.image, other_histograms)
-        change_colour_palette.show()

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -27,15 +27,11 @@ class ReconImagesView(GraphicsLayoutWidget):
         MIMiniImageView.set_siblings([self.imageview_projection, self.imageview_sinogram, self.imageview_recon],
                                      axis=True)
 
-        self.projection, self.projection_vb, self.projection_hist = self.imageview_projection.get_parts()
-        self.sinogram, self.sinogram_vb, self.sinogram_hist = self.imageview_sinogram.get_parts()
-        self.recon, self.recon_vb, self.recon_hist = self.imageview_recon.get_parts()
-
         self.slice_line = InfiniteLine(pos=1024,
                                        angle=0,
                                        bounds=[0, self.imageview_projection.image_item.width()],
                                        movable=True)
-        self.projection_vb.addItem(self.slice_line)
+        self.imageview_projection.viewbox.addItem(self.slice_line)
         self.tilt_line = InfiniteLine(pos=1024, angle=90, pen=(255, 0, 0, 255), movable=True)
 
         self.addItem(self.imageview_projection, 0, 0)
@@ -60,27 +56,27 @@ class ReconImagesView(GraphicsLayoutWidget):
     def update_projection(self, image_data: np.ndarray, preview_slice_index: int, tilt_angle: Optional[Degrees]):
         self.imageview_projection.clear()
         self.imageview_projection.setImage(image_data)
-        self.projection_hist.imageChanged(autoLevel=True, autoRange=True)
+        self.imageview_projection.histogram.imageChanged(autoLevel=True, autoRange=True)
         self.slice_line.setPos(preview_slice_index)
         if tilt_angle:
             self.set_tilt(tilt_angle, image_data.shape[1] // 2)
         else:
             self.hide_tilt()
-        set_histogram_log_scale(self.projection_hist)
+        set_histogram_log_scale(self.imageview_projection.histogram)
 
     def update_sinogram(self, image):
         self.imageview_sinogram.clear()
         self.imageview_sinogram.setImage(image)
-        self.sinogram_hist.imageChanged(autoLevel=True, autoRange=True)
-        set_histogram_log_scale(self.sinogram_hist)
+        self.imageview_sinogram.histogram.imageChanged(autoLevel=True, autoRange=True)
+        set_histogram_log_scale(self.imageview_sinogram.histogram)
 
     def update_recon(self, image_data):
         self.imageview_recon.clear()
         self.imageview_recon.setImage(image_data, autoLevels=False)
-        set_histogram_log_scale(self.recon_hist)
+        set_histogram_log_scale(self.imageview_recon.histogram)
 
     def update_recon_hist(self):
-        self.recon_hist.imageChanged(autoLevel=True, autoRange=True)
+        self.imageview_recon.histogram.imageChanged(autoLevel=True, autoRange=True)
 
     def mouse_click(self, ev, line: InfiniteLine):
         line.setPos(ev.pos())
@@ -104,7 +100,7 @@ class ReconImagesView(GraphicsLayoutWidget):
         :return:
         """
         if self.tilt_line.scene() is not None:
-            self.projection_vb.removeItem(self.tilt_line)
+            self.imageview_projection.viewbox.removeItem(self.tilt_line)
 
     def set_tilt(self, tilt: Degrees, pos: Optional[int] = None):
         if not isnan(tilt.value):  # is isnan it means there is no tilt, i.e. the line is vertical
@@ -112,7 +108,7 @@ class ReconImagesView(GraphicsLayoutWidget):
                 self.tilt_line.setAngle(90)
                 self.tilt_line.setPos(pos)
             self.tilt_line.setAngle(90 + tilt.value)
-        self.projection_vb.addItem(self.tilt_line)
+        self.imageview_projection.viewbox.addItem(self.tilt_line)
 
     def reset_recon_histogram(self):
-        self.recon_hist.autoHistogramRange()
+        self.imageview_recon.histogram.autoHistogramRange()

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -23,6 +23,9 @@ class ReconImagesView(GraphicsLayoutWidget):
         self.imageview_projection = MIMiniImageView(name="Projection")
         self.imageview_sinogram = MIMiniImageView(name="Sinogram")
         self.imageview_recon = MIMiniImageView(name="Recon")
+        # Set the three images as axis siblings so that auto colour palette changes will be applied to them all
+        MIMiniImageView.set_siblings([self.imageview_projection, self.imageview_sinogram, self.imageview_recon],
+                                     axis=True)
 
         self.projection, self.projection_vb, self.projection_hist = self.imageview_projection.get_parts()
         self.sinogram, self.sinogram_vb, self.sinogram_hist = self.imageview_sinogram.get_parts()

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -186,8 +186,7 @@ class ReconstructWindowView(BaseMainWindowView):
         self.updatePreviewButton.clicked.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_USER_CLICK))
 
         # Preparing the auto change colour map UI
-        self.auto_colour_action = self.image_view.imageview_recon.add_auto_color_action()
-        self.auto_colour_action.triggered.connect(self.on_change_colour_palette)
+        self.image_view.imageview_recon.add_auto_color_action(self, recon_mode=True)
 
         for spinbox in [self.lbhc_a0, self.lbhc_a1, self.lbhc_a2, self.lbhc_a3]:
             spinbox.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
@@ -473,7 +472,7 @@ class ReconstructWindowView(BaseMainWindowView):
 
     def on_change_colour_palette(self):
         """
-        Opens the Palette Changer window when the "Auto" option has been clicked.
+        Opens the Palette Changer window when the "Auto" button has been clicked.
         """
         self.change_colour_palette_dialog = PaletteChangerView(
             self, self.image_view.recon_hist, self.image_view.recon.image,

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -475,8 +475,8 @@ class ReconstructWindowView(BaseMainWindowView):
         Opens the Palette Changer window when the "Auto" button has been clicked.
         """
         self.change_colour_palette_dialog = PaletteChangerView(
-            self, self.image_view.recon_hist, self.image_view.recon.image,
-            [self.image_view.sinogram_hist, self.image_view.projection_hist], True)
+            self, self.image_view.imageview_recon.histogram, self.image_view.imageview_recon.image_data,
+            [self.image_view.imageview_sinogram.histogram, self.image_view.imageview_projection.histogram], True)
         self.change_colour_palette_dialog.show()
 
     def show_status_message(self, msg: str):


### PR DESCRIPTION
### Issue

Closes #1317

### Description

Moves the code for creating and connecting the auto colour right click menu option to a mixin class to avoid duplicating it in the MIImageView and MIMiniImageView classes.

For the MIMiniImageView class, I've used the `axis_siblings` to find the other histograms (for making sure colour palette changes are applied to all three images), as not all image views are added to the `histogram_siblings` in the Operations window.

### Testing & Acceptance Criteria 

1) The auto colour menu option works as expected for all relevant windows. For the Operations and Reconstruction windows, changing the value for one histogram should apply the change to all.

2) Check that the auto colour palette button in the Reconstruction window is still working as expected.

3) In the Operations window, check that the "Auto" menu option enables and disables correctly depending on if there is a difference image.


### Documentation

Issue added to release notes.
