### PR TITLE
1385: Load all NeXus rotation angles

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -9,6 +9,7 @@ New Features
 - #1340 : ROI norm - remove preserve max option
 - #1379 : Add angle/z axis slider in the operations window
 - #1217 : Basic NeXus Saving
+- #1385 : Load all NeXus rotation angles
 
 Fixes
 -----

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -310,5 +310,5 @@ class NexusLoadPresenter:
             return None
         image_stack = self._create_images(data_array, name)
         if image_stack is not None:
-            image_stack.set_projection_angles(ProjectionAngles(self._read_rotation_angles(image_key)))
+            image_stack.set_projection_angles(ProjectionAngles(self._read_rotation_angles(image_key, "Before" in name)))
         return image_stack

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -91,9 +91,11 @@ class NexusLoadPresenter:
                 if self.data is None:
                     return
 
-                self.image_key_dataset = self._look_for_tomo_data_and_update_view(IMAGE_KEY_PATH, 0)[:]
+                self.image_key_dataset = self._look_for_tomo_data_and_update_view(IMAGE_KEY_PATH, 0)
                 if self.image_key_dataset is None:
                     return
+                else:
+                    self.image_key_dataset = self.image_key_dataset[:]
 
                 self.rotation_angles = self._look_for_tomo_data_and_update_view(ROTATION_ANGLE_PATH, 1)
                 if self.rotation_angles is not None:
@@ -102,7 +104,7 @@ class NexusLoadPresenter:
                         self.degrees = np.abs(self.rotation_angles).max() > 2 * np.pi
                     else:
                         self.degrees = "deg" in self.rotation_angles.attrs["units"]
-                self.rotation_angles = self.rotation_angles[:]
+                    self.rotation_angles = self.rotation_angles[:]
 
                 self._get_data_from_image_key()
                 self.title = self._find_data_title()

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -58,6 +58,7 @@ class NexusLoadPresenter:
         self.data = None
         self.tomo_path = ""
         self.image_key_dataset = None
+        self.rotation_angles = None
         self.title = ""
 
         self.sample_array = None
@@ -89,7 +90,7 @@ class NexusLoadPresenter:
                 if self.data is None:
                     return
 
-                self.image_key_dataset = self._look_for_tomo_data_and_update_view(IMAGE_KEY_PATH, 0)
+                self.image_key_dataset = self._look_for_tomo_data_and_update_view(IMAGE_KEY_PATH, 0)[:]
                 if self.image_key_dataset is None:
                     return
 
@@ -100,6 +101,7 @@ class NexusLoadPresenter:
                         self.degrees = np.abs(self.rotation_angles).max() > 2 * np.pi
                     else:
                         self.degrees = "deg" in self.rotation_angles.attrs["units"]
+                self.rotation_angles = self.rotation_angles[:]
 
                 self._get_data_from_image_key()
                 self.title = self._find_data_title()

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -67,7 +67,6 @@ class NexusLoadPresenter:
         self.flat_before_array = None
         self.flat_after_array = None
         self.dark_after_array = None
-        self.projection_angles = None
 
     def notify(self, n: Notification):
         try:
@@ -104,6 +103,8 @@ class NexusLoadPresenter:
                         self.degrees = np.abs(self.rotation_angles).max() > 2 * np.pi
                     else:
                         self.degrees = "deg" in self.rotation_angles.attrs["units"]
+                    if self.degrees:
+                        self.rotation_angles = np.radians(self.rotation_angles)
                     self.rotation_angles = self.rotation_angles[:]
 
                 self._get_data_from_image_key()
@@ -133,8 +134,6 @@ class NexusLoadPresenter:
             else:
                 rotation_angles = self.rotation_angles[first_sample_image_index:][np.where(
                     self.image_key_dataset[first_sample_image_index:] == image_key)]
-        if self.degrees:
-            rotation_angles = np.radians(rotation_angles)
         return rotation_angles
 
     def _missing_data_error(self, field: str):

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -121,12 +121,14 @@ class NexusLoadPresenter:
         assert self.image_key_dataset is not None
         if before is None:
             rotation_angles = self.rotation_angles[np.where(self.image_key_dataset[...] == image_key)]
-        elif before:
-            split_array = np.split(self.rotation_angles, 2)[0]
-            rotation_angles = split_array[np.where(split_array[...] == image_key)]
         else:
-            split_array = np.split(self.rotation_angles, 2)[1]
-            rotation_angles = split_array[np.where(split_array[...] == image_key)]
+            first_sample_index = np.where(self.image_key_dataset == 0)[0][0]
+            if before:
+                rotation_angles = self.rotation_angles[:first_sample_index][np.where(
+                    self.image_key_dataset[:first_sample_index] == image_key)]
+            else:
+                rotation_angles = self.rotation_angles[first_sample_index:][np.where(
+                    self.image_key_dataset[first_sample_index:] == image_key)]
         if self.degrees:
             rotation_angles = np.radians(rotation_angles)
         return rotation_angles

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -60,7 +60,6 @@ class NexusLoadPresenter:
         self.image_key_dataset = None
         self.rotation_angles = None
         self.title = ""
-        self.degrees = None
 
         self.sample_array = None
         self.dark_before_array = None
@@ -102,10 +101,10 @@ class NexusLoadPresenter:
 
                 if "units" not in self.rotation_angles.attrs.keys():
                     logger.warning("No unit information found for rotation angles. Will infer from array values.")
-                    self.degrees = np.abs(self.rotation_angles).max() > 2 * np.pi
+                    degrees = np.abs(self.rotation_angles).max() > 2 * np.pi
                 else:
-                    self.degrees = "deg" in self.rotation_angles.attrs["units"]
-                if self.degrees:
+                    degrees = "deg" in self.rotation_angles.attrs["units"]
+                if degrees:
                     self.rotation_angles = np.radians(self.rotation_angles)
                 self.rotation_angles = self.rotation_angles[:]
 

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -255,13 +255,13 @@ class NexusLoadPresenter:
         sample_images.name = self.title
         return StrictDataset(sample=sample_images,
                              flat_before=self._create_images_if_required(self.flat_before_array, "Flat Before",
-                                                                         ImageKeys.FlatField),
+                                                                         ImageKeys.FlatField.value),
                              flat_after=self._create_images_if_required(self.flat_after_array, "Flat After",
-                                                                        ImageKeys.FlatField),
+                                                                        ImageKeys.FlatField.value),
                              dark_before=self._create_images_if_required(self.dark_before_array, "Dark Before",
-                                                                         ImageKeys.DarkField),
+                                                                         ImageKeys.DarkField.value),
                              dark_after=self._create_images_if_required(self.dark_after_array, "Dark After",
-                                                                        ImageKeys.DarkField),
+                                                                        ImageKeys.DarkField.value),
                              name=self.title), self.title
 
     def _create_sample_images(self):

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -93,19 +93,21 @@ class NexusLoadPresenter:
                 self.image_key_dataset = self._look_for_tomo_data_and_update_view(IMAGE_KEY_PATH, 0)
                 if self.image_key_dataset is None:
                     return
-                else:
-                    self.image_key_dataset = self.image_key_dataset[:]
+
+                self.image_key_dataset = self.image_key_dataset[:]
 
                 self.rotation_angles = self._look_for_tomo_data_and_update_view(ROTATION_ANGLE_PATH, 1)
-                if self.rotation_angles is not None:
-                    if "units" not in self.rotation_angles.attrs.keys():
-                        logger.warning("No unit information found for rotation angles. Will infer from array values.")
-                        self.degrees = np.abs(self.rotation_angles).max() > 2 * np.pi
-                    else:
-                        self.degrees = "deg" in self.rotation_angles.attrs["units"]
-                    if self.degrees:
-                        self.rotation_angles = np.radians(self.rotation_angles)
-                    self.rotation_angles = self.rotation_angles[:]
+                if self.rotation_angles is None:
+                    return
+
+                if "units" not in self.rotation_angles.attrs.keys():
+                    logger.warning("No unit information found for rotation angles. Will infer from array values.")
+                    self.degrees = np.abs(self.rotation_angles).max() > 2 * np.pi
+                else:
+                    self.degrees = "deg" in self.rotation_angles.attrs["units"]
+                if self.degrees:
+                    self.rotation_angles = np.radians(self.rotation_angles)
+                self.rotation_angles = self.rotation_angles[:]
 
                 self._get_data_from_image_key()
                 self.title = self._find_data_title()

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -93,13 +93,13 @@ class NexusLoadPresenter:
                 if self.image_key_dataset is None:
                     return
 
-                rotation_angles = self._look_for_tomo_data_and_update_view(ROTATION_ANGLE_PATH, 1)
-                if rotation_angles is not None:
-                    if "units" not in rotation_angles.attrs.keys():
+                self.rotation_angles = self._look_for_tomo_data_and_update_view(ROTATION_ANGLE_PATH, 1)
+                if self.rotation_angles is not None:
+                    if "units" not in self.rotation_angles.attrs.keys():
                         logger.warning("No unit information found for rotation angles. Will infer from array values.")
-                        self._read_rotation_angles(rotation_angles, np.abs(rotation_angles).max() > 2 * np.pi)
+                        self.degrees = np.abs(self.rotation_angles).max() > 2 * np.pi
                     else:
-                        self._read_rotation_angles(rotation_angles, "deg" in rotation_angles.attrs["units"])
+                        self.degrees = "deg" in self.rotation_angles.attrs["units"]
 
                 self._get_data_from_image_key()
                 self.title = self._find_data_title()
@@ -109,17 +109,22 @@ class NexusLoadPresenter:
             self.view.show_data_error(unable_message)
             self.view.disable_ok_button()
 
-    def _read_rotation_angles(self, rotation_angles: h5py.Dataset, degrees: bool):
+    def _read_rotation_angles(self, image_key: int, before: bool = None) -> np.ndarray:
         """
-        Reads the rotation angles array for the projections alone and coverts them to radians if needed.
-        :param rotation_angles: The rotation angle information for all the images.
-        :param degrees: Whether the data is in degrees or not. If this information isn't included in the file then a
-            guess was made.
+        Reads the rotation angles array and coverts them to radians if needed.
+        :param image_key: The image key for the angles to read.
+        :return: A numpy array of the rotation angles.
         """
         assert self.image_key_dataset is not None
-        self.projection_angles = rotation_angles[np.where(self.image_key_dataset[...] == ImageKeys.Projections.value)]
-        if degrees:
-            self.projection_angles = np.radians(self.projection_angles)
+        if before is None:
+            rotation_angles = self.rotation_angles[np.where(self.image_key_dataset[...] == image_key)]
+        elif before:
+            pass
+        else:
+            pass
+        if self.degrees:
+            rotation_angles = np.radians(rotation_angles)
+        return rotation_angles
 
     def _missing_data_error(self, field: str):
         """
@@ -245,10 +250,14 @@ class NexusLoadPresenter:
         sample_images = self._create_sample_images()
         sample_images.name = self.title
         return StrictDataset(sample=sample_images,
-                             flat_before=self._create_images_if_required(self.flat_before_array, "Flat Before"),
-                             flat_after=self._create_images_if_required(self.flat_after_array, "Flat After"),
-                             dark_before=self._create_images_if_required(self.dark_before_array, "Dark Before"),
-                             dark_after=self._create_images_if_required(self.dark_after_array, "Dark After"),
+                             flat_before=self._create_images_if_required(self.flat_before_array, "Flat Before",
+                                                                         ImageKeys.FlatField),
+                             flat_after=self._create_images_if_required(self.flat_after_array, "Flat After",
+                                                                        ImageKeys.FlatField),
+                             dark_before=self._create_images_if_required(self.dark_before_array, "Dark Before",
+                                                                         ImageKeys.DarkField),
+                             dark_after=self._create_images_if_required(self.dark_after_array, "Dark After",
+                                                                        ImageKeys.DarkField),
                              name=self.title), self.title
 
     def _create_sample_images(self):
@@ -266,10 +275,11 @@ class NexusLoadPresenter:
 
         # Set attributes
         sample_images.pixel_size = int(self.view.pixelSizeSpinBox.value())
-        if self.projection_angles is not None:
+        projection_angles = self._read_rotation_angles(ImageKeys.Projections.value)
+        if projection_angles is not None:
             sample_images.set_projection_angles(
-                ProjectionAngles(self.projection_angles[self.view.start_widget.value():self.view.stop_widget.value(
-                ):self.view.step_widget.value()]))
+                ProjectionAngles(projection_angles[self.view.start_widget.value():self.view.stop_widget.value():self.
+                                                   view.step_widget.value()]))
 
         return sample_images
 
@@ -284,7 +294,7 @@ class NexusLoadPresenter:
         data.array[:] = data_array
         return ImageStack(data, [f"{name} {self.title}"])
 
-    def _create_images_if_required(self, data_array: np.ndarray, name: str) -> Optional[ImageStack]:
+    def _create_images_if_required(self, data_array: np.ndarray, name: str, image_key: int) -> Optional[ImageStack]:
         """
         Create the ImageStack objects if the corresponding data was found in the NeXus file, and the user checked the
         "Use?" checkbox.
@@ -294,4 +304,7 @@ class NexusLoadPresenter:
         """
         if data_array.size == 0 or not self.view.checkboxes[name].isChecked():
             return None
-        return self._create_images(data_array, name)
+        image_stack = self._create_images(data_array, name)
+        if image_stack is not None:
+            image_stack.set_projection_angles(ProjectionAngles(self._read_rotation_angles(image_key)))
+        return image_stack

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -119,9 +119,11 @@ class NexusLoadPresenter:
         if before is None:
             rotation_angles = self.rotation_angles[np.where(self.image_key_dataset[...] == image_key)]
         elif before:
-            pass
+            split_array = np.split(self.rotation_angles, 2)[0]
+            rotation_angles = split_array[np.where(split_array[...] == image_key)]
         else:
-            pass
+            split_array = np.split(self.rotation_angles, 2)[1]
+            rotation_angles = split_array[np.where(split_array[...] == image_key)]
         if self.degrees:
             rotation_angles = np.radians(rotation_angles)
         return rotation_angles

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -116,19 +116,21 @@ class NexusLoadPresenter:
         """
         Reads the rotation angles array and coverts them to radians if needed.
         :param image_key: The image key for the angles to read.
+        :param before: Whether the rotation angles are for before/after images. This is None when rotation angles
+            for sample images are being read.
         :return: A numpy array of the rotation angles.
         """
         assert self.image_key_dataset is not None
         if before is None:
             rotation_angles = self.rotation_angles[np.where(self.image_key_dataset[...] == image_key)]
         else:
-            first_sample_index = np.where(self.image_key_dataset == 0)[0][0]
+            first_sample_image_index = np.where(self.image_key_dataset == 0)[0][0]
             if before:
-                rotation_angles = self.rotation_angles[:first_sample_index][np.where(
-                    self.image_key_dataset[:first_sample_index] == image_key)]
+                rotation_angles = self.rotation_angles[:first_sample_image_index][np.where(
+                    self.image_key_dataset[:first_sample_image_index] == image_key)]
             else:
-                rotation_angles = self.rotation_angles[first_sample_index:][np.where(
-                    self.image_key_dataset[first_sample_index:] == image_key)]
+                rotation_angles = self.rotation_angles[first_sample_image_index:][np.where(
+                    self.image_key_dataset[first_sample_image_index:] == image_key)]
         if self.degrees:
             rotation_angles = np.radians(rotation_angles)
         return rotation_angles
@@ -307,6 +309,7 @@ class NexusLoadPresenter:
         "Use?" checkbox.
         :param data_array: The images data array.
         :param name: The name of the images.
+        :param image_key: The image key index for the image type.
         :return: An ImageStack object or None.
         """
         if data_array.size == 0 or not self.view.checkboxes[name].isChecked():

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -60,6 +60,7 @@ class NexusLoadPresenter:
         self.image_key_dataset = None
         self.rotation_angles = None
         self.title = ""
+        self.degrees = None
 
         self.sample_array = None
         self.dark_before_array = None

--- a/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
@@ -302,3 +302,18 @@ class NexusLoaderTest(unittest.TestCase):
 
         self.nexus_loader.scan_nexus_file()
         assert np.array_equal(self.nexus_loader.rotation_angles, rotation_angles_array)
+
+    def test_rotation_angles_stored_in_projection_angles_object(self):
+        del self.tomo_entry[ROTATION_ANGLE_PATH]
+        rotation_angles_array = np.array([i for i in range(10)])
+        angle_dataset = self.tomo_entry.create_dataset(ROTATION_ANGLE_PATH, data=rotation_angles_array)
+        angle_dataset.attrs.create("units", "radians")
+
+        self.nexus_loader.scan_nexus_file()
+        ds, _ = self.nexus_loader.get_dataset()
+
+        assert np.array_equal(ds.flat_before.projection_angles().value, [0, 1])
+        assert np.array_equal(ds.dark_before.projection_angles().value, [2, 3])
+        assert np.array_equal(ds.sample.projection_angles().value, [4, 5])
+        assert np.array_equal(ds.dark_after.projection_angles().value, [6, 7])
+        assert np.array_equal(ds.flat_after.projection_angles().value, [8, 9])

--- a/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
@@ -284,10 +284,6 @@ class NexusLoaderTest(unittest.TestCase):
             self.nexus_loader.scan_nexus_file()
         self.assertIn("The NeXus file does not contain the sample/rotation_angle data.", log_mock.output[0])
 
-        dataset = self.nexus_loader.get_dataset()[0]
-        self.assertIsNone(dataset.sample._projection_angles)
-        self.assertIsNone(dataset.sample._proj180deg)
-
     def test_no_rotation_angle_units(self):
         del self.tomo_entry[ROTATION_ANGLE_PATH].attrs["units"]
         with self.assertLogs(nexus_logger, level="WARNING") as log_mock:

--- a/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
@@ -165,28 +165,28 @@ class NexusLoaderTest(unittest.TestCase):
         np.testing.assert_array_almost_equal(dataset.flat_after.data, self.flat_after)
 
     def test_no_flat_before_data(self):
-        self.replace_values_in_image_key("Flat Before", 0)
+        self.replace_values_in_image_key("Flat Before", 5)
         self.nexus_loader.scan_nexus_file()
         dataset = self.nexus_loader.get_dataset()[0]
         self.assertIsNone(dataset.flat_before)
         self.view.set_images_found.assert_any_call(1, False, (0, 10, 10))
 
     def test_no_dark_before_data(self):
-        self.replace_values_in_image_key("Dark Before", 0)
+        self.replace_values_in_image_key("Dark Before", 5)
         self.nexus_loader.scan_nexus_file()
         dataset = self.nexus_loader.get_dataset()[0]
         self.assertIsNone(dataset.dark_before)
         self.view.set_images_found.assert_any_call(3, False, (0, 10, 10))
 
     def test_no_flat_after_data(self):
-        self.replace_values_in_image_key("Flat After", 0)
+        self.replace_values_in_image_key("Flat After", 5)
         self.nexus_loader.scan_nexus_file()
         dataset = self.nexus_loader.get_dataset()[0]
         self.assertIsNone(dataset.flat_after)
         self.view.set_images_found.assert_any_call(2, False, (0, 10, 10))
 
     def test_no_dark_after_data(self):
-        self.replace_values_in_image_key("Dark After", 0)
+        self.replace_values_in_image_key("Dark After", 5)
         self.nexus_loader.scan_nexus_file()
         dataset = self.nexus_loader.get_dataset()[0]
         self.assertIsNone(dataset.dark_after)
@@ -296,7 +296,7 @@ class NexusLoaderTest(unittest.TestCase):
 
     def test_rotation_angles_converted_to_radians(self):
         self.nexus_loader.scan_nexus_file()
-        assert np.array_equal(self.nexus_loader.projection_angles, np.array([np.pi * 0.5, np.pi]))
+        assert np.array_equal(self.nexus_loader.rotation_angles, np.deg2rad(self.rotation_angles_array))
 
     def test_rotation_angles_already_in_radians(self):
         del self.tomo_entry[ROTATION_ANGLE_PATH]
@@ -305,4 +305,4 @@ class NexusLoaderTest(unittest.TestCase):
         angle_dataset.attrs.create("units", "radians")
 
         self.nexus_loader.scan_nexus_file()
-        assert np.array_equal(self.nexus_loader.projection_angles, np.array([np.pi * 0.5, np.pi]))
+        assert np.array_equal(self.nexus_loader.rotation_angles, rotation_angles_array)


### PR DESCRIPTION
### Issue

Closes #1385

### Description

Loads all the rotation angles to the StrictDataset rather than just the sample ones.

### Testing 

Wrote a new `test_rotation_angles_stored_in_projection_angles_object` test and made changes to a few existing tests.

### Acceptance Criteria 

Check that the tests pass. Try saving the Diamond NeXus data as a new NeXus file and compare the information in the rotation angle fields.

### Documentation

Updated release notes.
