### PR TITLE
Set package build to be noarch

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - ccpi-regulariser=21.0.*
 
 build:
+  noarch: python
   number: 1
   script:
     - {{ PYTHON }} -m pip install --ignore-installed .

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -14,6 +14,7 @@ New Features
 - #1394 : Add .nxs extension to NeXus save path
 - #1399 : NeXus Saving OSError message
 - #1331 : Make MI Windows compatible
+- #1430 : Provide an Anaconda package that is compatible with Windows
 
 Fixes
 -----


### PR DESCRIPTION
### Issue

Refs #1430

### Description

Adds the required setting to create a Conda noarch python package for Mantid Imaging. This only refs the issue as I wasn't able to create the package locally on Windows, only on Linux. As a first step it's fine to only create them on Linux, however I'm planning to investigate what we would need to do to be able to create them on Windows as well, just so we have the flexibility in future.

### Testing & Acceptance Criteria 

I've tested by creating the noarch package locally on Linux. It's hard to test properly on both Windows and Linux without the package being uploaded to Anaconda, though, so that will need to be done after this PR goes in.

### Documentation

Issue number added to release notes.
