### PR TITLE
1398: Save recons to NeXus file

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -14,6 +14,7 @@ New Features
 - #1394 : Add .nxs extension to NeXus save path
 - #1399 : NeXus Saving OSError message
 - #1331 : Make MI Windows compatible
+- #1398 : Save recons to NeXus file
 
 Fixes
 -----

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -257,10 +257,10 @@ def _save_recon_to_nexus(nexus_file: h5py.File, recon: ImageStack):
     recon_entry.create_dataset("title", data=np.string_(recon.name))
     recon_entry.create_dataset("definition", data=np.string_("NXtomoproc"))
 
-    instrument = recon_entry.create_group("instrument")
+    instrument = recon_entry.create_group("INSTRUMENT")
     _set_nx_class(instrument, "NXinstrument")
 
-    source = instrument.create_group("source")
+    source = instrument.create_group("SOURCE")
     _set_nx_class(source, "NXsource")
 
     source.create_dataset("type", data=np.string_("Neutron source"))

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -16,6 +16,7 @@ from ..data.imagestack import ImageStack
 from ..operations.rescale import RescaleFilter
 from ..utility.data_containers import Indices
 from ..utility.progress_reporting import Progress
+from ..utility.version_check import CheckVersion
 
 LOG = getLogger(__name__)
 
@@ -250,6 +251,34 @@ def _save_recon_to_nexus(nexus_file: h5py.File, recon: ImageStack):
 
     recon_entry.create_dataset("title", data=np.string_(recon.name))
     recon_entry.create_dataset("definition", data=np.string_("NXtomoproc"))
+
+    instrument = recon_entry.create_group("instrument")
+    _set_nx_class(instrument, "NXinstrument")
+
+    source = instrument.create_group("source")
+    _set_nx_class(source, "NXsource")
+
+    source.create_dataset("type", data=np.string_("Neutron source"))
+    source.create_dataset("name", data=np.string_("ISIS"))
+    source.create_dataset("probe", data=np.string_("neutron"))
+
+    sample = recon_entry.create_group("sample")
+    _set_nx_class(sample, "NXsample")
+    sample.create_dataset("name", data=np.string("sample description"))
+
+    reconstruction = recon_entry.create_group("reconstruction")
+    _set_nx_class(reconstruction, "NXprocess")
+
+    reconstruction.create_dataset("program", data=np.string_("Mantid Imaging"))
+    reconstruction.create_dataset("version", data=np.string_(CheckVersion().get_version()))
+    reconstruction.create_dataset("date")  # TODO
+    reconstruction.create_dataset("paramters")  # TODO
+
+    data = recon_entry.create_group("data")
+    _set_nx_class("data", "NXdata")
+
+    data.create_dataset("data", shape=recon.data.shape, dtype="uint16")
+    data["data"] = recon.data
 
 
 def _set_nx_class(group: h5py.Group, class_name: str):

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -245,6 +245,11 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
 
 
 def _save_recon_to_nexus(nexus_file: h5py.File, recon: ImageStack):
+    """
+    Saves a recon to a NeXus file.
+    :param nexus_file: The NeXus file.
+    :param recon: The recon data.
+    """
 
     recon_entry = nexus_file.create_group(recon.name)
     _set_nx_class(recon_entry, "NXentry")

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -267,7 +267,7 @@ def _save_recon_to_nexus(nexus_file: h5py.File, recon: ImageStack):
     source.create_dataset("name", data=np.string_("ISIS"))
     source.create_dataset("probe", data=np.string_("neutron"))
 
-    sample = recon_entry.create_group("sample")
+    sample = recon_entry.create_group("SAMPLE")
     _set_nx_class(sample, "NXsample")
     sample.create_dataset("name", data=np.string_("sample description"))
 

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -239,6 +239,18 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
     data["rotation_angle"] = rotation_angle
     data["image_key"] = detector["image_key"]
 
+    for recon in dataset.recons:
+        _save_recon_to_nexus(nexus_file, recon)
+
+
+def _save_recon_to_nexus(nexus_file: h5py.File, recon: ImageStack):
+
+    recon_entry = nexus_file.create_group(recon.name)
+    _set_nx_class(recon_entry, "NXentry")
+
+    recon_entry.create_dataset("title", data=np.string_(recon.name))
+    recon_entry.create_dataset("definition", data=np.string_("NXtomoproc"))
+
 
 def _set_nx_class(group: h5py.Group, class_name: str):
     """

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -283,7 +283,7 @@ def _save_recon_to_nexus(nexus_file: h5py.File, recon: ImageStack):
     _set_nx_class(data, "NXdata")
 
     data.create_dataset("data", shape=recon.data.shape, dtype="uint16")
-    data["data"][:] = recon.data
+    data["data"][:] = _scale_recon_data(recon.data)
 
 
 def _set_nx_class(group: h5py.Group, class_name: str):
@@ -293,6 +293,14 @@ def _set_nx_class(group: h5py.Group, class_name: str):
     :param class_name: The class name.
     """
     group.attrs["NX_class"] = np.string_(class_name)
+
+
+def _scale_recon_data(image: np.ndarray) -> np.ndarray:
+    min_value = np.min(image)
+    if min_value < 0:
+        image -= min_value
+    image *= (65535 / np.max(image))
+    return image
 
 
 def rescale_single_image(image: np.ndarray, min_input: float, max_input: float, max_output: float) -> np.ndarray:

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -282,7 +282,8 @@ def _save_recon_to_nexus(nexus_file: h5py.File, recon: ImageStack):
     data = recon_entry.create_group("data")
     _set_nx_class(data, "NXdata")
 
-    data.create_dataset("data", shape=recon.data.shape, dtype="uint16", data=recon.data)
+    data.create_dataset("data", shape=recon.data.shape, dtype="uint16")
+    data["data"][:] = recon.data
 
 
 def _set_nx_class(group: h5py.Group, class_name: str):

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-
+import datetime
 import os
 from logging import getLogger
 from typing import List, Union, Optional, Dict, Callable
@@ -264,21 +264,20 @@ def _save_recon_to_nexus(nexus_file: h5py.File, recon: ImageStack):
 
     sample = recon_entry.create_group("sample")
     _set_nx_class(sample, "NXsample")
-    sample.create_dataset("name", data=np.string("sample description"))
+    sample.create_dataset("name", data=np.string_("sample description"))
 
     reconstruction = recon_entry.create_group("reconstruction")
     _set_nx_class(reconstruction, "NXprocess")
 
     reconstruction.create_dataset("program", data=np.string_("Mantid Imaging"))
     reconstruction.create_dataset("version", data=np.string_(CheckVersion().get_version()))
-    reconstruction.create_dataset("date")  # TODO
-    reconstruction.create_dataset("paramters")  # TODO
+    reconstruction.create_dataset("date", data=np.string_("T".join(str(datetime.datetime.now()).split())))
+    reconstruction.create_group("parameters")
 
     data = recon_entry.create_group("data")
-    _set_nx_class("data", "NXdata")
+    _set_nx_class(data, "NXdata")
 
-    data.create_dataset("data", shape=recon.data.shape, dtype="uint16")
-    data["data"] = recon.data
+    data.create_dataset("data", shape=recon.data.shape, dtype="uint16", data=recon.data)
 
 
 def _set_nx_class(group: h5py.Group, class_name: str):

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -283,7 +283,7 @@ def _save_recon_to_nexus(nexus_file: h5py.File, recon: ImageStack):
     _set_nx_class(data, "NXdata")
 
     data.create_dataset("data", shape=recon.data.shape, dtype="uint16")
-    data["data"][:] = _scale_recon_data(recon.data)
+    data["data"][:] = _rescale_recon_data(recon.data)
 
 
 def _set_nx_class(group: h5py.Group, class_name: str):
@@ -295,12 +295,17 @@ def _set_nx_class(group: h5py.Group, class_name: str):
     group.attrs["NX_class"] = np.string_(class_name)
 
 
-def _scale_recon_data(image: np.ndarray) -> np.ndarray:
-    min_value = np.min(image)
+def _rescale_recon_data(data: np.ndarray) -> np.ndarray:
+    """
+    Rescales recon data so that it can be converted to uint.
+    :param data: The recon data.
+    :return: The rescaled recon data.
+    """
+    min_value = np.min(data)
     if min_value < 0:
-        image -= min_value
-    image *= (np.iinfo("uint16").max / np.max(image))
-    return image
+        data -= min_value
+    data *= (np.iinfo("uint16").max / np.max(data))
+    return data
 
 
 def rescale_single_image(image: np.ndarray, min_input: float, max_input: float, max_output: float) -> np.ndarray:

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -299,7 +299,7 @@ def _scale_recon_data(image: np.ndarray) -> np.ndarray:
     min_value = np.min(image)
     if min_value < 0:
         image -= min_value
-    image *= (65535 / np.max(image))
+    image *= (np.iinfo("uint16").max / np.max(image))
     return image
 
 

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -36,6 +36,7 @@ def test_rescale_negative_recon_data():
     recon.data -= np.min(recon.data) * 1.2
 
     assert np.min(_rescale_recon_data(recon.data)) >= 0
+    assert np.max(_rescale_recon_data(recon.data)) == np.iinfo("uint16").max
 
 
 class IOTest(FileOutputtingTestCase):

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -310,7 +310,7 @@ class IOTest(FileOutputtingTestCase):
 
         sd = StrictDataset(sample)
 
-        recon = th.generate_images()
+        recon = th.generate_images(seed=2)
         recon.name = recon_name = "Recon"
         sd.recons.append(recon)
 

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -14,6 +14,7 @@ from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.core.io import loader
 from mantidimaging.core.io import saver
+from mantidimaging.core.io.saver import _scale_recon_data
 from mantidimaging.core.utility.version_check import CheckVersion
 from mantidimaging.helper import initialise_logging
 from mantidimaging.test_helpers import FileOutputtingTestCase
@@ -329,6 +330,9 @@ class IOTest(FileOutputtingTestCase):
                              CheckVersion().get_version())
             self.assertIn(str(datetime.date.today()),
                           _nexus_dataset_to_string(nexus_file[recon_name]["reconstruction"]["date"]))
+
+            npt.assert_array_almost_equal(np.array(nexus_file[recon_name]["data"]["data"]),
+                                          _scale_recon_data(recon.data).astype("uint16"))
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -262,6 +262,32 @@ class IOTest(FileOutputtingTestCase):
         saver.nexus_save(StrictDataset(th.generate_images()), "path", "sample-name")
         file_mock.return_value.close.assert_called_once()
 
+    @mock.patch("mantidimaging.core.io.saver._save_recon_to_nexus")
+    def test_save_recons_if_present(self, recon_save_mock: mock.Mock):
+        sample = th.generate_images()
+        sample._projection_angles = sample.projection_angles()
+
+        sd = StrictDataset(sample)
+        sd.recons = [th.generate_images(), th.generate_images()]
+
+        with h5py.File("path", "w", driver="core", backing_store=False) as nexus_file:
+            saver._nexus_save(nexus_file, sd, "sample-name")
+
+        self.assertEqual(recon_save_mock.call_count, len(sd.recons))
+
+    @mock.patch("mantidimaging.core.io.saver._save_recon_to_nexus")
+    def test_dont_save_recons_if_none_present(self, recon_save_mock: mock.Mock):
+
+        sample = th.generate_images()
+        sample._projection_angles = sample.projection_angles()
+
+        sd = StrictDataset(sample)
+
+        with h5py.File("path", "w", driver="core", backing_store=False) as nexus_file:
+            saver._nexus_save(nexus_file, sd, "sample-name")
+
+        recon_save_mock.assert_not_called()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -14,7 +14,7 @@ from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.core.io import loader
 from mantidimaging.core.io import saver
-from mantidimaging.core.io.saver import _scale_recon_data
+from mantidimaging.core.io.saver import _rescale_recon_data
 from mantidimaging.core.utility.version_check import CheckVersion
 from mantidimaging.helper import initialise_logging
 from mantidimaging.test_helpers import FileOutputtingTestCase
@@ -332,7 +332,14 @@ class IOTest(FileOutputtingTestCase):
                           _nexus_dataset_to_string(nexus_file[recon_name]["reconstruction"]["date"]))
 
             npt.assert_array_almost_equal(np.array(nexus_file[recon_name]["data"]["data"]),
-                                          _scale_recon_data(recon.data).astype("uint16"))
+                                          _rescale_recon_data(recon.data).astype("uint16"))
+
+    def test_scale_negative_recon_data(self):
+
+        recon = th.generate_images()
+        recon.data -= np.min(recon.data) * 1.2
+
+        assert np.min(_rescale_recon_data(recon.data)) >= 0
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -283,7 +283,7 @@ class IOTest(FileOutputtingTestCase):
         sample._projection_angles = sample.projection_angles()
 
         sd = StrictDataset(sample)
-        sd.recons = [th.generate_images(), th.generate_images()]
+        sd.recons.data = [th.generate_images(), th.generate_images()]
 
         with h5py.File("path", "w", driver="core", backing_store=False) as nexus_file:
             saver._nexus_save(nexus_file, sd, "sample-name")

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -339,8 +339,10 @@ class IOTest(FileOutputtingTestCase):
             self.assertIn(str(datetime.date.today()),
                           _nexus_dataset_to_string(nexus_file[recon_name]["reconstruction"]["date"]))
 
-            npt.assert_array_almost_equal(np.array(nexus_file[recon_name]["data"]["data"]),
-                                          _rescale_recon_data(recon.data).astype("uint16"))
+            assert abs(
+                np.max(
+                    np.array(nexus_file[recon_name]["data"]["data"]) -
+                    _rescale_recon_data(recon.data).astype("uint16"))) <= 1
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -30,6 +30,14 @@ def _nexus_dataset_to_string(nexus_dataset) -> str:
     return np.array(nexus_dataset).tostring().decode("utf-8")
 
 
+def test_rescale_negative_recon_data():
+
+    recon = th.generate_images()
+    recon.data -= np.min(recon.data) * 1.2
+
+    assert np.min(_rescale_recon_data(recon.data)) >= 0
+
+
 class IOTest(FileOutputtingTestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -189,7 +197,7 @@ class IOTest(FileOutputtingTestCase):
             tomo_entry = nexus_file["entry1"]["tomo_entry"]
 
             # test definition field
-            self.assertEqual(np.array(tomo_entry["definition"]).tostring().decode("utf-8"), "NXtomo")
+            self.assertEqual(_nexus_dataset_to_string(tomo_entry["definition"]), "NXtomo")
 
             # test instrument field
             self.assertEqual(_decode_nexus_class(tomo_entry["instrument"]), "NXinstrument")
@@ -203,7 +211,7 @@ class IOTest(FileOutputtingTestCase):
 
             # test instrument/sample fields
             self.assertEqual(_decode_nexus_class(tomo_entry["sample"]), "NXsample")
-            self.assertEqual(np.array(tomo_entry["sample"]["name"]).tostring().decode("utf-8"), sample_name)
+            self.assertEqual(_nexus_dataset_to_string(tomo_entry["sample"]["name"]), sample_name)
             npt.assert_array_equal(np.array(tomo_entry["sample"]["rotation_angle"]),
                                    sd.sample.projection_angles().value)
 
@@ -333,13 +341,6 @@ class IOTest(FileOutputtingTestCase):
 
             npt.assert_array_almost_equal(np.array(nexus_file[recon_name]["data"]["data"]),
                                           _rescale_recon_data(recon.data).astype("uint16"))
-
-    def test_scale_negative_recon_data(self):
-
-        recon = th.generate_images()
-        recon.data -= np.min(recon.data) * 1.2
-
-        assert np.min(_rescale_recon_data(recon.data)) >= 0
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -36,7 +36,7 @@ def test_rescale_negative_recon_data():
     recon.data -= np.min(recon.data) * 1.2
 
     assert np.min(_rescale_recon_data(recon.data)) >= 0
-    assert np.max(_rescale_recon_data(recon.data)) == np.iinfo("uint16").max
+    assert int(np.max(_rescale_recon_data(recon.data))) == np.iinfo("uint16").max
 
 
 class IOTest(FileOutputtingTestCase):

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -313,10 +313,14 @@ class IOTest(FileOutputtingTestCase):
             self.assertEqual(_decode_nexus_class(nexus_file[recon_name]["INSTRUMENT"]), "NXinstrument")
             self.assertEqual(_decode_nexus_class(nexus_file[recon_name]["INSTRUMENT"]["SOURCE"]), "NXsource")
 
-            self.assertEqual(_decode_nexus_class(nexus_file[recon_name]["INSTRUMENT"]["SOURCE"]["type"]),
+            self.assertEqual(_nexus_dataset_to_string(nexus_file[recon_name]["INSTRUMENT"]["SOURCE"]["type"]),
                              "Neutron source")
-            self.assertEqual(_decode_nexus_class(nexus_file[recon_name]["INSTRUMENT"]["SOURCE"]["name"]), "ISIS")
-            self.assertEqual(_decode_nexus_class(nexus_file[recon_name]["INSTRUMENT"]["SOURCE"]["probe"]), "neutron")
+            self.assertEqual(_nexus_dataset_to_string(nexus_file[recon_name]["INSTRUMENT"]["SOURCE"]["name"]), "ISIS")
+            self.assertEqual(_nexus_dataset_to_string(nexus_file[recon_name]["INSTRUMENT"]["SOURCE"]["probe"]),
+                             "neutron")
+
+            self.assertEqual(_decode_nexus_class(nexus_file[recon_name]["SAMPLE"], "NXsample"))
+            self.assertEqual(_nexus_dataset_to_string(nexus_file[recon_name]["SAMPLE"]["name"], "sample description"))
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-
+import datetime
 import os
 import unittest
 from unittest import mock
@@ -14,6 +14,7 @@ from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.core.io import loader
 from mantidimaging.core.io import saver
+from mantidimaging.core.utility.version_check import CheckVersion
 from mantidimaging.helper import initialise_logging
 from mantidimaging.test_helpers import FileOutputtingTestCase
 
@@ -306,7 +307,7 @@ class IOTest(FileOutputtingTestCase):
         with h5py.File("path", "w", driver="core", backing_store=False) as nexus_file:
             saver._nexus_save(nexus_file, sd, "sample-name")
 
-            self.assertEqual(_decode_nexus_class(nexus_file[recon_name]), "NXextry")
+            self.assertEqual(_decode_nexus_class(nexus_file[recon_name]), "NXentry")
             self.assertEqual(_nexus_dataset_to_string(nexus_file[recon_name]["title"]), recon_name)
             self.assertEqual(_nexus_dataset_to_string(nexus_file[recon_name]["definition"]), "NXtomoproc")
 
@@ -319,8 +320,15 @@ class IOTest(FileOutputtingTestCase):
             self.assertEqual(_nexus_dataset_to_string(nexus_file[recon_name]["INSTRUMENT"]["SOURCE"]["probe"]),
                              "neutron")
 
-            self.assertEqual(_decode_nexus_class(nexus_file[recon_name]["SAMPLE"], "NXsample"))
-            self.assertEqual(_nexus_dataset_to_string(nexus_file[recon_name]["SAMPLE"]["name"], "sample description"))
+            self.assertEqual(_decode_nexus_class(nexus_file[recon_name]["SAMPLE"]), "NXsample")
+            self.assertEqual(_nexus_dataset_to_string(nexus_file[recon_name]["SAMPLE"]["name"]), "sample description")
+
+            self.assertEqual(_nexus_dataset_to_string(nexus_file[recon_name]["reconstruction"]["program"]),
+                             "Mantid Imaging")
+            self.assertEqual(_nexus_dataset_to_string(nexus_file[recon_name]["reconstruction"]["version"]),
+                             CheckVersion().get_version())
+            self.assertIn(str(datetime.date.today()),
+                          _nexus_dataset_to_string(nexus_file[recon_name]["reconstruction"]["date"]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Issue

Closes #1398 

### Description

Enables saving of recons in NeXus file. Not all fields completed.

### Testing 

Added a test for the recon save and for recon rescaling.

### Acceptance Criteria 

Check that the tests pass. Check that the fields are present in the NeXus file.

### Documentation

Updated release notes.
