### PR TITLE
Add Applitools tests to windows workflow

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -105,3 +105,14 @@ jobs:
         run: |
           python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov --run-system-tests --durations=10
         timeout-minutes: 30
+
+      - name: GUI Tests Screenshots Applitools
+        if: github.event_name == 'pull_request'
+        shell: bash -l {0}
+        env:
+          APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}
+          APPLITOOLS_BATCH_ID: ${{ github.sha }}
+          GITHUB_BRANCH_NAME: ${{ github.head_ref }}
+        run: |
+          python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests --durations=10
+        timeout-minutes: 15

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -106,6 +106,11 @@ jobs:
           python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov --run-system-tests --durations=10
         timeout-minutes: 30
 
+      - name: Set display resolution for screenshot tests
+        run: |
+          Set-DisplayResolution -Width 1920 -Height 1080 -Force
+        shell: pwsh
+
       - name: GUI Tests Screenshots Applitools
         if: github.event_name == 'pull_request'
         shell: bash -l {0}

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -36,3 +36,4 @@ Developer Changes
 - #1387 : Fix async task leak
 - #1384 : Remove StackSelectorWidget and StackSelectorDialog
 - #1420 : Save NeXus data without concatenate
+- #1402 : Add GitHub Actions tests for Windows

--- a/mantidimaging/eyes_tests/eyes_manager.py
+++ b/mantidimaging/eyes_tests/eyes_manager.py
@@ -3,6 +3,7 @@
 
 import inspect
 import os
+import sys
 from tempfile import mkdtemp
 from unittest import mock
 from uuid import uuid4
@@ -24,6 +25,7 @@ class EyesManager:
         self.application_name = application_name
         self.eyes = Eyes()
         self.eyes.match_level = MatchLevel.CONTENT
+        self.eyes.configure.host_os = sys.platform
         self.image_directory = None
         self.imaging = None
         if test_name is None:

--- a/mantidimaging/test_helpers/start_qapplication.py
+++ b/mantidimaging/test_helpers/start_qapplication.py
@@ -49,6 +49,7 @@ def get_application(name=''):
 
     if _QAPP is None:
         _QAPP = QApplication([name])
+        _QAPP.setStyle('Fusion')
         sys.excepthook = handle_uncaught_exceptions
 
     return _QAPP


### PR DESCRIPTION
### Issue

Closes #1402

### Description

Adds the Applitools tests to the windows workflow. We specify the operating system to make sure we compare against the right baselines for each OS.

I've also added a step to set the resolution on Windows, as the default viewport size for the GitHub Actions Windows runners was too small for some of our window sizes.

### Testing & Acceptance Criteria 

All tests pass in an acceptable duration

### Documentation

Issue number added to release notes
