### PR TITLE
1399: OSError Message

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -12,6 +12,7 @@ New Features
 - #1385 : Load all NeXus rotation angles
 - #1394 : NeXus Busy Indicator
 - #1394 : Add .nxs extension to NeXus save path
+- #1399 : NeXus Saving OSError message
 
 Fixes
 -----

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -176,15 +176,15 @@ def nexus_save(dataset: StrictDataset, path: str, sample_name: str):
     """
     try:
         nexus_file = h5py.File(path, "w", driver="core")
-    except OSError:
-        return
+    except OSError as e:
+        raise RuntimeError("Unable to save NeXus file. " + str(e))
 
     try:
         _nexus_save(nexus_file, dataset, sample_name)
     except OSError as e:
         nexus_file.close()
         os.remove(path)
-        raise RuntimeError("Unable to save NeXus file.", e)
+        raise RuntimeError("Unable to save NeXus file. " + str(e))
 
     nexus_file.close()
 

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -231,7 +231,8 @@ class IOTest(FileOutputtingTestCase):
     @mock.patch("mantidimaging.core.io.saver._nexus_save")
     def test_h5py_os_error_returns(self, nexus_save_mock: mock.Mock, file_mock: mock.Mock):
         file_mock.side_effect = OSError
-        saver.nexus_save(StrictDataset(th.generate_images()), "path", "sample-name")
+        with self.assertRaises(RuntimeError):
+            saver.nexus_save(StrictDataset(th.generate_images()), "path", "sample-name")
         nexus_save_mock.assert_not_called()
 
     @mock.patch("mantidimaging.core.io.saver.h5py.File")

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -55,7 +55,7 @@ def _generate_recon_item_name(recon_no: int) -> str:
 
 class MainWindowPresenter(BasePresenter):
     LOAD_ERROR_STRING = "Failed to load stack. Error: {}"
-    SAVE_ERROR_STRING = "Failed to save stack. Error: {}"
+    SAVE_ERROR_STRING = "Failed to save data. Error: {}"
 
     view: 'MainWindowView'
 


### PR DESCRIPTION
### Issue

Closes #1399

### Description

Shows a message when an `OSError` is encountered during NeXus saving.

### Testing 

Just modified an existing test.

### Acceptance Criteria 

Check that the tests pass. Check that a message is displayed when NeXus saving gives an `OSError`.

### Documentation

Updated release notes.
