### PR TITLE
Increase recon GUI test waits to prevent timeouts

### DIFF
--- a/mantidimaging/gui/test/gui_system_reconstruction_test.py
+++ b/mantidimaging/gui/test/gui_system_reconstruction_test.py
@@ -63,7 +63,7 @@ class TestGuiSystemReconstruction(GuiSystemBase):
     def test_refine(self):
         QTimer.singleShot(SHORT_DELAY, lambda: self._click_InputDialog(set_int=4))
         QTest.mouseClick(self.recon_window.minimiseBtn, Qt.MouseButton.LeftButton)
-        wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=200)
+        wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=500)
 
         for _ in range(5):
             QTimer.singleShot(SHORT_DELAY, lambda: self._click_cor_inspect())
@@ -81,7 +81,7 @@ class TestGuiSystemReconstruction(GuiSystemBase):
 
             QTimer.singleShot(SHORT_DELAY, lambda: self._click_InputDialog(set_int=3))
             QTest.mouseClick(self.recon_window.minimiseBtn, Qt.MouseButton.LeftButton)
-            wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=200)
+            wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=500)
 
             QTimer.singleShot(SHORT_DELAY, lambda: self._click_cor_inspect())
             QTest.mouseClick(self.recon_window.refineCorBtn, Qt.MouseButton.LeftButton)


### PR DESCRIPTION
### Issue

Closes #1455

### Description

We previously increased the wait time for the "Minimise error" button to be enabled in `test_minimise`, as it was taking longer than the existing timeout on Windows. This PR makes sure we're waiting just as long for this in `test_refine` and `test_refine_stress` as well.

### Testing & Acceptance Criteria 

All tests pass

### Documentation

None required
