### PR TITLE
WelcomeScreenPresenterTest test in isolation

### DIFF
--- a/mantidimaging/core/utility/test/version_check_test.py
+++ b/mantidimaging/core/utility/test/version_check_test.py
@@ -6,14 +6,18 @@ import unittest
 from unittest import mock
 
 from mantidimaging.core.utility.version_check import (CheckVersion, _version_is_uptodate, _parse_version)
+from mantidimaging.test_helpers import mock_versions
 
 
+@mock_versions
 class TestCheckVersion(unittest.TestCase):
     def setUp(self):
         with mock.patch("mantidimaging.core.utility.version_check.CheckVersion._retrieve_versions"):
             with mock.patch("shutil.which"):
                 self.versions = CheckVersion()
-                self.versions._use_test_values()
+                self.versions._conda_installed_version = "1.0.0_1"
+                self.versions._conda_installed_label = "main"
+                self.versions._conda_available_version = "1.0.0_1"
 
     def test_parse_version(self):
         parsed = _parse_version("9.9.9_1234")
@@ -58,13 +62,14 @@ class TestCheckVersion(unittest.TestCase):
         self.assertEqual(_version_is_uptodate(local_parsed, remote_parsed), is_uptodate)
 
     def test_is_conda_uptodate(self):
+        self.versions._conda_available_version = "1.0.0_1"
         self.assertTrue(self.versions.is_conda_uptodate())
 
-        self.versions._use_test_values(False)
+        self.versions._conda_available_version = "2.0.0_1"
         self.assertFalse(self.versions.is_conda_uptodate())
 
     def test_conda_update_message(self):
-        self.versions._use_test_values(False)
+        self.versions._conda_available_version = "2.0.0_1"
         msg, detailed = self.versions.conda_update_message()
         self.assertTrue("Found version 1.0.0_1" in msg)
         self.assertTrue("latest: 2.0.0_1" in msg)

--- a/mantidimaging/core/utility/version_check.py
+++ b/mantidimaging/core/utility/version_check.py
@@ -33,21 +33,9 @@ class CheckVersion:
         self._conda_available_version = None
         self._conda_exe = self.find_conda_executable()
 
-        # To test update warning message uncomment
-        # self._use_test_values(False)
-
     def _retrieve_versions(self) -> None:
         self._retrieve_conda_installed_version()
         self._retrieve_conda_available_version()
-
-    def _use_test_values(self, uptodate: bool = True) -> None:
-        """Avoid fetching version info"""
-        self._conda_installed_version = "1.0.0_1"
-        self._conda_installed_label = "main"
-        if uptodate:
-            self._conda_available_version = "1.0.0_1"
-        else:
-            self._conda_available_version = "2.0.0_1"
 
     @staticmethod
     def find_conda_executable() -> str:

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -13,12 +13,9 @@ from PyQt5.QtWidgets import QApplication, QMessageBox, QInputDialog
 import pytest
 
 from mantidimaging.core.utility.leak_tracker import leak_tracker
-from mantidimaging.core.utility.version_check import versions
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.test_helpers.qt_test_helpers import wait_until
-from mantidimaging.test_helpers.start_qapplication import start_qapplication
-
-versions._use_test_values()
+from mantidimaging.test_helpers import start_qapplication, mock_versions
 
 LOAD_SAMPLE = str(Path.home()) + "/mantidimaging-data/ISIS/IMAT/IMAT00010675/Tomo/IMAT_Flower_Tomo_000000.tif"
 LOAD_SAMPLE_MISSING_MESSAGE = """Data not present, please clone to your home directory e.g.
@@ -28,6 +25,7 @@ SHOW_DELAY = 10  # Can be increased to watch tests
 SHORT_DELAY = 100
 
 
+@mock_versions
 @pytest.mark.system
 @unittest.skipUnless(os.path.exists(LOAD_SAMPLE), LOAD_SAMPLE_MISSING_MESSAGE)
 @start_qapplication

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -14,14 +14,11 @@ from mantidimaging.core.utility.data_containers import ProjectionAngles
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.main.presenter import Notification as PresNotification
 from mantidimaging.gui.windows.main.view import RECON_GROUP_TEXT, SINO_TEXT
-from mantidimaging.test_helpers import start_qapplication
+from mantidimaging.test_helpers import start_qapplication, mock_versions
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
-from mantidimaging.core.utility.version_check import versions
 
-versions._use_test_values()
-
-
+@mock_versions
 @start_qapplication
 class MainWindowViewTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/mantidimaging/gui/windows/operations/test/view_test.py
+++ b/mantidimaging/gui/windows/operations/test/view_test.py
@@ -6,13 +6,10 @@ from unittest import mock
 
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.operations.view import FiltersWindowView
-from mantidimaging.test_helpers import start_qapplication
-
-from mantidimaging.core.utility.version_check import versions
-
-versions._use_test_values()
+from mantidimaging.test_helpers import start_qapplication, mock_versions
 
 
+@mock_versions
 @start_qapplication
 class OperationsWindowsViewTest(unittest.TestCase):
     def setUp(self):

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -10,13 +10,10 @@ from mantidimaging.gui.utility.qt_helpers import INPUT_DIALOG_FLAGS
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.recon import ReconstructWindowView
 from mantidimaging.gui.windows.recon.presenter import AutoCorMethod
-from mantidimaging.test_helpers import start_qapplication
-
-from mantidimaging.core.utility.version_check import versions
-
-versions._use_test_values()
+from mantidimaging.test_helpers import start_qapplication, mock_versions
 
 
+@mock_versions
 @start_qapplication
 class ReconstructWindowViewTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -7,14 +7,12 @@ from unittest import mock
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.utility.sensible_roi import SensibleROI
-from mantidimaging.core.utility.version_check import versions
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.stack_visualiser import StackVisualiserView
-from mantidimaging.test_helpers import start_qapplication
-
-versions._use_test_values()
+from mantidimaging.test_helpers import start_qapplication, mock_versions
 
 
+@mock_versions
 @start_qapplication
 class StackVisualiserViewTest(unittest.TestCase):
     test_data: ImageStack

--- a/mantidimaging/gui/windows/welcome_screen/tests/presenter_test.py
+++ b/mantidimaging/gui/windows/welcome_screen/tests/presenter_test.py
@@ -8,9 +8,10 @@ import tempfile
 from PyQt5.QtCore import QSettings, QCoreApplication
 
 from mantidimaging.gui.windows.welcome_screen.presenter import WelcomeScreenPresenter
-from mantidimaging.test_helpers import start_qapplication
+from mantidimaging.test_helpers import start_qapplication, mock_versions
 
 
+@mock_versions
 @start_qapplication
 class WelcomeScreenPresenterTest(unittest.TestCase):
     @classmethod

--- a/mantidimaging/gui/windows/wizard/test/view_test.py
+++ b/mantidimaging/gui/windows/wizard/test/view_test.py
@@ -6,14 +6,12 @@ from unittest import mock
 
 from mantidimaging.gui.windows.wizard.view import WizardView, WizardStep, WizardStage
 from mantidimaging.gui.windows.main import MainWindowView
-from mantidimaging.test_helpers import start_qapplication
-from mantidimaging.core.utility.version_check import versions
-
-versions._use_test_values()
+from mantidimaging.test_helpers import start_qapplication, mock_versions
 
 STEP_DATA = {'name': 'Loading files', 'description': 'desc'}
 
 
+@mock_versions
 @start_qapplication
 class WizardViewTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/mantidimaging/test_helpers/__init__.py
+++ b/mantidimaging/test_helpers/__init__.py
@@ -4,4 +4,4 @@
 This package contains testing helpers for unit tests across the application
 """
 from mantidimaging.test_helpers.file_outputting_test_case import FileOutputtingTestCase  # noqa: F401
-from mantidimaging.test_helpers.start_qapplication import start_qapplication  # noqa: F401
+from mantidimaging.test_helpers.start_qapplication import start_qapplication, mock_versions  # noqa: F401

--- a/mantidimaging/test_helpers/start_qapplication.py
+++ b/mantidimaging/test_helpers/start_qapplication.py
@@ -110,7 +110,7 @@ def mock_versions(cls):
     def tearDownClass():
         cls.mock_version_patch.stop()
         cls.mock_version_label_patch.stop()
-        cls.mock_version_available_patch.start()
+        cls.mock_version_available_patch.stop()
 
     return augment_test_setup_methods(cls, setup_class=setUpClass, teardown_class=tearDownClass)
 

--- a/mantidimaging/test_helpers/start_qapplication.py
+++ b/mantidimaging/test_helpers/start_qapplication.py
@@ -15,6 +15,7 @@ import gc
 import os
 import pytest
 import sys
+from unittest import mock
 
 import pyqtgraph
 from mantidimaging.core.parallel.manager import create_and_start_pool, end_pool
@@ -85,6 +86,31 @@ def start_multiprocessing_pool(cls):
 
     def tearDownClass():
         end_pool()
+
+    return augment_test_setup_methods(cls, setup_class=setUpClass, teardown_class=tearDownClass)
+
+
+def mock_versions(cls):
+    def setUpClass():
+        cls.mock_version_patch = mock.patch(
+            'mantidimaging.gui.windows.welcome_screen.presenter.versions.get_conda_installed_version')
+        cls.mock_version = cls.mock_version_patch.start()
+        cls.mock_version.return_value = "1.0.0_1"
+
+        cls.mock_version_label_patch = mock.patch(
+            'mantidimaging.gui.windows.welcome_screen.presenter.versions.get_conda_installed_label')
+        cls.mock_version_label = cls.mock_version_label_patch.start()
+        cls.mock_version_label.return_value = "main"
+
+        cls.mock_version_available_patch = mock.patch(
+            'mantidimaging.gui.windows.welcome_screen.presenter.versions.get_conda_available_version')
+        cls.mock_version_available = cls.mock_version_available_patch.start()
+        cls.mock_version_available.return_value = "1.0.0_1"
+
+    def tearDownClass():
+        cls.mock_version_patch.stop()
+        cls.mock_version_label_patch.stop()
+        cls.mock_version_available_patch.start()
 
     return augment_test_setup_methods(cls, setup_class=setUpClass, teardown_class=tearDownClass)
 


### PR DESCRIPTION
### Issue

Closes #1446 

### Description

The version check has `versions._use_test_values()` which sets some standard version to make tests work. `WelcomeScreenPresenterTest` was missing a call to set this. Usually this was not a problem, because several other tests call it at import time. If the test was run in isolation then the real version checking functions would run causing the test to fail. Running tests with xdist may also cause the import not to happen in the process that runs the WelcomeScreenPresenterTest tests.

A better fix than adding `versions._use_test_values()`, is to stop depending on global state. Its a bit fiddly to set up the mock every time this is needed (every time the main window is used), so add a helper.

### Testing & Acceptance Criteria 

Try the pytest command on the #1446

Add a RuntimeError to top of `CheckVersion._retrieve_conda_installed_version()` and `CheckVersion._retrieve_conda_available_version()`. Run `make check`. Confirm that the only tests that fail are the tests in `TestCheckVersion` that have proper mocks for `subprocess.check_output` and `requests.get`. This confirms that none of the tests depend on external version numbers.


### Documentation

Not needed