### PR TITLE
Add GitHub Actions workflow for Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -47,7 +47,18 @@ jobs:
           auto-activate-base: false
           use-mamba: true
 
+      - name: Cache Mambaforge environment
+        uses: actions/cache@v2
+        id: cache-mambaforge-environment
+        env:
+          CACHE_NUMBER: 0
+        with:
+          path: ${{env.CONDA}}/envs/mantidimaging-dev
+          key:
+            ${{runner.os}}-condaenv-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml')}}
+
       - name: Mantid Imaging developer dependencies
+        if: steps.cache-mambaforge-environment.outputs.cache-hit != 'true'
         shell: bash -l {0}
         run: |
           conda deactivate

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,43 @@
+name: Testing on Windows
+
+on:
+  push:
+    branches:
+    - 'main'
+    - 'release-*'
+  pull_request:
+    branches:
+      - 'main'
+      - 'release-*'
+  release:
+
+jobs:
+  test:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Needed to get tags so that git describe works during package build
+          fetch-depth: "0"
+
+      - name: Setup Mambaforge
+        uses: conda-incubator/setup-miniconda@v2.1.1
+        with:
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+          activate-environment: mantidimaging-dev
+          auto-activate-base: false
+          use-mamba: true
+
+      - name: Mantid Imaging developer dependencies
+        shell: bash -l {0}
+        run: |
+          conda deactivate
+          python ./setup.py create_dev_env
+
+      - name: List versions
+        shell: bash -l {0}
+        run: |
+          mamba env list
+          python --version; conda list ; pip list

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,3 +41,25 @@ jobs:
         run: |
           mamba env list
           python --version; conda list ; pip list
+
+      - name: Yapf
+        shell: bash -l {0}
+        run: |
+          yapf --parallel --diff --recursive .
+
+      - name: Flake8
+        shell: bash -l {0}
+        run: |
+          python -m flake8
+
+      - name: mypy
+        shell: bash -l {0}
+        # COMPAT: applitools has some bad signatures, so use --no-site-packages
+        run: |
+          mypy --ignore-missing-imports --no-site-packages mantidimaging
+
+      - name: pytest
+        timeout-minutes: 5
+        shell: bash -l {0}
+        run: |
+          python -m pytest --cov --cov-report=xml -n auto --ignore=mantidimaging/eyes_tests --durations=10

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,6 +21,23 @@ jobs:
           # Needed to get tags so that git describe works during package build
           fetch-depth: "0"
 
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y%V")"
+        shell: bash
+
+      - name: Cache Mambaforge and Pip packages
+        uses: actions/cache@v2
+        env:
+          CACHE_NUMBER: 0
+        with:
+          path: |
+            ~/conda_pkgs_dir
+            ~/.cache/pip
+          key:
+            ${{runner.os}}-condapkg-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml')}}
+
       - name: Setup Mambaforge
         uses: conda-incubator/setup-miniconda@v2.1.1
         with:


### PR DESCRIPTION
### Issue
Refs #1402

### Description
Adds a workflow to run our static analysis and unit tests against Windows. This PR doesn't close the issue as we will need to add the GUI system tests, Applitools tests and a packaging step when we get to that stage with the Windows compatibility work.

For now I have added a separate workflow for Windows. Once we have finished the Windows compatibility work, it would be good to evaluate if there would be any benefit to [using a build matrix](https://docs.github.com/en/actions/using-jobs/using-a-build-matrix-for-your-jobs#example-running-with-multiple-operating-systems) to remove duplication with the conda workflow, as a lot of the steps moved across so far are compatible with both environments (in this PR, only the pytest step is not).

I have slightly changed the approach used to cache the environment here, but I'm not sure if I'm misunderstanding why it was written as it was originally, so please shout if so 🙂. For that reason I've not changed the conda workflow version to match, but I could if we thought that would be beneficial.

### Testing & Acceptance Criteria
Tests should pass with an acceptable duration.

### Documentation
Not required.