### PR TITLE
TomopyRecon.find_cor use prepare_sinogram to apply negative log

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -24,6 +24,7 @@ Fixes
 - #1405 : MedianFilter work inplace on ImageStack
 - #1395 : Delete file when NeXus saving fails
 - #1397 : Only use real NeXus projection angles
+- #1473 : Tomopy COR finder use -log
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/reconstruct/tomopy_recon.py
+++ b/mantidimaging/core/reconstruct/tomopy_recon.py
@@ -19,9 +19,10 @@ tomopy = safe_import('tomopy')
 class TomopyRecon(BaseRecon):
     @staticmethod
     def find_cor(images: ImageStack, slice_idx: int, start_cor: float, recon_params: ReconstructionParameters) -> float:
-        return tomopy.find_center(images.sinograms,
+        sino = BaseRecon.prepare_sinogram(images.sinograms[slice_idx:slice_idx + 1], recon_params)
+        return tomopy.find_center(sino,
                                   images.projection_angles(recon_params.max_projection_angle).value,
-                                  ind=slice_idx,
+                                  ind=0,
                                   init=start_cor,
                                   sinogram_order=True)
 

--- a/mantidimaging/core/reconstruct/tomopy_recon.py
+++ b/mantidimaging/core/reconstruct/tomopy_recon.py
@@ -19,7 +19,8 @@ tomopy = safe_import('tomopy')
 class TomopyRecon(BaseRecon):
     @staticmethod
     def find_cor(images: ImageStack, slice_idx: int, start_cor: float, recon_params: ReconstructionParameters) -> float:
-        sino = BaseRecon.prepare_sinogram(images.sinograms[slice_idx:slice_idx + 1], recon_params)
+        sino = np.maximum(images.sinograms[slice_idx:slice_idx + 1], 1e-6)
+        sino = BaseRecon.prepare_sinogram(sino, recon_params)
         return tomopy.find_center(sino,
                                   images.projection_angles(recon_params.max_projection_angle).value,
                                   ind=0,

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -380,10 +380,13 @@ class ReconstructWindowPresenter(BasePresenter):
             initial_cor = self.view.rotation_centre
 
         def _completed_finding_cors(task: TaskWorkerThread):
-            cors = task.result
-            for slice_idx, cor in zip(slice_indices, cors):
-                self.view.add_cor_table_row(selected_row, slice_idx, cor)
-            self.do_cor_fit()
+            if task.error is not None:
+                self.view.warn_user("Failure!", "Finding the COR failed.\n\n" f"Error: {str(task.error)}")
+            else:
+                cors = task.result
+                for slice_idx, cor in zip(slice_indices, cors):
+                    self.view.add_cor_table_row(selected_row, slice_idx, cor)
+                self.do_cor_fit()
             self.view.set_correlate_buttons_enabled(True)
 
         self.view.set_correlate_buttons_enabled(False)


### PR DESCRIPTION
### Issue
Closes #1473

### Description

Use prepare_sinogram to apply negative log. This prevents artefacts lowering the reliability of the fit.


### Testing & Acceptance Criteria 

In the reconstruction window choose the gridrec method.
On the first tab press minimise and see how good the line is.

With the phantom spheres I see the following improvement

![image](https://user-images.githubusercontent.com/74248560/169543813-3f14cbf2-f3b9-4dd5-a5a6-1a555caeded7.png)
to
![image](https://user-images.githubusercontent.com/74248560/169543857-7da3ceb8-03e3-4314-9054-218cc67ff52e.png)

### Documentation

release_notes
