### PR TITLE
Set channels for automated package building

### DIFF
--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -26,9 +26,7 @@ runs:
     shell: bash -l {0}
     run: |
       conda config --set always_yes yes --set changeps1 no
-      conda create -n build-env anaconda-client python=3.8
-      conda activate build-env
-      conda install conda-build conda-verify
+      make install-build-requirements
 
   - name: Build package
     shell: bash -l {0}

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,13 @@ install-conda-env:
 install-run-requirements:
 	conda install --yes --only-deps -c $$UPLOAD_USER mantidimaging
 
+CHANNELS:=$(shell cat environment-dev.yml | sed -ne '/channels:/,/dependencies:/{//!p}' | sed 's/ - / --append channels /g' | tr -d '\n')
+
 install-build-requirements:
 	@echo "Installing packages required for starting the build process"
 	conda create -n build-env
 	$(CONDA_ACTIVATE) build-env ; conda install --yes conda-build anaconda-client conda-verify
-	$(CONDA_ACTIVATE) build-env ; conda config --env --add channels dtasev --add channels astra-toolbox/label/dev --add channels conda-forge --add channels ccpi
+	$(CONDA_ACTIVATE) build-env ; conda config --env $(CHANNELS)
 
 install-dev-requirements:
 	conda env create -f environment-dev.yml


### PR DESCRIPTION
### Issue
Closes #1364 

### Description

As part of #1350 the `environment-file: environment-dev.yml` option was removed from the conda-incubator/setup-miniconda step. This was needed so the environment could be cached. But as a side effect the channels are not added to the conda config.

The makefile `install-build-requirements` rule does set up the channels, so use that from the action.

Also update the makefile, which had an out of date list of channels. Now they are read from the  environment-dev.yml file

### Testing 

The package is not normally build on a pull request. I have been running with a some changes in 5ecaee3abc247e0a5c87e4426dd1ad867d1dc1cc (wont be part of the final PR) This removes the if condition so that the publish rule always runs. Also removes the API key so the uploading the package will fail. 

The test run at
https://github.com/mantidproject/mantidimaging/runs/5499391400?check_suite_focus=true
shows a successful package build and a failed upload as expected
`Error:  ('Authorization token is no longer valid', 401)`

The final PR will pass because the step is skipped on a PR. Once its merged we'll see for sure.

### Documentation
Not needed
