### PR TITLE
Update CUDA check and style setting for Windows compatibility

### DIFF
--- a/mantidimaging/gui/gui.py
+++ b/mantidimaging/gui/gui.py
@@ -14,6 +14,7 @@ from mantidimaging.gui.windows.main import MainWindowView
 
 def setup_application():
     q_application = QApplication(sys.argv)
+    q_application.setStyle('Fusion')
     q_application.setApplicationName("Mantid Imaging")
     q_application.setOrganizationName("mantidproject")
     q_application.setOrganizationDomain("mantidproject.org")


### PR DESCRIPTION
### Issue

Refs #1331

### Description

Addresses steps 2 and 3 on the issue plan. Setting the application style to Fusion doesn't affect the appearance on Linux, but makes sure that the appearance on Windows is as consistent with Linux as possible.

For the CUDA check, it seemed sufficient to check if we can import cupy, and this should be more resilient to different system setups. I've wrapped the import in a function to allow it to be mocked in the unit tests.

### Testing & Acceptance Criteria 

Check that the application correctly identifies whether or not there is a CUDA installation on start-up, for both Windows and Linux.

I've been able to test on Linux and Windows machines that have CUDA, and on a Linux machine without. I have also checked that trying to import cupy on a Windows machine without CUDA throws the relevant error.

### Documentation

None required at this stage - I'm thinking the issue can be added to the release notes when more of the Windows compatibility work has been done.