### PR TITLE
MedianFilter work inplace on ImageStack

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -13,6 +13,7 @@ New Features
 Fixes
 -----
 - #1381 : Don't use console progress bar in GUI application
+- #1405 : MedianFilter work inplace on ImageStack
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -95,7 +95,7 @@ class MedianFilter(BaseFilter):
             raise ValueError(f'Size parameter must be greater than 1, but value provided was {size}')
 
         if not force_cpu:
-            data = _execute_gpu(data.data, size, mode, progress)
+            _execute_gpu(data.data, size, mode, progress)
         else:
             _execute(data.data, size, mode, cores, chunksize, progress)
 
@@ -164,8 +164,6 @@ def _execute(data, size, mode, cores=None, chunksize=None, progress=None):
         ps.shared_list = [data]
         ps.execute(f, data.shape[0], progress, msg="Median filter", cores=cores)
 
-    return data
-
 
 def _execute_gpu(data, size, mode, progress=None):
     log = getLogger(__name__)
@@ -175,6 +173,4 @@ def _execute_gpu(data, size, mode, progress=None):
     with progress:
         log.info("GPU median filter, with pixel data type: {0}, filter " "size/width: {1}.".format(data.dtype, size))
 
-        data = cuda.median_filter(data, size, mode, progress)
-
-    return ImageStack(data)
+        cuda.median_filter(data, size, mode, progress)

--- a/mantidimaging/core/operations/test/__init__.py
+++ b/mantidimaging/core/operations/test/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/core/operations/test/operations_test.py
+++ b/mantidimaging/core/operations/test/operations_test.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+from typing import List
+import unittest
+from unittest import mock
+
+import numpy
+
+from mantidimaging.core.operations.loader import load_filter_packages, BaseFilter
+import mantidimaging.test_helpers.unit_test_helper as th
+from mantidimaging.core.utility.data_containers import Counts
+from mantidimaging.core.gpu import utility as gpu
+
+GPU_NOT_AVAIL = not gpu.gpu_available()
+
+filter_func_args = {
+    "Clip Values": {"clip_min": 0.1, "clip_max": 0.5},
+    "Crop Coordinates": {"region_of_interest": [0, 0, 5, 5]},
+    "Divide": {"value": 2},
+    "Flat-fielding": {"flat_before": th.generate_images(), "dark_before": th.generate_images(),
+                      "selected_flat_fielding": "Only Before", "use_dark": False},
+    "Gaussian": {"size": 2.0, "order": 1, "mode": "nearest"},
+    "Median": {"size": 3, "mode": "nearest", "force_cpu": GPU_NOT_AVAIL},
+    "Remove Outliers": {"diff": 0.1},
+    "Rebin": {"mode": "constant"},
+    "Stripe Removal": {"sf": {"size": 1}},
+    "Ring Removal": {"theta_min": 2},
+    "ROI Normalisation": {"region_of_interest": [0, 0, 5, 5]},
+    "Rotate Stack": {"angle": 10}
+}  # yapf: disable
+
+
+class OperationsTest(unittest.TestCase):
+    filters: List[BaseFilter]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.filters = load_filter_packages()
+
+    def test_load_filters(self):
+        self.assertGreater(len(self.filters), 10)
+
+    def test_operation_works_inplace(self):
+        for filter in self.filters:
+            filter_name = filter.filter_name
+            filter_args = filter_func_args.get(filter_name, {})
+
+            images = th.generate_images()
+            if filter_name == "Monitor Normalisation":
+                counts = Counts(numpy.ones(images.num_images))
+                images._log_file = mock.Mock(counts=lambda: counts)
+
+            returned = filter.filter_func(images, **filter_args)
+            self.assertEqual(id(images), id(returned))

--- a/mantidimaging/core/operations/test/operations_test.py
+++ b/mantidimaging/core/operations/test/operations_test.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-from typing import List
+from typing import Dict, List
 import unittest
 from unittest import mock
 
@@ -14,29 +14,34 @@ from mantidimaging.core.gpu import utility as gpu
 
 GPU_NOT_AVAIL = not gpu.gpu_available()
 
-filter_func_args = {
-    "Clip Values": {"clip_min": 0.1, "clip_max": 0.5},
-    "Crop Coordinates": {"region_of_interest": [0, 0, 5, 5]},
-    "Divide": {"value": 2},
-    "Flat-fielding": {"flat_before": th.generate_images(), "dark_before": th.generate_images(),
-                      "selected_flat_fielding": "Only Before", "use_dark": False},
-    "Gaussian": {"size": 2.0, "order": 1, "mode": "nearest"},
-    "Median": {"size": 3, "mode": "nearest", "force_cpu": GPU_NOT_AVAIL},
-    "Remove Outliers": {"diff": 0.1},
-    "Rebin": {"mode": "constant"},
-    "Stripe Removal": {"sf": {"size": 1}},
-    "Ring Removal": {"theta_min": 2},
-    "ROI Normalisation": {"region_of_interest": [0, 0, 5, 5]},
-    "Rotate Stack": {"angle": 10}
-}  # yapf: disable
+
+def get_filter_func_args():
+    filter_func_args = {
+        "Clip Values": {"clip_min": 0.1, "clip_max": 0.5},
+        "Crop Coordinates": {"region_of_interest": [0, 0, 5, 5]},
+        "Divide": {"value": 2},
+        "Flat-fielding": {"flat_before": th.generate_images(), "dark_before": th.generate_images(),
+                          "selected_flat_fielding": "Only Before", "use_dark": False},
+        "Gaussian": {"size": 2.0, "order": 1, "mode": "nearest"},
+        "Median": {"size": 3, "mode": "nearest", "force_cpu": GPU_NOT_AVAIL},
+        "Remove Outliers": {"diff": 0.1},
+        "Rebin": {"mode": "constant"},
+        "Stripe Removal": {"sf": {"size": 1}},
+        "Ring Removal": {"theta_min": 2},
+        "ROI Normalisation": {"region_of_interest": [0, 0, 5, 5]},
+        "Rotate Stack": {"angle": 10}
+    }  # yapf: disable
+    return filter_func_args
 
 
 class OperationsTest(unittest.TestCase):
     filters: List[BaseFilter]
+    filter_args: Dict
 
     @classmethod
     def setUpClass(cls) -> None:
         cls.filters = load_filter_packages()
+        cls.filter_args = get_filter_func_args()
 
     def test_load_filters(self):
         self.assertGreater(len(self.filters), 10)
@@ -44,7 +49,7 @@ class OperationsTest(unittest.TestCase):
     def test_operation_works_inplace(self):
         for filter in self.filters:
             filter_name = filter.filter_name
-            filter_args = filter_func_args.get(filter_name, {})
+            filter_args = self.filter_args.get(filter_name, {})
 
             images = th.generate_images()
             if filter_name == "Monitor Normalisation":


### PR DESCRIPTION
Check that all operations act on the ImageStack in place

### Issue

Closes #1405 

### Description

I think what was happening in 
```
                images = th.generate_images()

                gpu_result = MedianFilter.filter_func(images.copy(), size, mode, force_cpu=False)
                cpu_result = MedianFilter.filter_func(images.copy(), size, mode, force_cpu=True)
```
was that the GPU version was creating a new `ImageStack` which was not using SharedArray. Then the old SharedArray was being destructed even though its array was still being used.  

I cleaned up a bit of confusing modify-an-argument-and-return-it style. We should maybe stop doing that in the `BaseFilter.filter_func` 

I have added some Operations tests, that check that each operation is modifying its data inplace.

### Testing 

Because this is only hit on the GPU path it is not tested on the github actions workers. So needs local testing check.

`pytest -vs -rs --randomly-seed=2928879550 mantidimaging/core/gpu/`
should fail on main, but pass with these fixes.

### Acceptance Criteria 

Median should work properly in CPU and GPU mode

### Documentation

Release notes
