### PR TITLE
1420: Copy NeXus data without concatenate

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -34,3 +34,4 @@ Developer Changes
 - #1376 : Fix leak in StackChoiceView
 - #1387 : Fix async task leak
 - #1384 : Remove StackSelectorWidget and StackSelectorDialog
+- #1420 : Save NeXus data without concatenate

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -219,7 +219,7 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
     detector.create_dataset("data", shape=combined_data_shape, dtype="uint16")
     index = 0
     for arr in dataset.nexus_arrays:
-        detector["data"][index:index + arr.shape[0]] = arr.astype("uint16")
+        detector["data"][index:index + arr.shape[0]] = arr
         index += arr.shape[0]
     detector.create_dataset("image_key", data=dataset.image_keys)
 

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -216,7 +216,7 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
 
     # instrument data
     combined_data_shape = (sum([len(arr) for arr in dataset.nexus_arrays]), ) + dataset.nexus_arrays[0].shape[1:]
-    detector.create_dataset("data", shape=combined_data_shape)
+    detector.create_dataset("data", shape=combined_data_shape, dtype="uint16")
     index = 0
     for arr in dataset.nexus_arrays:
         detector["data"][index:index + arr.shape[0]] = arr.astype("uint16")

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -215,8 +215,12 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
     _set_nx_class(detector, "NXdetector")
 
     # instrument data
-    combined_data = np.concatenate(dataset.nexus_arrays).astype("uint16")
-    detector.create_dataset("data", data=combined_data)
+    combined_data_shape = (sum([len(arr) for arr in dataset.nexus_arrays]), ) + dataset.nexus_arrays[0].shape[1:]
+    detector.create_dataset("data", shape=combined_data_shape)
+    index = 0
+    for arr in dataset.nexus_arrays:
+        detector["data"][index:index + arr.shape[0]] = arr.astype("uint16")
+        index += arr.shape[0]
     detector.create_dataset("image_key", data=dataset.image_keys)
 
     # sample field

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -165,6 +165,9 @@ class IOTest(FileOutputtingTestCase):
         self.assertEqual(loaded_images.metadata, images.metadata)
 
     def test_nexus_simple_dataset_save(self):
+        sample = th.generate_images()
+        sample.data *= 12
+
         sd = StrictDataset(th.generate_images())
         path = "nexus/file/path"
         sample_name = "sample-name"
@@ -204,7 +207,12 @@ class IOTest(FileOutputtingTestCase):
 
     @staticmethod
     def test_nexus_complex_dataset_save():
-        image_stacks = [th.generate_images() for _ in range(5)]
+        image_stacks = []
+        for _ in range(5):
+            image_stack = th.generate_images()
+            image_stack.data *= 12
+            image_stacks.append(image_stack)
+
         sd = StrictDataset(*image_stacks)
 
         with h5py.File("nexus/file/path", "w", driver="core", backing_store=False) as nexus_file:


### PR DESCRIPTION
### Issue

Closes #1420

### Description

Creates an empty hdf5 Dataset and copies the `StrictDataset` data to it in chunks rather than using `np.concatenate`

### Testing 

The existing tests already cover the change. Also multiplied test arrays by 12 as 

### Acceptance Criteria 

Check that the tests pass.

### Documentation

Updated release notes.
