### PR TITLE
Add windows GUI System tests

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -99,3 +99,9 @@ jobs:
           unzip -q small.zip -d ~
           mv ~/mantidimaging-data-small ~/mantidimaging-data
         timeout-minutes: 5
+
+      - name: GUI Tests System
+        shell: bash -l {0}
+        run: |
+          python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov --run-system-tests --durations=10
+        timeout-minutes: 30

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -91,3 +91,11 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pytest --cov --cov-report=xml --ignore=mantidimaging/eyes_tests --durations=10
+
+      - name: Get test data
+        shell: bash -l {0}
+        run: |
+          curl -L https://github.com/mantidproject/mantidimaging-data/archive/refs/tags/small.zip --output small.zip
+          unzip -q small.zip -d ~
+          mv ~/mantidimaging-data-small ~/mantidimaging-data
+        timeout-minutes: 5

--- a/mantidimaging/gui/test/gui_system_reconstruction_test.py
+++ b/mantidimaging/gui/test/gui_system_reconstruction_test.py
@@ -48,7 +48,7 @@ class TestGuiSystemReconstruction(GuiSystemBase):
             QTest.mouseClick(self.recon_window.minimiseBtn, Qt.MouseButton.LeftButton)
 
             QTest.qWait(SHORT_DELAY)
-            wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=200)
+            wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=500)
             wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
             QTest.qWait(SHORT_DELAY)
 


### PR DESCRIPTION
### Issue

Refs #1402

### Description

Adds retrieving the test data and running the GUI system tests to the Windows workflow. The GUI tests run much slower on Windows than they do on Linux (10 mins compared to 2-3 mins). This seems acceptable for now and can hopefully be improved as we look at Windows performance over the longer time.

I've left the issue open as I intend to add the Applitools tests in a separate PR.

### Testing & Acceptance Criteria 

Tests pass with an acceptable duration.

### Documentation

Not required.
