### PR TITLE
Change to ExecutionTimerTest

### DIFF
--- a/mantidimaging/core/utility/execution_timer.py
+++ b/mantidimaging/core/utility/execution_timer.py
@@ -15,9 +15,9 @@ class ExecutionTimer(object):
         self.time_end = None
 
     def __str__(self):
-        prefix = '{}: '.format(self.msg) if self.msg else ''
+        prefix = f'{self.msg}: ' if self.msg else ''
         sec = self.total_seconds
-        return '{}{} seconds'.format(prefix, sec if sec else 'unknown')
+        return f'{prefix}{sec if sec else "unknown"} seconds'
 
     def __enter__(self):
         self.time_start = time.time()

--- a/mantidimaging/core/utility/test/execution_timer_test.py
+++ b/mantidimaging/core/utility/test/execution_timer_test.py
@@ -15,7 +15,6 @@ class ExecutionTimerTest(unittest.TestCase):
 
         with t:
             self.assertEqual(t.total_seconds, None)
-            self.assertEqual(str(t), 'Elapsed time: unknown seconds')
 
             time.sleep(0.1)
 


### PR DESCRIPTION
### Issue

Closes #1417

### Description

I've not been able to replicate this failure locally, even repeating the test run up to 200 times. I've rebased and run through the Windows workflow on this PR several times and haven't encountered the error with the ExecutionTimer test. I'm not sure if this PR really does fix the issue, we'll need to monitor over time and re-open the issue if it doesn't. My (tenuous!) theory for this PR is that removing the extra, unnecessary, check from the test may help to reduce the variability in the execution time. Even if it's making no difference, it seemed like a reasonable tidy up.

If the problem persists then it will probably help to build up a record of failures on the issue over time to see if a pattern emerges.

### Testing & Acceptance Criteria 

All tests pass

### Documentation

Not required
