### PR TITLE
cil and cil-astra 21.4.0, astra 2

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -28,13 +28,13 @@ requirements:
     - tomopy=1.10.*
     - cudatoolkit=10.2*
     - cupy=10.2.*
-    - astra-toolbox=1.9.9*
+    - astra-toolbox=2.0.*
     - requests=2.26.*
     - h5py=3.4.*
     - sarepy=2020.07
     - psutil=5.8.*
-    - cil=21.3.*
-    - cil-astra=21.3.*
+    - cil=21.4.*
+    - cil-astra=21.4.*
     - ccpi-regulariser=21.0.*
 
 build:

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -37,3 +37,4 @@ Developer Changes
 - #1384 : Remove StackSelectorWidget and StackSelectorDialog
 - #1420 : Save NeXus data without concatenate
 - #1402 : Add GitHub Actions tests for Windows
+- #1449 : Update CIL to 21.4, Astra to 2.0

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,7 +2,7 @@ name: mantidimaging-dev
 channels:
   - mantid/label/unstable
   - dtasev
-  - astra-toolbox/label/dev
+  - astra-toolbox
   - conda-forge
   - ccpi
   - algotom

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: mantidimaging-nightly
 channels:
   - mantid/label/unstable
   - dtasev
-  - astra-toolbox/label/dev
+  - astra-toolbox
   - conda-forge
   - ccpi
   - algotom


### PR DESCRIPTION
### Issue

Closes #1449 

### Description

Update CIL and Astra. This allows us to finally move away from the Astra dev releases. Also clears the path for the python 3.9 update.

### Testing & Acceptance Criteria 

Test a reconstruction

### Documentation

release notes
