### PR TITLE
Increase pytest timeouts

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -100,7 +100,7 @@ jobs:
           mypy --ignore-missing-imports --no-site-packages mantidimaging
 
       - name: pytest
-        timeout-minutes: 5
+        timeout-minutes: 10
         shell: bash -l {0}
         run: |
           xvfb-run --auto-servernum python -m pytest --cov --cov-report=xml -n auto --ignore=mantidimaging/eyes_tests --durations=10

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -87,7 +87,7 @@ jobs:
           mypy --ignore-missing-imports --no-site-packages mantidimaging
 
       - name: pytest
-        timeout-minutes: 5
+        timeout-minutes: 10
         shell: bash -l {0}
         run: |
           python -m pytest --cov --cov-report=xml -n auto --ignore=mantidimaging/eyes_tests --durations=10


### PR DESCRIPTION
### Issue

Refs #1427

### Description

Increases pytest timeouts as issue with failures still seems to exist despite the fix in #1439.

The plan was also to add an extra pytest step to run the unit tests excluding test `test_execute_impl_par`, as it seemed this may be the cause of the timeouts. However the extra step timed out on the first conda workflow run of the draft PR, so we've left it out.

### Testing & Acceptance Criteria 

All tests pass

### Documentation

None required
