### PR TITLE
Fix pyqt version

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
   - pip
   - pip:
       # For running
-      - pyqt5==5.15
+      - pyqt5==5.15.*
       - pyqtgraph>=0.12.1,<0.13
       - jenkspy==0.2.0
       # For developement

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,6 @@ dependencies:
   - mantidimaging
   - pip
   - pip:
-      - pyqt5==5.15
+      - pyqt5==5.15.*
       - pyqtgraph>=0.12.1,<0.13
       - jenkspy==0.2.0


### PR DESCRIPTION
### Issue
Closes #1452 

### Description

Change version specifier to pyqt5==5.15.* so that 5.15.6 gets picked up.

### Testing 

This causes some small changes to layouts. But they seem to be improvements
![image](https://user-images.githubusercontent.com/74248560/167664347-768ad1a1-7831-4382-840a-63080dde2ed5.png)


### Acceptance Criteria 

Worth having a quick check around the UI, incase there is anything the tests have missed

### Documentation
Not needed.
