### PR TITLE
Fix for pytest timeouts

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -103,7 +103,7 @@ jobs:
         timeout-minutes: 15
         shell: bash -l {0}
         run: |
-          xvfb-run --auto-servernum python -m pytest --cov --cov-report=xml --ignore=mantidimaging/eyes_tests --durations=10
+          xvfb-run --auto-servernum python -m pytest --cov --cov-report=xml -n auto --ignore=mantidimaging/eyes_tests --durations=10
 
       - name: Get test data
         shell: bash -l {0}

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -100,7 +100,7 @@ jobs:
           mypy --ignore-missing-imports --no-site-packages mantidimaging
 
       - name: pytest
-        timeout-minutes: 15
+        timeout-minutes: 5
         shell: bash -l {0}
         run: |
           xvfb-run --auto-servernum python -m pytest --cov --cov-report=xml -n auto --ignore=mantidimaging/eyes_tests --durations=10

--- a/.github/workflows/cos7_testing.yml
+++ b/.github/workflows/cos7_testing.yml
@@ -50,5 +50,5 @@ jobs:
       timeout-minutes: 5
       uses: ./.github/actions/test
       with:
-        command: xvfb-run pytest --ignore=mantidimaging/eyes_tests --durations=10
+        command: xvfb-run pytest -n auto --ignore=mantidimaging/eyes_tests --durations=10
         label: centos7

--- a/.github/workflows/u18_testing.yml
+++ b/.github/workflows/u18_testing.yml
@@ -45,4 +45,4 @@ jobs:
       timeout-minutes: 5
       uses: ./.github/actions/test
       with:
-        command: xvfb-run pytest --ignore=mantidimaging/eyes_tests --durations=10
+        command: xvfb-run pytest -n auto --ignore=mantidimaging/eyes_tests --durations=10

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -90,7 +90,7 @@ jobs:
         timeout-minutes: 15
         shell: bash -l {0}
         run: |
-          python -m pytest --cov --cov-report=xml --ignore=mantidimaging/eyes_tests --durations=10
+          python -m pytest --cov --cov-report=xml -n auto --ignore=mantidimaging/eyes_tests --durations=10
 
       - name: Get test data
         shell: bash -l {0}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -87,7 +87,7 @@ jobs:
           mypy --ignore-missing-imports --no-site-packages mantidimaging
 
       - name: pytest
-        timeout-minutes: 15
+        timeout-minutes: 5
         shell: bash -l {0}
         run: |
           python -m pytest --cov --cov-report=xml -n auto --ignore=mantidimaging/eyes_tests --durations=10

--- a/mantidimaging/core/parallel/test/utility_test.py
+++ b/mantidimaging/core/parallel/test/utility_test.py
@@ -32,7 +32,7 @@ def test_execute_impl_seq():
     mock_progress.update.assert_called_once_with(1, "Test")
 
 
-@mock.patch('mantidimaging.core.parallel.manager.pool')
+@mock.patch('mantidimaging.core.parallel.utility.pm.pool')
 def test_execute_impl_par(mock_pool):
     mock_partial = mock.Mock()
     mock_progress = mock.Mock()


### PR DESCRIPTION
### Issue

Closes #1427

### Description

Fixes some patching of a unit test that I think is behind the intermittent timeouts. It's hard to be sure because the problem is intermittent, but after testing against lots of workflow runs I'm as confident as I can be that this is the cause.

I'm reverting back some of the settings we changed while debugging this issue. In particular I'm reducing the timeouts back to their original levels so we can quickly identify if the problem still exists.

### Testing & Acceptance Criteria 

All tests pass.

### Documentation

None required.
