### PR TITLE
Rename Images class to ImageStack

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -17,3 +17,4 @@ Developer Changes
 - #1272: Consistent test class filenames
 - #1352 : Update astra-toolbox and cudatoolkit to allow windows installation
 - #1317 : Unify auto color palette code between MIMiniImageView and MIImageView
+- #1362 : Rename Images class to ImageStack

--- a/mantidimaging/core/data/__init__.py
+++ b/mantidimaging/core/data/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-from .images import Images  # noqa: F401
+from .imagestack import ImageStack  # noqa: F401

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -11,7 +11,7 @@ from mantidimaging.core.data.reconlist import ReconList
 
 
 def _delete_stack_error_message(images_id: uuid.UUID) -> str:
-    return f"Unable to delete stack: Images with ID {images_id} not present in dataset."
+    return f"Unable to delete stack: ImageStack with ID {images_id} not present in dataset."
 
 
 class BaseDataset:
@@ -53,7 +53,7 @@ class BaseDataset:
             if image.id == images_id:
                 image.data = new_data
                 return
-        raise KeyError(f"Unable to replace: Images with ID {images_id} not present in dataset.")
+        raise KeyError(f"Unable to replace: ImageStack with ID {images_id} not present in dataset.")
 
     def __contains__(self, images_id: uuid.UUID) -> bool:
         return any([image.id == images_id for image in self.all])

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -6,7 +6,7 @@ from typing import Optional, List
 
 import numpy as np
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.reconlist import ReconList
 
 
@@ -19,7 +19,7 @@ class BaseDataset:
         self._id: uuid.UUID = uuid.uuid4()
         self.recons = ReconList()
         self._name = name
-        self._sinograms: Optional[Images] = None
+        self._sinograms: Optional[ImageStack] = None
 
     @property
     def id(self) -> uuid.UUID:
@@ -34,11 +34,11 @@ class BaseDataset:
         self._name = arg
 
     @property
-    def sinograms(self) -> Optional[Images]:
+    def sinograms(self) -> Optional[ImageStack]:
         return self._sinograms
 
     @sinograms.setter
-    def sinograms(self, sino: Optional[Images]):
+    def sinograms(self, sino: Optional[ImageStack]):
         self._sinograms = sino
 
     @property
@@ -67,12 +67,12 @@ class BaseDataset:
 
 
 class MixedDataset(BaseDataset):
-    def __init__(self, stacks: List[Images] = [], name: str = ""):
+    def __init__(self, stacks: List[ImageStack] = [], name: str = ""):
         super().__init__(name=name)
         self._stacks = stacks
 
     @property
-    def all(self) -> List[Images]:
+    def all(self) -> List[ImageStack]:
         all_images = self._stacks + self.recons.stacks
         if self.sinograms is None:
             return all_images
@@ -95,18 +95,18 @@ class MixedDataset(BaseDataset):
 
 @dataclass
 class StrictDataset(BaseDataset):
-    sample: Images
-    flat_before: Optional[Images] = None
-    flat_after: Optional[Images] = None
-    dark_before: Optional[Images] = None
-    dark_after: Optional[Images] = None
+    sample: ImageStack
+    flat_before: Optional[ImageStack] = None
+    flat_after: Optional[ImageStack] = None
+    dark_before: Optional[ImageStack] = None
+    dark_after: Optional[ImageStack] = None
 
     def __init__(self,
-                 sample: Images,
-                 flat_before: Optional[Images] = None,
-                 flat_after: Optional[Images] = None,
-                 dark_before: Optional[Images] = None,
-                 dark_after: Optional[Images] = None,
+                 sample: ImageStack,
+                 flat_before: Optional[ImageStack] = None,
+                 flat_after: Optional[ImageStack] = None,
+                 dark_before: Optional[ImageStack] = None,
+                 dark_after: Optional[ImageStack] = None,
                  name: str = ""):
         super().__init__(name=name)
         self.sample = sample
@@ -119,7 +119,7 @@ class StrictDataset(BaseDataset):
             self._name = sample.name
 
     @property
-    def all(self) -> List[Images]:
+    def all(self) -> List[ImageStack]:
         image_stacks = [
             self.sample, self.proj180deg, self.flat_before, self.flat_after, self.dark_before, self.dark_after,
             self.sinograms
@@ -134,23 +134,23 @@ class StrictDataset(BaseDataset):
             return None
 
     @proj180deg.setter
-    def proj180deg(self, _180_deg: Images):
+    def proj180deg(self, _180_deg: ImageStack):
         self.sample.proj180deg = _180_deg
 
     def delete_stack(self, images_id: uuid.UUID):
-        if isinstance(self.sample, Images) and self.sample.id == images_id:
+        if isinstance(self.sample, ImageStack) and self.sample.id == images_id:
             self.sample = None  # type: ignore
-        elif isinstance(self.flat_before, Images) and self.flat_before.id == images_id:
+        elif isinstance(self.flat_before, ImageStack) and self.flat_before.id == images_id:
             self.flat_before = None
-        elif isinstance(self.flat_after, Images) and self.flat_after.id == images_id:
+        elif isinstance(self.flat_after, ImageStack) and self.flat_after.id == images_id:
             self.flat_after = None
-        elif isinstance(self.dark_before, Images) and self.dark_before.id == images_id:
+        elif isinstance(self.dark_before, ImageStack) and self.dark_before.id == images_id:
             self.dark_before = None
-        elif isinstance(self.dark_after, Images) and self.dark_after.id == images_id:
+        elif isinstance(self.dark_after, ImageStack) and self.dark_after.id == images_id:
             self.dark_after = None
-        elif isinstance(self.proj180deg, Images) and self.proj180deg.id == images_id:
+        elif isinstance(self.proj180deg, ImageStack) and self.proj180deg.id == images_id:
             self.sample.clear_proj180deg()
-        elif isinstance(self.sinograms, Images) and self.sinograms.id == images_id:
+        elif isinstance(self.sinograms, ImageStack) and self.sinograms.id == images_id:
             self.sinograms = None
         elif images_id in self.recons.ids:
             for recon in self.recons:

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -156,7 +156,7 @@ class ImageStack:
         mark_cropped(images, roi)
         return images
 
-    def index_as_images(self, index) -> 'ImageStack':
+    def index_as_image_stack(self, index) -> 'ImageStack':
         return ImageStack(np.asarray([self.data[index]]), metadata=deepcopy(self.metadata), sinograms=self.is_sinograms)
 
     @property
@@ -244,7 +244,7 @@ class ImageStack:
         return self._data.dtype
 
     @staticmethod
-    def create_empty_images(shape, dtype, metadata):
+    def create_empty_image_stack(shape, dtype, metadata) -> 'ImageStack':
         arr = pu.create_array(shape, dtype)
         return ImageStack(arr, metadata=metadata)
 

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -18,7 +18,7 @@ from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 
 
-class Images:
+class ImageStack:
     NO_FILENAME_IMAGE_TITLE_STRING = "Image: {}"
     name: str
 
@@ -47,7 +47,7 @@ class Images:
         self.metadata: Dict[str, Any] = deepcopy(metadata) if metadata else {}
         self._is_sinograms = sinograms
 
-        self._proj180deg: Optional[Images] = None
+        self._proj180deg: Optional[ImageStack] = None
         self._log_file: Optional[IMATLogFile] = None
         self._projection_angles: Optional[ProjectionAngles] = None
 
@@ -60,7 +60,7 @@ class Images:
             self.name = name
 
     def __eq__(self, other):
-        if isinstance(other, Images):
+        if isinstance(other, ImageStack):
             return np.array_equal(self.data, other.data) \
                    and self.is_sinograms == other.is_sinograms \
                    and self.metadata == other.metadata \
@@ -128,7 +128,7 @@ class Images:
             display_name
         })
 
-    def copy(self, flip_axes=False) -> 'Images':
+    def copy(self, flip_axes=False) -> 'ImageStack':
         shape = (self.data.shape[1], self.data.shape[0], self.data.shape[2]) if flip_axes else self.data.shape
         data_copy = pu.create_array(shape, self.data.dtype)
         if flip_axes:
@@ -136,10 +136,10 @@ class Images:
         else:
             data_copy[:] = self.data[:]
 
-        images = Images(data_copy,
-                        indices=deepcopy(self.indices),
-                        metadata=deepcopy(self.metadata),
-                        sinograms=not self.is_sinograms if flip_axes else self.is_sinograms)
+        images = ImageStack(data_copy,
+                            indices=deepcopy(self.indices),
+                            metadata=deepcopy(self.metadata),
+                            sinograms=not self.is_sinograms if flip_axes else self.is_sinograms)
         return images
 
     def copy_roi(self, roi: SensibleROI):
@@ -148,16 +148,16 @@ class Images:
         data_copy = pu.create_array(shape, self.data.dtype)
         data_copy[:] = self.data[:, roi.top:roi.bottom, roi.left:roi.right]
 
-        images = Images(data_copy,
-                        indices=deepcopy(self.indices),
-                        metadata=deepcopy(self.metadata),
-                        sinograms=self._is_sinograms)
+        images = ImageStack(data_copy,
+                            indices=deepcopy(self.indices),
+                            metadata=deepcopy(self.metadata),
+                            sinograms=self._is_sinograms)
 
         mark_cropped(images, roi)
         return images
 
-    def index_as_images(self, index) -> 'Images':
-        return Images(np.asarray([self.data[index]]), metadata=deepcopy(self.metadata), sinograms=self.is_sinograms)
+    def index_as_images(self, index) -> 'ImageStack':
+        return ImageStack(np.asarray([self.data[index]]), metadata=deepcopy(self.metadata), sinograms=self.is_sinograms)
 
     @property
     def height(self):
@@ -215,12 +215,12 @@ class Images:
         return self._proj180deg is not None
 
     @property
-    def proj180deg(self) -> Optional['Images']:
+    def proj180deg(self) -> Optional['ImageStack']:
         return self._proj180deg
 
     @proj180deg.setter
-    def proj180deg(self, value: 'Images'):
-        assert isinstance(value, Images)
+    def proj180deg(self, value: 'ImageStack'):
+        assert isinstance(value, ImageStack)
         self._proj180deg = value
 
     @property
@@ -246,7 +246,7 @@ class Images:
     @staticmethod
     def create_empty_images(shape, dtype, metadata):
         arr = pu.create_array(shape, dtype)
-        return Images(arr, metadata=metadata)
+        return ImageStack(arr, metadata=metadata)
 
     @property
     def is_sinograms(self) -> bool:

--- a/mantidimaging/core/data/reconlist.py
+++ b/mantidimaging/core/data/reconlist.py
@@ -5,11 +5,11 @@ import uuid
 from collections import UserList
 from typing import List
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 
 
 class ReconList(UserList):
-    def __init__(self, data: List[Images] = []):
+    def __init__(self, data: List[ImageStack] = []):
         super().__init__(data)
         self._id: uuid.UUID = uuid.uuid4()
 
@@ -22,5 +22,5 @@ class ReconList(UserList):
         return [recon.id for recon in self.data]
 
     @property
-    def stacks(self) -> List[Images]:
+    def stacks(self) -> List[ImageStack]:
         return self.data

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -7,7 +7,7 @@ import unittest
 
 import numpy as np
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.test.fake_logfile import generate_csv_logfile, generate_txt_logfile
 from mantidimaging.core.operations.crop_coords import CropCoordinatesFilter
 from mantidimaging.core.operation_history import const
@@ -20,7 +20,7 @@ class ImagesTest(unittest.TestCase):
         json_file = io.StringIO('{"a_int": 42, "a_string": "yes", "a_arr": ["one", "two", '
                                 '"three"], "a_float": 3.65e-05, "a_bool": true}')
 
-        imgs = Images(np.asarray([1]))
+        imgs = ImageStack(np.asarray([1]))
         imgs.load_metadata(json_file)
 
         def validate_prop(k, v):
@@ -32,7 +32,7 @@ class ImagesTest(unittest.TestCase):
         validate_prop('a_arr', ['one', 'two', 'three'])
 
     def test_record_parameters_in_metadata(self):
-        imgs = Images(np.asarray([1]))
+        imgs = ImageStack(np.asarray([1]))
 
         imgs.record_operation('test_func', 'A pretty name', this=765, that=495.0, roi=(1, 2, 3, 4))
 
@@ -156,7 +156,7 @@ class ImagesTest(unittest.TestCase):
         self.assertIsNotNone(images.data)
 
     def test_create_empty_images(self):
-        images = Images.create_empty_images((15, 10, 10), np.float32, {})
+        images = ImageStack.create_empty_images((15, 10, 10), np.float32, {})
         self.assertEqual(images.data.shape, (15, 10, 10))
 
     def test_get_projection_angles_from_logfile(self):
@@ -201,8 +201,8 @@ class ImagesTest(unittest.TestCase):
 
     def test_image_eq_method(self):
         data_array = np.arange(64, dtype=float).reshape([4, 4, 4])
-        data_images = Images(data_array.copy())
-        data_images2 = Images(data_array.copy())
+        data_images = ImageStack(data_array.copy())
+        data_images2 = ImageStack(data_array.copy())
 
         self.assertEqual(data_images, data_array)
         self.assertEqual(data_images, data_images2)
@@ -217,27 +217,27 @@ class ImagesTest(unittest.TestCase):
             generate_images().id = "id"
 
     def test_default_name(self):
-        imgs = Images(np.asarray([1]))
+        imgs = ImageStack(np.asarray([1]))
         self.assertEqual(imgs.name, "untitled")
 
     def test_name_from_filenames(self):
         filenames = ["/path/tomo_0000.tiff", "/path/tomo_0001.tiff"]
-        imgs = Images(np.asarray([1]), filenames=filenames)
+        imgs = ImageStack(np.asarray([1]), filenames=filenames)
         self.assertEqual(imgs.name, "tomo_0000")
 
     def test_name_from_argument(self):
         filenames = ["/path/tomo_0000.tiff", "/path/tomo_0001.tiff"]
-        imgs = Images(np.asarray([1]), filenames=filenames, name="given")
+        imgs = ImageStack(np.asarray([1]), filenames=filenames, name="given")
         self.assertEqual(imgs.name, "given")
 
     def test_name_unique_new(self):
         existing = []
-        imgs = Images(np.asarray([1]), name="tomo")
+        imgs = ImageStack(np.asarray([1]), name="tomo")
         imgs.make_name_unique(existing)
         self.assertEqual(imgs.name, "tomo")
 
     def test_name_unique_exists(self):
         existing = ["tomo"]
-        imgs = Images(np.asarray([1]), name="tomo")
+        imgs = ImageStack(np.asarray([1]), name="tomo")
         imgs.make_name_unique(existing)
         self.assertEqual(imgs.name, "tomo_2")

--- a/mantidimaging/core/data/test/images_test.py
+++ b/mantidimaging/core/data/test/images_test.py
@@ -155,8 +155,8 @@ class ImagesTest(unittest.TestCase):
         images = generate_images((10, 100, 350))
         self.assertIsNotNone(images.data)
 
-    def test_create_empty_images(self):
-        images = ImageStack.create_empty_images((15, 10, 10), np.float32, {})
+    def test_create_empty_image_stack(self):
+        images = ImageStack.create_empty_image_stack((15, 10, 10), np.float32, {})
         self.assertEqual(images.data.shape, (15, 10, 10))
 
     def test_get_projection_angles_from_logfile(self):

--- a/mantidimaging/core/data/utility.py
+++ b/mantidimaging/core/data/utility.py
@@ -6,10 +6,10 @@ from typing import TYPE_CHECKING
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 
 if TYPE_CHECKING:
-    from mantidimaging.core.data import Images  # pragma: no cover
+    from mantidimaging.core.data import ImageStack  # pragma: no cover
 
 
-def mark_cropped(images: 'Images', roi: SensibleROI):
+def mark_cropped(images: 'ImageStack', roi: SensibleROI):
     # avoids circular import error
     from mantidimaging.core.operations.crop_coords import CropCoordinatesFilter
     # not ideal.. but it will allow to replicate the result accurately

--- a/mantidimaging/core/io/loader/img_loader.py
+++ b/mantidimaging/core/io/loader/img_loader.py
@@ -13,7 +13,7 @@ from ...data.dataset import StrictDataset
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.io.utility import get_file_names, get_prefix
 from mantidimaging.core.parallel import utility as pu
 from mantidimaging.core.utility.progress_reporting import Progress
@@ -74,16 +74,16 @@ def execute(load_func: Callable[[str], np.ndarray],
     sample_data = il.load_sample_data(chosen_input_filenames)
 
     if isinstance(sample_data, np.ndarray):
-        sample_images = Images(sample_data, chosen_input_filenames, indices)
+        sample_images = ImageStack(sample_data, chosen_input_filenames, indices)
     else:
         sample_images = sample_data
 
     return StrictDataset(
         sample_images,
-        flat_before=Images(flat_before_data, flat_before_filenames) if flat_before_data is not None else None,
-        flat_after=Images(flat_after_data, flat_after_filenames) if flat_after_data is not None else None,
-        dark_before=Images(dark_before_data, dark_before_filenames) if dark_before_data is not None else None,
-        dark_after=Images(dark_after_data, dark_after_filenames) if dark_after_data is not None else None)
+        flat_before=ImageStack(flat_before_data, flat_before_filenames) if flat_before_data is not None else None,
+        flat_after=ImageStack(flat_after_data, flat_after_filenames) if flat_after_data is not None else None,
+        dark_before=ImageStack(dark_before_data, dark_before_filenames) if dark_before_data is not None else None,
+        dark_after=ImageStack(dark_after_data, dark_after_filenames) if dark_after_data is not None else None)
 
 
 class ImageLoader(object):
@@ -101,7 +101,7 @@ class ImageLoader(object):
         self.indices = indices
         self.progress = progress
 
-    def load_sample_data(self, input_file_names: List[str]) -> Union[np.ndarray, Images]:
+    def load_sample_data(self, input_file_names: List[str]) -> Union[np.ndarray, ImageStack]:
         # determine what the loaded data was
         if len(self.img_shape) == 2:
             # the loaded file was a single image

--- a/mantidimaging/core/io/loader/img_loader.py
+++ b/mantidimaging/core/io/loader/img_loader.py
@@ -46,7 +46,7 @@ def execute(load_func: Callable[[str], np.ndarray],
         '>f2' - float16
         '>f4' - float32
 
-    :returns: Images object
+    :returns: StrictDataset object
     """
 
     if not sample_path:

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -13,7 +13,7 @@ from mantidimaging.core.data.dataset import StrictDataset
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.io.loader import img_loader
 from mantidimaging.core.io.utility import (DEFAULT_IO_FILE_FORMAT, get_file_names, get_prefix, get_file_extension,
                                            find_images, find_first_file_that_is_possibly_a_sample, find_log,
@@ -113,7 +113,7 @@ def load_log(log_file: str) -> IMATLogFile:
         return IMATLogFile(f.readlines(), log_file)
 
 
-def load_p(parameters: ImageParameters, dtype: 'npt.DTypeLike', progress: Progress) -> Images:
+def load_p(parameters: ImageParameters, dtype: 'npt.DTypeLike', progress: Progress) -> ImageStack:
     return load(input_path=parameters.input_path,
                 in_prefix=parameters.prefix,
                 in_format=parameters.format,
@@ -122,7 +122,7 @@ def load_p(parameters: ImageParameters, dtype: 'npt.DTypeLike', progress: Progre
                 progress=progress).sample
 
 
-def load_stack(file_path: str, progress: Optional[Progress] = None) -> Images:
+def load_stack(file_path: str, progress: Optional[Progress] = None) -> ImageStack:
     image_format = get_file_extension(file_path)
     prefix = get_prefix(file_path)
     file_names = get_file_names(path=os.path.dirname(file_path), img_format=image_format, prefix=prefix)  # type: ignore

--- a/mantidimaging/core/io/loader/stack_loader.py
+++ b/mantidimaging/core/io/loader/stack_loader.py
@@ -6,7 +6,7 @@ import numpy as np
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.parallel import utility as pu
 from mantidimaging.core.utility.data_containers import Indices
 from mantidimaging.core.utility.progress_reporting import Progress
@@ -40,7 +40,7 @@ def execute(load_func: Callable[[str], np.ndarray],
             dtype: 'npt.DTypeLike',
             name: str,
             indices: Union[List[int], Indices, None] = None,
-            progress: Optional[Progress] = None) -> Images:
+            progress: Optional[Progress] = None) -> ImageStack:
     """
     Load a single image FILE that is expected to be a stack of images.
 
@@ -73,4 +73,4 @@ def execute(load_func: Callable[[str], np.ndarray],
 
     # Nexus doesn't load flat/dark images yet, if the functionality is
     # requested it should be changed here
-    return Images(data, [file_name])
+    return ImageStack(data, [file_name])

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -8,7 +8,7 @@ from typing import List, Union, Optional, Dict, Callable
 import numpy as np
 
 from .utility import DEFAULT_IO_FILE_FORMAT
-from ..data.images import Images
+from ..data.imagestack import ImageStack
 from ..operations.rescale import RescaleFilter
 from ..utility.data_containers import Indices
 from ..utility.progress_reporting import Progress
@@ -53,7 +53,7 @@ def write_nxs(data: np.ndarray, filename: str, projection_angles: Optional[np.nd
         rangle[...] = projection_angles
 
 
-def save(images: Images,
+def save(images: ImageStack,
          output_dir: str,
          name_prefix: str = DEFAULT_NAME_PREFIX,
          swap_axes: bool = False,

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -7,7 +7,7 @@ import unittest
 import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.io import loader
 from mantidimaging.core.io import saver
 from mantidimaging.helper import initialise_logging
@@ -205,7 +205,7 @@ class IOTest(FileOutputtingTestCase):
     def test_metadata_round_trip(self):
         # Create dummy image stack
         sample = th.gen_img_numpy_rand()
-        images = Images(sample)
+        images = ImageStack(sample)
         images.metadata['message'] = 'hello, world!'
 
         # Save image stack

--- a/mantidimaging/core/operations/arithmetic/arithmetic.py
+++ b/mantidimaging/core/operations/arithmetic/arithmetic.py
@@ -47,14 +47,14 @@ class ArithmeticFilter(BaseFilter):
                     progress=None) -> ImageStack:
         """
         Apply arithmetic operations to the pixels.
-        :param images: The Images object.
+        :param images: The ImageStack object.
         :param mult_val: The multiplication value.
         :param div_val: The division value.
         :param add_val: The addition value.
         :param sub_val: The subtraction value.
         :param cores: The number of cores that will be used to process the data.
         :param progress: The Progress object isn't used.
-        :return: The processed Images object.
+        :return: The processed ImageStack object.
         """
         if div_val == 0 or mult_val == 0:
             raise ValueError("Unable to proceed with operation because division/multiplication value is zero.")

--- a/mantidimaging/core/operations/arithmetic/arithmetic.py
+++ b/mantidimaging/core/operations/arithmetic/arithmetic.py
@@ -9,7 +9,7 @@ from PyQt5.QtWidgets import QFormLayout, QWidget, QDoubleSpinBox
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.utility.qt_helpers import add_property_to_form, MAX_SPIN_BOX, Type
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.parallel import shared as ps
 
@@ -38,13 +38,13 @@ class ArithmeticFilter(BaseFilter):
     filter_name = "Arithmetic"
 
     @staticmethod
-    def filter_func(images: Images,
+    def filter_func(images: ImageStack,
                     div_val: float = 1.0,
                     mult_val: float = 1.0,
                     add_val: float = 0.0,
                     sub_val: float = 0.0,
                     cores: Optional[int] = None,
-                    progress=None) -> Images:
+                    progress=None) -> ImageStack:
         """
         Apply arithmetic operations to the pixels.
         :param images: The Images object.

--- a/mantidimaging/core/operations/base_filter.py
+++ b/mantidimaging/core/operations/base_filter.py
@@ -7,7 +7,7 @@ from enum import Enum, auto
 
 import numpy as np
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 
 if TYPE_CHECKING:
     from PyQt5.QtWidgets import QFormLayout, QWidget  # noqa: F401   # pragma: no cover
@@ -33,7 +33,7 @@ class BaseFilter:
     which are optional.
     """
     @staticmethod
-    def filter_func(data: Images) -> Images:
+    def filter_func(data: ImageStack) -> ImageStack:
         """
         Executes the filter algorithm on a given set of image data with the given parameters.
 
@@ -42,7 +42,7 @@ class BaseFilter:
         :return: the image data after applying the filter
         """
         raise_not_implemented("filter_func")
-        return Images(np.asarray([]))
+        return ImageStack(np.asarray([]))
 
     @staticmethod
     def execute_wrapper(args) -> partial:  # type: ignore
@@ -88,7 +88,7 @@ class BaseFilter:
         return FilterGroup.NoGroup
 
     @staticmethod
-    def get_images_from_stack(widget: "DatasetSelectorWidgetView", msg: str) -> Optional[Images]:
+    def get_images_from_stack(widget: "DatasetSelectorWidgetView", msg: str) -> Optional[ImageStack]:
         stack_uuid = widget.current()
         if stack_uuid is None:
             raise ValueError(f"No stack for {msg}")

--- a/mantidimaging/core/operations/circular_mask/circular_mask.py
+++ b/mantidimaging/core/operations/circular_mask/circular_mask.py
@@ -3,7 +3,7 @@
 
 from functools import partial
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.tools import importer
 from mantidimaging.core.utility.progress_reporting import Progress
@@ -24,11 +24,11 @@ class CircularMaskFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(data: Images,
+    def filter_func(data: ImageStack,
                     circular_mask_ratio=0.95,
                     circular_mask_value=0.,
                     cores=None,
-                    progress=None) -> Images:
+                    progress=None) -> ImageStack:
         """
         :param data: Input data as a 3D numpy.ndarray
         :param circular_mask_ratio: The ratio to the full image.

--- a/mantidimaging/core/operations/clip_values/clip_values.py
+++ b/mantidimaging/core/operations/clip_values/clip_values.py
@@ -3,7 +3,7 @@
 
 from functools import partial
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.utility.progress_reporting import Progress
 
@@ -27,7 +27,7 @@ class ClipValuesFilter(BaseFilter):
                     clip_max=None,
                     clip_min_new_value=None,
                     clip_max_new_value=None,
-                    progress=None) -> Images:
+                    progress=None) -> ImageStack:
         """Clip values below the min and above the max pixels.
 
         :param data: Input data as a 3D numpy.ndarray.

--- a/mantidimaging/core/operations/crop_coords/crop_coords.py
+++ b/mantidimaging/core/operations/crop_coords/crop_coords.py
@@ -7,7 +7,7 @@ from typing import Union, Optional, List
 from PyQt5.QtWidgets import QLineEdit
 
 from mantidimaging import helper as h
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
 from mantidimaging.core.parallel import utility as pu
 from mantidimaging.core.utility.progress_reporting import Progress
@@ -30,9 +30,9 @@ class CropCoordinatesFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images: Images,
+    def filter_func(images: ImageStack,
                     region_of_interest: Optional[Union[List[int], List[float], SensibleROI]] = None,
-                    progress=None) -> Images:
+                    progress=None) -> ImageStack:
         """Execute the Crop Coordinates by Region of Interest filter. This does
         NOT do any checks if the Region of interest is out of bounds!
 

--- a/mantidimaging/core/operations/divide/divide.py
+++ b/mantidimaging/core/operations/divide/divide.py
@@ -7,7 +7,7 @@ from typing import Union, Callable, Dict, Any
 from PyQt5.QtWidgets import QFormLayout, QDoubleSpinBox, QComboBox
 
 from mantidimaging import helper as h
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.utility.qt_helpers import Type
@@ -27,7 +27,7 @@ class DivideFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images: Images, value: Union[int, float] = 0, unit="micron", progress=None) -> Images:
+    def filter_func(images: ImageStack, value: Union[int, float] = 0, unit="micron", progress=None) -> ImageStack:
         h.check_data_stack(images)
         if not value:
             raise ValueError('value parameter must not equal 0 or None')

--- a/mantidimaging/core/operations/divide/test/divide_test.py
+++ b/mantidimaging/core/operations/divide/test/divide_test.py
@@ -7,7 +7,7 @@ from unittest import mock
 import numpy as np
 
 import mantidimaging.test_helpers.unit_test_helper as th
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.divide import DivideFilter
 
 
@@ -26,7 +26,7 @@ class DivideTest(unittest.TestCase):
 
         th.assert_not_equals(result.data, copy)
 
-    def do_divide(self, images: Images, value: float) -> Images:
+    def do_divide(self, images: ImageStack, value: float) -> ImageStack:
         return DivideFilter.filter_func(images, value)
 
     def test_execute_wrapper_return_is_runnable(self):

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import QComboBox, QCheckBox
 import numpy as np
 
 from mantidimaging import helper as h
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
 from mantidimaging.core.parallel import utility as pu, shared as ps
 from mantidimaging.core.utility.progress_reporting import Progress
@@ -63,16 +63,16 @@ class FlatFieldFilter(BaseFilter):
     filter_name = 'Flat-fielding'
 
     @staticmethod
-    def filter_func(images: Images,
-                    flat_before: Images = None,
-                    flat_after: Images = None,
-                    dark_before: Images = None,
-                    dark_after: Images = None,
+    def filter_func(images: ImageStack,
+                    flat_before: ImageStack = None,
+                    flat_after: ImageStack = None,
+                    dark_before: ImageStack = None,
+                    dark_after: ImageStack = None,
                     selected_flat_fielding: str = None,
                     use_dark: bool = True,
                     cores=None,
                     chunksize=None,
-                    progress=None) -> Images:
+                    progress=None) -> ImageStack:
         """Do background correction with flat and dark images.
 
         :param images: Sample data which is to be processed. Expected in radiograms

--- a/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
+++ b/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
@@ -11,7 +11,7 @@ import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.flat_fielding.flat_fielding import enable_correct_fields_only
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.flat_fielding import FlatFieldFilter
 
 
@@ -21,7 +21,7 @@ class FlatFieldingTest(unittest.TestCase):
 
     Tests return value and in-place modified data.
     """
-    def _make_images(self) -> Tuple[Images, Images, Images, Images, Images]:
+    def _make_images(self) -> Tuple[ImageStack, ImageStack, ImageStack, ImageStack, ImageStack]:
         images = th.generate_images()
         flat_before = th.generate_images()
         dark_before = th.generate_images()

--- a/mantidimaging/core/operations/gaussian/gaussian.py
+++ b/mantidimaging/core/operations/gaussian/gaussian.py
@@ -8,7 +8,7 @@ import numpy as np
 import scipy.ndimage as scipy_ndimage
 
 from mantidimaging import helper as h
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.core.utility.progress_reporting import Progress
@@ -27,7 +27,7 @@ class GaussianFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(data: Images, size=None, mode=None, order=None, cores=None, chunksize=None, progress=None):
+    def filter_func(data: ImageStack, size=None, mode=None, order=None, cores=None, chunksize=None, progress=None):
         """
         :param data: Input data as a 3D numpy.ndarray
         :param size: Size of the kernel

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -11,7 +11,7 @@ from PyQt5.QtGui import QValidator
 from PyQt5.QtWidgets import QSpinBox, QLabel, QSizePolicy
 
 from mantidimaging import helper as h
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.gpu import utility as gpu
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.parallel import shared as ps
@@ -67,7 +67,13 @@ class MedianFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(data: Images, size=None, mode="reflect", cores=None, chunksize=None, progress=None, force_cpu=True):
+    def filter_func(data: ImageStack,
+                    size=None,
+                    mode="reflect",
+                    cores=None,
+                    chunksize=None,
+                    progress=None,
+                    force_cpu=True):
         """
         :param data: Input data as an Images object.
         :param size: Size of the kernel
@@ -171,4 +177,4 @@ def _execute_gpu(data, size, mode, progress=None):
 
         data = cuda.median_filter(data, size, mode, progress)
 
-    return Images(data)
+    return ImageStack(data)

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -75,7 +75,7 @@ class MedianFilter(BaseFilter):
                     progress=None,
                     force_cpu=True):
         """
-        :param data: Input data as an Images object.
+        :param data: Input data as an ImageStack object.
         :param size: Size of the kernel
         :param mode: The mode with which to handle the edges.
                      One of [reflect, constant, nearest, mirror, wrap].

--- a/mantidimaging/core/operations/median_filter/test/median_filter_test.py
+++ b/mantidimaging/core/operations/median_filter/test/median_filter_test.py
@@ -9,7 +9,7 @@ import numpy as np
 import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
-from mantidimaging.core.data.images import Images
+from mantidimaging.core.data.imagestack import ImageStack
 from mantidimaging.core.gpu import utility as gpu
 from mantidimaging.core.operations.median_filter import MedianFilter
 
@@ -59,7 +59,7 @@ class MedianTest(unittest.TestCase):
     def test_executed_par(self):
         self.do_execute(th.generate_images_for_parallel())
 
-    def do_execute(self, images: Images):
+    def do_execute(self, images: ImageStack):
         size = 3
         mode = 'reflect'
 

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -6,7 +6,7 @@ from typing import Callable, Dict, Any
 import numpy as np
 from PyQt5.QtWidgets import QFormLayout, QWidget
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.gui.mvp_base import BaseMainWindowView
@@ -29,7 +29,7 @@ class MonitorNormalisation(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images: Images, cores=None, chunksize=None, progress=None) -> Images:
+    def filter_func(images: ImageStack, cores=None, chunksize=None, progress=None) -> ImageStack:
         if images.num_projections == 1:
             # we can't really compute the preview as the image stack copy
             # passed in doesn't have the logfile in it

--- a/mantidimaging/core/operations/nan_removal/nan_removal.py
+++ b/mantidimaging/core/operations/nan_removal/nan_removal.py
@@ -52,7 +52,7 @@ class NaNRemovalFilter(BaseFilter):
         :param cores: The number of cores that will be used to process the data.
         :param chunksize: The number of chunks that each worker will receive.
         :param progress: The optional Progress object.
-        :return: The Images object with the NaNs replaced.
+        :return: The ImageStack object with the NaNs replaced.
         """
 
         sample = data.data

--- a/mantidimaging/core/operations/nan_removal/nan_removal.py
+++ b/mantidimaging/core/operations/nan_removal/nan_removal.py
@@ -10,7 +10,7 @@ import numpy as np
 from PyQt5.QtWidgets import QFormLayout, QWidget
 import scipy.ndimage as scipy_ndimage
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.core.utility.progress_reporting import Progress
@@ -44,7 +44,7 @@ class NaNRemovalFilter(BaseFilter):
                     mode_value="Constant",
                     cores=None,
                     chunksize=None,
-                    progress=None) -> Images:
+                    progress=None) -> ImageStack:
         """
         :param data: The input data.
         :param mode_value: Values to replace NaNs with. One of ["Constant", "Median"]

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -6,7 +6,7 @@ from functools import partial
 import numpy as np
 import scipy.ndimage as scipy_ndimage
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.core.utility.progress_reporting import Progress
@@ -44,7 +44,7 @@ class OutliersFilter(BaseFilter):
             return np.where((median - data) > diff, median, data)
 
     @staticmethod
-    def filter_func(images: Images,
+    def filter_func(images: ImageStack,
                     diff=None,
                     radius=_default_radius,
                     mode=_default_mode,

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -5,7 +5,7 @@ from functools import partial
 import skimage.transform
 
 from mantidimaging import helper as h
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.core.parallel import utility as pu
@@ -27,7 +27,12 @@ class RebinFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images: Images, rebin_param=0.5, mode=None, cores=None, chunksize=None, progress=None) -> Images:
+    def filter_func(images: ImageStack,
+                    rebin_param=0.5,
+                    mode=None,
+                    cores=None,
+                    chunksize=None,
+                    progress=None) -> ImageStack:
         """
         :param images: Sample data which is to be processed. Expects radiograms
         :param rebin_param: int, float or tuple

--- a/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
+++ b/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial
-from mantidimaging.core.data.images import Images
+from mantidimaging.core.data.imagestack import ImageStack
 
 from PyQt5.QtWidgets import QSpinBox, QDoubleSpinBox
 from algotom.prep.removal import remove_all_stripe
@@ -30,7 +30,14 @@ class RemoveAllStripesFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images: Images, snr=3, la_size=61, sm_size=21, dim=1, cores=None, chunksize=None, progress=None):
+    def filter_func(images: ImageStack,
+                    snr=3,
+                    la_size=61,
+                    sm_size=21,
+                    dim=1,
+                    cores=None,
+                    chunksize=None,
+                    progress=None):
         f = ps.create_partial(remove_all_stripe, ps.return_to_self, snr=snr, la_size=la_size, sm_size=sm_size, dim=dim)
         ps.shared_list = [images.data]
         ps.execute(f, images.data.shape[0], progress, cores=cores)

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial
-from mantidimaging.core.data.images import Images
+from mantidimaging.core.data.imagestack import ImageStack
 
 from PyQt5.QtWidgets import QDoubleSpinBox, QSpinBox
 from algotom.prep.removal import remove_dead_stripe
@@ -30,7 +30,7 @@ class RemoveDeadStripesFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images: Images, snr=3, size=61, cores=None, chunksize=None, progress=None):
+    def filter_func(images: ImageStack, snr=3, size=61, cores=None, chunksize=None, progress=None):
         f = ps.create_partial(remove_dead_stripe, ps.return_to_self, snr=snr, size=size, residual=False)
         ps.shared_list = [images.data]
         ps.execute(f, images.data.shape[0], progress, cores=cores)

--- a/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial
-from mantidimaging.core.data.images import Images
+from mantidimaging.core.data.imagestack import ImageStack
 
 from PyQt5.QtWidgets import QSpinBox
 from algotom.prep.removal import remove_stripe_based_filtering, remove_stripe_based_2d_filtering_sorting
@@ -30,7 +30,7 @@ class RemoveStripeFilteringFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images: Images,
+    def filter_func(images: ImageStack,
                     sigma=3,
                     size=21,
                     window_dim=1,

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial
-from mantidimaging.core.data.images import Images
+from mantidimaging.core.data.imagestack import ImageStack
 
 from PyQt5.QtWidgets import QSpinBox
 from algotom.prep.removal import remove_stripe_based_fitting
@@ -30,7 +30,7 @@ class RemoveStripeSortingFittingFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images: Images, order=1, sigma=3, cores=None, chunksize=None, progress=None):
+    def filter_func(images: ImageStack, order=1, sigma=3, cores=None, chunksize=None, progress=None):
         f = ps.create_partial(remove_stripe_based_fitting, ps.return_to_self, order=order, sigma=sigma, sort=True)
 
         ps.shared_list = [images.data]

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -8,7 +8,7 @@ import numpy as np
 from numpy import float32, nanmax, nanmin, ndarray, uint16
 from PyQt5.QtWidgets import QComboBox, QDoubleSpinBox
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.gui.utility.qt_helpers import Type
 from mantidimaging.gui.windows.operations import FiltersWindowView
@@ -24,12 +24,12 @@ class RescaleFilter(BaseFilter):
     filter_name = 'Rescale'
 
     @staticmethod
-    def filter_func(images: Images,
+    def filter_func(images: ImageStack,
                     min_input: float = 0.0,
                     max_input: float = 10000.0,
                     max_output: float = 256.0,
                     progress=None,
-                    data_type=None) -> Images:
+                    data_type=None) -> ImageStack:
         np.clip(images.data, min_input, max_input, out=images.data)
         # offset - it removes any negative values so that they don't overflow when in uint16 range
         images.data -= nanmin(images.data)

--- a/mantidimaging/core/operations/ring_removal/ring_removal.py
+++ b/mantidimaging/core/operations/ring_removal/ring_removal.py
@@ -6,7 +6,7 @@ from functools import partial
 from PyQt5.QtWidgets import QComboBox
 
 from mantidimaging import helper as h
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.utility.optional_imports import safe_import
 from mantidimaging.core.utility.progress_reporting import Progress
@@ -26,7 +26,7 @@ class RingRemovalFilter(BaseFilter):
     show_negative_overlay = False
 
     @staticmethod
-    def filter_func(images: Images,
+    def filter_func(images: ImageStack,
                     center_mode="image center",
                     center_x=None,
                     center_y=None,

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 import numpy as np
 
 from mantidimaging import helper as h
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.core.parallel import utility as pu
@@ -39,10 +39,10 @@ class RoiNormalisationFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images: Images,
+    def filter_func(images: ImageStack,
                     region_of_interest: SensibleROI = None,
                     normalisation_mode: str = modes()[0],
-                    flat_field: Optional[Images] = None,
+                    flat_field: Optional[ImageStack] = None,
                     cores=None,
                     chunksize=None,
                     progress=None):

--- a/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
@@ -8,7 +8,7 @@ import numpy as np
 import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
-from mantidimaging.core.data.images import Images
+from mantidimaging.core.data.imagestack import ImageStack
 from mantidimaging.core.operations.roi_normalisation import RoiNormalisationFilter
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 
@@ -37,7 +37,7 @@ class ROINormalisationTest(unittest.TestCase):
     def test_executed_seq(self):
         self.do_execute(th.generate_images(seed=2021))
 
-    def do_execute(self, images: Images):
+    def do_execute(self, images: ImageStack):
         original = np.copy(images.data[0])
 
         air = SensibleROI.from_list([3, 3, 4, 4])

--- a/mantidimaging/core/operations/rotate_stack/rotate_stack.py
+++ b/mantidimaging/core/operations/rotate_stack/rotate_stack.py
@@ -7,7 +7,7 @@ import numpy as np
 from skimage.transform import rotate
 
 from mantidimaging import helper as h
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.core.utility.progress_reporting import Progress
@@ -29,7 +29,7 @@ class RotateFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(data: Images, angle=None, dark=None, cores=None, chunksize=None, progress=None):
+    def filter_func(data: ImageStack, angle=None, dark=None, cores=None, chunksize=None, progress=None):
         """
         Rotates images by an arbitrary degree.
 

--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -10,7 +10,7 @@ import astra
 import numpy as np
 from scipy.optimize import minimize
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.reconstruct.base_recon import BaseRecon
 from mantidimaging.core.utility.cuda_check import CudaChecker
 from mantidimaging.core.utility.data_containers import ScalarCoR, ProjectionAngles, ReconstructionParameters
@@ -82,7 +82,7 @@ class AstraRecon(BaseRecon):
         return num_gpus
 
     @staticmethod
-    def find_cor(images: Images, slice_idx: int, start_cor: float, recon_params: ReconstructionParameters) -> float:
+    def find_cor(images: ImageStack, slice_idx: int, start_cor: float, recon_params: ReconstructionParameters) -> float:
         """
         Find the best CoR for this slice by maximising the squared sum of the reconstructed slice.
 
@@ -124,13 +124,13 @@ class AstraRecon(BaseRecon):
                 return astra.data2d.get(rec_id)
 
     @staticmethod
-    def full(images: Images,
+    def full(images: ImageStack,
              cors: List[ScalarCoR],
              recon_params: ReconstructionParameters,
-             progress: Optional[Progress] = None) -> Images:
+             progress: Optional[Progress] = None) -> ImageStack:
         progress = Progress.ensure_instance(progress, num_steps=images.height)
         output_shape = (images.num_sinograms, images.width, images.width)
-        output_images: Images = Images.create_empty_images(output_shape, images.dtype, images.metadata)
+        output_images: ImageStack = ImageStack.create_empty_images(output_shape, images.dtype, images.metadata)
         output_images.record_operation('AstraRecon.full', 'Volume Reconstruction', **recon_params.to_dict())
 
         proj_angles = images.projection_angles(recon_params.max_projection_angle)

--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -130,7 +130,7 @@ class AstraRecon(BaseRecon):
              progress: Optional[Progress] = None) -> ImageStack:
         progress = Progress.ensure_instance(progress, num_steps=images.height)
         output_shape = (images.num_sinograms, images.width, images.width)
-        output_images: ImageStack = ImageStack.create_empty_images(output_shape, images.dtype, images.metadata)
+        output_images: ImageStack = ImageStack.create_empty_image_stack(output_shape, images.dtype, images.metadata)
         output_images.record_operation('AstraRecon.full', 'Volume Reconstruction', **recon_params.to_dict())
 
         proj_angles = images.projection_angles(recon_params.max_projection_angle)

--- a/mantidimaging/core/reconstruct/base_recon.py
+++ b/mantidimaging/core/reconstruct/base_recon.py
@@ -6,14 +6,14 @@ from typing import List, Optional
 import numpy as np
 from numpy.polynomial import Polynomial
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.utility.data_containers import ScalarCoR, ProjectionAngles, ReconstructionParameters
 from mantidimaging.core.utility.progress_reporting import Progress
 
 
 class BaseRecon:
     @staticmethod
-    def find_cor(images: Images, slice_idx: int, start_cor: float, recon_params: ReconstructionParameters) -> float:
+    def find_cor(images: ImageStack, slice_idx: int, start_cor: float, recon_params: ReconstructionParameters) -> float:
         raise NotImplementedError("Base class call")
 
     @staticmethod
@@ -50,10 +50,10 @@ class BaseRecon:
         raise NotImplementedError("Base class call")
 
     @staticmethod
-    def full(images: Images,
+    def full(images: ImageStack,
              cors: List[ScalarCoR],
              recon_params: ReconstructionParameters,
-             progress: Optional[Progress] = None) -> Images:
+             progress: Optional[Progress] = None) -> ImageStack:
         """
         Performs a volume reconstruction using sample data provided as sinograms.
 

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -17,7 +17,7 @@ from cil.optimisation.functions import MixedL21Norm, L2NormSquared, BlockFunctio
 # CIL ASTRA plugin
 from cil.plugins.astra.operators import ProjectionOperator
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.reconstruct.base_recon import BaseRecon
 from mantidimaging.core.utility.data_containers import ProjectionAngles, ReconstructionParameters, ScalarCoR
 from mantidimaging.core.utility.optional_imports import safe_import
@@ -55,7 +55,7 @@ class CILRecon(BaseRecon):
         return (K, f1, f2, G)
 
     @staticmethod
-    def find_cor(images: Images, slice_idx: int, start_cor: float, recon_params: ReconstructionParameters) -> float:
+    def find_cor(images: ImageStack, slice_idx: int, start_cor: float, recon_params: ReconstructionParameters) -> float:
         return tomopy.find_center(images.sinograms,
                                   images.projection_angles(recon_params.max_projection_angle).value,
                                   ind=slice_idx,
@@ -126,7 +126,7 @@ class CILRecon(BaseRecon):
             return pdhg.solution.as_array()
 
     @staticmethod
-    def full(images: Images,
+    def full(images: ImageStack,
              cors: List[ScalarCoR],
              recon_params: ReconstructionParameters,
              progress: Optional[Progress] = None):
@@ -214,7 +214,7 @@ class CILRecon(BaseRecon):
                     pdhg.next()
                 volume = pdhg.solution.as_array()
                 LOG.info('Reconstructed 3D volume with shape: {0}'.format(volume.shape))
-            return Images(volume)
+            return ImageStack(volume)
 
 
 def allowed_recon_kwargs() -> dict:

--- a/mantidimaging/core/reconstruct/tomopy_recon.py
+++ b/mantidimaging/core/reconstruct/tomopy_recon.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 import numpy as np
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.reconstruct.base_recon import BaseRecon
 from mantidimaging.core.utility.data_containers import ProjectionAngles, ReconstructionParameters, ScalarCoR
 from mantidimaging.core.utility.optional_imports import safe_import
@@ -18,7 +18,7 @@ tomopy = safe_import('tomopy')
 
 class TomopyRecon(BaseRecon):
     @staticmethod
-    def find_cor(images: Images, slice_idx: int, start_cor: float, recon_params: ReconstructionParameters) -> float:
+    def find_cor(images: ImageStack, slice_idx: int, start_cor: float, recon_params: ReconstructionParameters) -> float:
         return tomopy.find_center(images.sinograms,
                                   images.projection_angles(recon_params.max_projection_angle).value,
                                   ind=slice_idx,
@@ -42,7 +42,7 @@ class TomopyRecon(BaseRecon):
         return volume[0]
 
     @staticmethod
-    def full(images: Images,
+    def full(images: ImageStack,
              cors: List[ScalarCoR],
              recon_params: ReconstructionParameters,
              progress: Optional[Progress] = None):
@@ -75,7 +75,7 @@ class TomopyRecon(BaseRecon):
             volume = tomopy.recon(**kwargs)
             LOG.info('Reconstructed 3D volume with shape: {0}'.format(volume.shape))
 
-        return Images(volume)
+        return ImageStack(volume)
 
     @staticmethod
     def allowed_filters() -> List[str]:

--- a/mantidimaging/core/rotation/polyfit_correlation.py
+++ b/mantidimaging/core/rotation/polyfit_correlation.py
@@ -6,7 +6,7 @@ from typing import Tuple
 
 import numpy as np
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.parallel import utility as pu, shared as ps
 from mantidimaging.core.utility.data_containers import Degrees, ScalarCoR
 from mantidimaging.core.utility.progress_reporting import Progress
@@ -22,7 +22,7 @@ def do_calculate_correlation_err(store: np.ndarray, search_index: int, p0_and_18
     store[:] = np.square(np.roll(p0_and_180[0], search_index, axis=1) - p0_and_180[1]).sum(axis=1) / image_width
 
 
-def find_center(images: Images, progress: Progress) -> Tuple[ScalarCoR, Degrees]:
+def find_center(images: ImageStack, progress: Progress) -> Tuple[ScalarCoR, Degrees]:
     # assume the ROI is the full image, i.e. the slices are ALL rows of the image
     slices = np.arange(images.height)
     shift = pu.create_array((images.height, ))
@@ -66,7 +66,7 @@ def _calculate_correlation_error(images, shared_search_range, min_correlation_er
                msg="Finding correlation on row")
 
 
-def _find_shift(images: Images, search_range: range, min_correlation_error: np.ndarray, shift: np.ndarray):
+def _find_shift(images: ImageStack, search_range: range, min_correlation_error: np.ndarray, shift: np.ndarray):
     min_correlation_error = np.transpose(min_correlation_error)
     for row in range(images.height):
         # then we just find the index of the minimum one (minimum error)

--- a/mantidimaging/core/rotation/test/polyfit_correlation_test.py
+++ b/mantidimaging/core/rotation/test/polyfit_correlation_test.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from mantidimaging.test_helpers.unit_test_helper import generate_images, assert_not_equals
 from ..polyfit_correlation import do_calculate_correlation_err, get_search_range, find_center, _find_shift
-from ...data import Images
+from ...data import ImageStack
 from ...utility.progress_reporting import Progress
 
 
@@ -32,7 +32,7 @@ def test_do_search():
 def test_find_center():
     images = generate_images((10, 10, 10))
     images.data[0] = np.identity(10)
-    images.proj180deg = Images(np.fliplr(images.data))
+    images.proj180deg = ImageStack(np.fliplr(images.data))
     mock_progress = mock.create_autospec(Progress)
     res_cor, res_tilt = find_center(images, mock_progress)
     assert mock_progress.update.call_count == 11

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -12,7 +12,7 @@ from PyQt5.QtGui import QFont
 from PyQt5.QtWidgets import QMainWindow, QMenu, QWidget, QApplication
 from applitools.common import MatchLevel
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.io.loader import loader
 from mantidimaging.eyes_tests.eyes_manager import EyesManager
 from mantidimaging.test_helpers.start_qapplication import start_qapplication
@@ -100,7 +100,7 @@ class BaseEyesTest(unittest.TestCase):
         self.imaging.presenter.create_strict_dataset_tree_view_items(dataset)
 
         if set_180:
-            dataset.sample.proj180deg = _180_proj = Images(dataset.sample.data[0:1])
+            dataset.sample.proj180deg = _180_proj = ImageStack(dataset.sample.data[0:1])
             self.imaging.presenter.create_single_tabbed_images_stack(_180_proj)
 
         self.imaging.presenter.model.add_dataset_to_model(dataset)

--- a/mantidimaging/gui/dialogs/cor_inspection/model.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/model.py
@@ -4,7 +4,7 @@ from dataclasses import replace
 from logging import getLogger
 from typing import Union
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.reconstruct import get_reconstructor_for
 from mantidimaging.core.utility.data_containers import ScalarCoR, ReconstructionParameters
 from .types import ImageType
@@ -16,8 +16,8 @@ INIT_ITERS_STEP = 50
 
 
 class CORInspectionDialogModel(object):
-    def __init__(self, images: Images, slice_idx: int, initial_cor: ScalarCoR, recon_params: ReconstructionParameters,
-                 iters_mode: bool):
+    def __init__(self, images: ImageStack, slice_idx: int, initial_cor: ScalarCoR,
+                 recon_params: ReconstructionParameters, iters_mode: bool):
         self.image_width = images.width
         self.sino = images.sino(slice_idx)
 

--- a/mantidimaging/gui/dialogs/cor_inspection/presenter.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/presenter.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from PyQt5.QtCore import pyqtSignal
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.utility.data_containers import ScalarCoR, ReconstructionParameters
 from mantidimaging.gui.mvp_base import BasePresenter
 from .model import CORInspectionDialogModel
@@ -34,7 +34,7 @@ class CORInspectionDialogPresenter(BasePresenter):
 
     view: 'CORInspectionDialogView'
 
-    def __init__(self, view, images: Images, slice_index: int, initial_cor: ScalarCoR,
+    def __init__(self, view, images: ImageStack, slice_index: int, initial_cor: ScalarCoR,
                  recon_params: ReconstructionParameters, iters_mode: bool):
         super().__init__(view)
 

--- a/mantidimaging/gui/dialogs/cor_inspection/view.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/view.py
@@ -6,7 +6,7 @@ from typing import List, Union
 import numpy as np
 from PyQt5.QtWidgets import QPushButton, QDoubleSpinBox, QSpinBox, QStackedWidget
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.utility.data_containers import ScalarCoR, ReconstructionParameters
 from mantidimaging.gui.dialogs.cor_inspection.presenter import CORInspectionDialogPresenter
 from mantidimaging.gui.dialogs.cor_inspection.recon_slice_view import CompareSlicesView
@@ -26,7 +26,7 @@ class CORInspectionDialogView(BaseDialogView):
 
     spin_box: Union[QSpinBox, QDoubleSpinBox]
 
-    def __init__(self, parent, images: Images, slice_index: int, initial_cor: ScalarCoR,
+    def __init__(self, parent, images: ImageStack, slice_index: int, initial_cor: ScalarCoR,
                  recon_params: ReconstructionParameters, iters_mode: bool):
         super().__init__(parent, 'gui/ui/cor_inspection_dialog.ui')
         self.iters_mode = iters_mode

--- a/mantidimaging/gui/dialogs/op_history_copy/model.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/model.py
@@ -3,13 +3,13 @@
 
 from typing import Iterable
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operation_history.operations import ops_to_partials, ImageOperation
 
 
 class OpHistoryCopyDialogModel:
     def __init__(self, images):
-        self.images: Images = images
+        self.images: ImageStack = images
 
     def apply_ops(self, ops: Iterable[ImageOperation], copy: bool):
         if copy:

--- a/mantidimaging/gui/dialogs/op_history_copy/presenter.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/presenter.py
@@ -3,7 +3,7 @@
 
 from typing import List, TYPE_CHECKING, Iterable, Any, Dict
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operation_history import const
 from mantidimaging.core.operation_history.operations import ImageOperation, deserialize_metadata
 from mantidimaging.gui.mvp_base import BasePresenter
@@ -20,7 +20,7 @@ class OpHistoryCopyDialogPresenter(BasePresenter):
     main_window: 'MainWindowView'
     view: 'OpHistoryCopyDialogView'
 
-    def __init__(self, view, images: Images, main_window):
+    def __init__(self, view, images: ImageStack, main_window):
         super().__init__(view)
         self.view = view
         self.model = OpHistoryCopyDialogModel(images)

--- a/mantidimaging/gui/dialogs/op_history_copy/test/model_test.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/test/model_test.py
@@ -6,13 +6,13 @@ from unittest.mock import patch, MagicMock
 
 import numpy as np
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.gui.dialogs.op_history_copy import OpHistoryCopyDialogModel
 
 
 class OpHistoryCopyDialogModelTest(unittest.TestCase):
     def setUp(self):
-        self.images = Images(data=np.ndarray(shape=(128, 10, 128), dtype=np.float32))
+        self.images = ImageStack(data=np.ndarray(shape=(128, 10, 128), dtype=np.float32))
         self.images.data[:] = 100
         self.model = OpHistoryCopyDialogModel(self.images)
 

--- a/mantidimaging/gui/test/gui_system_operations_test.py
+++ b/mantidimaging/gui/test/gui_system_operations_test.py
@@ -11,7 +11,7 @@ from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtWidgets import QFormLayout, QLabel, QWidget
 
 from mantidimaging.gui.windows.stack_choice.presenter import StackChoicePresenter
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHOW_DELAY, SHORT_DELAY
 from mantidimaging.gui.windows.operations.view import FiltersWindowView
 
@@ -115,7 +115,7 @@ class TestGuiSystemOperations(GuiSystemBase):
         self.op_window.safeApply.setChecked(True)
         QTest.qWait(SHOW_DELAY)
 
-        def mock_wait_for_stack_choice(self, new_stack: Images, stack_uuid: UUID):
+        def mock_wait_for_stack_choice(self, new_stack: ImageStack, stack_uuid: UUID):
             print("mock_wait_for_stack_choice")
             stack_choice = StackChoicePresenter(self.original_images_stack, new_stack, self, stack_uuid)
             stack_choice.show()

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional, List, Union, NoReturn, TYPE_CHECKING
 
 import numpy as np
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
 from mantidimaging.core.io import loader, saver
 from mantidimaging.core.utility.data_containers import LoadingParameters, ProjectionAngles
@@ -17,8 +17,8 @@ if TYPE_CHECKING:
 logger = getLogger(__name__)
 
 
-def _matching_dataset_attribute(dataset_attribute: Optional[Images], images_id: uuid.UUID) -> bool:
-    return isinstance(dataset_attribute, Images) and dataset_attribute.id == images_id
+def _matching_dataset_attribute(dataset_attribute: Optional[ImageStack], images_id: uuid.UUID) -> bool:
+    return isinstance(dataset_attribute, ImageStack) and dataset_attribute.id == images_id
 
 
 class MainWindowModel(object):
@@ -26,7 +26,7 @@ class MainWindowModel(object):
         super().__init__()
         self.datasets: Dict[uuid.UUID, Union[MixedDataset, StrictDataset]] = {}
 
-    def get_images_by_uuid(self, images_uuid: uuid.UUID) -> Optional[Images]:
+    def get_images_by_uuid(self, images_uuid: uuid.UUID) -> Optional[ImageStack]:
         for dataset in self.datasets.values():
             for image in dataset.all:
                 if images_uuid == image.id:
@@ -110,11 +110,11 @@ class MainWindowModel(object):
         else:
             raise RuntimeError(f"Failed to get StrictDataset with ID {dataset_id}")
 
-        if isinstance(dataset.proj180deg, Images):  # type: ignore
+        if isinstance(dataset.proj180deg, ImageStack):  # type: ignore
             return dataset.proj180deg.id  # type: ignore
         return None
 
-    def add_180_deg_to_dataset(self, dataset_id: uuid.UUID, _180_deg_file: str) -> Images:
+    def add_180_deg_to_dataset(self, dataset_id: uuid.UUID, _180_deg_file: str) -> ImageStack:
         """
         Loads to 180 projection and adds this to a given Images ID.
         :param dataset_id: The ID of the Dataset.
@@ -196,14 +196,14 @@ class MainWindowModel(object):
         return [image.id for image in images if image is not None]
 
     @property
-    def images(self) -> List[Images]:
+    def images(self) -> List[ImageStack]:
         images = []
         for dataset in self.datasets.values():
             images += dataset.all
         return images
 
     @property
-    def proj180s(self) -> List[Images]:
+    def proj180s(self) -> List[ImageStack]:
         proj180s = []
         for dataset in self.datasets.values():
             if isinstance(dataset, StrictDataset) and dataset.proj180deg is not None:
@@ -221,7 +221,7 @@ class MainWindowModel(object):
                 return dataset.id
         self.raise_error_when_parent_dataset_not_found(member_id)
 
-    def add_recon_to_dataset(self, recon_data: Images, stack_id: uuid.UUID) -> uuid.UUID:
+    def add_recon_to_dataset(self, recon_data: ImageStack, stack_id: uuid.UUID) -> uuid.UUID:
         """
         Adds a recon to a dataset using recon data and an ID from one of the stacks in the dataset.
         :param recon_data: The recon data.

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -116,10 +116,10 @@ class MainWindowModel(object):
 
     def add_180_deg_to_dataset(self, dataset_id: uuid.UUID, _180_deg_file: str) -> ImageStack:
         """
-        Loads to 180 projection and adds this to a given Images ID.
+        Loads the 180 projection and adds this to a given Dataset ID.
         :param dataset_id: The ID of the Dataset.
         :param _180_deg_file: The location of the 180 projection.
-        :return: The loaded 180 Image object.
+        :return: The loaded 180 ImageStack object.
         """
         if dataset_id in self.datasets:
             dataset = self.datasets[dataset_id]
@@ -140,13 +140,13 @@ class MainWindowModel(object):
         images.set_projection_angles(proj_angles)
 
     def raise_error_when_images_not_found(self, images_id: uuid.UUID) -> NoReturn:
-        raise RuntimeError(f"Failed to get Images with ID {images_id}")
+        raise RuntimeError(f"Failed to get ImageStack with ID {images_id}")
 
     def raise_error_when_parent_dataset_not_found(self, images_id: uuid.UUID) -> NoReturn:
-        raise RuntimeError(f"Failed to find dataset containing Images with ID {images_id}")
+        raise RuntimeError(f"Failed to find dataset containing ImageStack with ID {images_id}")
 
     def raise_error_when_parent_strict_dataset_not_found(self, images_id: uuid.UUID) -> NoReturn:
-        raise RuntimeError(f"Failed to find strict dataset containing Images with ID {images_id}")
+        raise RuntimeError(f"Failed to find strict dataset containing ImageStack with ID {images_id}")
 
     def add_log_to_sample(self, images_id: uuid.UUID, log_file: str):
         images = self.get_images_by_uuid(images_id)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -173,9 +173,9 @@ class MainWindowPresenter(BasePresenter):
 
     def _create_and_tabify_stack_window(self, images: ImageStack, sample_dock: StackVisualiserView) -> None:
         """
-        Creates a new stack window with a given Images object then makes sure it is placed on top of a sample/original
-        stack window.
-        :param images: The Images object for the new stack window.
+        Creates a new stack window with a given ImageStack object then makes sure it is placed on top of a
+        sample/original stack window.
+        :param images: The ImageStack object for the new stack window.
         :param sample_dock: The existing stack window that the new one should be placed on top of.
         """
         stack_visualiser = self._create_lone_stack_window(images)
@@ -265,8 +265,8 @@ class MainWindowPresenter(BasePresenter):
 
     def create_single_tabbed_images_stack(self, images: ImageStack) -> StackVisualiserView:
         """
-        Creates a stack for a single Images object and focuses on it.
-        :param images: The Images object for the new stack window.
+        Creates a stack for a single ImageStack object and focuses on it.
+        :param images: The ImageStack object for the new stack window.
         :return: The new StackVisualiserView.
         """
         stack_vis = self._create_lone_stack_window(images)
@@ -277,7 +277,7 @@ class MainWindowPresenter(BasePresenter):
     def _create_lone_stack_window(self, images: ImageStack):
         """
         Creates a stack window and adds it to the stack list without tabifying.
-        :param images: The Images array for the stack window to display.
+        :param images: The ImageStack array for the stack window to display.
         :return: The new stack window.
         """
         stack_vis = self.view.create_stack_window(images)
@@ -425,7 +425,6 @@ class MainWindowPresenter(BasePresenter):
         Loads a 180 file then adds it to the dataset, creates a stack window, and updates the dataset tree view.
         :param dataset_id: The ID of the dataset to update.
         :param _180_deg_file: The filename for the 180 file.
-        :return: The 180 Images object if loading was successful, None otherwise.
         """
         existing_180_id = self.model.get_existing_180_id(dataset_id)
         _180_deg = self.model.add_180_deg_to_dataset(dataset_id, _180_deg_file)
@@ -519,7 +518,7 @@ class MainWindowPresenter(BasePresenter):
         """
         Adds a child item to the tree view.
         :param parent_id: The ID of the parent dataset.
-        :param child_id: The ID of the corresponding Images object.
+        :param child_id: The ID of the corresponding ImageStack object.
         :param child_name: The name that should appear in the tree view.
         """
         dataset_item = self.view.get_dataset_tree_view_item(parent_id)
@@ -529,7 +528,7 @@ class MainWindowPresenter(BasePresenter):
         """
         Adds a recon item to the tree view.
         :param parent_id: The ID of the parent dataset.
-        :param child_id: The ID of the corresponding Images object.
+        :param child_id: The ID of the corresponding ImageStack object.
         :param recon_count: The number of the recon in the dataset. One indicates the first recon that has been added.
         """
         dataset_item = self.view.get_dataset_tree_view_item(parent_id)
@@ -611,7 +610,7 @@ class MainWindowPresenter(BasePresenter):
         """
         Adds a sinograms item to the tree view or updates the id of an existing one.
         :param parent_id: The ID of the parent dataset.
-        :param sino_id: The ID of the corresponding Images object.
+        :param sino_id: The ID of the corresponding ImageStack object.
         """
         dataset_item = self.view.get_dataset_tree_view_item(parent_id)
         sinograms_item = self.view.get_sinograms_item(dataset_item)

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -8,7 +8,7 @@ from unittest import mock
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
 from mantidimaging.core.data.reconlist import ReconList
 from mantidimaging.core.utility.data_containers import LoadingParameters, ProjectionAngles
@@ -386,7 +386,7 @@ class MainWindowModelTest(unittest.TestCase):
         ds2 = StrictDataset(generate_images())
         ds3 = MixedDataset([generate_images()])
 
-        proj180s = [Images(ds1.sample.data[0]), Images(ds2.sample.data[0])]
+        proj180s = [ImageStack(ds1.sample.data[0]), ImageStack(ds2.sample.data[0])]
         ds1.proj180deg = proj180s[0]
         ds2.proj180deg = proj180s[1]
 

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -10,7 +10,7 @@ from unittest.mock import patch, call
 
 import numpy as np
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
 from mantidimaging.core.utility.data_containers import ProjectionAngles
 from mantidimaging.gui.dialogs.async_task import TaskWorkerThread
@@ -24,7 +24,7 @@ def test_generate_recon_item_name():
     assert _generate_recon_item_name(4) == "Recon 4"
 
 
-def generate_images_with_filenames(n_images: int) -> List[Images]:
+def generate_images_with_filenames(n_images: int) -> List[ImageStack]:
     images = []
     for _ in range(n_images):
         im = generate_images()

--- a/mantidimaging/gui/windows/main/test/strictdataset_test.py
+++ b/mantidimaging/gui/windows/main/test/strictdataset_test.py
@@ -11,8 +11,8 @@ from mantidimaging.test_helpers.unit_test_helper import generate_images
 
 
 def test_delete_stack_error_message():
-    assert _delete_stack_error_message("stack-id") == "Unable to delete stack: Images with ID stack-id not present in" \
-                                                      " dataset."
+    assert _delete_stack_error_message("stack-id") == "Unable to delete stack: ImageStack with ID stack-id not " \
+                                                      "present in dataset."
 
 
 class StrictDatasetTest(unittest.TestCase):

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -13,7 +13,7 @@ from PyQt5.QtGui import QIcon, QDragEnterEvent, QDropEvent, QDesktopServices
 from PyQt5.QtWidgets import QAction, QDialog, QLabel, QMessageBox, QMenu, QFileDialog, QSplitter, \
     QTreeWidgetItem, QTreeWidget
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.core.utility import finder
 from mantidimaging.core.utility.command_line_arguments import CommandLineArguments
@@ -339,16 +339,16 @@ class MainWindowView(BaseMainWindowView):
     def get_stack_visualiser(self, stack_uuid):
         return self.presenter.get_stack_visualiser(stack_uuid)
 
-    def get_stack(self, stack_uuid: uuid.UUID) -> Images:
+    def get_stack(self, stack_uuid: uuid.UUID) -> ImageStack:
         return self.presenter.get_stack(stack_uuid)
 
-    def get_images_from_stack_uuid(self, stack_uuid) -> Images:
+    def get_images_from_stack_uuid(self, stack_uuid) -> ImageStack:
         return self.presenter.get_stack_visualiser(stack_uuid).presenter.images
 
     def get_all_stack_visualisers(self):
         return self.presenter.get_active_stack_visualisers()
 
-    def get_all_stacks(self) -> List[Images]:
+    def get_all_stacks(self) -> List[ImageStack]:
         return self.presenter.get_all_stacks()
 
     def get_all_180_projections(self):
@@ -360,17 +360,17 @@ class MainWindowView(BaseMainWindowView):
     def get_stack_history(self, stack_uuid):
         return self.presenter.get_stack_visualiser_history(stack_uuid)
 
-    def create_new_stack(self, images: Images):
+    def create_new_stack(self, images: ImageStack):
         self.presenter.create_single_tabbed_images_stack(images)
 
-    def update_stack_with_images(self, images: Images):
+    def update_stack_with_images(self, images: ImageStack):
         self.presenter.update_stack_with_images(images)
 
-    def get_stack_with_images(self, images: Images) -> StackVisualiserView:
+    def get_stack_with_images(self, images: ImageStack) -> StackVisualiserView:
         return self.presenter.get_stack_with_images(images)
 
     def create_stack_window(self,
-                            stack: Images,
+                            stack: ImageStack,
                             position: Qt.DockWidgetArea = Qt.DockWidgetArea.RightDockWidgetArea,
                             floating: bool = False) -> StackVisualiserView:
         stack.make_name_unique(self.stack_names)
@@ -429,7 +429,7 @@ class MainWindowView(BaseMainWindowView):
 
             return stack_choice
 
-    def find_images_stack_title(self, images: Images) -> str:
+    def find_images_stack_title(self, images: ImageStack) -> str:
         return self.presenter.get_stack_with_images(images).name
 
     def dragEnterEvent(self, event: QDragEnterEvent):
@@ -517,7 +517,7 @@ class MainWindowView(BaseMainWindowView):
         """
         self.presenter.notify(PresNotification.FOCUS_TAB, stack_id=item.id)
 
-    def add_recon_to_dataset(self, recon_data: Images, stack_id: uuid.UUID):
+    def add_recon_to_dataset(self, recon_data: ImageStack, stack_id: uuid.UUID):
         self.presenter.notify(PresNotification.ADD_RECON, recon_data=recon_data, stack_id=stack_id)
 
     @staticmethod

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -253,13 +253,13 @@ class NexusLoadPresenter:
 
     def _create_sample_images(self):
         """
-        Creates the sample Images object.
-        :return: An Images object containing projections. If given, projection angles, pixel size, and 180deg are also
-            set.
+        Creates the sample ImageStack object.
+        :return: An ImageStack object containing projections. If given, projection angles, pixel size, and 180deg are
+            also set.
         """
         assert self.sample_array is not None
 
-        # Create sample array and Images object
+        # Create sample array and ImageStack object
         self.sample_array = self.sample_array[self.view.start_widget.value():self.view.stop_widget.value():self.view.
                                               step_widget.value()]
         sample_images = self._create_images(self.sample_array, "Projections")
@@ -275,10 +275,10 @@ class NexusLoadPresenter:
 
     def _create_images(self, data_array: np.ndarray, name: str) -> ImageStack:
         """
-        Use a data array to create an Images object.
+        Use a data array to create an ImageStack object.
         :param data_array: The images array obtained from the NeXus file.
         :param name: The name of the image dataset.
-        :return: An Images object.
+        :return: An ImageStack object.
         """
         data = pu.create_array(data_array.shape, self.view.pixelDepthComboBox.currentText())
         data[:] = data_array
@@ -286,11 +286,11 @@ class NexusLoadPresenter:
 
     def _create_images_if_required(self, data_array: np.ndarray, name: str) -> Optional[ImageStack]:
         """
-        Create the Images objects if the corresponding data was found in the NeXus file, and the user checked the
+        Create the ImageStack objects if the corresponding data was found in the NeXus file, and the user checked the
         "Use?" checkbox.
         :param data_array: The images data array.
         :param name: The name of the images.
-        :return: An Images object or None.
+        :return: An ImageStack object or None.
         """
         if data_array.size == 0 or not self.view.checkboxes[name].isChecked():
             return None

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Optional, Union, Tuple
 import h5py
 import numpy as np
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.core.parallel import utility as pu
 from mantidimaging.core.utility.data_containers import ProjectionAngles
@@ -273,7 +273,7 @@ class NexusLoadPresenter:
 
         return sample_images
 
-    def _create_images(self, data_array: np.ndarray, name: str) -> Images:
+    def _create_images(self, data_array: np.ndarray, name: str) -> ImageStack:
         """
         Use a data array to create an Images object.
         :param data_array: The images array obtained from the NeXus file.
@@ -282,9 +282,9 @@ class NexusLoadPresenter:
         """
         data = pu.create_array(data_array.shape, self.view.pixelDepthComboBox.currentText())
         data[:] = data_array
-        return Images(data, [f"{name} {self.title}"])
+        return ImageStack(data, [f"{name} {self.title}"])
 
-    def _create_images_if_required(self, data_array: np.ndarray, name: str) -> Optional[Images]:
+    def _create_images_if_required(self, data_array: np.ndarray, name: str) -> Optional[ImageStack]:
         """
         Create the Images objects if the corresponding data was found in the NeXus file, and the user checked the
         "Use?" checkbox.

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -12,7 +12,7 @@ from mantidimaging.gui.mvp_base import BaseMainWindowView
 if TYPE_CHECKING:
     from PyQt5.QtWidgets import QFormLayout  # noqa: F401  # pragma: no cover
     from mantidimaging.gui.windows.operations import FiltersWindowPresenter  # pragma: no cover
-    from mantidimaging.core.data import Images
+    from mantidimaging.core.data import ImageStack
 
 
 def ensure_tuple(val):
@@ -100,7 +100,7 @@ class FiltersWindowModel(object):
         self.selected_filter = self.filters[filter_idx]
         self.filter_widget_kwargs = filter_widget_kwargs
 
-    def apply_to_stacks(self, stacks: List['Images'], progress=None):
+    def apply_to_stacks(self, stacks: List['ImageStack'], progress=None):
         """
         Applies the selected filter to a given image stack.
 
@@ -128,7 +128,7 @@ class FiltersWindowModel(object):
             *exec_func.args,
             **exec_func.keywords)
 
-    def do_apply_filter(self, stacks: List['Images'], post_filter: Callable[[Any], None]):
+    def do_apply_filter(self, stacks: List['ImageStack'], post_filter: Callable[[Any], None]):
         """
         Applies the selected filter to the selected stack.
         """
@@ -140,7 +140,7 @@ class FiltersWindowModel(object):
         apply_func = partial(self.apply_to_stacks, stacks)
         start_async_task_view(self.presenter.view, apply_func, post_filter)
 
-    def do_apply_filter_sync(self, stacks: List['Images'], post_filter: Callable[[Any], None]):
+    def do_apply_filter_sync(self, stacks: List['ImageStack'], post_filter: Callable[[Any], None]):
         """
         Applies the selected filter to the selected stack in a synchronous manner
         """

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -314,7 +314,7 @@ class FiltersWindowPresenter(BasePresenter):
             if lock_scale:
                 self.view.previews.record_histogram_regions()
 
-            subset: ImageStack = self.stack.index_as_images(self.model.preview_image_idx)
+            subset: ImageStack = self.stack.index_as_image_stack(self.model.preview_image_idx)
             before_image = np.copy(subset.data[0])
 
             try:

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -14,7 +14,7 @@ import numpy as np
 from PyQt5.QtWidgets import QApplication, QLineEdit
 from pyqtgraph import ImageItem
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operation_history.const import OPERATION_HISTORY, OPERATION_DISPLAY_NAME
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.utility import BlockQtSignals
@@ -89,7 +89,7 @@ def _group_consecutive_values(slices: List[int]) -> List[str]:
 
 class FiltersWindowPresenter(BasePresenter):
     view: 'FiltersWindowView'
-    stack: Optional[Images] = None
+    stack: Optional[ImageStack] = None
     divider = "------------------------------------"
 
     def __init__(self, view: 'FiltersWindowView', main_window: 'MainWindowView'):
@@ -98,7 +98,7 @@ class FiltersWindowPresenter(BasePresenter):
         self.model = FiltersWindowModel(self)
         self._main_window = main_window
 
-        self.original_images_stack: Union[List[Tuple[Images, UUID]]] = []
+        self.original_images_stack: Union[List[Tuple[ImageStack, UUID]]] = []
         self.applying_to_all = False
         self.filter_is_running = False
 
@@ -139,7 +139,7 @@ class FiltersWindowPresenter(BasePresenter):
         else:
             self.set_stack(None)
 
-    def set_stack(self, stack: Optional[Images]):
+    def set_stack(self, stack: Optional[ImageStack]):
         self.stack = stack
 
         # Update the preview image index
@@ -226,7 +226,7 @@ class FiltersWindowPresenter(BasePresenter):
             self.applying_to_all = True
         self._do_apply_filter(stacks)
 
-    def _wait_for_stack_choice(self, new_stack: Images, stack_uuid: UUID):
+    def _wait_for_stack_choice(self, new_stack: ImageStack, stack_uuid: UUID):
         stack_choice = StackChoicePresenter(self.original_images_stack, new_stack, self, stack_uuid)
         if self.model.show_negative_overlay():
             stack_choice.enable_nonpositive_check()
@@ -239,10 +239,10 @@ class FiltersWindowPresenter(BasePresenter):
 
         return stack_choice.use_new_data
 
-    def is_a_proj180deg(self, stack_to_check: Images):
+    def is_a_proj180deg(self, stack_to_check: ImageStack):
         return stack_to_check in self.main_window.get_all_180_projections()
 
-    def _post_filter(self, updated_stacks: List[Images], task):
+    def _post_filter(self, updated_stacks: List[ImageStack], task):
         try:
             use_new_data = True
             attempt_repair = task.error is not None
@@ -295,7 +295,7 @@ class FiltersWindowPresenter(BasePresenter):
             self._set_apply_buttons_enabled(self.prev_apply_single_state, self.prev_apply_all_state)
             self.filter_is_running = False
 
-    def _do_apply_filter(self, apply_to: List[Images]):
+    def _do_apply_filter(self, apply_to: List[ImageStack]):
         self.filter_is_running = True
         # Record the previous button states
         self.prev_apply_single_state = self.view.applyButton.isEnabled()
@@ -314,7 +314,7 @@ class FiltersWindowPresenter(BasePresenter):
             if lock_scale:
                 self.view.previews.record_histogram_regions()
 
-            subset: Images = self.stack.index_as_images(self.model.preview_image_idx)
+            subset: ImageStack = self.stack.index_as_images(self.model.preview_image_idx)
             before_image = np.copy(subset.data[0])
 
             try:
@@ -413,7 +413,7 @@ class FiltersWindowPresenter(BasePresenter):
         crop_string = ", ".join(["0", "0", str(y), str(x)])
         roi_field.setText(crop_string)
 
-    def _show_negative_values_error(self, negative_stacks: List[Images]):
+    def _show_negative_values_error(self, negative_stacks: List[ImageStack]):
         """
         Shows information on the view and in the log about negative values in the output.
         :param negative_stacks: A list of stacks with negative values in the data.

--- a/mantidimaging/gui/windows/operations/test/model_test.py
+++ b/mantidimaging/gui/windows/operations/test/model_test.py
@@ -11,7 +11,7 @@ import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operation_history import const
 from mantidimaging.gui.windows.operations import FiltersWindowModel
 from mantidimaging.gui.windows.stack_visualiser import SVParameters
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 
 
 class FiltersWindowModelTest(unittest.TestCase):
@@ -23,7 +23,7 @@ class FiltersWindowModelTest(unittest.TestCase):
         cls.test_data = th.generate_images()
 
     def setUp(self):
-        self.stack = Images(np.zeros([3, 3, 3]))
+        self.stack = ImageStack(np.zeros([3, 3, 3]))
 
         self.model = FiltersWindowModel(mock.MagicMock())
 

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -213,12 +213,12 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         apply_mock.side_effect = Exception
         stack = mock.Mock()
         images = generate_images()
-        stack.index_as_images.return_value = images
+        stack.index_as_image_stack.return_value = images
         self.presenter.stack = stack
 
         self.presenter.do_update_previews()
 
-        stack.index_as_images.assert_called_once_with(self.presenter.model.preview_image_idx)
+        stack.index_as_image_stack.assert_called_once_with(self.presenter.model.preview_image_idx)
         self.view.clear_previews.assert_called_once()
         apply_mock.assert_called_once()
 
@@ -227,13 +227,13 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     def test_update_previews_with_no_lock_checked(self, apply_mock: mock.Mock, update_preview_image_mock: mock.Mock):
         stack = mock.Mock()
         images = generate_images()
-        stack.index_as_images.return_value = images
+        stack.index_as_image_stack.return_value = images
         self.presenter.stack = stack
         self.view.lockZoomCheckBox.isChecked.return_value = False
         self.view.lockScaleCheckBox.isChecked.return_value = False
         self.presenter.do_update_previews()
 
-        stack.index_as_images.assert_called_once_with(self.presenter.model.preview_image_idx)
+        stack.index_as_image_stack.assert_called_once_with(self.presenter.model.preview_image_idx)
         self.view.clear_previews.assert_called_once()
         self.assertEqual(3, update_preview_image_mock.call_count)
         apply_mock.assert_called_once()
@@ -247,7 +247,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
                                                       update_preview_image_mock: mock.Mock):
         stack = mock.Mock()
         images = generate_images()
-        stack.index_as_images.return_value = images
+        stack.index_as_image_stack.return_value = images
         self.presenter.stack = stack
         self.view.lockZoomCheckBox.isChecked.return_value = True
         self.view.lockScaleCheckBox.isChecked.return_value = True
@@ -507,7 +507,8 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.presenter.model.preview_image_idx = slice_idx = 14
         self.presenter.model.apply_to_images = mock.Mock()
         self.presenter.stack = mock.Mock()
-        self.presenter.stack.index_as_images.return_value.data = np.array([[-1 for _ in range(3)] for _ in range(3)])
+        self.presenter.stack.index_as_image_stack.return_value.data = np.array([[-1 for _ in range(3)]
+                                                                                for _ in range(3)])
         self.presenter.do_update_previews()
 
         self.view.show_error_dialog.assert_called_once_with(
@@ -516,7 +517,8 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     def test_no_negative_values_preview_message(self):
         self.presenter.model.apply_to_images = mock.Mock()
         self.presenter.stack = mock.Mock()
-        self.presenter.stack.index_as_images.return_value.data = np.array([[1 for _ in range(3)] for _ in range(3)])
+        self.presenter.stack.index_as_image_stack.return_value.data = np.array([[1 for _ in range(3)]
+                                                                                for _ in range(3)])
         self.presenter.do_update_previews()
 
         self.view.show_error_dialog.assert_not_called()

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -186,7 +186,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
                                                                   _do_apply_filter: Mock = Mock(),
                                                                   _do_apply_filter_sync: Mock = Mock()):
         """
-        Test that when an `Images` stack is encountered which also has a
+        Test that when an `ImageStack` stack is encountered which also has a
         180deg projection stack reference, that 180deg stack is also processed
         with the same operation, to ensure consistency between the two images
         """

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -18,7 +18,7 @@ from mantidimaging.gui.windows.operations import FiltersWindowPresenter
 from mantidimaging.gui.windows.operations.presenter import REPEAT_FLAT_FIELDING_MSG, FLAT_FIELDING, _find_nan_change, \
     _group_consecutive_values
 from mantidimaging.test_helpers.unit_test_helper import assert_called_once_with, generate_images
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 
 
 class FiltersWindowPresenterTest(unittest.TestCase):
@@ -28,7 +28,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.presenter = FiltersWindowPresenter(self.view, self.main_window)
         self.presenter.model.filter_widget_kwargs = {"roi_field": None}
         self.view.presenter = self.presenter
-        self.mock_stacks: List[Images] = []
+        self.mock_stacks: List[ImageStack] = []
         for _ in range(2):
             mock_stack = mock.Mock()
             mock_stack.data = np.zeros([3, 3, 3])
@@ -195,7 +195,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         mock_stack = mock.MagicMock()
         mock_stack.has_proj180deg.return_value = True
         mock_stack.data = np.array([i for i in range(3)])
-        mock_stacks: List[Images] = [mock_stack]
+        mock_stacks: List[ImageStack] = [mock_stack]
         mock_task = mock.MagicMock()
         mock_task.error = None
 

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -234,7 +234,7 @@ class FiltersWindowView(BaseMainWindowView):
     def roi_visualiser(self, roi_field):
         # Start the stack visualiser and ensure that it uses the ROI from here in the rest of this
         try:
-            images = self.presenter.stack.index_as_images(self.presenter.model.preview_image_idx)
+            images = self.presenter.stack.index_as_image_stack(self.presenter.model.preview_image_idx)
         except IndexError:
             # Happens if nothing has been loaded, so do nothing as nothing can't be visualised
             return

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operation_history import const
 from mantidimaging.core.operations.divide import DivideFilter
 from mantidimaging.core.reconstruct import get_reconstructor_for
@@ -26,7 +26,7 @@ LOG = getLogger(__name__)
 
 class ReconstructWindowModel(object):
     def __init__(self, data_model: CorTiltPointQtModel):
-        self._images: Optional[Images] = None
+        self._images: Optional[ImageStack] = None
         self._preview_projection_idx = 0
         self._preview_slice_idx = 0
         self._selected_row = 0
@@ -89,7 +89,7 @@ class ReconstructWindowModel(object):
     def num_points(self):
         return self.data_model.num_points
 
-    def initial_select_data(self, images: 'Images'):
+    def initial_select_data(self, images: 'ImageStack'):
         self._images = images
         self.reset_cor_model()
 
@@ -129,7 +129,7 @@ class ReconstructWindowModel(object):
                           slice_idx: int,
                           cor: ScalarCoR,
                           recon_params: ReconstructionParameters,
-                          progress: Progress = None) -> Optional[Images]:
+                          progress: Progress = None) -> Optional[ImageStack]:
         # Ensure we have some sample data
         images = self.images
         if images is None:
@@ -138,7 +138,7 @@ class ReconstructWindowModel(object):
         # Perform single slice reconstruction
         reconstructor = get_reconstructor_for(recon_params.algorithm)
         output_shape = (1, images.width, images.width)
-        recon: Images = Images.create_empty_images(output_shape, images.dtype, images.metadata)
+        recon: ImageStack = ImageStack.create_empty_images(output_shape, images.dtype, images.metadata)
         recon.data[0] = reconstructor.single_sino(images.sino(slice_idx),
                                                   cor,
                                                   images.projection_angles(recon_params.max_projection_angle),
@@ -147,7 +147,7 @@ class ReconstructWindowModel(object):
         recon = self._apply_pixel_size(recon, recon_params)
         return recon
 
-    def run_full_recon(self, recon_params: ReconstructionParameters, progress: Progress) -> Optional[Images]:
+    def run_full_recon(self, recon_params: ReconstructionParameters, progress: Progress) -> Optional[ImageStack]:
         # Ensure we have some sample data
         images = self.images
         if images is None:

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -138,7 +138,7 @@ class ReconstructWindowModel(object):
         # Perform single slice reconstruction
         reconstructor = get_reconstructor_for(recon_params.algorithm)
         output_shape = (1, images.width, images.width)
-        recon: ImageStack = ImageStack.create_empty_images(output_shape, images.dtype, images.metadata)
+        recon: ImageStack = ImageStack.create_empty_image_stack(output_shape, images.dtype, images.metadata)
         recon.data[0] = reconstructor.single_sino(images.sino(slice_idx),
                                                   cor,
                                                   images.projection_angles(recon_params.max_projection_angle),

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -419,6 +419,6 @@ class ReconstructWindowPresenter(BasePresenter):
         """
         Replaces infinity values in a data array with NaNs. Used because pyqtgraph has programs with arrays containing
         inf.
-        :param images: The Images object.
+        :param images: The ImageStack object.
         """
         images.data[np.isinf(images.data)] = np.nan

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Callable, Set
 import numpy as np
 from PyQt5.QtWidgets import QWidget
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.utility.data_containers import ScalarCoR, Degrees
 from mantidimaging.gui.dialogs.async_task import start_async_task_view, TaskWorkerThread
 from mantidimaging.gui.dialogs.cor_inspection.view import CORInspectionDialogView
@@ -236,7 +236,7 @@ class ReconstructWindowPresenter(BasePresenter):
             self.view.show_error_dialog(f"Encountered error while trying to reconstruct: {str(task.error)}")
             return
 
-        images: Images = task.result
+        images: ImageStack = task.result
         if images is not None:
             self.view.update_recon_preview(images.data[0])
 
@@ -249,7 +249,7 @@ class ReconstructWindowPresenter(BasePresenter):
             self.view.show_error_dialog(f"Encountered error while trying to reconstruct: {str(task.error)}")
             return
 
-        images: Images = task.result
+        images: ImageStack = task.result
         slice_idx = self._get_slice_index(None)
         if images is not None:
             assert self.model.images is not None
@@ -415,7 +415,7 @@ class ReconstructWindowPresenter(BasePresenter):
             self.view.show_status_message(" ".join(msg_list))
 
     @staticmethod
-    def _replace_inf_nan(images: Images):
+    def _replace_inf_nan(images: ImageStack):
         """
         Replaces infinity values in a data array with NaNs. Used because pyqtgraph has programs with arrays containing
         inf.

--- a/mantidimaging/gui/windows/recon/test/model_test.py
+++ b/mantidimaging/gui/windows/recon/test/model_test.py
@@ -6,7 +6,7 @@ import unittest
 from unittest import mock
 import numpy as np
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operation_history import const
 from mantidimaging.core.reconstruct.astra_recon import allowed_recon_kwargs as astra_allowed_kwargs
 from mantidimaging.core.reconstruct.tomopy_recon import allowed_recon_kwargs as tomopy_allowed_kwargs
@@ -21,7 +21,7 @@ class ReconWindowModelTest(unittest.TestCase):
     def setUp(self):
         self.model = ReconstructWindowModel(CorTiltPointQtModel())
 
-        self.data = Images(data=np.ndarray(shape=(10, 128, 256), dtype=np.float32))
+        self.data = ImageStack(data=np.ndarray(shape=(10, 128, 256), dtype=np.float32))
         self.model.initial_select_data(self.data)
 
     def test_empty_init(self):

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -6,7 +6,7 @@ import unittest
 from unittest import mock
 import numpy as np
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.rotation.data_model import Point
 from mantidimaging.core.utility.data_containers import ScalarCoR, ReconstructionParameters
 from mantidimaging.gui.windows.recon import ReconstructWindowPresenter, ReconstructWindowView
@@ -21,7 +21,7 @@ class ReconWindowPresenterTest(unittest.TestCase):
 
         self.presenter = ReconstructWindowPresenter(self.view, mock.Mock())
 
-        self.data = Images(data=np.ndarray(shape=(128, 10, 128), dtype=np.float32))
+        self.data = ImageStack(data=np.ndarray(shape=(128, 10, 128), dtype=np.float32))
         self.data.pixel_size = TEST_PIXEL_SIZE
 
         self.presenter.model.initial_select_data(self.data)
@@ -282,7 +282,7 @@ class ReconWindowPresenterTest(unittest.TestCase):
             "projection to (10, 10)")
 
     def test_do_stack_reconstruct_slice(self):
-        test_data = Images(np.ndarray(shape=(200, 250), dtype=np.float32))
+        test_data = ImageStack(np.ndarray(shape=(200, 250), dtype=np.float32))
         test_data.record_operation = mock.Mock()
         task_mock = mock.Mock(result=test_data, error=None)
         self.presenter._get_slice_index = mock.Mock(return_value=7)

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -10,7 +10,7 @@ from PyQt5.QtWidgets import (QAbstractItemView, QComboBox, QDoubleSpinBox, QInpu
                              QVBoxLayout, QWidget, QMessageBox, QTextEdit, QLabel, QApplication, QStyle, QCheckBox)
 from PyQt5.QtCore import QSignalBlocker
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.net.help_pages import SECTION_USER_GUIDE, open_help_webpage
 from mantidimaging.core.utility.cuda_check import CudaChecker
 from mantidimaging.core.utility.data_containers import Degrees, ReconstructionParameters, ScalarCoR, Slope
@@ -422,10 +422,10 @@ class ReconstructWindowView(BaseMainWindowView):
         # handled as an internal Qt event in the model
         self.cor_table_model.set_point(idx, slice_idx, cor, reset_results=False)
 
-    def show_recon_volume(self, data: Images, stack_id: uuid.UUID):
+    def show_recon_volume(self, data: ImageStack, stack_id: uuid.UUID):
         self.main_window.add_recon_to_dataset(data, stack_id)
 
-    def get_stack(self, uuid) -> Optional['Images']:
+    def get_stack(self, uuid) -> Optional['ImageStack']:
         if uuid is not None:
             return self.main_window.get_stack(uuid)
         return None

--- a/mantidimaging/gui/windows/stack_choice/compare_presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/compare_presenter.py
@@ -3,13 +3,13 @@
 
 import traceback
 
-from mantidimaging.core.data.images import Images
+from mantidimaging.core.data.imagestack import ImageStack
 from mantidimaging.gui.windows.stack_choice.presenter_base import StackChoicePresenterMixin
 from mantidimaging.gui.windows.stack_choice.view import StackChoiceView
 
 
 class StackComparePresenter(StackChoicePresenterMixin):
-    def __init__(self, stack_one: Images, stack_two: Images, parent):
+    def __init__(self, stack_one: ImageStack, stack_two: ImageStack, parent):
         self.view = StackChoiceView(stack_one, stack_two, self, parent)
         self.view.originalDataButton.hide()
         self.view.newDataButton.hide()

--- a/mantidimaging/gui/windows/stack_choice/presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/presenter.py
@@ -5,7 +5,7 @@ import traceback
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 from uuid import UUID
 
-from mantidimaging.core.data.images import Images
+from mantidimaging.core.data.imagestack import ImageStack
 from mantidimaging.gui.windows.stack_choice.presenter_base import StackChoicePresenterMixin
 from mantidimaging.gui.windows.stack_choice.view import Notification, StackChoiceView
 
@@ -22,8 +22,8 @@ def _get_stack_from_uuid(original_stack, stack_uuid):
 
 class StackChoicePresenter(StackChoicePresenterMixin):
     def __init__(self,
-                 original_stack: Union[List[Tuple[Images, UUID]], Images],
-                 new_stack: Images,
+                 original_stack: Union[List[Tuple[ImageStack, UUID]], ImageStack],
+                 new_stack: ImageStack,
                  operations_presenter: 'FiltersWindowPresenter',
                  stack_uuid: Optional[UUID],
                  view: Optional[StackChoiceView] = None):

--- a/mantidimaging/gui/windows/stack_choice/tests/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/presenter_test.py
@@ -11,7 +11,7 @@ import numpy as np
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.gui.windows.stack_choice.presenter import StackChoicePresenter
 from mantidimaging.gui.windows.stack_choice.view import Notification
-from mantidimaging.core.data.images import Images
+from mantidimaging.core.data.imagestack import ImageStack
 
 
 class StackChoicePresenterTest(unittest.TestCase):
@@ -80,9 +80,9 @@ class StackChoicePresenterTest(unittest.TestCase):
     def test_do_reapply_original_data(self):
         self.p._clean_up_original_images_stack = mock.MagicMock()
         self.p.close_view = mock.MagicMock()
-        img1 = Images(np.zeros((3, 3, 3)) + 1)
+        img1 = ImageStack(np.zeros((3, 3, 3)) + 1)
         img1.metadata = {"name": 1}
-        img2 = Images(np.zeros((3, 3, 3)) + 2)
+        img2 = ImageStack(np.zeros((3, 3, 3)) + 2)
         img2.metadata = {"name": 2}
         self.p.original_stack = img1
         self.p.new_stack = img2

--- a/mantidimaging/gui/windows/stack_choice/view.py
+++ b/mantidimaging/gui/windows/stack_choice/view.py
@@ -9,7 +9,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QCheckBox, QMainWindow, QMessageBox, QPushButton, QSizePolicy
 from pyqtgraph import ViewBox
 
-from mantidimaging.core.data.images import Images
+from mantidimaging.core.data.imagestack import ImageStack
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.widgets.mi_image_view.view import MIImageView
 
@@ -29,7 +29,7 @@ class StackChoiceView(BaseMainWindowView):
     newDataButton: QPushButton
     lockHistograms: QCheckBox
 
-    def __init__(self, original_stack: Images, new_stack: Images,
+    def __init__(self, original_stack: ImageStack, new_stack: ImageStack,
                  presenter: Union['StackComparePresenter', 'StackChoicePresenter'], parent: Optional[QMainWindow]):
         super().__init__(parent, "gui/ui/stack_choice_window.ui")
 

--- a/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
+++ b/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
@@ -7,7 +7,7 @@ from PyQt5.QtWidgets import (QWidget, QTreeWidget, QTreeWidgetItem, QDialog, QDi
                              QPushButton)
 from PyQt5.QtGui import QKeySequence, QGuiApplication
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operation_history import const
 
 
@@ -15,7 +15,7 @@ class MetadataDialog(QDialog):
     """
     Dialog used to show a pretty formatted version of the image metadata.
     """
-    def __init__(self, parent: QWidget, images: Images):
+    def __init__(self, parent: QWidget, images: ImageStack):
         super().__init__(parent)
 
         self.setWindowTitle('Image Metadata')

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -7,7 +7,7 @@ from enum import IntEnum, auto
 from logging import getLogger
 from typing import TYPE_CHECKING
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operation_history import const
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.mvp_base import BasePresenter
@@ -42,7 +42,7 @@ class SVImageMode(IntEnum):
 class StackVisualiserPresenter(BasePresenter):
     view: 'StackVisualiserView'
 
-    def __init__(self, view: 'StackVisualiserView', images: Images):
+    def __init__(self, view: 'StackVisualiserView', images: ImageStack):
         super().__init__(view)
         self.model = SVModel()
         self.images = images
@@ -69,7 +69,7 @@ class StackVisualiserPresenter(BasePresenter):
     def delete_data(self):
         self.images = None
 
-    def get_image(self, index) -> Images:
+    def get_image(self, index) -> ImageStack:
         return self.images.index_as_images(index)
 
     def refresh_image(self):
@@ -121,7 +121,7 @@ class StackVisualiserPresenter(BasePresenter):
             new_images.name = self.images.name
             self.add_mixed_dataset_to_model_and_update_view(new_images)
 
-    def add_mixed_dataset_to_model_and_update_view(self, images: Images):
+    def add_mixed_dataset_to_model_and_update_view(self, images: ImageStack):
         dataset = MixedDataset([images], images.name)
         self.view._main_window.presenter.model.add_dataset_to_model(dataset)
         self.view._main_window.presenter.create_mixed_dataset_tree_view_items(dataset)
@@ -138,5 +138,5 @@ class StackVisualiserPresenter(BasePresenter):
                 return index
         return len(self.images.projection_angles().value)
 
-    def add_sinograms_to_model_and_update_view(self, new_stack: Images):
+    def add_sinograms_to_model_and_update_view(self, new_stack: ImageStack):
         self.view._main_window.presenter.add_sinograms_to_dataset_and_update_view(new_stack, self.images.id)

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -69,9 +69,6 @@ class StackVisualiserPresenter(BasePresenter):
     def delete_data(self):
         self.images = None
 
-    def get_image(self, index) -> ImageStack:
-        return self.images.index_as_images(index)
-
     def refresh_image(self):
         self.view.image = self.summed_image if self.image_mode is SVImageMode.SUMMED \
             else self.images.data

--- a/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
@@ -10,13 +10,13 @@ import numpy as np
 from mantidimaging.gui.windows.stack_visualiser.presenter import SVParameters
 
 import mantidimaging.test_helpers.unit_test_helper as th
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.gui.windows.stack_visualiser import StackVisualiserPresenter, StackVisualiserView, SVNotification, \
     SVImageMode
 
 
 class StackVisualiserPresenterTest(unittest.TestCase):
-    test_data: Images
+    test_data: ImageStack
 
     def setUp(self):
         self.test_data = th.generate_images()

--- a/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
@@ -5,7 +5,6 @@ import unittest
 from unittest import mock
 from unittest.mock import patch
 
-import numpy.testing as npt
 import numpy as np
 from mantidimaging.gui.windows.stack_visualiser.presenter import SVParameters
 
@@ -25,14 +24,6 @@ class StackVisualiserPresenterTest(unittest.TestCase):
         self.presenter = StackVisualiserPresenter(self.view, self.test_data)
         self.presenter.model = mock.Mock()
         self.view._main_window = mock.Mock()
-
-    def test_get_image(self):
-        index = 3
-
-        test_data = self.test_data
-
-        img = self.presenter.get_image(index)
-        npt.assert_equal(test_data.data[index], img.data[0])
 
     def test_delete_data(self):
         self.presenter.images = th.generate_images()

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -5,7 +5,7 @@ from typing import Tuple
 from unittest import mock
 
 import mantidimaging.test_helpers.unit_test_helper as th
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.core.utility.version_check import versions
 from mantidimaging.gui.windows.main import MainWindowView
@@ -17,7 +17,7 @@ versions._use_test_values()
 
 @start_qapplication
 class StackVisualiserViewTest(unittest.TestCase):
-    test_data: Images
+    test_data: ImageStack
     window: MainWindowView
 
     def setUp(self):
@@ -25,7 +25,7 @@ class StackVisualiserViewTest(unittest.TestCase):
             self.window = MainWindowView()
         self.view, self.test_data = self._add_stack_visualiser()
 
-    def _add_stack_visualiser(self) -> Tuple[StackVisualiserView, Images]:
+    def _add_stack_visualiser(self) -> Tuple[StackVisualiserView, ImageStack]:
         test_data = th.generate_images()
         test_data.name = "Test Data"
         self.window.create_new_stack(test_data)

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -7,7 +7,7 @@ from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtGui import QGuiApplication
 from PyQt5.QtWidgets import QAction, QDockWidget, QInputDialog, QMenu, QMessageBox, QVBoxLayout, QWidget
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.dialogs.op_history_copy.view import OpHistoryCopyDialogView
 from mantidimaging.gui.widgets.mi_image_view.view import MIImageView
@@ -29,7 +29,7 @@ class StackVisualiserView(QDockWidget):
     presenter: StackVisualiserPresenter
     layout: QVBoxLayout
 
-    def __init__(self, parent: 'MainWindowView', images: Images):
+    def __init__(self, parent: 'MainWindowView', images: ImageStack):
         # enforce not showing a single image
         assert images.data.ndim == 3, \
             "Data does NOT have 3 dimensions! Dimensions found: {0}".format(images.data.ndim)

--- a/mantidimaging/helper.py
+++ b/mantidimaging/helper.py
@@ -7,7 +7,7 @@ Module for commonly used functions across the modules.
 import logging
 import sys
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 
 _log_file_handler = None
 _log_formatter = None
@@ -41,7 +41,7 @@ def initialise_logging(default_level=logging.DEBUG):
     logging.getLogger('PyQt5').setLevel(logging.INFO)
 
 
-def check_data_stack(data, expected_dims=3, expected_class=Images):
+def check_data_stack(data, expected_dims=3, expected_class=ImageStack):
     """
     Make sure the data has expected dimensions and class.
     """

--- a/mantidimaging/helper.py
+++ b/mantidimaging/helper.py
@@ -49,7 +49,8 @@ def check_data_stack(data, expected_dims=3, expected_class=ImageStack):
         raise ValueError("Data is a None type.")
 
     if not isinstance(data, expected_class):
-        raise ValueError("Invalid data type. It must be an Images object. Instead found: {0}".format(type(data)))
+        raise ValueError(
+            f"Invalid data type. It must be an {expected_class.__name__} object. Instead found: {type(data).__name__}")
 
     if expected_dims != data.data.ndim:
-        raise ValueError("Invalid data format. It does not have 3 dimensions. " "Shape: {0}".format(data.data.shape))
+        raise ValueError(f"Invalid data format. It does not have 3 dimensions. Shape: {data.data.shape}")

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -12,7 +12,7 @@ import numpy.random
 import numpy.testing as npt
 from io import StringIO
 
-from mantidimaging.core.data import Images
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.parallel import utility as pu
 from mantidimaging.core.utility.data_containers import ProjectionAngles
 
@@ -41,12 +41,12 @@ def generate_shared_array(shape=g_shape, dtype=np.float32, seed: Optional[int] =
     return generated_array
 
 
-def generate_images(shape=g_shape, dtype=np.float32, seed: Optional[int] = None) -> Images:
+def generate_images(shape=g_shape, dtype=np.float32, seed: Optional[int] = None) -> ImageStack:
     d = pu.create_array(shape, dtype)
     return _set_random_data(d, shape, seed=seed)
 
 
-def generate_images_for_parallel(shape=(15, 8, 10), dtype=np.float32, seed: Optional[int] = None) -> Images:
+def generate_images_for_parallel(shape=(15, 8, 10), dtype=np.float32, seed: Optional[int] = None) -> ImageStack:
     """
     Doesn't do anything special, just makes a number of images big enough to be
     ran in parallel from the logic of multiprocessing_necessary
@@ -60,7 +60,7 @@ def _set_random_data(data, shape, seed: Optional[int] = None):
     # move the data in the shared array
     data[:] = n[:]
 
-    images = Images(data)
+    images = ImageStack(data)
     return images
 
 
@@ -159,7 +159,7 @@ def assert_called_once_with(mock: mock.Mock, *args):
             np.testing.assert_equal(actual, expected)
         elif isinstance(actual, ProjectionAngles):
             np.testing.assert_equal(actual.value, expected.value)
-        elif isinstance(actual, Images):
+        elif isinstance(actual, ImageStack):
             assert actual is expected, f"Expected {expected}, got {actual}"
         elif isinstance(actual, partial):
             assert actual.args == expected.args


### PR DESCRIPTION
### Issue

Closes #1362

### Description

Renames the `Images` class to `ImageStack`. I've also updated the names of a couple of methods within the class for consistency with the new name, as well as updating some comments, docs and error messages.

The code still uses "images" as the name for a number of variables and attributes that now refer to `ImageStack` objects, along with a number of other naming conventions. Over time we would like to rationalise this, but we agreed to do this gradually rather than within this PR.

Reviewing per commit may be helpful with this PR.

### Testing & Acceptance Criteria 

Check that everything still works as expected. The release manual testing script could be useful to help with this.

### Documentation

Issue number added to release notes.
