### PR TITLE
Fix leak in StackChoiceView

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -21,3 +21,4 @@ Developer Changes
 - #1362 : Rename Images class to ImageStack
 - #1148 : Re-enable coverage checking
 - #1375 : Leak tracking tool
+- #1376 : Fix leak in StackChoiceView

--- a/mantidimaging/gui/windows/stack_choice/view.py
+++ b/mantidimaging/gui/windows/stack_choice/view.py
@@ -163,6 +163,7 @@ class StackChoiceView(BaseMainWindowView):
 
         self.original_stack.close()
         self.new_stack.close()
+        self.presenter = None
 
     def _set_from_old_to_new(self):
         """


### PR DESCRIPTION
### Issue
Closes #1376

Note, needs rebasing after #1375 

### Description

StackChoiceView: drop reference to presenter when closed
    
Prevents a reference loop that keeps an ImageStack alive

For local runs of `xvfb-run --auto-servernum /bin/time -v  pytest -vs -rs -p no:randomly --run-system-tests` this reduces Maximum resident set size from 18 to 11 GB.

The system tests on actions on is down to 8 mins, recent runs on main have been between 9 and 12.

### Testing &  Acceptance Criteria 

Should no longer be a message from 
`xvfb-run --auto-servernum  pytest -vs -rs --run-system-tests -k test_run_operation_stack_safe_0`
about
`Items still alive`


### Documentation

Release notes updated
