### PR TITLE
Use wait_until in test_reconstruction_window_opens_with_data

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -124,7 +124,7 @@ jobs:
           APPLITOOLS_BATCH_ID: ${{ github.sha }}
           GITHUB_BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          xvfb-run --auto-servernum python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests --durations=10
+          xvfb-run --auto-servernum /bin/time -v python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests --durations=10
         timeout-minutes: 15
 
       - name: Coveralls

--- a/mantidimaging/eyes_tests/reconstruct_window_test.py
+++ b/mantidimaging/eyes_tests/reconstruct_window_test.py
@@ -1,11 +1,13 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+
 import numpy as np
 from PyQt5.QtWidgets import QApplication
 
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 from mantidimaging.core.data.dataset import MixedDataset
+from mantidimaging.test_helpers.qt_test_helpers import wait_until
 
 
 class ReconstructionWindowTest(BaseEyesTest):
@@ -25,6 +27,7 @@ class ReconstructionWindowTest(BaseEyesTest):
         self._load_data_set()
 
         self.imaging.show_recon_window()
+        wait_until(lambda: len(self.imaging.recon.presenter.async_tracker) == 0)
 
         self.check_target(widget=self.imaging.recon)
 

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -3,7 +3,7 @@
 
 import os
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Optional
 import unittest
 from unittest import mock
 
@@ -17,6 +17,7 @@ from mantidimaging.core.utility.version_check import versions
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.load_dialog.presenter import Notification
 from mantidimaging.test_helpers.start_qapplication import start_qapplication
+from mantidimaging.test_helpers.qt_test_helpers import wait_until
 
 versions._use_test_values()
 
@@ -76,17 +77,6 @@ class GuiSystemBase(unittest.TestCase):
         self.main_window.welcome_window.view.close()
 
     @classmethod
-    def _wait_until(cls, test_func: Callable[[], bool], delay=0.1, max_retry=100):
-        """
-        Repeat test_func every delay seconds until is becomes true. Or if max_retry is reached return false.
-        """
-        for _ in range(max_retry):
-            if test_func():
-                return True
-            QTest.qWait(int(delay * 1000))
-        raise RuntimeError("_wait_until reach max retries")
-
-    @classmethod
     def _wait_for_widget_visible(cls, widget_type, delay=0.1, max_retry=100):
         for _ in range(max_retry):
             for widget in cls.app.topLevelWidgets():
@@ -109,7 +99,7 @@ class GuiSystemBase(unittest.TestCase):
         self.main_window.load_dialogue.presenter.notify(Notification.UPDATE_ALL_FIELDS)
         QTest.qWait(SHOW_DELAY)
         self.main_window.load_dialogue.accept()
-        self._wait_until(test_func, max_retry=600)
+        wait_until(test_func, max_retry=600)
 
     def _open_operations(self):
         self.main_window.actionFilters.trigger()

--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -11,6 +11,7 @@ from PyQt5.QtWidgets import QApplication, QDialogButtonBox
 from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHORT_DELAY, LOAD_SAMPLE
 from mantidimaging.gui.widgets.dataset_selector_dialog.dataset_selector_dialog import DatasetSelectorDialog
 from mantidimaging.gui.windows.main.save_dialog import MWSaveDialog
+from mantidimaging.test_helpers.qt_test_helpers import wait_until
 
 
 class TestGuiSystemLoading(GuiSystemBase):
@@ -34,7 +35,7 @@ class TestGuiSystemLoading(GuiSystemBase):
             current_stacks = len(self.main_window.presenter.get_active_stack_visualisers())
             return (current_stacks - initial_stacks) >= 1
 
-        self._wait_until(test_func, max_retry=600)
+        wait_until(test_func, max_retry=600)
 
     @classmethod
     def _click_stack_selector(cls):
@@ -75,7 +76,7 @@ class TestGuiSystemLoading(GuiSystemBase):
         QTimer.singleShot(SHORT_DELAY, lambda: self._click_stack_selector())
         self.main_window.actionLoad180deg.trigger()
 
-        self._wait_until(lambda: len(self.main_window.presenter.get_active_stack_visualisers()) == 5)
+        wait_until(lambda: len(self.main_window.presenter.get_active_stack_visualisers()) == 5)
 
         stacks_after = self.main_window.presenter.get_active_stack_visualisers()
         self.assertEqual(len(stacks_after), 5)
@@ -95,6 +96,6 @@ class TestGuiSystemLoading(GuiSystemBase):
             QTest.mouseClick(ok_button, Qt.LeftButton)
 
             QApplication.processEvents()
-            self._wait_until(lambda: mock_save.call_count == 1)
+            wait_until(lambda: mock_save.call_count == 1)
             # Confirm that save has been called only once
             mock_save.assert_called_once()

--- a/mantidimaging/gui/test/gui_system_operations_test.py
+++ b/mantidimaging/gui/test/gui_system_operations_test.py
@@ -14,6 +14,7 @@ from mantidimaging.gui.windows.stack_choice.presenter import StackChoicePresente
 from mantidimaging.core.data import ImageStack
 from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHOW_DELAY, SHORT_DELAY
 from mantidimaging.gui.windows.operations.view import FiltersWindowView
+from mantidimaging.test_helpers.qt_test_helpers import wait_until
 
 OP_LIST = [
     ("Arithmetic", [["Multiply", "2"]]),
@@ -90,7 +91,7 @@ class TestGuiSystemOperations(GuiSystemBase):
         self.op_window.safeApply.setChecked(False)
         QTest.mouseClick(self.op_window.applyButton, Qt.MouseButton.LeftButton)
         QTest.qWait(SHORT_DELAY)
-        self._wait_until(lambda: self.op_window.presenter.filter_is_running is False, max_retry=600)
+        wait_until(lambda: self.op_window.presenter.filter_is_running is False, max_retry=600)
 
         self.main_window.filters.close()
         QTest.qWait(SHOW_DELAY)
@@ -134,7 +135,7 @@ class TestGuiSystemOperations(GuiSystemBase):
             QTest.mouseClick(self.op_window.applyButton, Qt.MouseButton.LeftButton)
 
             QTest.qWait(SHORT_DELAY)
-            self._wait_until(lambda: self.op_window.presenter.filter_is_running is False)
+            wait_until(lambda: self.op_window.presenter.filter_is_running is False)
             self.main_window.filters.close()
             QTest.qWait(SHOW_DELAY)
 
@@ -143,11 +144,11 @@ class TestGuiSystemOperations(GuiSystemBase):
         self.op_window.previewAutoUpdate.setCheckState(Qt.CheckState.Unchecked)
 
         QTest.mouseClick(self.op_window.previewAutoUpdate, Qt.MouseButton.LeftButton)
-        self._wait_until(lambda: mock_do_update_previews.call_count == 1)
+        wait_until(lambda: mock_do_update_previews.call_count == 1)
 
     @mock.patch("mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter.do_update_previews")
     def test_clicking_update_now_btn_triggers_preview(self, mock_do_update_previews):
         self.op_window.previewAutoUpdate.setCheckState(Qt.CheckState.Unchecked)
 
         QTest.mouseClick(self.op_window.updatePreviewButton, Qt.MouseButton.LeftButton)
-        self._wait_until(lambda: mock_do_update_previews.call_count == 1)
+        wait_until(lambda: mock_do_update_previews.call_count == 1)

--- a/mantidimaging/gui/test/gui_system_reconstruction_test.py
+++ b/mantidimaging/gui/test/gui_system_reconstruction_test.py
@@ -8,6 +8,7 @@ from PyQt5.QtCore import Qt, QTimer
 from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHOW_DELAY, SHORT_DELAY
 from mantidimaging.gui.windows.recon.view import ReconstructWindowView
 from mantidimaging.gui.dialogs.cor_inspection.view import CORInspectionDialogView
+from mantidimaging.test_helpers.qt_test_helpers import wait_until
 
 
 class TestGuiSystemReconstruction(GuiSystemBase):
@@ -21,10 +22,10 @@ class TestGuiSystemReconstruction(GuiSystemBase):
         assert isinstance(self.main_window.recon, ReconstructWindowView)  # for yapf
         self.assertTrue(self.main_window.recon.isVisible())
         self.recon_window = self.main_window.recon
-        self._wait_until(lambda: self.recon_window.presenter.model.images is not None, max_retry=600)
+        wait_until(lambda: self.recon_window.presenter.model.images is not None, max_retry=600)
 
     def tearDown(self) -> None:
-        self._wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
+        wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
         self.recon_window.close()
         assert isinstance(self.main_window.recon, ReconstructWindowView)
         self.assertFalse(self.main_window.recon.isVisible())
@@ -36,8 +37,8 @@ class TestGuiSystemReconstruction(GuiSystemBase):
         for _ in range(5):
             QTest.mouseClick(self.recon_window.correlateBtn, Qt.MouseButton.LeftButton)
             QTest.qWait(SHORT_DELAY)
-            self._wait_until(lambda: self.recon_window.correlateBtn.isEnabled())
-            self._wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
+            wait_until(lambda: self.recon_window.correlateBtn.isEnabled())
+            wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
 
     def test_minimise(self):
         for i in range(2, 6):
@@ -45,8 +46,8 @@ class TestGuiSystemReconstruction(GuiSystemBase):
             QTest.mouseClick(self.recon_window.minimiseBtn, Qt.MouseButton.LeftButton)
 
             QTest.qWait(SHORT_DELAY)
-            self._wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=200)
-            self._wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
+            wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=200)
+            wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
             QTest.qWait(SHORT_DELAY)
 
     @classmethod
@@ -60,7 +61,7 @@ class TestGuiSystemReconstruction(GuiSystemBase):
     def test_refine(self):
         QTimer.singleShot(SHORT_DELAY, lambda: self._click_InputDialog(set_int=4))
         QTest.mouseClick(self.recon_window.minimiseBtn, Qt.MouseButton.LeftButton)
-        self._wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=200)
+        wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=200)
 
         for _ in range(5):
             QTimer.singleShot(SHORT_DELAY, lambda: self._click_cor_inspect())
@@ -74,16 +75,16 @@ class TestGuiSystemReconstruction(GuiSystemBase):
             print(f"test_refine_stress iteration {i}")
             QTest.mouseClick(self.recon_window.correlateBtn, Qt.MouseButton.LeftButton)
             QTest.qWait(SHORT_DELAY)
-            self._wait_until(lambda: self.recon_window.correlateBtn.isEnabled())
+            wait_until(lambda: self.recon_window.correlateBtn.isEnabled())
 
             QTimer.singleShot(SHORT_DELAY, lambda: self._click_InputDialog(set_int=3))
             QTest.mouseClick(self.recon_window.minimiseBtn, Qt.MouseButton.LeftButton)
-            self._wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=200)
+            wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=200)
 
             QTimer.singleShot(SHORT_DELAY, lambda: self._click_cor_inspect())
             QTest.mouseClick(self.recon_window.refineCorBtn, Qt.MouseButton.LeftButton)
             QTest.qWait(SHORT_DELAY * 2)
-            self._wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
+            wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
 
         QTest.qWait(SHOW_DELAY)
 
@@ -92,11 +93,11 @@ class TestGuiSystemReconstruction(GuiSystemBase):
         self.recon_window.previewAutoUpdate.setCheckState(Qt.CheckState.Unchecked)
 
         QTest.mouseClick(self.recon_window.previewAutoUpdate, Qt.MouseButton.LeftButton)
-        self._wait_until(lambda: mock_do_preview_reconstruct_slice.call_count == 1)
+        wait_until(lambda: mock_do_preview_reconstruct_slice.call_count == 1)
 
     @mock.patch("mantidimaging.gui.windows.recon.presenter.ReconstructWindowPresenter._get_reconstruct_slice")
     def test_clicking_update_now_btn_triggers_preview(self, mock_get_reconstruct_slice):
         self.recon_window.previewAutoUpdate.setCheckState(Qt.CheckState.Unchecked)
 
         QTest.mouseClick(self.recon_window.updatePreviewButton, Qt.MouseButton.LeftButton)
-        self._wait_until(lambda: mock_get_reconstruct_slice.call_count == 1)
+        wait_until(lambda: mock_get_reconstruct_slice.call_count == 1)

--- a/mantidimaging/gui/test/gui_system_windows_test.py
+++ b/mantidimaging/gui/test/gui_system_windows_test.py
@@ -4,6 +4,7 @@
 from PyQt5.QtTest import QTest
 
 from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHOW_DELAY
+from mantidimaging.test_helpers.qt_test_helpers import wait_until
 
 
 class TestGuiSystemWindows(GuiSystemBase):
@@ -45,7 +46,7 @@ class TestGuiSystemWindows(GuiSystemBase):
         self.assertIsNotNone(self.main_window.recon)
         self.assertTrue(self.main_window.recon.isVisible())
         QTest.qWait(SHOW_DELAY)
-        self._wait_until(lambda: len(self.main_window.recon.presenter.async_tracker) == 0)
+        wait_until(lambda: len(self.main_window.recon.presenter.async_tracker) == 0)
         self.main_window.recon.close()
         QTest.qWait(SHOW_DELAY)
         self._close_image_stacks()

--- a/mantidimaging/test_helpers/qt_test_helpers.py
+++ b/mantidimaging/test_helpers/qt_test_helpers.py
@@ -1,0 +1,17 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+from typing import Callable
+
+from PyQt5.QtTest import QTest
+
+
+def wait_until(test_func: Callable[[], bool], delay=0.1, max_retry=100):
+    """
+    Repeat test_func every delay seconds until is becomes true. Or if max_retry is reached return false.
+    """
+    for _ in range(max_retry):
+        if test_func():
+            return True
+        QTest.qWait(int(delay * 1000))
+    raise RuntimeError("wait_until reach max retries")


### PR DESCRIPTION
### Issue
Closes #1382

### Description

Move the _wait_until method from `GuiSystemBase` to `test_helpers/qt_test_helpers.py` so it can be used in the screenshot tests.

Use wait_until in test_reconstruction_window_opens_with_data

### Testing & Acceptance Criteria 
Tests should keep passing

### Documentation

not needed