### PR TITLE
Only show part of version update message on Windows

### DIFF
--- a/mantidimaging/core/utility/version_check.py
+++ b/mantidimaging/core/utility/version_check.py
@@ -4,6 +4,7 @@
 import json
 import os
 import subprocess
+import sys
 from logging import getLogger
 import requests
 from typing import Optional
@@ -95,7 +96,8 @@ class CheckVersion:
         detailed += f"Found version {self.get_conda_installed_version()}, "
         detailed += f"latest: {self.get_conda_available_version()}.\n"
         detailed += "To update your environment please copy and run the following command:\n"
-        detailed += f"source {os.environ['CONDA_EXE'].rsplit('/',1)[0]}/activate {os.environ['CONDA_PREFIX']} && "
+        if sys.platform == 'linux':
+            detailed += f"source {os.environ['CONDA_EXE'].rsplit('/',1)[0]}/activate {os.environ['CONDA_PREFIX']} && "
         detailed += f"{self._conda_exe} update -c mantid/label/{suffix} mantidimaging"
         return msg, detailed
 


### PR DESCRIPTION
### Issue

Refs #1430

The issue can be closed after we have confirmed that the package can be built on Windows.

### Description

Only prints the second half of the version check message on Windows. The first half is only really required for IDAaaS and is not compatible with cmd or Powershell terminals. People using MI on a Windows machine should only need to run the second part of the message as they should already have the relevant environment activated.

### Testing & Acceptance Criteria 

I tested by changing `WelcomeScreenPresenter.check_issues` to force the console message to be printed on start-up.

### Documentation

Not required
