### PR TITLE
Change test to assertGreaterEqual

### DIFF
--- a/mantidimaging/core/utility/test/execution_timer_test.py
+++ b/mantidimaging/core/utility/test/execution_timer_test.py
@@ -18,7 +18,7 @@ class ExecutionTimerTest(unittest.TestCase):
 
             time.sleep(0.1)
 
-        self.assertAlmostEqual(t.total_seconds, 0.1, delta=0.05)
+        self.assertGreaterEqual(t.total_seconds, 0.1)
 
     def test_custom_message(self):
         t = ExecutionTimer(msg='Task')


### PR DESCRIPTION
### Issue
Closes #1417 

### Description

time.sleep() is only guaranteed to be a minimum time. If the computer is busy it can take much longer.

On github actions sleep(0.1) sometimes takes over 0.5 seconds.

### Testing &Acceptance Criteria 

Tests should pass.

### Documentation

Not needed