### PR TITLE
Use small tag of mantidimaging-data to speed up tests

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -105,9 +105,9 @@ jobs:
       - name: Get test data
         shell: bash -l {0}
         run: |
-          wget -nv https://github.com/mantidproject/mantidimaging-data/archive/refs/heads/main.zip
-          unzip -q main.zip -d ~
-          mv ~/mantidimaging-data-main ~/mantidimaging-data
+          wget -nv https://github.com/mantidproject/mantidimaging-data/archive/refs/tags/small.zip
+          unzip -q small.zip -d ~
+          mv ~/mantidimaging-data-small ~/mantidimaging-data
         timeout-minutes: 5
 
       - name: GUI Tests System


### PR DESCRIPTION
### Issue

Closes #1339

### Description

I have created a 128x128 branch of the flower dataset on mantidimaging-data. The change here is to use that instead of the full dataset. This reduces download time and speeds up gui test runtimes.

Compared to the last successful conda action run on a PR
Get test data:  47s -> 1s
GUI test system: 7:55 -> 3:23
GUI test screenshots: 1:48 -> 2:38 

Not sure why the screenshots got slower. Maybe dominated by time uploading to api?
Some more old screenshot times: 1:47, 1:48

### Testing & Acceptance Criteria 

I have updated all of the applitools baselines for the smaller image.


### Documentation

not needed
