### PR TITLE
Coveralls: specify service name

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -133,7 +133,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
         run: |
-          coveralls
+          coveralls --service=github
 
       # Always label as unstable. Builds of stable releases can be manually labeled to 'main' once tested
       - name: publish 'unstable' package

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -131,7 +131,6 @@ jobs:
         shell: bash -l {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
         run: |
           coveralls --service=github
 

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -19,3 +19,4 @@ Developer Changes
 - #1317 : Unify auto color palette code between MIMiniImageView and MIImageView
 - #1363 : Add auto color menu from constructor in MIMiniImageView
 - #1362 : Rename Images class to ImageStack
+- #1148 : Re-enable coverage checking

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -18,12 +18,12 @@ dependencies:
       # For developement
       - pytest==6.2.*
       - pytest-cov==2.12.*
-      - coveralls==3.2.*
+      - coveralls==3.3.*
       - yapf==0.31.*
       - mypy==0.910
       - flake8==3.9.*
       - testfixtures==6.18.*
-      - coverage==5.5
+      - coverage==6.3.*
       - gitpython==3.1.*
       - pylint==2.11.*
       - sphinx==4.2.*


### PR DESCRIPTION
Avoids 422 error
https://github.com/TheKevJames/coveralls-python/issues/252

### Issue
Closes #1148

### Description
Added the service name argument

Updated versions

Make coverage step required to pass again

I have also updated the default branch name at https://coveralls.io/github/mantidproject/mantidimaging

### Testing & Acceptance Criteria 

Check that the coverage section in the conda tests is passing

### Documentation

Release notes
