### PR TITLE
1395: Delete incomplete NeXus file when saving fails

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -14,6 +14,7 @@ Fixes
 -----
 - #1381 : Don't use console progress bar in GUI application
 - #1405 : MedianFilter work inplace on ImageStack
+- #1395 : Delete file when NeXus saving fails
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -178,7 +178,7 @@ def nexus_save(dataset: StrictDataset, path: str, sample_name: str):
         with h5py.File(path, "w", driver="core") as nexus_file:
             _nexus_save(nexus_file, dataset, sample_name)
     except OSError:
-        pass
+        os.remove(path)
 
 
 def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str):

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -175,10 +175,16 @@ def nexus_save(dataset: StrictDataset, path: str, sample_name: str):
     :param sample_name: The sample name.
     """
     try:
-        with h5py.File(path, "w", driver="core") as nexus_file:
-            _nexus_save(nexus_file, dataset, sample_name)
+        nexus_file = h5py.File(path, "w", driver="core")
+    except OSError:
+        return
+
+    try:
+        _nexus_save(nexus_file, dataset, sample_name)
     except OSError:
         os.remove(path)
+
+    nexus_file.close()
 
 
 def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str):


### PR DESCRIPTION
### Issue

Closes #1395

### Description

Deletes the incomplete NeXus file when saving raises an `OSError`.

### Testing 

No test as it's an IO thing.

### Acceptance Criteria 

Raise an `OSError` in the NeXus save method and check that the file isn't written.

### Documentation

Updated release notes.
