### PR TITLE
Create pool of processes on start-up

### DIFF
--- a/docs/ext/operations_user_doc.py
+++ b/docs/ext/operations_user_doc.py
@@ -29,7 +29,7 @@ def split_lines(s: str) -> List[str]:
     return s.split("\n")
 
 
-PARAM_SKIP_LIST = ["images", "cores", "chunksize", "progress"]
+PARAM_SKIP_LIST = ["images", "progress"]
 
 
 def get_params(s: str) -> List[str]:

--- a/mantidimaging/core/gpu/test/gpu_test.py
+++ b/mantidimaging/core/gpu/test/gpu_test.py
@@ -9,12 +9,14 @@ import numpy.testing as npt
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.median_filter import MedianFilter, modes
 from mantidimaging.core.gpu import utility as gpu
+from mantidimaging.test_helpers.start_qapplication import start_multiprocessing_pool
 
 GPU_NOT_AVAIL = not gpu.gpu_available()
 GPU_SKIP_REASON = "Skip GPU tests if cupy isn't installed."
 GPU_UTILITY_LOC = "mantidimaging.core.gpu.utility.gpu_available"
 
 
+@start_multiprocessing_pool
 class GPUTest(unittest.TestCase):
     """
     Test median filter.

--- a/mantidimaging/core/operations/arithmetic/arithmetic.py
+++ b/mantidimaging/core/operations/arithmetic/arithmetic.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from functools import partial
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict
 
 import numpy as np
 from PyQt5.QtWidgets import QFormLayout, QWidget, QDoubleSpinBox
@@ -43,7 +43,6 @@ class ArithmeticFilter(BaseFilter):
                     mult_val: float = 1.0,
                     add_val: float = 0.0,
                     sub_val: float = 0.0,
-                    cores: Optional[int] = None,
                     progress=None) -> ImageStack:
         """
         Apply arithmetic operations to the pixels.
@@ -52,14 +51,13 @@ class ArithmeticFilter(BaseFilter):
         :param div_val: The division value.
         :param add_val: The addition value.
         :param sub_val: The subtraction value.
-        :param cores: The number of cores that will be used to process the data.
         :param progress: The Progress object isn't used.
         :return: The processed ImageStack object.
         """
         if div_val == 0 or mult_val == 0:
             raise ValueError("Unable to proceed with operation because division/multiplication value is zero.")
 
-        _execute(images, div_val, mult_val, add_val, sub_val, cores, progress)
+        _execute(images, div_val, mult_val, add_val, sub_val, progress)
         return images
 
     @staticmethod
@@ -116,8 +114,7 @@ class ArithmeticFilter(BaseFilter):
                        sub_val=sub_input_widget.value())
 
 
-def _execute(images: ImageStack, div_val: float, mult_val: float, add_val: float, sub_val: float, cores: Optional[int],
-             progress):
+def _execute(images: ImageStack, div_val: float, mult_val: float, add_val: float, sub_val: float, progress):
     arg_list = [div_val, mult_val, add_val, sub_val]
     do_arithmetic = ps.create_partial(_arithmetic_func, fwd_function=ps.arithmetic, arg_list=arg_list)
-    ps.execute(do_arithmetic, [images.shared_array], images.data.shape[0], progress, cores=cores)
+    ps.execute(do_arithmetic, [images.shared_array], images.data.shape[0], progress)

--- a/mantidimaging/core/operations/circular_mask/circular_mask.py
+++ b/mantidimaging/core/operations/circular_mask/circular_mask.py
@@ -24,11 +24,7 @@ class CircularMaskFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(data: ImageStack,
-                    circular_mask_ratio=0.95,
-                    circular_mask_value=0.,
-                    cores=None,
-                    progress=None) -> ImageStack:
+    def filter_func(data: ImageStack, circular_mask_ratio=0.95, circular_mask_value=0., progress=None) -> ImageStack:
         """
         :param data: Input data as a 3D numpy.ndarray
         :param circular_mask_ratio: The ratio to the full image.
@@ -47,9 +43,7 @@ class CircularMaskFilter(BaseFilter):
         with progress:
             progress.update(msg="Applying circular mask")
 
-            # for some reason this doesn't like the ncore param, even though
-            # it's in the official tomopy docs
-            tomopy.circ_mask(arr=data.data, axis=0, ratio=circular_mask_ratio, val=circular_mask_value, ncore=cores)
+            tomopy.circ_mask(arr=data.data, axis=0, ratio=circular_mask_ratio, val=circular_mask_value)
 
         return data
 

--- a/mantidimaging/core/operations/gaussian/gaussian.py
+++ b/mantidimaging/core/operations/gaussian/gaussian.py
@@ -26,7 +26,7 @@ class GaussianFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(data: ImageStack, size=None, mode=None, order=None, cores=None, chunksize=None, progress=None):
+    def filter_func(data: ImageStack, size=None, mode=None, order=None, progress=None):
         """
         :param data: Input data as a 3D numpy.ndarray
         :param size: Size of the kernel
@@ -41,8 +41,6 @@ class GaussianFilter(BaseFilter):
                       An order of 1, 2, or 3 corresponds to convolution
                       with the first, second or third derivatives of a Gaussian.
                       Higher order derivatives are not implemented
-        :param cores: The number of cores that will be used to process the data.
-        :param chunksize: The number of chunks that each worker will receive.
 
         :return: The processed 3D numpy.ndarray
         """
@@ -51,7 +49,7 @@ class GaussianFilter(BaseFilter):
         if not size or not size > 1:
             raise ValueError(f'Size parameter must be greater than 1, but value provided was {size}')
 
-        _execute(data, size, mode, order, cores, progress)
+        _execute(data, size, mode, order, progress)
         h.check_data_stack(data)
         return data
 
@@ -92,7 +90,7 @@ def modes():
     return ['reflect', 'constant', 'nearest', 'mirror', 'wrap']
 
 
-def _execute(images: ImageStack, size, mode, order, cores=None, progress=None):
+def _execute(images: ImageStack, size, mode, order, progress=None):
     log = getLogger(__name__)
     progress = Progress.ensure_instance(progress, task_name='Gaussian filter')
 
@@ -102,7 +100,7 @@ def _execute(images: ImageStack, size, mode, order, cores=None, progress=None):
              "filter size/width: {1}.".format(images.dtype, size))
 
     progress.update()
-    ps.execute(f, [images.shared_array], images.data.shape[0], progress, msg="Gaussian filter", cores=cores)
+    ps.execute(f, [images.shared_array], images.data.shape[0], progress, msg="Gaussian filter")
 
     progress.mark_complete()
     log.info("Finished  gaussian filter, with pixel data type: {0}, "

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -67,13 +67,7 @@ class MedianFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(data: ImageStack,
-                    size=None,
-                    mode="reflect",
-                    cores=None,
-                    chunksize=None,
-                    progress=None,
-                    force_cpu=True):
+    def filter_func(data: ImageStack, size=None, mode="reflect", progress=None, force_cpu=True):
         """
         :param data: Input data as an ImageStack object.
         :param size: Size of the kernel
@@ -81,8 +75,6 @@ class MedianFilter(BaseFilter):
                      One of [reflect, constant, nearest, mirror, wrap].
                      Modes are described in the `SciPy documentation
                      <https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.median_filter.html>`_.
-        :param cores: The number of cores that will be used to process the data.
-        :param chunksize: The number of chunks that each worker will receive.
         :param progress: The object for displaying the progress.
         :param force_cpu: Whether or not to use the CPU.
 
@@ -97,7 +89,7 @@ class MedianFilter(BaseFilter):
         if not force_cpu:
             _execute_gpu(data.data, size, mode, progress)
         else:
-            _execute(data, size, mode, cores, chunksize, progress)
+            _execute(data, size, mode, progress)
 
         h.check_data_stack(data)
         return data
@@ -150,7 +142,7 @@ def _median_filter(data: np.ndarray, size: int, mode: str):
     return data
 
 
-def _execute(images: ImageStack, size, mode, cores=None, chunksize=None, progress=None):
+def _execute(images: ImageStack, size, mode, progress=None):
     log = getLogger(__name__)
     progress = Progress.ensure_instance(progress, task_name='Median filter')
 
@@ -161,7 +153,7 @@ def _execute(images: ImageStack, size, mode, cores=None, chunksize=None, progres
         log.info("PARALLEL median filter, with pixel data type: {0}, filter "
                  "size/width: {1}.".format(images.dtype, size))
 
-        ps.execute(f, [images.shared_array], images.data.shape[0], progress, msg="Median filter", cores=cores)
+        ps.execute(f, [images.shared_array], images.data.shape[0], progress, msg="Median filter")
 
 
 def _execute_gpu(data, size, mode, progress=None):

--- a/mantidimaging/core/operations/median_filter/test/median_filter_test.py
+++ b/mantidimaging/core/operations/median_filter/test/median_filter_test.py
@@ -12,10 +12,12 @@ import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.data.imagestack import ImageStack
 from mantidimaging.core.gpu import utility as gpu
 from mantidimaging.core.operations.median_filter import MedianFilter
+from mantidimaging.test_helpers.start_qapplication import start_multiprocessing_pool
 
 GPU_UTIL_LOC = "mantidimaging.core.gpu.utility.gpu_available"
 
 
+@start_multiprocessing_pool
 class MedianTest(unittest.TestCase):
     """
     Test median filter.

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -30,7 +30,7 @@ class MonitorNormalisation(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images: ImageStack, cores=None, chunksize=None, progress=None) -> ImageStack:
+    def filter_func(images: ImageStack, progress=None) -> ImageStack:
         if images.num_projections == 1:
             # we can't really compute the preview as the image stack copy
             # passed in doesn't have the logfile in it
@@ -44,7 +44,7 @@ class MonitorNormalisation(BaseFilter):
         counts_val = pu.copy_into_shared_memory(counts.value / counts.value[0])
         do_division = ps.create_partial(_divide_by_counts, fwd_function=ps.inplace2)
         arrays = [images.shared_array, counts_val]
-        ps.execute(do_division, arrays, images.num_projections, progress, cores=cores)
+        ps.execute(do_division, arrays, images.num_projections, progress)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -48,7 +48,6 @@ class OutliersFilter(BaseFilter):
                     diff=None,
                     radius=_default_radius,
                     mode=_default_mode,
-                    cores=None,
                     progress: Progress = None):
         """
         :param images: Input data
@@ -56,7 +55,6 @@ class OutliersFilter(BaseFilter):
         :param radius: Size of the median filter to apply
         :param mode: Whether to remove bright or dark outliers
                     One of [OUTLIERS_BRIGHT, OUTLIERS_DARK]
-        :param cores: The number of cores that will be used to process the data.
 
         :return: The processed 3D numpy.ndarray
         """

--- a/mantidimaging/core/operations/outliers/test/outliers_test.py
+++ b/mantidimaging/core/operations/outliers/test/outliers_test.py
@@ -44,7 +44,7 @@ class OutliersTest(unittest.TestCase):
         threshold = 0.1
 
         sample = np.copy(images.data)
-        result = OutliersFilter.filter_func(images, threshold, radius, cores=1)
+        result = OutliersFilter.filter_func(images, threshold, radius)
 
         th.assert_not_equals(result.data, sample)
 

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -28,12 +28,7 @@ class RebinFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images: ImageStack,
-                    rebin_param=0.5,
-                    mode=None,
-                    cores=None,
-                    chunksize=None,
-                    progress=None) -> ImageStack:
+    def filter_func(images: ImageStack, rebin_param=0.5, mode=None, progress=None) -> ImageStack:
         """
         :param images: Sample data which is to be processed. Expects radiograms
         :param rebin_param: int, float or tuple
@@ -42,8 +37,6 @@ class RebinFilter(BaseFilter):
                             tuple - Size of the output image (x, y).
         :param mode: Interpolation to use for re-sizing
                      ('nearest', 'lanczos', 'bilinear', 'bicubic' or 'cubic').
-        :param cores: The number of cores that will be used to process the data.
-        :param chunksize: The number of chunks that each worker will receive.
 
         :return: The processed 3D numpy.ndarray
         """
@@ -66,7 +59,6 @@ class RebinFilter(BaseFilter):
         ps.execute(partial_func=f,
                    arrays=[images.shared_array, empty_resized_data],
                    num_operations=images.data.shape[0],
-                   cores=cores,
                    msg="Applying Rebin",
                    progress=progress)
         images.shared_array = empty_resized_data

--- a/mantidimaging/core/operations/rebin/test/rebin_test.py
+++ b/mantidimaging/core/operations/rebin/test/rebin_test.py
@@ -10,8 +10,10 @@ import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.rebin import RebinFilter
+from mantidimaging.test_helpers.start_qapplication import start_multiprocessing_pool
 
 
+@start_multiprocessing_pool
 class RebinTest(unittest.TestCase):
     """
     Test rebin filter.

--- a/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
+++ b/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
@@ -30,16 +30,9 @@ class RemoveAllStripesFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images: ImageStack,
-                    snr=3,
-                    la_size=61,
-                    sm_size=21,
-                    dim=1,
-                    cores=None,
-                    chunksize=None,
-                    progress=None):
+    def filter_func(images: ImageStack, snr=3, la_size=61, sm_size=21, dim=1, progress=None):
         f = ps.create_partial(remove_all_stripe, ps.return_to_self, snr=snr, la_size=la_size, sm_size=sm_size, dim=dim)
-        ps.execute(f, [images.shared_array], images.data.shape[0], progress, cores=cores)
+        ps.execute(f, [images.shared_array], images.data.shape[0], progress)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -30,9 +30,9 @@ class RemoveDeadStripesFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images: ImageStack, snr=3, size=61, cores=None, chunksize=None, progress=None):
+    def filter_func(images: ImageStack, snr=3, size=61, progress=None):
         f = ps.create_partial(remove_dead_stripe, ps.return_to_self, snr=snr, size=size, residual=False)
-        ps.execute(f, [images.shared_array], images.data.shape[0], progress, cores=cores)
+        ps.execute(f, [images.shared_array], images.data.shape[0], progress)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
+++ b/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
@@ -33,14 +33,14 @@ class RemoveLargeStripesFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images: 'ImageStack', snr=3, la_size=61, cores=None, chunksize=None, progress=None):
+    def filter_func(images: 'ImageStack', snr=3, la_size=61, progress=None):
         f = ps.create_partial(
             remove_large_stripe,
             ps.return_to_self,
             snr=snr,
             size=la_size,
         )
-        ps.execute(f, [images.shared_array], images.data.shape[0], progress, cores=cores)
+        ps.execute(f, [images.shared_array], images.data.shape[0], progress)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_stripe/stripe_removal.py
+++ b/mantidimaging/core/operations/remove_stripe/stripe_removal.py
@@ -26,7 +26,7 @@ class StripeRemovalFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images, wf=None, ti=None, sf=None, cores=None, chunksize=None, progress=None):
+    def filter_func(images, wf=None, ti=None, sf=None, progress=None):
         """
         Execute stripe removal operations.
 
@@ -77,10 +77,10 @@ class StripeRemovalFilter(BaseFilter):
         with progress:
             if wf:
                 progress.update(msg=msg.format('Fourier-wavelet'))
-                func = partial(_wf, images.data, wf, cores, chunksize)
+                func = partial(_wf, images.data, wf)
             elif sf:
                 progress.update(msg=msg.format('Smoothing-Filter'))
-                func = partial(_sf, images.data, sf, cores, chunksize)
+                func = partial(_sf, images.data, sf)
 
             images.data = func()
 
@@ -210,11 +210,11 @@ def _get_params(params):
         return dict(map(lambda p: p.split('='), params))
 
 
-def _wf(data, params, cores, chunksize):
+def _wf(data, params):
     tomopy = importer.do_importing('tomopy')
 
     # creating a dictionary with all possible params for this func
-    kwargs = dict(level=None, wname=u'db5', sigma=2, pad=True, ncore=cores, nchunk=chunksize)
+    kwargs = dict(level=None, wname=u'db5', sigma=2, pad=True)
 
     # process the input parameters
     params = _get_params(params)
@@ -251,11 +251,11 @@ def _wf(data, params, cores, chunksize):
 #     return tomopy.prep.stripe.remove_stripe_ti(data, **kwargs)
 
 
-def _sf(data, params, cores, chunksize):
+def _sf(data, params):
     tomopy = importer.do_importing('tomopy')
 
     # creating a dictionary with all possible params for this func
-    kwargs = dict(size=5, ncore=cores, nchunk=chunksize)
+    kwargs = dict(size=5)
 
     # process the input parameters
     params = _get_params(params)

--- a/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
@@ -30,14 +30,7 @@ class RemoveStripeFilteringFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images: ImageStack,
-                    sigma=3,
-                    size=21,
-                    window_dim=1,
-                    filtering_dim=1,
-                    cores=None,
-                    chunksize=None,
-                    progress=None):
+    def filter_func(images: ImageStack, sigma=3, size=21, window_dim=1, filtering_dim=1, progress=None):
         if filtering_dim == 1:
             f = ps.create_partial(remove_stripe_based_filtering,
                                   ps.return_to_self,
@@ -51,7 +44,7 @@ class RemoveStripeFilteringFilter(BaseFilter):
                                   sigma=sigma,
                                   size=size,
                                   dim=window_dim)
-        ps.execute(f, [images.shared_array], images.data.shape[0], progress, cores=cores)
+        ps.execute(f, [images.shared_array], images.data.shape[0], progress)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
@@ -30,10 +30,10 @@ class RemoveStripeSortingFittingFilter(BaseFilter):
     link_histograms = True
 
     @staticmethod
-    def filter_func(images: ImageStack, order=1, sigma=3, cores=None, chunksize=None, progress=None):
+    def filter_func(images: ImageStack, order=1, sigma=3, progress=None):
         f = ps.create_partial(remove_stripe_based_fitting, ps.return_to_self, order=order, sigma=sigma, sort=True)
 
-        ps.execute(f, [images.shared_array], images.data.shape[0], progress, cores=cores)
+        ps.execute(f, [images.shared_array], images.data.shape[0], progress)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/ring_removal/ring_removal.py
+++ b/mantidimaging/core/operations/ring_removal/ring_removal.py
@@ -35,8 +35,6 @@ class RingRemovalFilter(BaseFilter):
                     thresh_min=-100.0,
                     theta_min=30,
                     rwidth=30,
-                    cores=None,
-                    chunksize=None,
                     progress=None):
         """
         Removal of ring artifacts in reconstructed volume. Uses Wavelet-Fourier based ring removal
@@ -91,8 +89,6 @@ class RingRemovalFilter(BaseFilter):
                            thresh_min=thresh_min,
                            theta_min=theta_min,
                            rwidth=rwidth,
-                           ncore=cores,
-                           nchunk=chunksize,
                            out=sample)
 
         return images

--- a/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
@@ -11,8 +11,10 @@ import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.data.imagestack import ImageStack
 from mantidimaging.core.operations.roi_normalisation import RoiNormalisationFilter
 from mantidimaging.core.utility.sensible_roi import SensibleROI
+from mantidimaging.test_helpers.start_qapplication import start_multiprocessing_pool
 
 
+@start_multiprocessing_pool
 class ROINormalisationTest(unittest.TestCase):
     """
     Test contrast ROI normalisation filter.

--- a/mantidimaging/core/operations/rotate_stack/test/rotate_stack_test.py
+++ b/mantidimaging/core/operations/rotate_stack/test/rotate_stack_test.py
@@ -8,8 +8,10 @@ import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.rotate_stack import RotateFilter
+from mantidimaging.test_helpers.start_qapplication import start_multiprocessing_pool
 
 
+@start_multiprocessing_pool
 class RotateStackTest(unittest.TestCase):
     """
     Test rotate stack filter.
@@ -24,19 +26,22 @@ class RotateStackTest(unittest.TestCase):
         self.assertRaises(ValueError, RotateFilter.filter_func, images, rotation)
 
     def test_executed_par(self):
-        self.do_execute()
+        self.do_execute(True)
 
     def test_executed_seq(self):
-        self.do_execute(cores=1)
+        self.do_execute(False)
 
-    def do_execute(self, cores=None):
+    def do_execute(self, in_parallel):
         # only works on square images
-        images = th.generate_images((10, 10, 10))
+        if in_parallel:
+            images = th.generate_images_for_parallel((15, 15, 15))
+        else:
+            images = th.generate_images((10, 10, 10))
 
         rotation = -90
         images.data[:, 0, :] = 42
 
-        result = RotateFilter.filter_func(images, rotation, cores=cores)
+        result = RotateFilter.filter_func(images, rotation)
 
         npt.assert_equal(result.data[:, :, -1], 42)
 

--- a/mantidimaging/core/parallel/manager.py
+++ b/mantidimaging/core/parallel/manager.py
@@ -18,12 +18,14 @@ CURRENT_PID = psutil.Process().pid
 
 LOG = getLogger(__name__)
 
+cores: int = 1
 pool: Optional['Pool'] = None
 
 
 def create_and_start_pool():
     LOG.info('Creating process pool')
     context = get_context('spawn')
+    global cores
     cores = context.cpu_count()
     global pool
     pool = context.Pool(cores)

--- a/mantidimaging/core/parallel/test/utility_test.py
+++ b/mantidimaging/core/parallel/test/utility_test.py
@@ -2,7 +2,6 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import numpy as np
-from typing import List, Tuple, Union
 from unittest import mock
 
 import pytest
@@ -14,29 +13,21 @@ from mantidimaging.core.parallel.utility import _create_shared_array, execute_im
 
 
 @pytest.mark.parametrize(
-    'shape,cores,should_be_parallel',
+    'shape,is_shared_data,should_be_parallel',
     (
-        [(100, 10, 10), 1, False],  # forcing 1 core should always return False
+        [11, False, False],  # not shared data should return False
         # shapes <= 10 should return False
-        [(10, 10, 10), 12, False],
-        [10, 12, False],
-        # shapes over 10 should return True
-        [(11, 10, 10), 12, True],
-        [11, 12, True],
-        # repeat from above but with list, to cover that branch of the if
-        [[100, 10, 10], 1, False],
-        [[10, 10, 10], 12, False],
-        [[11, 10, 10], 12, True],
-    ))
-def test_correctly_chooses_parallel(shape: Union[int, List, Tuple[int, int, int]], cores: int,
-                                    should_be_parallel: bool):
-    assert multiprocessing_necessary(shape, cores) is should_be_parallel
+        [10, True, False],
+        # shapes > 10 with shared data should return True
+        [11, True, True]))
+def test_correctly_chooses_parallel(shape: int, is_shared_data: bool, should_be_parallel: bool):
+    assert multiprocessing_necessary(shape, is_shared_data) is should_be_parallel
 
 
-def test_execute_impl_one_core():
+def test_execute_impl_seq():
     mock_partial = mock.Mock()
     mock_progress = mock.Mock()
-    execute_impl(1, mock_partial, 1, 1, mock_progress, "Test")
+    execute_impl(1, mock_partial, False, mock_progress, "Test")
     mock_partial.assert_called_once_with(0)
     mock_progress.update.assert_called_once_with(1, "Test")
 
@@ -46,7 +37,7 @@ def test_execute_impl_par(mock_pool):
     mock_partial = mock.Mock()
     mock_progress = mock.Mock()
     mock_pool.imap.return_value = range(15)
-    execute_impl(15, mock_partial, 10, 1, mock_progress, "Test")
+    execute_impl(15, mock_partial, True, mock_progress, "Test")
     mock_pool.imap.assert_called_once()
     assert mock_progress.update.call_count == 15
 

--- a/mantidimaging/core/parallel/test/utility_test.py
+++ b/mantidimaging/core/parallel/test/utility_test.py
@@ -33,8 +33,7 @@ def test_correctly_chooses_parallel(shape: Union[int, List, Tuple[int, int, int]
     assert multiprocessing_necessary(shape, cores) is should_be_parallel
 
 
-@mock.patch('mantidimaging.core.parallel.utility.Pool')
-def test_execute_impl_one_core(mock_pool):
+def test_execute_impl_one_core():
     mock_partial = mock.Mock()
     mock_progress = mock.Mock()
     execute_impl(1, mock_partial, 1, 1, mock_progress, "Test")
@@ -42,15 +41,13 @@ def test_execute_impl_one_core(mock_pool):
     mock_progress.update.assert_called_once_with(1, "Test")
 
 
-@mock.patch('mantidimaging.core.parallel.utility.Pool')
+@mock.patch('mantidimaging.core.parallel.manager.pool')
 def test_execute_impl_par(mock_pool):
     mock_partial = mock.Mock()
     mock_progress = mock.Mock()
-    mock_pool_instance = mock.Mock()
-    mock_pool_instance.imap.return_value = range(15)
-    mock_pool.return_value.__enter__.return_value = mock_pool_instance
+    mock_pool.imap.return_value = range(15)
     execute_impl(15, mock_partial, 10, 1, mock_progress, "Test")
-    mock_pool_instance.imap.assert_called_once()
+    mock_pool.imap.assert_called_once()
     assert mock_progress.update.call_count == 15
 
 

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -1,13 +1,12 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-import multiprocessing
 import os
 from functools import partial
 from logging import getLogger
 from multiprocessing import shared_memory
 from multiprocessing.shared_memory import SharedMemory
-from typing import List, Tuple, Union, TYPE_CHECKING, Optional
+from typing import Tuple, TYPE_CHECKING, Optional
 
 import numpy as np
 
@@ -63,17 +62,27 @@ def copy_into_shared_memory(array: np.ndarray) -> 'SharedArray':
     return shared_array
 
 
-def get_cores():
-    return multiprocessing.cpu_count()
-
-
 def calculate_chunksize(cores):
-    # TODO possible proper calculation of chunksize, although best performance
-    # has been with 1
+    """
+    TODO possible proper calculation of chunksize, although best performance has been with 1
+    From performance tests, the chunksize doesn't seem to make much of a
+    difference, but having larger chunks usually led to slower performance:
+
+    Shape: (50,512,512)
+    1 chunk 3.06s
+    2 chunks 3.05s
+    3 chunks 3.07s
+    4 chunks 3.06s
+    5 chunks 3.16s
+    6 chunks 3.06s
+    7 chunks 3.058s
+    8 chunks 3.25s
+    9 chunks 3.45s
+    """
     return 1
 
 
-def multiprocessing_necessary(shape: Union[int, Tuple[int, int, int], List], cores) -> bool:
+def multiprocessing_necessary(shape: int, is_shared_data: bool) -> bool:
     # This environment variable will be present when running PYDEVD from PyCharm
     # and that has the bug that multiprocessing Pools can never finish `.join()` ing
     # thus never actually finish their processing.
@@ -81,29 +90,29 @@ def multiprocessing_necessary(shape: Union[int, Tuple[int, int, int], List], cor
         LOG.info("Debugging environment variable 'PYDEVD_LOAD_VALUES_ASYNC' found. Running synchronously on 1 core")
         return False
 
-    if cores == 1:
-        LOG.info("1 core specified")
+    if not is_shared_data:
+        LOG.info("Not all of the data uses shared memory")
         return False
-    elif isinstance(shape, int):
-        if shape <= 10:
-            LOG.info("Shape under 10")
-            return False
-    elif isinstance(shape, tuple) or isinstance(shape, list):
-        if shape[0] <= 10:
-            LOG.info("3D axis 0 shape under 10")
-            return False
+    elif shape <= 10:
+        LOG.info("Shape under 10")
+        return False
 
     LOG.info("Multiprocessing required")
     return True
 
 
-def execute_impl(img_num: int, partial_func: partial, cores: int, chunksize: int, progress: Progress, msg: str):
-    task_name = f"{msg} {cores}c {chunksize}chs"
+def execute_impl(img_num: int, partial_func: partial, is_shared_data: bool, progress: Progress, msg: str):
+    task_name = f"{msg}"
     progress = Progress.ensure_instance(progress, num_steps=img_num, task_name=task_name)
     indices_list = range(img_num)
-    if multiprocessing_necessary(img_num, cores) and pm.pool:
-        LOG.info(f"Running async on {cores} cores")
-        for _ in pm.pool.imap(partial_func, indices_list, chunksize=chunksize):
+    if multiprocessing_necessary(img_num, is_shared_data) and pm.pool:
+        LOG.info(f"Running async on {pm.cores} cores")
+        # Using _ in the for _ enumerate is slightly faster, because the tuple from enumerate isn't unpacked,
+        # and thus some time is saved
+        # Using imap here seems to be the best choice:
+        # - imap_unordered gives the images back in random order
+        # - map and map_async do not improve speed performance
+        for _ in pm.pool.imap(partial_func, indices_list, chunksize=calculate_chunksize(pm.cores)):
             progress.update(1, msg)
     else:
         LOG.info("Running synchronously on 1 core")

--- a/mantidimaging/core/rotation/test/polyfit_correlation_test.py
+++ b/mantidimaging/core/rotation/test/polyfit_correlation_test.py
@@ -4,12 +4,14 @@ import unittest
 from unittest import mock
 import numpy as np
 
+from mantidimaging.test_helpers.start_qapplication import start_multiprocessing_pool
 from mantidimaging.test_helpers.unit_test_helper import generate_images, assert_not_equals
 from ..polyfit_correlation import do_calculate_correlation_err, get_search_range, find_center, _find_shift
 from ...data import ImageStack
 from ...utility.progress_reporting import Progress
 
 
+@start_multiprocessing_pool
 class PolyfitCorrelationTest(unittest.TestCase):
     def test_do_search(self):
         test_p0 = np.identity(10)

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -57,11 +57,14 @@ def main():
 
     from mantidimaging import gui
     try:
+        pm.create_and_start_pool()
         gui.execute()
     except BaseException as e:
         if sys.platform == 'linux':
             pm.clear_memory_from_current_process_linux()
         raise e
+    finally:
+        pm.end_pool()
 
 
 if __name__ == "__main__":

--- a/mantidimaging/test_helpers/start_qapplication.py
+++ b/mantidimaging/test_helpers/start_qapplication.py
@@ -17,6 +17,7 @@ import pytest
 import sys
 
 import pyqtgraph
+from mantidimaging.core.parallel.manager import create_and_start_pool, end_pool
 from PyQt5.QtWidgets import QApplication
 
 _QAPP = QApplication.instance()
@@ -75,6 +76,16 @@ def start_qapplication(cls):
             gc.collect()
 
     return augment_test_setup_methods(cls, setUp, tearDown, setUpClass, tearDownClass)
+
+
+def start_multiprocessing_pool(cls):
+    def setUpClass():
+        create_and_start_pool()
+
+    def tearDownClass():
+        end_pool()
+
+    return augment_test_setup_methods(cls, setup_class=setUpClass, teardown_class=tearDownClass)
 
 
 def augment_test_setup_methods(cls, setup=None, teardown=None, setup_class=None, teardown_class=None):


### PR DESCRIPTION
### Issue

Refs #1331

### Description

Completes the work required for step 3 of bullet point 5 in the referenced issue description. The pool of processes are now started when the application begins (asynchronously to minimise the impact on start-up time) to improve performance on Windows. This change means that there is little performance difference between spawn and fork on Linux, and there are potentially other benefits to switching to spawn (one example being to avoid incorrect resource tracker warnings from the sub processes when the application ends), so this PR switches us to use spawn everywhere.

I've removed the core and chunksize parameters from the filter functions, as these were not being used by the code to run MI as a GUI application and we don't have any API users as yet. These changes mean that making calls to the API would always run the filters synchronously, so if we do have people interested in using the API in the future we may want to look at how to maximise performance from direct calls.

### Testing & Acceptance Criteria 

All tests should pass in a reasonable duration. Note tests are likely to become a bit slower because of the extra time needed to spawn the process pool when testing parallel processing.

Test the operations affected in the PR, and the reconstruction auto correlate button.

### Documentation

There is one final step required on the issue before it can be added to the release notes.
