### PR TITLE
pytest: disable multithreading to show more output

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -103,7 +103,7 @@ jobs:
         timeout-minutes: 5
         shell: bash -l {0}
         run: |
-          xvfb-run --auto-servernum python -m pytest --cov --cov-report=xml -n auto --ignore=mantidimaging/eyes_tests --durations=10
+          xvfb-run --auto-servernum python -m pytest --cov --cov-report=xml --ignore=mantidimaging/eyes_tests --durations=10
 
       - name: Get test data
         shell: bash -l {0}

--- a/.github/workflows/cos7_testing.yml
+++ b/.github/workflows/cos7_testing.yml
@@ -50,5 +50,5 @@ jobs:
       timeout-minutes: 5
       uses: ./.github/actions/test
       with:
-        command: xvfb-run pytest -n auto --ignore=mantidimaging/eyes_tests --durations=10
+        command: xvfb-run pytest --ignore=mantidimaging/eyes_tests --durations=10
         label: centos7

--- a/.github/workflows/u18_testing.yml
+++ b/.github/workflows/u18_testing.yml
@@ -45,4 +45,4 @@ jobs:
       timeout-minutes: 5
       uses: ./.github/actions/test
       with:
-        command: xvfb-run pytest -n auto --ignore=mantidimaging/eyes_tests --durations=10
+        command: xvfb-run pytest --ignore=mantidimaging/eyes_tests --durations=10

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -90,4 +90,4 @@ jobs:
         timeout-minutes: 5
         shell: bash -l {0}
         run: |
-          python -m pytest --cov --cov-report=xml -n auto --ignore=mantidimaging/eyes_tests --durations=10
+          python -m pytest --cov --cov-report=xml --ignore=mantidimaging/eyes_tests --durations=10


### PR DESCRIPTION
### Description

There have been a few pytest timeouts recently. We use the `-n auto` option to run multiple tests simultaneously, but this disables the output of the currently running test, making it hard to see if there is a pattern.
