### PR TITLE
Add LeakTracker

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -20,3 +20,4 @@ Developer Changes
 - #1363 : Add auto color menu from constructor in MIMiniImageView
 - #1362 : Rename Images class to ImageStack
 - #1148 : Re-enable coverage checking
+- #1375 : Leak tracking tool

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -16,6 +16,7 @@ from mantidimaging.core.parallel import utility as pu
 from mantidimaging.core.utility.data_containers import ProjectionAngles, Counts, Indices
 from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
 from mantidimaging.core.utility.sensible_roi import SensibleROI
+from mantidimaging.core.utility.leak_tracker import leak_tracker
 
 
 class ImageStack:
@@ -58,6 +59,8 @@ class ImageStack:
                 self.name = "untitled"
         else:
             self.name = name
+
+        leak_tracker.add(data, msg=f"ImageStack {self.name}")
 
     def __eq__(self, other):
         if isinstance(other, ImageStack):

--- a/mantidimaging/core/utility/leak_tracker.py
+++ b/mantidimaging/core/utility/leak_tracker.py
@@ -1,0 +1,112 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+import gc
+import sys
+import traceback
+import weakref
+from typing import NamedTuple, List, Set, Iterable
+
+from numpy import ndarray
+
+
+class ItemInfo(NamedTuple):
+    ref: weakref.ref
+    msg: str
+    created: List[str]
+
+
+def obj_to_string(obj, relative=None) -> str:
+    """Shows object type, id and extra info for some classes"""
+    extra_info = ""
+    if isinstance(obj, dict) and relative is not None:
+        keys = {k for k, v in obj.items() if v is relative}
+        extra_info += f" keys={keys}"
+
+    try:
+        if hasattr(obj, "name"):
+            extra_info += f" obj.name={obj.name}"
+
+        if hasattr(obj, "id"):
+            extra_info += f" obj.id={obj.id}"
+    except RuntimeError as e:
+        # Can happen with a deleted QWidget
+        extra_info += str(e)
+
+    if isinstance(obj, ndarray):
+        extra_info += f" ndarray: {obj.shape} {obj.dtype}"
+
+    return f"{type(obj)} pyid={id(obj)} {extra_info}"
+
+
+def find_owners(obj, depth: int, path: List[str] = None, ignore: Set[int] = None) -> List[List[str]]:
+    """Recursively track though references to objects and return a list of routes"""
+    all_routes = []
+    if path is None:
+        path = [obj_to_string(obj)]
+    if ignore is None:
+        ignore = set()
+    ignore.add(id(sys._getframe()))
+    ignore.add(id(path))
+    ignore.add(id(obj))
+
+    new_refs = [r for r in gc.get_referrers(obj) if id(r) not in ignore]
+    ignore.add(id(new_refs))
+    if len(new_refs) == 0:
+        all_routes.append(path)
+    for owner in new_refs:
+        if type(owner).__name__ in ['frame', 'function', 'list_iterator']:
+            continue
+        route = [obj_to_string(owner, obj)] + path
+        ignore.add(id(route))
+        if depth > 0:
+            new_routes = find_owners(owner, depth - 1, route, ignore)
+            all_routes.extend(new_routes)
+        else:
+            all_routes.append(route)
+
+    return all_routes
+
+
+class LeakTracker:
+    """
+    Track object to debug why large objects are still referenced.
+
+    All objects of interest should be added in their constructor. The pretty_print() method can be called later, so see
+    some information about which of the objects are alive.
+    """
+    def __init__(self):
+        self.tracked_objects = []
+
+    def add(self, item, msg=""):
+        created = traceback.format_stack()[:-1]
+        item_info = ItemInfo(weakref.ref(item), msg, created)
+        self.tracked_objects.append(item_info)
+
+    def live_objects(self) -> Iterable[ItemInfo]:
+        return (item for item in self.tracked_objects if item.ref() is not None)
+
+    def count(self) -> int:
+        return sum(1 for _ in self.live_objects())
+
+    def pretty_print(self, debug_init=False, debug_owners=False, trace_depth=5, output=sys.stdout) -> None:
+        for item_info in self.live_objects():
+            item = item_info.ref()
+            print(" Object:", obj_to_string(item_info.ref()), file=output)
+            print(f"  {item_info.msg=}", file=output)
+            if debug_init:
+                print(" Created at:", file=output)
+                for line in item_info.created[-trace_depth:]:
+                    print("\t", line.strip(), file=output)
+                print(file=output)
+
+            if debug_owners:
+                print(" Ownership:", file=output)
+                routes = find_owners(item, trace_depth)
+                for route in routes:
+                    for step in route:
+                        print("\t", step, file=output)
+                    print(file=output)
+            print(file=output)
+
+
+leak_tracker = LeakTracker()

--- a/mantidimaging/core/utility/test/leak_tracker_test.py
+++ b/mantidimaging/core/utility/test/leak_tracker_test.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+import unittest
+from io import StringIO
+
+from mantidimaging.core.utility.leak_tracker import LeakTracker
+
+
+class TestObject:
+    pass
+
+
+class TestContainer:
+    def __init__(self, obj):
+        self.held_reference = obj
+
+
+class CommandLineArgumentsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.leak_tracker = LeakTracker()
+
+    def test_empty(self):
+        self.assertEqual(self.leak_tracker.count(), 0)
+        live_objects = self.leak_tracker.live_objects()
+        self.assertEqual(len(list(live_objects)), 0)
+
+    def test_add_object(self):
+        self.assertEqual(self.leak_tracker.count(), 0)
+        ob1 = TestObject()
+        self.leak_tracker.add(ob1)
+        self.assertEqual(self.leak_tracker.count(), 1)
+        live_obs = [ob.ref() for ob in self.leak_tracker.live_objects()]
+        self.assertIn(ob1, live_obs)
+
+    def test_add_objects(self):
+        self.assertEqual(self.leak_tracker.count(), 0)
+        ob1 = TestObject()
+        ob2 = TestObject()
+        self.leak_tracker.add(ob1)
+        self.leak_tracker.add(ob2)
+        self.assertEqual(self.leak_tracker.count(), 2)
+
+    def test_remove_objects(self):
+        self.assertEqual(self.leak_tracker.count(), 0)
+        ob1 = TestObject()
+        ob2 = TestObject()
+        ob3 = TestObject()
+        self.leak_tracker.add(ob1)
+        self.leak_tracker.add(ob2)
+        self.leak_tracker.add(ob3)
+
+        self.assertEqual(self.leak_tracker.count(), 3)
+
+        del ob3
+        self.assertEqual(self.leak_tracker.count(), 2)
+
+    def test_tracking(self):
+        self.assertEqual(self.leak_tracker.count(), 0)
+        ob1 = TestObject()
+        self.leak_tracker.add(ob1, "created_in_test_tracking")
+        container = TestContainer(ob1)  # noqa: F841
+
+        self.assertEqual(self.leak_tracker.count(), 1)
+        del ob1
+        self.assertEqual(self.leak_tracker.count(), 1)
+
+        def check_output(message, **kwargs):
+            track_output = StringIO()
+            self.leak_tracker.pretty_print(output=track_output, **kwargs)
+            track_output_value = track_output.getvalue()
+            self.assertIn(message, track_output_value)
+
+        # check that the object type and message are in the output
+        check_output("leak_tracker_test.TestObject")
+        check_output("created_in_test_tracking")
+
+        # Check that this file and the line of code are listed in the output
+        check_output(__file__, debug_init=True)
+        check_output('self.leak_tracker.add(ob1, "created_in_test_tracking")', debug_init=True)
+
+        # Check that container holding the reference is listed in the output
+        check_output("leak_tracker_test.TestContainer", debug_owners=True)
+        check_output("held_reference", debug_owners=True)

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -12,6 +12,7 @@ from PyQt5.QtTest import QTest
 from PyQt5.QtWidgets import QApplication, QMessageBox, QInputDialog
 import pytest
 
+from mantidimaging.core.utility.leak_tracker import leak_tracker
 from mantidimaging.core.utility.version_check import versions
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.load_dialog.presenter import Notification
@@ -43,6 +44,10 @@ class GuiSystemBase(unittest.TestCase):
         self.main_window.close()
         QTest.qWait(SHORT_DELAY)
         self.assertDictEqual(self.main_window.presenter.model.datasets, {})
+
+        if leak_count := leak_tracker.count():
+            print("\nItems still alive:", leak_count)
+            leak_tracker.pretty_print(debug_init=False, debug_owners=False, trace_depth=5)
 
     @classmethod
     def _click_messageBox(cls, button_text: str):


### PR DESCRIPTION
### Issue

Closes #1374 

### Description

Class for tracking references to objects. Uses weak references to avoid keeping the objects alive. Then the leak_tracker can be queried later to see if the objects are still alive.

Use the tracker for the numpy array in `ImageStack`

Show leaked objects in the system test `tearDown` method

### Testing & Acceptance Criteria 

In the system test run leaked ImageStacks should be reported, e.g.

`xvfb-run --auto-servernum  pytest -vs -rs --run-system-tests -k test_run_operation_stack_safe_0`

If you change the `gui_system_base.py` line 50 to
`leak_tracker.pretty_print(debug_init=True, debug_owners=True, trace_depth=5)`

Then some extra debug information will be shown

### Documentation

Release notes updated
