### PR TITLE
CIL PDHG non-negativity constraint

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -15,6 +15,7 @@ New Features
 - #1399 : NeXus Saving OSError message
 - #1331 : Make MI Windows compatible
 - #1430 : Provide an Anaconda package that is compatible with Windows
+- #1444 : CIL PDHG non-negativity constraint
 
 Fixes
 -----

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -218,4 +218,4 @@ class CILRecon(BaseRecon):
 
 
 def allowed_recon_kwargs() -> dict:
-    return {'CIL: PDHG-TV': ['alpha', 'num_iter']}
+    return {'CIL: PDHG-TV': ['alpha', 'num_iter', 'non_negative']}

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -101,6 +101,7 @@ class ReconstructionParameters:
     tilt: Optional[Degrees] = None
     pixel_size: float = 0.0
     alpha: float = 0.0
+    non_negative: bool = False
     max_projection_angle: float = 360.0
     beam_hardening_coefs: Optional[List[float]] = None
 

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -538,17 +538,43 @@
              <layout class="QVBoxLayout" name="verticalLayout_6">
               <item>
                <layout class="QGridLayout" name="optionsLayout">
-                <item row="5" column="0">
-                 <widget class="QLabel" name="pixelSizeLabel">
-                  <property name="text">
-                   <string>Pixel size (microns)</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="5" column="1">
+                <item row="6" column="1">
                  <widget class="QDoubleSpinBox" name="pixelSize">
                   <property name="maximum">
                    <double>99999.000000000000000</double>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="0">
+                 <widget class="QLabel" name="filterNameLabel">
+                  <property name="text">
+                   <string>Reconstruction filter:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="0">
+                 <widget class="QLabel" name="numIterLabel">
+                  <property name="text">
+                   <string>Number of iterations:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="4" column="1">
+                 <widget class="QDoubleSpinBox" name="alphaSpinbox">
+                  <property name="decimals">
+                   <number>6</number>
+                  </property>
+                  <property name="minimum">
+                   <double>0.000001000000000</double>
+                  </property>
+                  <property name="maximum">
+                   <double>1000000.000000000000000</double>
+                  </property>
+                  <property name="singleStep">
+                   <double>0.010000000000000</double>
+                  </property>
+                  <property name="value">
+                   <double>1.000000000000000</double>
                   </property>
                  </widget>
                 </item>
@@ -603,13 +629,31 @@
                   </item>
                  </widget>
                 </item>
-                <item row="0" column="1">
-                 <widget class="QDoubleSpinBox" name="maxProjAngle">
-                  <property name="maximum">
-                   <double>9999.000000000000000</double>
+                <item row="0" column="0">
+                 <widget class="QLabel" name="maxProjAngleLabel">
+                  <property name="text">
+                   <string>Maximum projection angle</string>
                   </property>
-                  <property name="value">
-                   <double>360.000000000000000</double>
+                 </widget>
+                </item>
+                <item row="6" column="0">
+                 <widget class="QLabel" name="pixelSizeLabel">
+                  <property name="text">
+                   <string>Pixel size (microns)</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QLabel" name="algorithmNameLabel">
+                  <property name="text">
+                   <string>Algorithm:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="4" column="0">
+                 <widget class="QLabel" name="alphaLabel">
+                  <property name="text">
+                   <string>Alpha</string>
                   </property>
                  </widget>
                 </item>
@@ -623,57 +667,27 @@
                   </property>
                  </widget>
                 </item>
-                <item row="2" column="0">
-                 <widget class="QLabel" name="filterNameLabel">
-                  <property name="text">
-                   <string>Reconstruction filter:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="1" column="0">
-                 <widget class="QLabel" name="algorithmNameLabel">
-                  <property name="text">
-                   <string>Algorithm:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="0">
-                 <widget class="QLabel" name="maxProjAngleLabel">
-                  <property name="text">
-                   <string>Maximum projection angle</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="3" column="0">
-                 <widget class="QLabel" name="numIterLabel">
-                  <property name="text">
-                   <string>Number of iterations:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="4" column="0">
-                 <widget class="QLabel" name="alphaLabel">
-                  <property name="text">
-                   <string>Alpha</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="4" column="1">
-                 <widget class="QDoubleSpinBox" name="alphaSpinbox">
-                  <property name="decimals">
-                   <number>6</number>
-                  </property>
-                  <property name="minimum">
-                   <double>0.000001000000000</double>
-                  </property>
+                <item row="0" column="1">
+                 <widget class="QDoubleSpinBox" name="maxProjAngle">
                   <property name="maximum">
-                   <double>1000000.000000000000000</double>
-                  </property>
-                  <property name="singleStep">
-                   <double>0.010000000000000</double>
+                   <double>9999.000000000000000</double>
                   </property>
                   <property name="value">
-                   <double>1.000000000000000</double>
+                   <double>360.000000000000000</double>
+                  </property>
+                 </widget>
+                </item>
+                <item row="5" column="0">
+                 <widget class="QLabel" name="nonNegativeLabel">
+                  <property name="text">
+                   <string>Non-negative</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="5" column="1">
+                 <widget class="QCheckBox" name="nonNegativeCheckBox">
+                  <property name="text">
+                   <string/>
                   </property>
                  </widget>
                 </item>

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -61,6 +61,7 @@ class ReconstructWindowPresenter(BasePresenter):
             'filter_name': [self.view.filterName, self.view.filterNameLabel],
             'num_iter': [self.view.numIter, self.view.numIterLabel],
             'alpha': [self.view.alphaSpinbox, self.view.alphaLabel],
+            'non_negative': [self.view.nonNegativeCheckBox, self.view.nonNegativeLabel],
         }
         self.main_window = main_window
 

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -38,6 +38,8 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.view.image_view = mock.Mock()
         self.view.alphaSpinbox = mock.Mock()
         self.view.alphaLabel = mock.Mock()
+        self.view.nonNegativeCheckBox = mock.Mock()
+        self.view.nonNegativeLabel = mock.Mock()
 
     @mock.patch('mantidimaging.gui.windows.recon.presenter.start_async_task_view')
     def test_set_stack_uuid(self, mock_start_async: mock.Mock):

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -29,6 +29,7 @@ class ReconstructWindowViewTest(unittest.TestCase):
         self.view.numIter = self.numIter = mock.Mock()
         self.view.pixelSize = self.pixelSize = mock.Mock()
         self.view.alphaSpinbox = self.alpha = mock.Mock()
+        self.view.nonNegativeCheckBox = self.non_negative = mock.Mock()
         self.view.algorithmName = self.algorithmName = mock.Mock()
         self.view.filterName = self.filterName = mock.Mock()
         self.view.maxProjAngle = self.maxProjAngle = mock.Mock()
@@ -237,6 +238,7 @@ class ReconstructWindowViewTest(unittest.TestCase):
                                                   tilt=Degrees(self.resultTilt.value.return_value),
                                                   pixel_size=self.pixelSize.value.return_value,
                                                   alpha=self.alpha.value.return_value,
+                                                  non_negative=self.non_negative.isChecked.return_value,
                                                   max_projection_angle=self.maxProjAngle.value.return_value,
                                                   beam_hardening_coefs=self.view.beam_hardening_coefs)
 

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -58,6 +58,7 @@ class ReconstructWindowView(BaseMainWindowView):
     maxProjAngle: QDoubleSpinBox
     pixelSize: QDoubleSpinBox
     alphaSpinbox: QDoubleSpinBox
+    nonNegativeCheckBox: QCheckBox
     resultCor: QDoubleSpinBox
     resultTilt: QDoubleSpinBox
     resultSlope: QDoubleSpinBox
@@ -180,6 +181,7 @@ class ReconstructWindowView(BaseMainWindowView):
 
         self.pixelSize.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
         self.alphaSpinbox.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
+        self.nonNegativeCheckBox.stateChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
         self.reconHelpButton.clicked.connect(lambda: self.open_help_webpage("reconstructions/index"))
         self.corHelpButton.clicked.connect(lambda: self.open_help_webpage("reconstructions/center_of_rotation"))
 
@@ -387,6 +389,10 @@ class ReconstructWindowView(BaseMainWindowView):
     @alpha.setter
     def alpha(self, value: float):
         self.alphaSpinbox.setValue(value)
+
+    @property
+    def non_negative(self):
+        return self.nonNegativeCheckBox.isChecked()
 
     @property
     def beam_hardening_coefs(self) -> Optional[List[float]]:

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -414,6 +414,7 @@ class ReconstructWindowView(BaseMainWindowView):
                                         tilt=Degrees(self.tilt),
                                         pixel_size=self.pixel_size,
                                         alpha=self.alpha,
+                                        non_negative=self.non_negative,
                                         max_projection_angle=self.max_proj_angle,
                                         beam_hardening_coefs=self.beam_hardening_coefs)
 


### PR DESCRIPTION
### Issue

Closes #1444 

### Description

Add CIL PDHG non-negativity constraint.

Add checkbox to the reconstruction tab

Also clean up some old comments and commented code

### Testing & Acceptance Criteria 

Load some data (e.g phantom_spheres_float32.tar.xz from the example folder)
In recon window choose the CIL method and set number of iterations to 10
Toggle the Non-negative checkbox.

When off there should be some negative values in the output, when on the output should be all positive.

### Documentation

Release notes
