### PR TITLE
Fix async task leak

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -24,3 +24,4 @@ Developer Changes
 - #1148 : Re-enable coverage checking
 - #1375 : Leak tracking tool
 - #1376 : Fix leak in StackChoiceView
+- #1387 : Fix async task leak

--- a/mantidimaging/gui/dialogs/async_task/test/view_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/view_test.py
@@ -13,7 +13,7 @@ from mantidimaging.test_helpers import start_qapplication
 class AsyncTaskDialogViewTest(unittest.TestCase):
     @mock.patch('mantidimaging.gui.dialogs.async_task.view.AsyncTaskDialogPresenter')
     def setUp(self, mock_atd) -> None:
-        self.view = AsyncTaskDialogView(None, True)
+        self.view = AsyncTaskDialogView(None)
         self.view.infoText = mock.Mock()
         self.mock_qtimer = mock.Mock()
         self.view.show_timer = self.mock_qtimer

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -12,11 +12,10 @@ from PyQt5.QtCore import QTimer
 
 
 class AsyncTaskDialogView(BaseDialogView):
-    def __init__(self, parent: QMainWindow, auto_close: bool = False):
+    def __init__(self, parent: QMainWindow):
         super().__init__(parent, 'gui/ui/async_task_dialog.ui')
 
         self.presenter = AsyncTaskDialogPresenter(self)
-        self.auto_close = auto_close
 
         self.progressBar.setMinimum(0)
         self.progressBar.setMaximum(1000)
@@ -37,10 +36,7 @@ class AsyncTaskDialogView(BaseDialogView):
         else:
             self.infoText.setText("Task failed.")
 
-        # If auto close is enabled and the task was successful then hide the UI
-        if self.auto_close:
-            self.hide()
-
+        self.hide()
         self.presenter.progress = None
 
     def set_progress(self, progress: float, message: str):
@@ -65,7 +61,7 @@ def start_async_task_view(parent: QMainWindow,
                           on_complete: Callable,
                           kwargs: Optional[Dict] = None,
                           tracker: Optional[Set[Any]] = None):
-    atd = AsyncTaskDialogView(parent, auto_close=True)
+    atd = AsyncTaskDialogView(parent)
     if not kwargs:
         kwargs = {'progress': Progress()}
     else:

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -12,16 +12,24 @@ from PyQt5.QtCore import QTimer
 
 
 class AsyncTaskDialogView(BaseDialogView):
+    _presenter: Optional[AsyncTaskDialogPresenter]
+
     def __init__(self, parent: QMainWindow):
         super().__init__(parent, 'gui/ui/async_task_dialog.ui')
 
-        self.presenter = AsyncTaskDialogPresenter(self)
+        self._presenter = AsyncTaskDialogPresenter(self)
 
         self.progressBar.setMinimum(0)
         self.progressBar.setMaximum(1000)
 
         self.show_timer = QTimer(self)
         self.hide()
+
+    @property
+    def presenter(self) -> AsyncTaskDialogPresenter:
+        if self._presenter is None:
+            raise RuntimeError("Presenter accessed after handle_completion")
+        return self._presenter
 
     def handle_completion(self, successful: bool):
         """
@@ -36,8 +44,12 @@ class AsyncTaskDialogView(BaseDialogView):
         else:
             self.infoText.setText("Task failed.")
 
-        self.hide()
+        self.close()
+        self.setParent(None)
+
         self.presenter.progress = None
+        self.presenter.model = None
+        self._presenter = None
 
     def set_progress(self, progress: float, message: str):
         # Set status message
@@ -52,7 +64,8 @@ class AsyncTaskDialogView(BaseDialogView):
         self.show_timer.start()
 
     def show_from_timer(self):
-        if self.presenter.task_is_running:
+        # Might not run until after handle_completion
+        if self._presenter is not None and self.presenter.task_is_running:
             self.show()
 
 


### PR DESCRIPTION
### Issue
Closes #1378

### Description

Use close instead of hide, because we are not going to reshow
    
Set parent to None, otherwise ReconstructWindowView holds a references to the child dialog
   
Drop the presenter and model references as well to ensure everything can be deleted. Use property to prevent access to the presenter after this.

Also, remove unused auto_close option

Note: I wanted to avoid WA_DeleteOnClose, because that can lead to a case where the python object still exists but the c++ object is gone, which can in turn lead to runtimeerrors

### Testing & Acceptance Criteria 

`xvfb-run --auto-servernum pytest -vs -rs --run-system-tests -k test_minimise`
should no longer report `Items still alive`

Test some operation and recon steps which show a progress bar. 

There is still 1 (or more) smaller leak remaining, but LeakTracker can't see their referrers. That will need some further investigation.

### Documentation

release notes
