### PR TITLE
Cleanup image stacks in test_load_images and test_load_180

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -100,7 +100,7 @@ jobs:
         timeout-minutes: 5
         shell: bash -l {0}
         run: |
-          xvfb-run --auto-servernum python -m pytest --cov --cov-report=xml -n auto --ignore=mantidimaging/eyes_tests
+          xvfb-run --auto-servernum python -m pytest --cov --cov-report=xml -n auto --ignore=mantidimaging/eyes_tests --durations=10
 
       - name: Get test data
         shell: bash -l {0}
@@ -113,7 +113,7 @@ jobs:
       - name: GUI Tests System
         shell: bash -l {0}
         run: |
-          xvfb-run --auto-servernum python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov --run-system-tests
+          xvfb-run --auto-servernum python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov --run-system-tests --durations=10
         timeout-minutes: 30
 
       - name: GUI Tests Screenshots Applitools
@@ -124,7 +124,7 @@ jobs:
           APPLITOOLS_BATCH_ID: ${{ github.sha }}
           GITHUB_BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          xvfb-run --auto-servernum python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests
+          xvfb-run --auto-servernum python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests --durations=10
         timeout-minutes: 15
 
       - name: Coveralls

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -113,7 +113,7 @@ jobs:
       - name: GUI Tests System
         shell: bash -l {0}
         run: |
-          xvfb-run --auto-servernum python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov --run-system-tests --durations=10
+          xvfb-run --auto-servernum /bin/time -v python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov --run-system-tests --durations=10
         timeout-minutes: 30
 
       - name: GUI Tests Screenshots Applitools

--- a/.github/workflows/cos7_testing.yml
+++ b/.github/workflows/cos7_testing.yml
@@ -50,5 +50,5 @@ jobs:
       timeout-minutes: 5
       uses: ./.github/actions/test
       with:
-        command: xvfb-run pytest -n auto --ignore=mantidimaging/eyes_tests
+        command: xvfb-run pytest -n auto --ignore=mantidimaging/eyes_tests --durations=10
         label: centos7

--- a/.github/workflows/u18_testing.yml
+++ b/.github/workflows/u18_testing.yml
@@ -45,4 +45,4 @@ jobs:
       timeout-minutes: 5
       uses: ./.github/actions/test
       with:
-        command: xvfb-run pytest -n auto --ignore=mantidimaging/eyes_tests
+        command: xvfb-run pytest -n auto --ignore=mantidimaging/eyes_tests --durations=10

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -42,6 +42,7 @@ class GuiSystemBase(unittest.TestCase):
         QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("Yes"))
         self.main_window.close()
         QTest.qWait(SHORT_DELAY)
+        self.assertDictEqual(self.main_window.presenter.model.datasets, {})
 
     @classmethod
     def _click_messageBox(cls, button_text: str):

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -112,7 +112,7 @@ class GuiSystemBase(unittest.TestCase):
     def _open_reconstruction(self):
         self.main_window.actionRecon.trigger()
 
-    def _close_stack_tabs(self):
+    def _close_image_stacks(self):
         while self.main_window.dataset_tree_widget.topLevelItemCount():
             self.main_window.dataset_tree_widget.topLevelItem(0).setSelected(True)
             self.main_window._delete_container()

--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -18,6 +18,11 @@ class TestGuiSystemLoading(GuiSystemBase):
         super().setUp()
         self._close_welcome()
 
+    def tearDown(self) -> None:
+        self._close_stack_tabs()
+        super().tearDown()
+        self.assertFalse(self.main_window.isVisible())
+
     @mock.patch("mantidimaging.gui.windows.main.MainWindowView._get_file_name")
     def _load_images(self, mocked_select_file):
         mocked_select_file.return_value = LOAD_SAMPLE

--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -19,7 +19,7 @@ class TestGuiSystemLoading(GuiSystemBase):
         self._close_welcome()
 
     def tearDown(self) -> None:
-        self._close_stack_tabs()
+        self._close_image_stacks()
         super().tearDown()
         self.assertFalse(self.main_window.isVisible())
 

--- a/mantidimaging/gui/test/gui_system_operations_test.py
+++ b/mantidimaging/gui/test/gui_system_operations_test.py
@@ -54,7 +54,7 @@ class TestGuiSystemOperations(GuiSystemBase):
         self.op_window = self.main_window.filters
 
     def tearDown(self) -> None:
-        self._close_stack_tabs()
+        self._close_image_stacks()
         super().tearDown()
         self.assertFalse(self.main_window.isVisible())
 

--- a/mantidimaging/gui/test/gui_system_reconstruction_test.py
+++ b/mantidimaging/gui/test/gui_system_reconstruction_test.py
@@ -28,7 +28,7 @@ class TestGuiSystemReconstruction(GuiSystemBase):
         self.recon_window.close()
         assert isinstance(self.main_window.recon, ReconstructWindowView)
         self.assertFalse(self.main_window.recon.isVisible())
-        self._close_stack_tabs()
+        self._close_image_stacks()
         super().tearDown()
         self.assertFalse(self.main_window.isVisible())
 

--- a/mantidimaging/gui/test/gui_system_windows_test.py
+++ b/mantidimaging/gui/test/gui_system_windows_test.py
@@ -8,7 +8,7 @@ from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHOW_DELAY
 
 class TestGuiSystemWindows(GuiSystemBase):
     def tearDown(self) -> None:
-        self._close_stack_tabs()
+        self._close_image_stacks()
         super().tearDown()
         self.assertFalse(self.main_window.isVisible())
 
@@ -48,5 +48,5 @@ class TestGuiSystemWindows(GuiSystemBase):
         self._wait_until(lambda: len(self.main_window.recon.presenter.async_tracker) == 0)
         self.main_window.recon.close()
         QTest.qWait(SHOW_DELAY)
-        self._close_stack_tabs()
+        self._close_image_stacks()
         QTest.qWait(SHOW_DELAY)

--- a/mantidimaging/gui/test/gui_system_windows_test.py
+++ b/mantidimaging/gui/test/gui_system_windows_test.py
@@ -7,6 +7,11 @@ from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHOW_DELAY
 
 
 class TestGuiSystemWindows(GuiSystemBase):
+    def tearDown(self) -> None:
+        self._close_stack_tabs()
+        super().tearDown()
+        self.assertFalse(self.main_window.isVisible())
+
     def test_main_window_shows(self):
         self.assertTrue(self.main_window.isVisible())
         self.assertTrue(self.main_window.welcome_window.view.isVisible())


### PR DESCRIPTION
### Issue
Closes #1354

### Description

The tests in `TestGuiSystemLoading` were not closing the datasets when finishing. Adding new tests in #1265 meant that there was more data that was not being cleaned up. This slowed down the tests overall.

This PR adds a bit more reporting, and fixes the cleanup. Also adds an assertion to prevent similar leaks in the future.

Before and after runs went from 13:49 to 9:48.

Looking at the /bin/time -v output, both still reach over 6GB of RSS (github actions instances have 7GB). Major page faults drops from 29 million to 17 million, so there is a lot less swapping.

### Testing & Acceptance Criteria 

Automated testing should pass

### Documentation
Not needed
