### PR TITLE
Checkout full history so that git describe can see tags

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Needed to get tags so that git describe works during package build
           fetch-depth: "0"

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -17,6 +17,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          # Needed to get tags so that git describe works during package build
+          fetch-depth: "0"
 
       - name: Get Date
         id: get-date


### PR DESCRIPTION
### Issue

Closes #1388 

### Description

`fetch-depth: "0"` was removed in #1368 as a small performance improvement. But this meant the tags were not available so the package building step could not set the package version.

Switch back to `fetch-depth: "0"`. It only saved a few seconds

Also bump actions version to 3.

### Testing & Acceptance Criteria 

We wont know until this is merged to master. But it is undoing a previous change so should be safe.

### Documentation

Not needed
