### PR TITLE
Refactor auto colour menu in MIMiniImageView

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -17,3 +17,4 @@ Developer Changes
 - #1272: Consistent test class filenames
 - #1352 : Update astra-toolbox and cudatoolkit to allow windows installation
 - #1317 : Unify auto color palette code between MIMiniImageView and MIImageView
+- #1363 : Add auto color menu from constructor in MIMiniImageView

--- a/mantidimaging/gui/dialogs/cor_inspection/recon_slice_view.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/recon_slice_view.py
@@ -18,9 +18,9 @@ class CompareSlicesView(GraphicsLayoutWidget):
         super().__init__(parent)
         self.parent = parent
 
-        self.imageview_less = MIMiniImageView(name="less")
-        self.imageview_current = MIMiniImageView(name="current")
-        self.imageview_more = MIMiniImageView(name="more")
+        self.imageview_less = MIMiniImageView(name="less", parent=parent, recon_mode=True)
+        self.imageview_current = MIMiniImageView(name="current", parent=parent, recon_mode=True)
+        self.imageview_more = MIMiniImageView(name="more", parent=parent, recon_mode=True)
         self.all_imageviews = [self.imageview_less, self.imageview_current, self.imageview_more]
         MIMiniImageView.set_siblings(self.all_imageviews, axis=True, hist=True)
 

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -16,7 +16,7 @@ from mantidimaging.gui.widgets.bad_data_overlay.bad_data_overlay import BadDataO
 
 if TYPE_CHECKING:
     import numpy as np
-    from PyQt5.QtWidgets import QAction, QWidget
+    from PyQt5.QtWidgets import QWidget
 
 graveyard = []
 
@@ -31,7 +31,7 @@ def pairwise(iterable):
 
 
 class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
-    def __init__(self, name: str = "MIMiniImageView"):
+    def __init__(self, name: str = "MIMiniImageView", parent: 'Optional[QWidget]' = None, recon_mode: bool = False):
         super().__init__()
 
         self.name = name.title()
@@ -53,6 +53,8 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
 
         self.axis_siblings: "WeakSet[MIMiniImageView]" = WeakSet()
         self.histogram_siblings: "WeakSet[MIMiniImageView]" = WeakSet()
+
+        self.add_auto_color_menu_action(parent if parent else self, recon_mode=recon_mode, set_enabled=False)
 
     @property
     def histogram(self) -> HistogramLUTItem:
@@ -152,6 +154,3 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
         for img_view in self.histogram_siblings:
             with BlockQtSignals(img_view.hist):
                 img_view.hist.setLevels(*hist_range)
-
-    def add_auto_color_action(self, parent: 'Optional[QWidget]', recon_mode: bool = False) -> 'QAction':
-        return self.add_auto_color_menu_action(parent, recon_mode=recon_mode, set_enabled=False)

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -54,7 +54,7 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
         self.axis_siblings: "WeakSet[MIMiniImageView]" = WeakSet()
         self.histogram_siblings: "WeakSet[MIMiniImageView]" = WeakSet()
 
-        self.add_auto_color_menu_action(parent if parent else self, recon_mode=recon_mode, set_enabled=False)
+        self.add_auto_color_menu_action(parent, recon_mode=recon_mode, set_enabled=False)
 
     @property
     def histogram(self) -> HistogramLUTItem:

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -55,9 +55,9 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.addLabel("Image difference")
         self.nextRow()
 
-        self.imageview_before = MIMiniImageView(name="before")
-        self.imageview_after = MIMiniImageView(name="after")
-        self.imageview_difference = MIMiniImageView(name="difference")
+        self.imageview_before = MIMiniImageView(name="before", parent=self)
+        self.imageview_after = MIMiniImageView(name="after", parent=self)
+        self.imageview_difference = MIMiniImageView(name="difference", parent=self)
         self.all_imageviews = [self.imageview_before, self.imageview_after, self.imageview_difference]
         MIMiniImageView.set_siblings(self.all_imageviews, axis=True)
         MIMiniImageView.set_siblings([self.imageview_before, self.imageview_after], hist=True)
@@ -78,10 +78,6 @@ class FilterPreviews(GraphicsLayoutWidget):
 
         # Work around for https://github.com/mantidproject/mantidimaging/issues/565
         self.scene().contextMenu = [item for item in self.scene().contextMenu if "export" not in item.text().lower()]
-
-        self.imageview_before.add_auto_color_action(self)
-        self.imageview_after.add_auto_color_action(self)
-        self.imageview_difference.add_auto_color_action(self)
 
         self.imageview_before.link_sibling_axis()
 

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -20,9 +20,9 @@ class ReconImagesView(GraphicsLayoutWidget):
         super().__init__(parent)
         self.parent = parent
 
-        self.imageview_projection = MIMiniImageView(name="Projection")
-        self.imageview_sinogram = MIMiniImageView(name="Sinogram")
-        self.imageview_recon = MIMiniImageView(name="Recon")
+        self.imageview_projection = MIMiniImageView(name="Projection", parent=parent)
+        self.imageview_sinogram = MIMiniImageView(name="Sinogram", parent=parent)
+        self.imageview_recon = MIMiniImageView(name="Recon", parent=parent, recon_mode=True)
         # Set the three images as axis siblings so that auto colour palette changes will be applied to them all
         MIMiniImageView.set_siblings([self.imageview_projection, self.imageview_sinogram, self.imageview_recon],
                                      axis=True)

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -185,9 +185,6 @@ class ReconstructWindowView(BaseMainWindowView):
         self.previewAutoUpdate.stateChanged.connect(self.handle_auto_update_preview_selection)
         self.updatePreviewButton.clicked.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_USER_CLICK))
 
-        # Preparing the auto change colour map UI
-        self.image_view.imageview_recon.add_auto_color_action(self, recon_mode=True)
-
         for spinbox in [self.lbhc_a0, self.lbhc_a1, self.lbhc_a2, self.lbhc_a3]:
             spinbox.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
             self.lbhc_enabled.toggled.connect(spinbox.setEnabled)


### PR DESCRIPTION
### Issue

Closes #1363

### Description

Refactors the initialising of the auto colour menu for `MIMiniImageView` so that it happens in the constructor. This means that the following histograms will now offer this menu when they didn't previously:

1) Images in the COR Inspection dialog
2) The projection and sinogram images in the Reconstruction window

### Testing & Acceptance Criteria 

Test auto colour palette menu functionality in the Operations and Reconstruction windows, and the COR Inspection dialog.

### Documentation

Issue 1363 added to release notes
