### PR TITLE
1397: Only use real projection angles

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -20,6 +20,7 @@ Fixes
 - #1381 : Don't use console progress bar in GUI application
 - #1405 : MedianFilter work inplace on ImageStack
 - #1395 : Delete file when NeXus saving fails
+- #1397 : Only use real NeXus projection angles
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -136,7 +136,7 @@ class StrictDataset(BaseDataset):
         proj_angles = [image_stack.real_projection_angles() for image_stack in self._nexus_stack_order]
         if None in proj_angles:
             raise RuntimeError("Incomplete rotation angle data.")
-        return [angles.value for angles in proj_angles]
+        return [angles.value for angles in proj_angles]  # type: ignore
 
     @property
     def image_keys(self) -> List[int]:

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -135,7 +135,7 @@ class StrictDataset(BaseDataset):
     def rotation_angles(self) -> List[np.ndarray]:
         proj_angles = [image_stack.real_projection_angles() for image_stack in self._nexus_stack_order]
         if None in proj_angles:
-            pass
+            raise RuntimeError("Incomplete rotation angle data.")
         return [angles.value for angles in proj_angles]
 
     @property

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -132,7 +132,7 @@ class StrictDataset(BaseDataset):
         return [image_stack.data for image_stack in self._nexus_stack_order]
 
     @property
-    def rotation_angles(self) -> List[np.ndarray]:
+    def nexus_rotation_angles(self) -> List[np.ndarray]:
         proj_angles = [image_stack.real_projection_angles() for image_stack in self._nexus_stack_order]
         if None in proj_angles:
             raise RuntimeError("Incomplete rotation angle data.")

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -133,7 +133,10 @@ class StrictDataset(BaseDataset):
 
     @property
     def rotation_angles(self) -> List[np.ndarray]:
-        return [image_stack.projection_angles().value for image_stack in self._nexus_stack_order]
+        proj_angles = [image_stack.real_projection_angles() for image_stack in self._nexus_stack_order]
+        if None in proj_angles:
+            pass
+        return [angles.value for angles in proj_angles]
 
     @property
     def image_keys(self) -> List[int]:

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -284,6 +284,17 @@ class ImageStack:
 
         self._projection_angles = angles
 
+    def real_projection_angles(self) -> Optional[ProjectionAngles]:
+        """
+        Return only the projection angles that are from a log file or have been manually loaded.
+        :return: Real projection angles if they were found, None otherwise.
+        """
+        if self._log_file is not None:
+            return self._log_file.projection_angles()
+        if self._projection_angles is not None:
+            return self._projection_angles
+        return None
+
     def projection_angles(self, max_angle: float = 360.0) -> ProjectionAngles:
         """
         Return projection angles, in priority order:
@@ -295,10 +306,9 @@ class ImageStack:
                           Only used when the angles are generated, if they are provided
                           via a log or a file the argument will be ignored.
         """
-        if self._log_file is not None:
-            return self._log_file.projection_angles()
-        elif self._projection_angles is not None:
-            return self._projection_angles
+        projection_angles = self.real_projection_angles()
+        if projection_angles is not None:
+            return projection_angles
         else:
             return ProjectionAngles(np.linspace(0, np.deg2rad(max_angle), self.num_projections))
 

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -229,7 +229,7 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
     sample_group.create_dataset("name", data=np.string_(sample_name))
 
     # rotation angle
-    rotation_angle = sample_group.create_dataset("rotation_angle", data=np.concatenate(dataset.rotation_angles))
+    rotation_angle = sample_group.create_dataset("rotation_angle", data=np.concatenate(dataset.nexus_rotation_angles))
     rotation_angle.attrs["units"] = "rad"
 
     # data field

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -167,8 +167,9 @@ class IOTest(FileOutputtingTestCase):
     def test_nexus_simple_dataset_save(self):
         sample = th.generate_images()
         sample.data *= 12
+        sample._projection_angles = sample.projection_angles()
 
-        sd = StrictDataset(th.generate_images())
+        sd = StrictDataset(sample)
         path = "nexus/file/path"
         sample_name = "sample-name"
 
@@ -212,6 +213,7 @@ class IOTest(FileOutputtingTestCase):
             image_stack = th.generate_images()
             image_stack.data *= 12
             image_stacks.append(image_stack)
+            image_stack._projection_angles = image_stack.projection_angles()
 
         sd = StrictDataset(*image_stacks)
 

--- a/mantidimaging/gui/windows/main/test/strictdataset_test.py
+++ b/mantidimaging/gui/windows/main/test/strictdataset_test.py
@@ -5,6 +5,7 @@ import unittest
 
 import numpy as np
 
+from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset, _delete_stack_error_message, _image_key_list
 from mantidimaging.core.data.reconlist import ReconList
 from mantidimaging.test_helpers.unit_test_helper import generate_images
@@ -17,6 +18,14 @@ def test_delete_stack_error_message():
 
 def test_image_key_list():
     assert _image_key_list(2, 5) == [2, 2, 2, 2, 2]
+
+
+def _set_fake_projection_angles(image_stack: ImageStack):
+    """
+    Sets the private projection angles attribute.
+    :param image_stack: The ImageStack object.
+    """
+    image_stack._projection_angles = image_stack.projection_angles()
 
 
 class StrictDatasetTest(unittest.TestCase):
@@ -149,6 +158,8 @@ class StrictDatasetTest(unittest.TestCase):
         ])
 
     def test_rotation_angles(self):
+        for stack in self.strict_dataset._nexus_stack_order:
+            _set_fake_projection_angles(stack)
         assert np.array_equal(self.strict_dataset.rotation_angles, [
             self.strict_dataset.dark_before.projection_angles().value,
             self.strict_dataset.flat_before.projection_angles().value,

--- a/mantidimaging/gui/windows/main/test/strictdataset_test.py
+++ b/mantidimaging/gui/windows/main/test/strictdataset_test.py
@@ -160,7 +160,7 @@ class StrictDatasetTest(unittest.TestCase):
     def test_rotation_angles(self):
         for stack in self.strict_dataset._nexus_stack_order:
             _set_fake_projection_angles(stack)
-        assert np.array_equal(self.strict_dataset.rotation_angles, [
+        assert np.array_equal(self.strict_dataset.nexus_rotation_angles, [
             self.strict_dataset.dark_before.projection_angles().value,
             self.strict_dataset.flat_before.projection_angles().value,
             self.strict_dataset.sample.projection_angles().value,

--- a/mantidimaging/gui/windows/main/test/strictdataset_test.py
+++ b/mantidimaging/gui/windows/main/test/strictdataset_test.py
@@ -217,3 +217,7 @@ class StrictDatasetTest(unittest.TestCase):
         self.strict_dataset.sample = None
         with self.assertRaises(RuntimeError):
             self.strict_dataset.image_keys
+
+    def test_incomplete_nexus_rotation_angles(self):
+        with self.assertRaises(RuntimeError):
+            self.strict_dataset.nexus_rotation_angles


### PR DESCRIPTION
### Issue

Closes #1397

### Description

Prevents fake rotation angle data from being saved to a NeXus file.

### Testing 

Wrote a test for the exception and modified some existing tests.

### Acceptance Criteria 

Check that the tests pass.

### Documentation

Updated release notes.
