### PR TITLE
Cleanup FiltersWindowPresenter._post_filter

### DIFF
--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -52,13 +52,6 @@ class BaseDataset:
     def delete_stack(self, images_id: uuid.UUID):
         raise NotImplementedError()
 
-    def replace(self, images_id: uuid.UUID, image_stack: ImageStack):
-        for image in self.all:
-            if image.id == images_id:
-                image.shared_array = image_stack.shared_array
-                return
-        raise KeyError(f"Unable to replace: ImageStack with ID {images_id} not present in dataset.")
-
     def __contains__(self, images_id: uuid.UUID) -> bool:
         return any([image.id == images_id for image in self.all])
 

--- a/mantidimaging/gui/test/gui_system_operations_test.py
+++ b/mantidimaging/gui/test/gui_system_operations_test.py
@@ -5,7 +5,6 @@ from itertools import product
 from unittest import mock
 from uuid import UUID
 
-import pytest
 from parameterized import parameterized
 from PyQt5.QtTest import QTest
 from PyQt5.QtCore import Qt, QTimer
@@ -154,7 +153,6 @@ class TestGuiSystemOperations(GuiSystemBase):
         QTest.mouseClick(self.op_window.updatePreviewButton, Qt.MouseButton.LeftButton)
         wait_until(lambda: mock_do_update_previews.call_count == 1)
 
-    @pytest.mark.xfail  # See #1404
     def test_run_operation_after_deletes(self):
         self._close_image_stacks()
         QTest.qWait(SHOW_DELAY)

--- a/mantidimaging/gui/test/gui_system_operations_test.py
+++ b/mantidimaging/gui/test/gui_system_operations_test.py
@@ -5,6 +5,7 @@ from itertools import product
 from unittest import mock
 from uuid import UUID
 
+import pytest
 from parameterized import parameterized
 from PyQt5.QtTest import QTest
 from PyQt5.QtCore import Qt, QTimer
@@ -152,3 +153,27 @@ class TestGuiSystemOperations(GuiSystemBase):
 
         QTest.mouseClick(self.op_window.updatePreviewButton, Qt.MouseButton.LeftButton)
         wait_until(lambda: mock_do_update_previews.call_count == 1)
+
+    @pytest.mark.xfail  # See #1404
+    def test_run_operation_after_deletes(self):
+        self._close_image_stacks()
+        QTest.qWait(SHOW_DELAY)
+        self._load_data_set()
+        QTest.qWait(SHOW_DELAY)
+        index = self.op_window.filterSelector.findText("Crop Coordinates")
+        self.op_window.filterSelector.setCurrentIndex(index)
+        QTest.qWait(SHOW_DELAY)
+
+        widget = self._get_operation_parameter_widget(self.op_window.filterPropertiesLayout, "ROI")
+        widget.selectAll()
+        QTest.keyClicks(widget, "0,0,20,20")
+        QTest.keyClick(widget, Qt.Key_Return)
+        QTest.qWait(SHOW_DELAY)
+
+        self.op_window.safeApply.setChecked(False)
+        QTest.mouseClick(self.op_window.applyButton, Qt.MouseButton.LeftButton)
+        QTest.qWait(SHORT_DELAY)
+        wait_until(lambda: self.op_window.presenter.filter_is_running is False, max_retry=600)
+
+        self.main_window.filters.close()
+        QTest.qWait(SHOW_DELAY)

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -253,3 +253,7 @@ class MIImageView(ImageView, BadDataOverlay, AutoColorMenu):
 
     def set_log_scale(self):
         set_histogram_log_scale(self.getHistogramWidget().item)
+
+    def close(self):
+        self.roi_changed_callback = None
+        super().close()

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -91,18 +91,6 @@ class MainWindowModel(object):
         else:
             raise RuntimeError(f"Failed to get StrictDataset with ID {dataset_id}")
 
-    def set_image_data_by_uuid(self, images_id: uuid.UUID, new_stack: ImageStack) -> None:
-        """
-        Updates the data of an existing dataset/images object.
-        :param images_id: The id of the image to update.
-        :param new_stack: The ImageStack containing the new data.
-        """
-        for dataset in self.datasets.values():
-            if images_id in dataset:
-                dataset.replace(images_id, new_stack)
-                return
-        self.raise_error_when_images_not_found(images_id)
-
     def get_existing_180_id(self, dataset_id: uuid.UUID) -> Optional[uuid.UUID]:
         """
         Gets the ID of the 180 projection object in a Dataset.

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -413,16 +413,6 @@ class MainWindowPresenter(BasePresenter):
                 return sv
         raise RuntimeError(f"Did not find stack {images} in stacks! " f"Stacks: {self.stack_visualisers.items()}")
 
-    def set_images_in_stack(self, stack_id: uuid.UUID, images: ImageStack) -> None:
-        self.model.set_image_data_by_uuid(stack_id, images)
-        stack = self.stack_visualisers[stack_id]
-        if not stack.presenter.images == images:  # todo - refactor
-            stack.image_view.clear()
-            stack.image_view.setImage(images.data)
-
-            # Free previous images stack before reassignment
-            stack.presenter.images.data = images.data
-
     def add_180_deg_file_to_dataset(self, dataset_id: uuid.UUID, _180_deg_file: str):
         """
         Loads a 180 file then adds it to the dataset, creates a stack window, and updates the dataset tree view.

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -16,7 +16,6 @@ from mantidimaging.core.io.utility import find_projection_closest_to_180, THRESH
 from mantidimaging.core.utility.data_containers import ProjectionAngles, LoadingParameters
 from mantidimaging.gui.dialogs.async_task import start_async_task_view
 from mantidimaging.gui.mvp_base import BasePresenter
-from mantidimaging.gui.windows.stack_visualiser.presenter import SVNotification
 from mantidimaging.gui.windows.stack_visualiser.view import StackVisualiserView
 from .model import MainWindowModel
 from mantidimaging.gui.windows.main.image_save_dialog import ImageSaveDialog
@@ -401,11 +400,6 @@ class MainWindowPresenter(BasePresenter):
     @property
     def have_active_stacks(self) -> bool:
         return len(self.active_stacks) > 0
-
-    def update_stack_with_images(self, images: ImageStack) -> None:
-        sv = self.get_stack_with_images(images)
-        if sv is not None:
-            sv.presenter.notify(SVNotification.REFRESH_IMAGE)
 
     def get_stack_with_images(self, images: ImageStack) -> StackVisualiserView:
         for _, sv in self.stack_visualisers.items():

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -6,7 +6,6 @@ import uuid
 
 from unittest import mock
 import numpy as np
-from numpy.testing import assert_array_equal
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
@@ -292,20 +291,6 @@ class MainWindowModelTest(unittest.TestCase):
             self.model.do_images_saving(uuid.uuid4(), "output", "name_prefix", "image_format", True, "pixel_depth",
                                         mock.Mock())
         save_mock.assert_not_called()
-
-    def test_set_images_by_uuid_success(self):
-        prev_images = generate_images()
-        new_images = generate_images()
-        ds = StrictDataset(prev_images)
-        self.model.datasets[ds.id] = ds
-
-        self.model.set_image_data_by_uuid(prev_images.id, new_images)
-        assert_array_equal(ds.sample.data, new_images.data)
-        assert ds.sample.shared_array == new_images.shared_array
-
-    def test_set_images_by_uuid_failure(self):
-        with self.assertRaises(RuntimeError):
-            self.model.set_image_data_by_uuid("cant-find-this-id", generate_images())
 
     def test_remove_dataset_from_model(self):
         images = [generate_images() for _ in range(5)]

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -307,27 +307,6 @@ class MainWindowPresenterTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.presenter.get_stack_with_images(generate_images())
 
-    def test_set_images_in_stack(self):
-        mock_stack = mock.Mock()
-        mock_stack.presenter.images = old_images = generate_images()
-        self.presenter.stack_visualisers[old_images.id] = mock_stack
-        new_images = generate_images()
-
-        self.presenter.set_images_in_stack(old_images.id, new_images)
-        mock_stack.image_view.clear.assert_called_once()
-        mock_stack.image_view.setImage.assert_called_once_with(new_images.data)
-        self.assertEqual(self.presenter.stack_visualisers[old_images.id].presenter.images, new_images)
-
-    def test_set_same_image_in_stack(self):
-        mock_stack = mock.Mock()
-        mock_stack.presenter.images = old_images = generate_images()
-        self.presenter.stack_visualisers[old_images.id] = mock_stack
-
-        self.presenter.set_images_in_stack(old_images.id, old_images)
-        mock_stack.image_view.clear.assert_not_called()
-        mock_stack.image_view.setImage.assert_not_called()
-        self.assertEqual(self.presenter.stack_visualisers[old_images.id].presenter.images, old_images)
-
     def test_add_first_180_deg_to_dataset(self):
         dataset_id = "dataset-id"
         filename_for_180 = "path/to/180"

--- a/mantidimaging/gui/windows/main/test/strictdataset_test.py
+++ b/mantidimaging/gui/windows/main/test/strictdataset_test.py
@@ -4,7 +4,6 @@
 import unittest
 
 import numpy as np
-from numpy import array_equal
 
 from mantidimaging.core.data.dataset import StrictDataset, _delete_stack_error_message, _image_key_list
 from mantidimaging.core.data.reconlist import ReconList
@@ -37,17 +36,6 @@ class StrictDatasetTest(unittest.TestCase):
         self.assertIsNone(dataset.flat_after)
         self.assertIsNone(dataset.dark_before)
         self.assertIsNone(dataset.dark_after)
-
-    def test_replace_success(self):
-        sample_id = self.images[0].id
-        new_sample_data = generate_images()
-        self.strict_dataset.replace(sample_id, new_sample_data)
-        assert array_equal(self.strict_dataset.sample.data, new_sample_data.data)
-        assert self.strict_dataset.sample.shared_array == new_sample_data.shared_array
-
-    def test_replace_failure(self):
-        with self.assertRaises(KeyError):
-            self.strict_dataset.replace("nonexistent-id", generate_images())
 
     def test_cant_change_dataset_id(self):
         with self.assertRaises(Exception):

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -119,12 +119,6 @@ class MainWindowViewTest(unittest.TestCase):
 
         self.presenter.create_single_tabbed_images_stack.assert_called_once_with(images)
 
-    def test_update_stack_with_images(self):
-        images = generate_images()
-        self.view.update_stack_with_images(images)
-
-        self.presenter.update_stack_with_images.assert_called_once_with(images)
-
     def test_rename_stack(self):
         self.view.rename_stack("apples", "oranges")
 

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -373,9 +373,6 @@ class MainWindowView(BaseMainWindowView):
     def create_new_stack(self, images: ImageStack):
         self.presenter.create_single_tabbed_images_stack(images)
 
-    def update_stack_with_images(self, images: ImageStack):
-        self.presenter.update_stack_with_images(images)
-
     def get_stack_with_images(self, images: ImageStack) -> StackVisualiserView:
         return self.presenter.get_stack_with_images(images)
 

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -264,8 +264,6 @@ class FiltersWindowPresenter(BasePresenter):
                         # and running another async instance causes a race condition in the parallel module
                         # where the shared data can be removed in the middle of the operation of another operation
                         self._do_apply_filter_sync([stack.proj180deg])
-                        self.view.main_window.update_stack_with_images(stack.proj180deg)  # type: ignore
-                    self.view.main_window.update_stack_with_images(stack)
                 if np.any(stack.data < 0):
                     negative_stacks.append(stack)
 

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -250,15 +250,10 @@ class FiltersWindowPresenter(BasePresenter):
     def _post_filter(self, updated_stacks: List[ImageStack], task):
         try:
             use_new_data = True
-            attempt_repair = task.error is not None
             negative_stacks = []
             for stack in updated_stacks:
-                # If the operation encountered an error during processing,
-                # try to restore the original data else continue processing as usual
-                if attempt_repair:
-                    self.main_window.presenter.set_images_in_stack(stack.id, stack)
                 # Ensure there is no error if we are to continue with safe apply and 180 degree.
-                elif task.error is None:
+                if task.error is None:
                     # otherwise check with user which one to keep
                     if self.view.safeApply.isChecked():
                         use_new_data = self._wait_for_stack_choice(stack, stack.id)

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -113,6 +113,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
 
         self.view.clear_notification_dialog.assert_called_once()
         self.view.show_operation_completed.assert_called_once_with(self.presenter.model.selected_filter.filter_name)
+        self.presenter.view.filter_applied.emit.assert_called_once()
 
     @mock.patch.multiple('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter',
                          do_update_previews=DEFAULT,
@@ -130,7 +131,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
 
         self.presenter.view.show_error_dialog.assert_called_once_with('Operation failed: 123')
         do_update_previews.assert_called_once()
-        self.presenter.main_window.presenter.set_images_in_stack.assert_called_once()
+        self.presenter.view.filter_applied.emit.assert_called_once()
 
     @mock.patch.multiple('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter',
                          do_update_previews=DEFAULT,
@@ -156,6 +157,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.view.clear_notification_dialog.assert_called_once()
         self.view.show_operation_completed.assert_not_called()
         self.view.show_operation_cancelled.assert_called_once_with(self.presenter.model.selected_filter.filter_name)
+        self.presenter.view.filter_applied.emit.assert_called_once()
 
     @mock.patch.multiple('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter',
                          do_update_previews=DEFAULT,
@@ -176,6 +178,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
 
         self.assertRaises(ValueError, self.presenter._post_filter, self.mock_stacks, mock_task)
         self.assertFalse(self.presenter.filter_is_running)
+        self.presenter.view.filter_applied.emit.assert_called_once()
 
     @mock.patch.multiple(
         'mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter',

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -68,6 +68,8 @@ class StackVisualiserPresenter(BasePresenter):
 
     def delete_data(self):
         self.images = None
+        self.view.cleanup()
+        self.view = None
 
     def refresh_image(self):
         self.view.image = self.summed_image if self.image_mode is SVImageMode.SUMMED \

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -75,6 +75,8 @@ class StackVisualiserView(QDockWidget):
         self.image_view.roi_changed_callback = self.roi_changed_callback
         self.layout.addWidget(self.image_view)
 
+        self._main_window.stack_changed.connect(lambda: self.presenter.notify(SVNotification.REFRESH_IMAGE))
+
     @property
     def name(self):
         return self.windowTitle()

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -75,7 +75,8 @@ class StackVisualiserView(QDockWidget):
         self.image_view.roi_changed_callback = self.roi_changed_callback
         self.layout.addWidget(self.image_view)
 
-        self._main_window.stack_changed.connect(lambda: self.presenter.notify(SVNotification.REFRESH_IMAGE))
+        self.connection_stack_changed = self._main_window.stack_changed.connect(
+            lambda: self.presenter.notify(SVNotification.REFRESH_IMAGE))
 
     @property
     def name(self):
@@ -200,3 +201,7 @@ class StackVisualiserView(QDockWidget):
     def ask_confirmation(self, msg: str):
         response = QMessageBox.question(self, "Confirm action", msg, QMessageBox.Ok | QMessageBox.Cancel)  # type:ignore
         return response == QMessageBox.Ok
+
+    def cleanup(self):
+        self._main_window.stack_changed.disconnect(self.connection_stack_changed)
+        self.presenter = None


### PR DESCRIPTION
### Issue

Closes #1322

### Description

The `attempt_repair` did not actually do any repairing. It just called a method to redraw the the visualiser. (The only defence we have against an operations doing something bad tot he data and then failing is the safe mode). We need to redraw the visualisers no matter what happens, but we already emit `filter_applied` signal, so makes sense for the visualisers to just listen for that. The operations are all in-place, so the visualisers don't need to be told that there is a new image stack.

This means that several methods are no longer needed. `set_image_data_by_uuid()`, `update_stack_with_images()`, `set_images_in_stack()` 

### Testing 

Run some operations in the ops window.

### Acceptance Criteria 

Visualisers in the main window should be updated when an operation finishes.

### Documentation

Not needed.
