### PR TITLE
Increase pytest timeout in conda and windows workflows

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -100,7 +100,7 @@ jobs:
           mypy --ignore-missing-imports --no-site-packages mantidimaging
 
       - name: pytest
-        timeout-minutes: 5
+        timeout-minutes: 15
         shell: bash -l {0}
         run: |
           xvfb-run --auto-servernum python -m pytest --cov --cov-report=xml --ignore=mantidimaging/eyes_tests --durations=10

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -87,7 +87,7 @@ jobs:
           mypy --ignore-missing-imports --no-site-packages mantidimaging
 
       - name: pytest
-        timeout-minutes: 5
+        timeout-minutes: 15
         shell: bash -l {0}
         run: |
           python -m pytest --cov --cov-report=xml --ignore=mantidimaging/eyes_tests --durations=10


### PR DESCRIPTION
### Issue

Refs #1427

### Description

We still seem to be seeing intermittent timeouts of the pytest step in our GitHub Actions tests. This PR increases the timeout to 15 minutes to try and reduce the number of failed runs while we continue to monitor and investigate where possible. From testing, there are likely to be a very small number of runs that hang indefinitely and so won't be sorted by increasing the timeout, however 15 minutes should be sufficient to allow the majority of slow runs to pass.

We've only been seeing failures in the conda and windows workflows, so these are the only pytests timeouts that I'm increasing. If we start seeing similar failures for pytest steps in other workflows we can increase those timeouts later.

### Testing & Acceptance Criteria 

All tests pass

### Documentation

None required.
