### PR TITLE
Use shared memory for compatibility with spawn

### DIFF
--- a/mantidimaging/core/operations/arithmetic/arithmetic.py
+++ b/mantidimaging/core/operations/arithmetic/arithmetic.py
@@ -120,5 +120,4 @@ def _execute(images: ImageStack, div_val: float, mult_val: float, add_val: float
              progress):
     arg_list = [div_val, mult_val, add_val, sub_val]
     do_arithmetic = ps.create_partial(_arithmetic_func, fwd_function=ps.arithmetic, arg_list=arg_list)
-    ps.shared_list = [images.shared_array]
-    ps.execute(do_arithmetic, images.data.shape[0], progress, cores=cores)
+    ps.execute(do_arithmetic, [images.shared_array], images.data.shape[0], progress, cores=cores)

--- a/mantidimaging/core/operations/arithmetic/arithmetic.py
+++ b/mantidimaging/core/operations/arithmetic/arithmetic.py
@@ -59,7 +59,7 @@ class ArithmeticFilter(BaseFilter):
         if div_val == 0 or mult_val == 0:
             raise ValueError("Unable to proceed with operation because division/multiplication value is zero.")
 
-        _execute(images.data, div_val, mult_val, add_val, sub_val, cores, progress)
+        _execute(images, div_val, mult_val, add_val, sub_val, cores, progress)
         return images
 
     @staticmethod
@@ -116,8 +116,9 @@ class ArithmeticFilter(BaseFilter):
                        sub_val=sub_input_widget.value())
 
 
-def _execute(data: np.ndarray, div_val: float, mult_val: float, add_val: float, sub_val: float, cores: Optional[int],
+def _execute(images: ImageStack, div_val: float, mult_val: float, add_val: float, sub_val: float, cores: Optional[int],
              progress):
-    do_arithmetic = ps.create_partial(_arithmetic_func, fwd_function=ps.arithmetic)
-    ps.shared_list = [data, div_val, mult_val, add_val, sub_val]
-    ps.execute(do_arithmetic, data.shape[0], progress, cores=cores)
+    arg_list = [div_val, mult_val, add_val, sub_val]
+    do_arithmetic = ps.create_partial(_arithmetic_func, fwd_function=ps.arithmetic, arg_list=arg_list)
+    ps.shared_list = [images.shared_array]
+    ps.execute(do_arithmetic, images.data.shape[0], progress, cores=cores)

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -270,7 +270,7 @@ def _subtract(data, dark=None):
     np.subtract(data, dark, out=data)
 
 
-def _norm_divide(flat, dark):
+def _norm_divide(flat: np.ndarray, dark: np.ndarray) -> np.ndarray:
     # subtract dark from flat
     return np.subtract(flat, dark)
 

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -307,12 +307,12 @@ def _execute(images: ImageStack, flat=None, dark=None, cores=None, chunksize=Non
 
         # subtract the dark from all images
         do_subtract = ps.create_partial(_subtract, fwd_function=ps.inplace_second_2d)
-        ps.shared_list = [images.shared_array, shared_dark]
-        ps.execute(do_subtract, images.data.shape[0], progress, cores=cores)
+        arrays = [images.shared_array, shared_dark]
+        ps.execute(do_subtract, arrays, images.data.shape[0], progress, cores=cores)
 
         # divide the data by (flat - dark)
         do_divide = ps.create_partial(_divide, fwd_function=ps.inplace_second_2d)
-        ps.shared_list = [images.shared_array, norm_divide]
-        ps.execute(do_divide, images.data.shape[0], progress, cores=cores)
+        arrays = [images.shared_array, norm_divide]
+        ps.execute(do_divide, arrays, images.data.shape[0], progress, cores=cores)
 
     return images

--- a/mantidimaging/core/operations/gaussian/gaussian.py
+++ b/mantidimaging/core/operations/gaussian/gaussian.py
@@ -102,8 +102,7 @@ def _execute(images: ImageStack, size, mode, order, cores=None, progress=None):
              "filter size/width: {1}.".format(images.dtype, size))
 
     progress.update()
-    ps.shared_list = [images.shared_array]
-    ps.execute(f, images.data.shape[0], progress, msg="Gaussian filter", cores=cores)
+    ps.execute(f, [images.shared_array], images.data.shape[0], progress, msg="Gaussian filter", cores=cores)
 
     progress.mark_complete()
     log.info("Finished  gaussian filter, with pixel data type: {0}, "

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -161,8 +161,7 @@ def _execute(images: ImageStack, size, mode, cores=None, chunksize=None, progres
         log.info("PARALLEL median filter, with pixel data type: {0}, filter "
                  "size/width: {1}.".format(images.dtype, size))
 
-        ps.shared_list = [images.shared_array]
-        ps.execute(f, images.data.shape[0], progress, msg="Median filter", cores=cores)
+        ps.execute(f, [images.shared_array], images.data.shape[0], progress, msg="Median filter", cores=cores)
 
 
 def _execute_gpu(data, size, mode, progress=None):

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -97,7 +97,7 @@ class MedianFilter(BaseFilter):
         if not force_cpu:
             _execute_gpu(data.data, size, mode, progress)
         else:
-            _execute(data.data, size, mode, cores, chunksize, progress)
+            _execute(data, size, mode, cores, chunksize, progress)
 
         h.check_data_stack(data)
         return data
@@ -150,7 +150,7 @@ def _median_filter(data: np.ndarray, size: int, mode: str):
     return data
 
 
-def _execute(data, size, mode, cores=None, chunksize=None, progress=None):
+def _execute(images: ImageStack, size, mode, cores=None, chunksize=None, progress=None):
     log = getLogger(__name__)
     progress = Progress.ensure_instance(progress, task_name='Median filter')
 
@@ -159,10 +159,10 @@ def _execute(data, size, mode, cores=None, chunksize=None, progress=None):
 
     with progress:
         log.info("PARALLEL median filter, with pixel data type: {0}, filter "
-                 "size/width: {1}.".format(data.dtype, size))
+                 "size/width: {1}.".format(images.dtype, size))
 
-        ps.shared_list = [data]
-        ps.execute(f, data.shape[0], progress, msg="Median filter", cores=cores)
+        ps.shared_list = [images.shared_array]
+        ps.execute(f, images.data.shape[0], progress, msg="Median filter", cores=cores)
 
 
 def _execute_gpu(data, size, mode, progress=None):

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -43,8 +43,8 @@ class MonitorNormalisation(BaseFilter):
 
         counts_val = pu.copy_into_shared_memory(counts.value / counts.value[0])
         do_division = ps.create_partial(_divide_by_counts, fwd_function=ps.inplace2)
-        ps.shared_list = [images.shared_array, counts_val]
-        ps.execute(do_division, images.num_projections, progress, cores=cores)
+        arrays = [images.shared_array, counts_val]
+        ps.execute(do_division, arrays, images.num_projections, progress, cores=cores)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -9,6 +9,7 @@ from PyQt5.QtWidgets import QFormLayout, QWidget
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.parallel import shared as ps
+from mantidimaging.core.parallel import utility as pu
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 
 
@@ -40,9 +41,9 @@ class MonitorNormalisation(BaseFilter):
         if counts is None:
             raise RuntimeError("No loaded log values for this stack.")
 
-        counts_val = counts.value / counts.value[0]
+        counts_val = pu.copy_into_shared_memory(counts.value / counts.value[0])
         do_division = ps.create_partial(_divide_by_counts, fwd_function=ps.inplace2)
-        ps.shared_list = [images.data, counts_val]
+        ps.shared_list = [images.shared_array, counts_val]
         ps.execute(do_division, images.num_projections, progress, cores=cores)
         return images
 

--- a/mantidimaging/core/operations/nan_removal/nan_removal.py
+++ b/mantidimaging/core/operations/nan_removal/nan_removal.py
@@ -122,7 +122,6 @@ def _execute(images: ImageStack, size, edgemode, cores=None, chunksize=None, pro
     with progress:
         log.info("PARALLEL NaN Removal filter, with pixel data type: {0}".format(images.dtype))
 
-        ps.shared_list = [images.shared_array]
-        ps.execute(f, images.data.shape[0], progress, msg="NaN Removal", cores=cores)
+        ps.execute(f, [images.shared_array], images.data.shape[0], progress, msg="NaN Removal", cores=cores)
 
     return images

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -67,8 +67,7 @@ class OutliersFilter(BaseFilter):
             raise ValueError(f'radius parameter must be greater than 0. Value provided was {radius}')
 
         func = ps.create_partial(OutliersFilter._execute, ps.return_to_self, diff=diff, radius=radius, mode=mode)
-        ps.shared_list = [images.shared_array]
-        ps.execute(func,
+        ps.execute(func, [images.shared_array],
                    images.num_projections,
                    progress=progress,
                    msg=f"Outliers with threshold {diff} and kernel {radius}")

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -67,7 +67,7 @@ class OutliersFilter(BaseFilter):
             raise ValueError(f'radius parameter must be greater than 0. Value provided was {radius}')
 
         func = ps.create_partial(OutliersFilter._execute, ps.return_to_self, diff=diff, radius=radius, mode=mode)
-        ps.shared_list = [images.data]
+        ps.shared_list = [images.shared_array]
         ps.execute(func,
                    images.num_projections,
                    progress=progress,

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -2,6 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial
+
 import skimage.transform
 
 from mantidimaging import helper as h
@@ -62,8 +63,8 @@ class RebinFilter(BaseFilter):
                               ps.return_to_second_at_i,
                               mode=mode,
                               output_shape=empty_resized_data.array.shape[1:])
-        ps.shared_list = [images.shared_array, empty_resized_data]
         ps.execute(partial_func=f,
+                   arrays=[images.shared_array, empty_resized_data],
                    num_operations=images.data.shape[0],
                    cores=cores,
                    msg="Applying Rebin",

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -56,15 +56,18 @@ class RebinFilter(BaseFilter):
         if not param_valid:
             raise ValueError('Rebin parameter must be greater than 0')
 
-        sample = images.data
         empty_resized_data = _create_reshaped_array(images, rebin_param)
 
         f = ps.create_partial(skimage.transform.resize,
                               ps.return_to_second_at_i,
                               mode=mode,
                               output_shape=empty_resized_data.array.shape[1:])
-        ps.shared_list = [sample, empty_resized_data.array]
-        ps.execute(partial_func=f, num_operations=sample.shape[0], cores=cores, msg="Applying Rebin", progress=progress)
+        ps.shared_list = [images.shared_array, empty_resized_data]
+        ps.execute(partial_func=f,
+                   num_operations=images.data.shape[0],
+                   cores=cores,
+                   msg="Applying Rebin",
+                   progress=progress)
         images.shared_array = empty_resized_data
 
         return images

--- a/mantidimaging/core/operations/rebin/test/rebin_test.py
+++ b/mantidimaging/core/operations/rebin/test/rebin_test.py
@@ -121,21 +121,6 @@ class RebinTest(unittest.TestCase):
         self.assertEqual(factor.value.call_count, 1)
         self.assertEqual(mode_field.currentText.call_count, 1)
 
-    @mock.patch("mantidimaging.core.operations.rebin.rebin.ps")
-    def test_execute_argument_order(self, ps_mock):
-
-        images = th.generate_images()
-        mode = 'reflect'
-        cores = 4
-        progress_mock = mock.Mock()
-        RebinFilter.filter_func(images=images, mode=mode, cores=cores, progress=progress_mock)
-
-        ps_mock.execute.assert_called_once_with(partial_func=ps_mock.create_partial.return_value,
-                                                num_operations=images.data.shape[0],
-                                                cores=cores,
-                                                msg="Applying Rebin",
-                                                progress=progress_mock)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
+++ b/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
@@ -39,8 +39,7 @@ class RemoveAllStripesFilter(BaseFilter):
                     chunksize=None,
                     progress=None):
         f = ps.create_partial(remove_all_stripe, ps.return_to_self, snr=snr, la_size=la_size, sm_size=sm_size, dim=dim)
-        ps.shared_list = [images.shared_array]
-        ps.execute(f, images.data.shape[0], progress, cores=cores)
+        ps.execute(f, [images.shared_array], images.data.shape[0], progress, cores=cores)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
+++ b/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
@@ -39,7 +39,7 @@ class RemoveAllStripesFilter(BaseFilter):
                     chunksize=None,
                     progress=None):
         f = ps.create_partial(remove_all_stripe, ps.return_to_self, snr=snr, la_size=la_size, sm_size=sm_size, dim=dim)
-        ps.shared_list = [images.data]
+        ps.shared_list = [images.shared_array]
         ps.execute(f, images.data.shape[0], progress, cores=cores)
         return images
 

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -32,8 +32,7 @@ class RemoveDeadStripesFilter(BaseFilter):
     @staticmethod
     def filter_func(images: ImageStack, snr=3, size=61, cores=None, chunksize=None, progress=None):
         f = ps.create_partial(remove_dead_stripe, ps.return_to_self, snr=snr, size=size, residual=False)
-        ps.shared_list = [images.shared_array]
-        ps.execute(f, images.data.shape[0], progress, cores=cores)
+        ps.execute(f, [images.shared_array], images.data.shape[0], progress, cores=cores)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -32,7 +32,7 @@ class RemoveDeadStripesFilter(BaseFilter):
     @staticmethod
     def filter_func(images: ImageStack, snr=3, size=61, cores=None, chunksize=None, progress=None):
         f = ps.create_partial(remove_dead_stripe, ps.return_to_self, snr=snr, size=size, residual=False)
-        ps.shared_list = [images.data]
+        ps.shared_list = [images.shared_array]
         ps.execute(f, images.data.shape[0], progress, cores=cores)
         return images
 

--- a/mantidimaging/core/operations/remove_dead_stripe/test/remove_dead_stripe_test.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/test/remove_dead_stripe_test.py
@@ -15,11 +15,11 @@ class RemoveDeadStripesTest(unittest.TestCase):
     Tests that it executes and returns a valid object, but does not verify the numerical results.
     """
     def test_executed(self):
-        images = th.generate_images()
+        images = th.generate_images((10, 400, 500))
         control = images.copy()
 
         # size=3 makes sure that the data will be changed, as the default kernel is bigger
-        # than the size of the test data
+        # than the size of the test data. This requires a large enough test dataset to pass on Windows
         result = RemoveDeadStripesFilter.filter_func(images, size=3)
 
         th.assert_not_equals(result.data, control.data)

--- a/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
+++ b/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
@@ -40,8 +40,7 @@ class RemoveLargeStripesFilter(BaseFilter):
             snr=snr,
             size=la_size,
         )
-        ps.shared_list = [images.shared_array]
-        ps.execute(f, images.data.shape[0], progress, cores=cores)
+        ps.execute(f, [images.shared_array], images.data.shape[0], progress, cores=cores)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
+++ b/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
@@ -2,6 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial
+from typing import TYPE_CHECKING
 
 from PyQt5.QtWidgets import QSpinBox, QDoubleSpinBox
 from algotom.prep.removal import remove_large_stripe
@@ -9,6 +10,9 @@ from algotom.prep.removal import remove_large_stripe
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.gui.utility.qt_helpers import Type
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data.imagestack import ImageStack
 
 
 class RemoveLargeStripesFilter(BaseFilter):
@@ -29,14 +33,14 @@ class RemoveLargeStripesFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images, snr=3, la_size=61, cores=None, chunksize=None, progress=None):
+    def filter_func(images: 'ImageStack', snr=3, la_size=61, cores=None, chunksize=None, progress=None):
         f = ps.create_partial(
             remove_large_stripe,
             ps.return_to_self,
             snr=snr,
             size=la_size,
         )
-        ps.shared_list = [images.data]
+        ps.shared_list = [images.shared_array]
         ps.execute(f, images.data.shape[0], progress, cores=cores)
         return images
 

--- a/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
@@ -51,7 +51,7 @@ class RemoveStripeFilteringFilter(BaseFilter):
                                   sigma=sigma,
                                   size=size,
                                   dim=window_dim)
-        ps.shared_list = [images.data]
+        ps.shared_list = [images.shared_array]
         ps.execute(f, images.data.shape[0], progress, cores=cores)
         return images
 

--- a/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
@@ -51,8 +51,7 @@ class RemoveStripeFilteringFilter(BaseFilter):
                                   sigma=sigma,
                                   size=size,
                                   dim=window_dim)
-        ps.shared_list = [images.shared_array]
-        ps.execute(f, images.data.shape[0], progress, cores=cores)
+        ps.execute(f, [images.shared_array], images.data.shape[0], progress, cores=cores)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
@@ -33,7 +33,7 @@ class RemoveStripeSortingFittingFilter(BaseFilter):
     def filter_func(images: ImageStack, order=1, sigma=3, cores=None, chunksize=None, progress=None):
         f = ps.create_partial(remove_stripe_based_fitting, ps.return_to_self, order=order, sigma=sigma, sort=True)
 
-        ps.shared_list = [images.data]
+        ps.shared_list = [images.shared_array]
         ps.execute(f, images.data.shape[0], progress, cores=cores)
         return images
 

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
@@ -33,8 +33,7 @@ class RemoveStripeSortingFittingFilter(BaseFilter):
     def filter_func(images: ImageStack, order=1, sigma=3, cores=None, chunksize=None, progress=None):
         f = ps.create_partial(remove_stripe_based_fitting, ps.return_to_self, order=order, sigma=sigma, sort=True)
 
-        ps.shared_list = [images.shared_array]
-        ps.execute(f, images.data.shape[0], progress, cores=cores)
+        ps.execute(f, [images.shared_array], images.data.shape[0], progress, cores=cores)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/rotate_stack/rotate_stack.py
+++ b/mantidimaging/core/operations/rotate_stack/rotate_stack.py
@@ -78,7 +78,10 @@ def _execute(images: ImageStack, angle: float, cores: int, chunksize: int, progr
 
     with progress:
         f = ps.create_partial(_rotate_image_inplace, ps.inplace1, angle=angle)
-        ps.shared_list = [images.shared_array]
-        ps.execute(f, images.data.shape[0], progress, msg=f"Rotating by {angle} degrees", cores=cores)
+        ps.execute(f, [images.shared_array],
+                   images.data.shape[0],
+                   progress,
+                   msg=f"Rotating by {angle} degrees",
+                   cores=cores)
 
     return images

--- a/mantidimaging/core/operations/rotate_stack/rotate_stack.py
+++ b/mantidimaging/core/operations/rotate_stack/rotate_stack.py
@@ -2,7 +2,6 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial
-import numpy as np
 
 from skimage.transform import rotate
 
@@ -47,7 +46,7 @@ class RotateFilter(BaseFilter):
 
         # No need to run the filter for an angle of 0 as it won't have any effect
         if not angle == 0:
-            _execute(data.data, angle, cores, chunksize, progress)
+            _execute(data, angle, cores, chunksize, progress)
 
         return data
 
@@ -74,12 +73,12 @@ def _rotate_image_inplace(data, angle=None):
     data[:, :] = rotate(data[:, :], angle)
 
 
-def _execute(data: np.ndarray, angle: float, cores: int, chunksize: int, progress: Progress):
+def _execute(images: ImageStack, angle: float, cores: int, chunksize: int, progress: Progress):
     progress = Progress.ensure_instance(progress, task_name='Rotate Stack')
 
     with progress:
         f = ps.create_partial(_rotate_image_inplace, ps.inplace1, angle=angle)
-        ps.shared_list = [data]
-        ps.execute(f, data.shape[0], progress, msg=f"Rotating by {angle} degrees", cores=cores)
+        ps.shared_list = [images.shared_array]
+        ps.execute(f, images.data.shape[0], progress, msg=f"Rotating by {angle} degrees", cores=cores)
 
-    return data
+    return images

--- a/mantidimaging/core/parallel/shared.py
+++ b/mantidimaging/core/parallel/shared.py
@@ -9,42 +9,42 @@ from mantidimaging.core.parallel import utility as pu
 shared_list: List[pu.SharedArray] = []
 
 
-def inplace3(func, array_details, i, **kwargs):
+def inplace3(func, array_details: List[pu.SharedArrayDetails], i, **kwargs):
     data = _get_array_list(array_details)
     func(data[0].array[i], data[1].array[i], data[2].array, **kwargs)
 
 
-def inplace2(func, array_details, i, **kwargs):
+def inplace2(func, array_details: List[pu.SharedArrayDetails], i, **kwargs):
     data = _get_array_list(array_details)
     func(data[0].array[i], data[1].array[i], **kwargs)
 
 
-def inplace1(func, array_details, i, **kwargs):
+def inplace1(func, array_details: List[pu.SharedArrayDetails], i, **kwargs):
     data = _get_array_list(array_details)
     func(data[0].array[i], **kwargs)
 
 
-def return_to_self(func, array_details, i, **kwargs):
+def return_to_self(func, array_details: List[pu.SharedArrayDetails], i, **kwargs):
     data = _get_array_list(array_details)
     data[0].array[i] = func(data[0].array[i], **kwargs)
 
 
-def inplace_second_2d(func, array_details, i, **kwargs):
+def inplace_second_2d(func, array_details: List[pu.SharedArrayDetails], i, **kwargs):
     data = _get_array_list(array_details)
     func(data[0].array[i], data[1].array, **kwargs)
 
 
-def return_to_second_at_i(func, array_details, i, **kwargs):
+def return_to_second_at_i(func, array_details: List[pu.SharedArrayDetails], i, **kwargs):
     data = _get_array_list(array_details)
     data[1].array[i] = func(data[0].array[i], **kwargs)
 
 
-def arithmetic(func, array_details, i, arg_list):
+def arithmetic(func, array_details: List[pu.SharedArrayDetails], i, arg_list):
     data = _get_array_list(array_details)
     func(data[0].array[i], *arg_list)
 
 
-def _get_array_list(array_details):
+def _get_array_list(array_details: List[pu.SharedArrayDetails]) -> List[pu.SharedArray]:
     if not array_details:
         return shared_list
     else:

--- a/mantidimaging/core/parallel/test/shared_test.py
+++ b/mantidimaging/core/parallel/test/shared_test.py
@@ -2,41 +2,38 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 import unittest
 from unittest import mock
-from unittest.mock import patch
 
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.core.parallel.utility import SharedArrayProxy
 
 
-def _populate_shared_list(num_arrays, has_shared_mem):
-    array_list = []
-    for n in range(num_arrays):
-        mock_array = mock.Mock()
-        mock_array.has_shared_memory = has_shared_mem
-        mock_array.array_proxy = SharedArrayProxy(None, (2, 2), 'float32') if has_shared_mem else mock.Mock()
-        array_list.append(mock_array)
-    return array_list
-
-
 class SharedTest(unittest.TestCase):
-    @patch('mantidimaging.core.parallel.shared.shared_list', _populate_shared_list(5, True))
     def test_check_shared_mem_and_get_data_all_shared(self):
-        all_in_shared_memory, data = ps._check_shared_mem_and_get_data()
+        arrays = self._create_array_list(5, True)
+        all_in_shared_memory, data = ps._check_shared_mem_and_get_data(arrays)
         self.assertTrue(all_in_shared_memory)
         self.assertTrue(len(data) == 5)
         self.assertTrue(isinstance(data[0], SharedArrayProxy))
 
-    @patch('mantidimaging.core.parallel.shared.shared_list', _populate_shared_list(5, False))
     def test_check_shared_mem_and_get_data_none_shared(self):
-        all_in_shared_memory, data = ps._check_shared_mem_and_get_data()
+        arrays = self._create_array_list(5, False)
+        all_in_shared_memory, data = ps._check_shared_mem_and_get_data(arrays)
         self.assertFalse(all_in_shared_memory)
         self.assertTrue(len(data) == 5)
         self.assertTrue(isinstance(data[0], mock.Mock))
 
-    @patch('mantidimaging.core.parallel.shared.shared_list',
-           _populate_shared_list(3, True) + _populate_shared_list(2, False))
     def test_check_shared_mem_and_get_data_some_shared(self):
-        all_in_shared_memory, data = ps._check_shared_mem_and_get_data()
+        arrays = self._create_array_list(3, True) + self._create_array_list(2, False)
+        all_in_shared_memory, data = ps._check_shared_mem_and_get_data(arrays)
         self.assertFalse(all_in_shared_memory)
         self.assertTrue(len(data) == 5)
         self.assertTrue(isinstance(data[0], mock.Mock))
+
+    def _create_array_list(self, num_arrays, has_shared_mem):
+        array_list = []
+        for n in range(num_arrays):
+            mock_array = mock.Mock()
+            mock_array.has_shared_memory = has_shared_mem
+            mock_array.array_proxy = SharedArrayProxy(None, (2, 2), 'float32') if has_shared_mem else mock.Mock()
+            array_list.append(mock_array)
+        return array_list

--- a/mantidimaging/core/parallel/test/shared_test.py
+++ b/mantidimaging/core/parallel/test/shared_test.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+import unittest
+from unittest import mock
+from unittest.mock import patch
+
+from mantidimaging.core.parallel import shared as ps
+
+
+def _populate_shared_list(num_arrays, has_shared_mem):
+    array_list = []
+    for n in range(num_arrays):
+        mock_array = mock.Mock()
+        mock_array.has_shared_memory = has_shared_mem
+        mock_array.details = mock.Mock()
+        array_list.append(mock_array)
+    return array_list
+
+
+class SharedTest(unittest.TestCase):
+    @patch('mantidimaging.core.parallel.shared.shared_list', _populate_shared_list(5, True))
+    def test_check_shared_mem_details_all_shared(self):
+        all_in_shared_memory, details_list = ps._check_shared_mem_details()
+        self.assertTrue(all_in_shared_memory)
+        self.assertTrue(len(details_list) == 5)
+
+    @patch('mantidimaging.core.parallel.shared.shared_list', _populate_shared_list(5, False))
+    def test_check_shared_mem_details_none_shared(self):
+        all_in_shared_memory, details_list = ps._check_shared_mem_details()
+        self.assertFalse(all_in_shared_memory)
+        self.assertTrue(len(details_list) == 0)
+
+    @patch('mantidimaging.core.parallel.shared.shared_list',
+           _populate_shared_list(3, True) + _populate_shared_list(2, False))
+    def test_check_shared_mem_details_some_shared(self):
+        all_in_shared_memory, details_list = ps._check_shared_mem_details()
+        self.assertFalse(all_in_shared_memory)
+        self.assertTrue(len(details_list) == 0)
+
+    @patch('mantidimaging.core.parallel.utility.lookup_shared_arrays')
+    def test_get_array_list_with_array_details(self, mock_lookup_shared_arrays):
+        mock_details = mock.Mock()
+        mock_list = mock.Mock()
+        mock_lookup_shared_arrays.return_value = mock_list
+
+        array_list = ps._get_array_list([mock_details])
+        mock_lookup_shared_arrays.assert_called_once()
+        self.assertIs(array_list, mock_list)
+
+    @patch('mantidimaging.core.parallel.shared.shared_list', [mock.Mock])
+    @patch('mantidimaging.core.parallel.utility.lookup_shared_arrays')
+    def test_get_array_list_without_array_details(self, mock_lookup_shared_arrays):
+        array_list = ps._get_array_list([])
+        mock_lookup_shared_arrays.assert_not_called()
+        self.assertIs(array_list, ps.shared_list)

--- a/mantidimaging/core/parallel/test/shared_test.py
+++ b/mantidimaging/core/parallel/test/shared_test.py
@@ -5,6 +5,7 @@ from unittest import mock
 from unittest.mock import patch
 
 from mantidimaging.core.parallel import shared as ps
+from mantidimaging.core.parallel.utility import SharedArrayProxy
 
 
 def _populate_shared_list(num_arrays, has_shared_mem):
@@ -12,44 +13,30 @@ def _populate_shared_list(num_arrays, has_shared_mem):
     for n in range(num_arrays):
         mock_array = mock.Mock()
         mock_array.has_shared_memory = has_shared_mem
-        mock_array.details = mock.Mock()
+        mock_array.array_proxy = SharedArrayProxy(None, (2, 2), 'float32') if has_shared_mem else mock.Mock()
         array_list.append(mock_array)
     return array_list
 
 
 class SharedTest(unittest.TestCase):
     @patch('mantidimaging.core.parallel.shared.shared_list', _populate_shared_list(5, True))
-    def test_check_shared_mem_details_all_shared(self):
-        all_in_shared_memory, details_list = ps._check_shared_mem_details()
+    def test_check_shared_mem_and_get_data_all_shared(self):
+        all_in_shared_memory, data = ps._check_shared_mem_and_get_data()
         self.assertTrue(all_in_shared_memory)
-        self.assertTrue(len(details_list) == 5)
+        self.assertTrue(len(data) == 5)
+        self.assertTrue(isinstance(data[0], SharedArrayProxy))
 
     @patch('mantidimaging.core.parallel.shared.shared_list', _populate_shared_list(5, False))
-    def test_check_shared_mem_details_none_shared(self):
-        all_in_shared_memory, details_list = ps._check_shared_mem_details()
+    def test_check_shared_mem_and_get_data_none_shared(self):
+        all_in_shared_memory, data = ps._check_shared_mem_and_get_data()
         self.assertFalse(all_in_shared_memory)
-        self.assertTrue(len(details_list) == 0)
+        self.assertTrue(len(data) == 5)
+        self.assertTrue(isinstance(data[0], mock.Mock))
 
     @patch('mantidimaging.core.parallel.shared.shared_list',
            _populate_shared_list(3, True) + _populate_shared_list(2, False))
-    def test_check_shared_mem_details_some_shared(self):
-        all_in_shared_memory, details_list = ps._check_shared_mem_details()
+    def test_check_shared_mem_and_get_data_some_shared(self):
+        all_in_shared_memory, data = ps._check_shared_mem_and_get_data()
         self.assertFalse(all_in_shared_memory)
-        self.assertTrue(len(details_list) == 0)
-
-    @patch('mantidimaging.core.parallel.utility.lookup_shared_arrays')
-    def test_get_array_list_with_array_details(self, mock_lookup_shared_arrays):
-        mock_details = mock.Mock()
-        mock_list = mock.Mock()
-        mock_lookup_shared_arrays.return_value = mock_list
-
-        array_list = ps._get_array_list([mock_details])
-        mock_lookup_shared_arrays.assert_called_once()
-        self.assertIs(array_list, mock_list)
-
-    @patch('mantidimaging.core.parallel.shared.shared_list', [mock.Mock])
-    @patch('mantidimaging.core.parallel.utility.lookup_shared_arrays')
-    def test_get_array_list_without_array_details(self, mock_lookup_shared_arrays):
-        array_list = ps._get_array_list([])
-        mock_lookup_shared_arrays.assert_not_called()
-        self.assertIs(array_list, ps.shared_list)
+        self.assertTrue(len(data) == 5)
+        self.assertTrue(isinstance(data[0], mock.Mock))

--- a/mantidimaging/core/rotation/polyfit_correlation.py
+++ b/mantidimaging/core/rotation/polyfit_correlation.py
@@ -59,8 +59,9 @@ def _calculate_correlation_error(images, shared_search_range, min_correlation_er
 
     do_search_partial = ps.create_partial(do_calculate_correlation_err, ps.inplace3, image_width=images.width)
 
-    ps.shared_list = [min_correlation_error, shared_search_range, shared_projections]
+    arrays = [min_correlation_error, shared_search_range, shared_projections]
     ps.execute(do_search_partial,
+               arrays,
                num_operations=min_correlation_error.array.shape[0],
                progress=progress,
                msg="Finding correlation on row")

--- a/mantidimaging/core/rotation/polyfit_correlation.py
+++ b/mantidimaging/core/rotation/polyfit_correlation.py
@@ -31,7 +31,7 @@ def find_center(images: ImageStack, progress: Progress) -> Tuple[ScalarCoR, Degr
     min_correlation_error = pu.create_array((len(search_range), images.height))
     shared_search_range = pu.create_array((len(search_range), ), dtype=np.int32)
     shared_search_range.array[:] = np.asarray(search_range, dtype=np.int32)
-    _calculate_correlation_error(images, shared_search_range.array, min_correlation_error.array, progress)
+    _calculate_correlation_error(images, shared_search_range, min_correlation_error, progress)
 
     # Originally the output of do_search is stored in dimensions
     # corresponding to (search_range, square sum). This is awkward to navigate
@@ -59,9 +59,9 @@ def _calculate_correlation_error(images, shared_search_range, min_correlation_er
 
     do_search_partial = ps.create_partial(do_calculate_correlation_err, ps.inplace3, image_width=images.width)
 
-    ps.shared_list = [min_correlation_error, shared_search_range, shared_projections.array]
+    ps.shared_list = [min_correlation_error, shared_search_range, shared_projections]
     ps.execute(do_search_partial,
-               num_operations=min_correlation_error.shape[0],
+               num_operations=min_correlation_error.array.shape[0],
                progress=progress,
                msg="Finding correlation on row")
 


### PR DESCRIPTION
### Issue

Refs #1331

### Description

Changes the way we work with shared memory when performing parallel processing tasks to be compatible with spawn (and consequently still fork). This completes step two of the multiprocessing changes described under point 5 of the issue description.

I have also updated one of the unit tests for the dead stripe removal functionality that was failing on Windows. This was because the algotom algorithm that we use for this filter uses `numpy.polyfit`, which gives slightly different results due to small differences in handling of floating point numbers between Linux and Windows. Increasing the size of the test dataset seemed get the test passing in this case.

### Testing & Acceptance Criteria 

At this stage the application should now be fully functional on both Windows and Linux, although performance will be quite slow on Windows. The operations that were updated in this PR should be tested on both platforms to confirm this, as well as testing the "Correlate 0 and 180" functionality in the recon window.

All unit tests should pass on both platforms. Further changes will be required to get the GUI system tests and Applitools tests running on Windows.

### Documentation

Issue to be added to release notes once all steps are completed.
