### PR TITLE
1396: Add nxs extension when saving NeXus files

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -11,6 +11,7 @@ New Features
 - #1217 : Basic NeXus Saving
 - #1385 : Load all NeXus rotation angles
 - #1394 : NeXus Busy Indicator
+- #1394 : Add .nxs extension to NeXus save path
 
 Fixes
 -----

--- a/mantidimaging/gui/windows/main/nexus_save_dialog.py
+++ b/mantidimaging/gui/windows/main/nexus_save_dialog.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+import os
 import uuid
 from typing import Optional, List
 
@@ -7,6 +8,8 @@ from PyQt5.QtWidgets import QDialog, QDialogButtonBox, QFileDialog
 
 from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.gui.utility import compile_ui
+
+NXS_EXT = ".nxs"
 
 
 class NexusSaveDialog(QDialog):
@@ -51,5 +54,7 @@ class NexusSaveDialog(QDialog):
                                                                                and self.sample_name().strip() != "")
 
     def _set_save_path(self):
-        path = QFileDialog.getSaveFileName(self, "Save NeXus file", "", "NeXus (*.nxs)")[0]
+        path = QFileDialog.getSaveFileName(self, "Save NeXus file", "", f"NeXus (*{NXS_EXT})")[0]
+        if os.path.splitext(path)[1] != NXS_EXT:
+            path += NXS_EXT
         self.savePath.setText(path)

--- a/mantidimaging/gui/windows/main/test/nexus_save_test.py
+++ b/mantidimaging/gui/windows/main/test/nexus_save_test.py
@@ -67,8 +67,15 @@ class NexusSaveDialogTest(unittest.TestCase):
         self.nexus_save_dialog.datasetNames.addItems.assert_called_once_with((dataset_name, ))
 
     @mock.patch("mantidimaging.gui.windows.main.nexus_save_dialog.QFileDialog.getSaveFileName")
-    def test_set_save_path(self, get_save_file_name_mock):
+    def test_set_save_path_adds_extension(self, get_save_file_name_mock):
         save_path = "save_path"
+        get_save_file_name_mock.return_value = (save_path, )
+        self.nexus_save_dialog._set_save_path()
+        self.assertEqual(save_path + ".nxs", self.nexus_save_dialog.savePath.text())
+
+    @mock.patch("mantidimaging.gui.windows.main.nexus_save_dialog.QFileDialog.getSaveFileName")
+    def test_set_save_path_doesnt_add_extention_when_not_needed(self, get_save_file_name_mock):
+        save_path = "save_path.nxs"
         get_save_file_name_mock.return_value = (save_path, )
         self.nexus_save_dialog._set_save_path()
         self.assertEqual(save_path, self.nexus_save_dialog.savePath.text())


### PR DESCRIPTION
### Issue

Closes #1396

### Description

Adds an .nxs extension when saving NeXus files. Doesn't add one if the user types it in manually.

### Testing 

Modified an existing test and added a new one in `NexusSaveDialogTest`.

### Acceptance Criteria 

Check that the tests pass. Check that the .nxs extension is added automatically if only if it's missing from the filename you entered.

### Documentation

Updated release notes.
