### PR TITLE
Update entry point configuration to work better on Windows

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -42,6 +42,9 @@ build:
   number: 1
   script:
     - {{ PYTHON }} -m pip install --ignore-installed .
+  entry_points:
+    - mantidimaging = mantidimaging.main:main
+    - mantidimaging-ipython = mantidimaging.ipython:main
 
 test:
   imports:

--- a/setup.py
+++ b/setup.py
@@ -222,8 +222,8 @@ setup(
         "mantidimaging.core": ["gpu/*.cu"],
     },
     entry_points={
-        "console_scripts": ["mantidimaging-ipython = mantidimaging.ipython:main"],
-        "gui_scripts": ["mantidimaging = mantidimaging.main:main"],
+        "console_scripts":
+        ["mantidimaging-ipython = mantidimaging.ipython:main", "mantidimaging = mantidimaging.main:main"],
     },
     url="https://github.com/mantidproject/mantidimaging",
     license="GPL-3.0",


### PR DESCRIPTION
### Issue

Refs #1430

### Description

Makes some configuration changes that have successfully produced noarch packages that run on Windows for other Mantid projects. Using `"console-scripts"` for the entry points in `setup.py`, even if the application is a GUI app, seemed to be necessary for other packages, as was specifying the entry points in `meta.yaml`.

For other projects, this configuration created a package that contained everything required to generate the executable for the relevant platform as part of installation.

### Testing & Acceptance Criteria 

I was able to run the local package creation script successfully on Windows with these settings, however it was tricky to figure out how to install it locally with all the required dependencies, so I wasn't able to test fully. It would be good to test what happens with the real package creation script that will upload it to Anaconda.

### Documentation

Not required.