### PR TITLE
Add angle/z axis slider in the operations window

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -7,6 +7,7 @@ New Features
 ------------
 
 - #1340 : ROI norm - remove preserve max option
+- #1379 : Add angle/z axis slider in the operations window
 
 Fixes
 -----

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -8,7 +8,7 @@ from typing import Optional
 import numpy as np
 from PyQt5.QtCore import QPoint, QRect
 from PyQt5.QtGui import QGuiApplication, QResizeEvent
-from pyqtgraph import ColorMap, GraphicsLayoutWidget, ImageItem, LegendItem, PlotItem
+from pyqtgraph import ColorMap, GraphicsLayoutWidget, ImageItem, LegendItem, PlotItem, InfiniteLine
 from pyqtgraph.graphicsItems.GraphicsLayout import GraphicsLayout
 
 from mantidimaging.core.utility.histogram import set_histogram_log_scale
@@ -33,8 +33,25 @@ def _data_valid_for_histogram(data):
     return data is not None and any(d is not None for d in data)
 
 
+class ZSlider(PlotItem):
+    z_line: InfiniteLine
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setFixedHeight(40)
+        self.hideAxis("left")
+        self.setXRange(0, 1)
+        self.setMouseEnabled(x=False, y=False)
+        self.hideButtons()
+
+        self.z_line = InfiniteLine(0, movable=True)
+        self.z_line.setPen((255, 255, 0, 200))
+        self.addItem(self.z_line)
+
+
 class FilterPreviews(GraphicsLayoutWidget):
     histogram: Optional[PlotItem]
+    z_slider: ZSlider
 
     def __init__(self, parent=None, **kwargs):
         super().__init__(parent, **kwargs)
@@ -73,6 +90,9 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.image_layout.addItem(self.imageview_after)
         self.image_layout.addItem(self.imageview_difference)
         self.nextRow()
+
+        self.z_slider = ZSlider()
+        self.addItem(self.z_slider, colspan=3)
 
         self.init_histogram()
 

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -56,6 +56,9 @@ class ZSlider(PlotItem):
         self.setXRange(min, max)
         self.z_line.setBounds([min, max])
 
+    def set_value(self, value):
+        self.z_line.setValue(value)
+
     def value_changed(self):
         self.valueChanged.emit(int(self.z_line.value()))
 

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -2,15 +2,19 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from logging import getLogger
+from typing import TYPE_CHECKING
 
 import numpy as np
-from PyQt5.QtCore import QPoint, QRect, pyqtSignal
+from PyQt5.QtCore import Qt, QPoint, QRect, pyqtSignal
 from PyQt5.QtGui import QGuiApplication, QResizeEvent
 from pyqtgraph import ColorMap, GraphicsLayoutWidget, ImageItem, LegendItem, PlotItem, InfiniteLine
 from pyqtgraph.graphicsItems.GraphicsLayout import GraphicsLayout
 
 from mantidimaging.core.utility.histogram import set_histogram_log_scale
 from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
+
+if TYPE_CHECKING:
+    from PyQt5.QtWidgets import QGraphicsSceneMouseEvent
 
 LOG = getLogger(__name__)
 
@@ -55,6 +59,12 @@ class ZSlider(PlotItem):
 
     def value_changed(self):
         self.valueChanged.emit(int(self.z_line.value()))
+
+    def mousePressEvent(self, ev: 'QGraphicsSceneMouseEvent'):
+        if ev.button() == Qt.MouseButton.LeftButton:
+            x = round(self.vb.mapSceneToView(ev.scenePos()).x())
+            self.set_value(x)
+        super().mousePressEvent(ev)
 
 
 class FilterPreviews(GraphicsLayoutWidget):

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -6,7 +6,7 @@ from logging import getLogger
 from typing import Optional
 
 import numpy as np
-from PyQt5.QtCore import QPoint, QRect
+from PyQt5.QtCore import QPoint, QRect, pyqtSignal
 from PyQt5.QtGui import QGuiApplication, QResizeEvent
 from pyqtgraph import ColorMap, GraphicsLayoutWidget, ImageItem, LegendItem, PlotItem, InfiniteLine
 from pyqtgraph.graphicsItems.GraphicsLayout import GraphicsLayout
@@ -35,6 +35,7 @@ def _data_valid_for_histogram(data):
 
 class ZSlider(PlotItem):
     z_line: InfiniteLine
+    valueChanged = pyqtSignal(int)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -48,10 +49,15 @@ class ZSlider(PlotItem):
         self.z_line.setPen((255, 255, 0, 200))
         self.addItem(self.z_line)
 
+        self.z_line.sigPositionChanged.connect(self.value_changed)
+
     def set_range(self, min, max):
         self.z_line.setValue(min)
         self.setXRange(min, max)
         self.z_line.setBounds([min, max])
+
+    def value_changed(self):
+        self.valueChanged.emit(int(self.z_line.value()))
 
 
 class FilterPreviews(GraphicsLayoutWidget):

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -48,6 +48,11 @@ class ZSlider(PlotItem):
         self.z_line.setPen((255, 255, 0, 200))
         self.addItem(self.z_line)
 
+    def set_range(self, min, max):
+        self.z_line.setValue(min)
+        self.setXRange(min, max)
+        self.z_line.setBounds([min, max])
+
 
 class FilterPreviews(GraphicsLayoutWidget):
     histogram: Optional[PlotItem]

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-from collections import namedtuple
 from logging import getLogger
 from typing import Optional
 
@@ -23,10 +22,6 @@ diff_pen = (0, 0, 200)
 
 OVERLAY_THRESHOLD = 1e-3
 OVERLAY_COLOUR_DIFFERENCE = [0, 255, 0, 255]
-
-Coord = namedtuple('Coord', ['row', 'col'])
-histogram_coords = Coord(4, 0)
-label_coords = Coord(3, 1)
 
 
 def _data_valid_for_histogram(data):
@@ -107,6 +102,7 @@ class FilterPreviews(GraphicsLayoutWidget):
 
         self.z_slider = ZSlider()
         self.addItem(self.z_slider, colspan=3)
+        self.nextRow()
 
         self.init_histogram()
 
@@ -132,12 +128,7 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.image_diff_overlay.clear()
 
     def init_histogram(self):
-        self.histogram = self.addPlot(row=histogram_coords.row,
-                                      col=histogram_coords.col,
-                                      labels=histogram_axes_labels,
-                                      lockAspect=True,
-                                      colspan=3)
-        self.addLabel("Pixel values", row=label_coords.row, col=label_coords.col)
+        self.histogram = self.addPlot(labels=histogram_axes_labels, lockAspect=True, colspan=3)
 
         self.legend = self.histogram.addLegend()
         self.legend.setOffset((0, 1))

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -46,12 +46,12 @@ class ZSlider(PlotItem):
 
         self.z_line.sigPositionChanged.connect(self.value_changed)
 
-    def set_range(self, min, max):
+    def set_range(self, min: int, max: int):
         self.z_line.setValue(min)
         self.setXRange(min, max)
         self.z_line.setBounds([min, max])
 
-    def set_value(self, value):
+    def set_value(self, value: int):
         self.z_line.setValue(value)
 
     def value_changed(self):

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -156,7 +156,7 @@ class FiltersWindowPresenter(BasePresenter):
 
         self.do_update_previews()
 
-    def set_preview_image_index(self, image_idx):
+    def set_preview_image_index(self, image_idx: int):
         """
         Sets the current preview image index.
         """

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -167,6 +167,9 @@ class FiltersWindowPresenter(BasePresenter):
         with BlockQtSignals([preview_idx_spin]):
             preview_idx_spin.setValue(self.model.preview_image_idx)
 
+        with BlockQtSignals([self.view.previews.z_slider]):
+            self.view.previews.z_slider.set_value(self.model.preview_image_idx)
+
         # Trigger preview updating
         self.view.auto_update_triggered.emit()
 

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -145,7 +145,9 @@ class FiltersWindowPresenter(BasePresenter):
         # Update the preview image index
         with BlockQtSignals([self.view]):
             self.set_preview_image_index(0)
-            self.view.previewImageIndex.setMaximum(self.max_preview_image_idx)
+            max_slice = self.max_preview_image_idx
+            self.view.previewImageIndex.setMaximum(max_slice)
+            self.view.previews.z_slider.set_range(0, max_slice)
 
             for row_id in range(self.view.filterPropertiesLayout.count()):
                 widget = self.view.filterPropertiesLayout.itemAt(row_id).widget()

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -95,6 +95,7 @@ class FiltersWindowView(BaseMainWindowView):
 
         # Handle preview index selection
         self.previewImageIndex.valueChanged[int].connect(self.presenter.set_preview_image_index)
+        self.previews.z_slider.valueChanged.connect(self.presenter.set_preview_image_index)
 
         # Preview update triggers
         self.auto_update_triggered.connect(self.on_auto_update_triggered)


### PR DESCRIPTION
### Issue

Closes #1369 

### Description

This implements a `ZSlider` class and uses it in the operations window to allow sliding through the stack slices. For a stack of projections this slides through the angles. For reconstructed stack, it slides through the z axis.

![image](https://user-images.githubusercontent.com/74248560/159523438-02516a8e-633f-45e9-8460-2011b3251b03.png)


### Testing 
Load a dataset, open the operations window.
Play with the slider

### Acceptance Criteria 

Should be easy to slide though a stack.
Interaction with the image spinbox should be sensible.


### Documentation

Release notes
