### PR TITLE
Fix scaling when saving to int

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -25,6 +25,8 @@ Fixes
 - #1395 : Delete file when NeXus saving fails
 - #1397 : Only use real NeXus projection angles
 - #1473 : Tomopy COR finder use -log
+- #1475 : Fix scaling when saving to int
+
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -154,11 +154,11 @@ def image_save(images: ImageStack,
             for idx in range(num_images):
                 # Overwrite images with the copy that has been rescaled.
                 if pixel_depth == "int16":
-                    write_func(
-                        rescale_single_image(np.copy(images.data[idx]),
-                                             min_input=min_value,
-                                             max_input=max_value,
-                                             max_output=INT16_SIZE - 1), names[idx], overwrite_all, rescale_info)
+                    output_data = RescaleFilter.filter_single_image(np.copy(images.data[idx]),
+                                                                    min_input=min_value,
+                                                                    max_input=max_value,
+                                                                    max_output=INT16_SIZE - 1).astype(np.uint16)
+                    write_func(output_data, names[idx], overwrite_all, rescale_info)
                 else:
                     write_func(data[idx, :, :], names[idx], overwrite_all, rescale_info)
 
@@ -306,10 +306,6 @@ def _rescale_recon_data(data: np.ndarray) -> np.ndarray:
         data -= min_value
     data *= (np.iinfo("uint16").max / np.max(data))
     return data
-
-
-def rescale_single_image(image: np.ndarray, min_input: float, max_input: float, max_output: float) -> np.ndarray:
-    return RescaleFilter.filter_single_image(image, min_input, max_input, max_output, data_type=np.uint16)
 
 
 def generate_names(name_prefix: str,

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -154,10 +154,10 @@ def image_save(images: ImageStack,
             for idx in range(num_images):
                 # Overwrite images with the copy that has been rescaled.
                 if pixel_depth == "int16":
-                    output_data = RescaleFilter.filter_single_image(np.copy(images.data[idx]),
-                                                                    min_input=min_value,
-                                                                    max_input=max_value,
-                                                                    max_output=INT16_SIZE - 1).astype(np.uint16)
+                    output_data = RescaleFilter.filter_array(np.copy(images.data[idx]),
+                                                             min_input=min_value,
+                                                             max_input=max_value,
+                                                             max_output=INT16_SIZE - 1).astype(np.uint16)
                     write_func(output_data, names[idx], overwrite_all, rescale_info)
                 else:
                     write_func(data[idx, :, :], names[idx], overwrite_all, rescale_info)

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -5,7 +5,7 @@ from functools import partial
 from typing import Any, Dict
 
 import numpy as np
-from numpy import float32, nanmax, nanmin, ndarray, uint16
+from numpy import nanmax, nanmin, ndarray
 from PyQt5.QtWidgets import QComboBox, QDoubleSpinBox
 
 from mantidimaging.core.data import ImageStack
@@ -28,8 +28,7 @@ class RescaleFilter(BaseFilter):
                     min_input: float = 0.0,
                     max_input: float = 10000.0,
                     max_output: float = 256.0,
-                    progress=None,
-                    data_type=None) -> ImageStack:
+                    progress=None) -> ImageStack:
         np.clip(images.data, min_input, max_input, out=images.data)
         # offset - it removes any negative values so that they don't overflow when in uint16 range
         images.data -= nanmin(images.data)
@@ -37,32 +36,17 @@ class RescaleFilter(BaseFilter):
         # slope
         images.data *= (max_output / data_max)
 
-        if data_type is not None:
-            if data_type == uint16 and not images.dtype == uint16:
-                images.data = images.data.astype(uint16)
-            elif data_type == float32 and not images.dtype == float32:
-                images.data = images.data.astype(float32)
-
         return images
 
     @staticmethod
-    def filter_single_image(image: ndarray,
-                            min_input: float,
-                            max_input: float,
-                            max_output: float,
-                            data_type=float32) -> np.ndarray:
+    def filter_single_image(image: ndarray, min_input: float, max_input: float, max_output: float) -> np.ndarray:
         np.clip(image, min_input, max_input, out=image)
         image -= min_input
         data_max = nanmax(image)
 
         image *= (max_output / data_max)
 
-        if data_type == float32:
-            return image.astype(float32)
-        elif data_type == uint16:
-            return image.astype(uint16)
-        else:
-            raise ValueError("Only float32 and int16 data types are supported by single image rescale")
+        return image
 
     @staticmethod
     def register_gui(form, on_change, view: FiltersWindowView) -> Dict[str, Any]:

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -5,7 +5,6 @@ from functools import partial
 from typing import Any, Dict
 
 import numpy as np
-from numpy import nanmax, ndarray
 from PyQt5.QtWidgets import QComboBox, QDoubleSpinBox
 
 from mantidimaging.core.data import ImageStack
@@ -34,13 +33,8 @@ class RescaleFilter(BaseFilter):
         return images
 
     @staticmethod
-    def filter_array(image: ndarray, min_input: float, max_input: float, max_output: float) -> np.ndarray:
-        np.clip(image, min_input, max_input, out=image)
-        image -= min_input
-        data_max = nanmax(image)
-
-        image *= (max_output / data_max)
-
+    def filter_array(image: np.ndarray, min_input: float, max_input: float, max_output: float) -> np.ndarray:
+        image[:] = np.interp(image, [min_input, max_input], [0, max_output])
         return image
 
     @staticmethod

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -30,11 +30,11 @@ class RescaleFilter(BaseFilter):
                     max_output: float = 256.0,
                     progress=None) -> ImageStack:
 
-        RescaleFilter.filter_single_image(images.data, min_input, max_input, max_output)
+        RescaleFilter.filter_array(images.data, min_input, max_input, max_output)
         return images
 
     @staticmethod
-    def filter_single_image(image: ndarray, min_input: float, max_input: float, max_output: float) -> np.ndarray:
+    def filter_array(image: ndarray, min_input: float, max_input: float, max_output: float) -> np.ndarray:
         np.clip(image, min_input, max_input, out=image)
         image -= min_input
         data_max = nanmax(image)

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -5,7 +5,7 @@ from functools import partial
 from typing import Any, Dict
 
 import numpy as np
-from numpy import nanmax, nanmin, ndarray
+from numpy import nanmax, ndarray
 from PyQt5.QtWidgets import QComboBox, QDoubleSpinBox
 
 from mantidimaging.core.data import ImageStack
@@ -29,13 +29,8 @@ class RescaleFilter(BaseFilter):
                     max_input: float = 10000.0,
                     max_output: float = 256.0,
                     progress=None) -> ImageStack:
-        np.clip(images.data, min_input, max_input, out=images.data)
-        # offset - it removes any negative values so that they don't overflow when in uint16 range
-        images.data -= nanmin(images.data)
-        data_max = nanmax(images.data)
-        # slope
-        images.data *= (max_output / data_max)
 
+        RescaleFilter.filter_single_image(images.data, min_input, max_input, max_output)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/rescale/rescale_test.py
+++ b/mantidimaging/core/operations/rescale/rescale_test.py
@@ -70,10 +70,10 @@ def test_scale_single_image():
 
     images.data[0:2] = np.arange(-1, 1, step=0.0002).reshape(100, 100)
 
-    scaled_image = RescaleFilter.filter_single_image(copy(images.data[0]),
-                                                     min_input=images.data[0].min(),
-                                                     max_input=images.data[0].max(),
-                                                     max_output=65535)
+    scaled_image = RescaleFilter.filter_array(copy(images.data[0]),
+                                              min_input=images.data[0].min(),
+                                              max_input=images.data[0].max(),
+                                              max_output=65535)
     assert scaled_image.min() == 0
     assert scaled_image.max() == 65535
 
@@ -81,7 +81,7 @@ def test_scale_single_image():
 def test_scale_single_image_bad_offset():
     images = th.generate_images((2, 100, 100))
     try:
-        RescaleFilter.filter_single_image(copy(images.data[0]), min_input=-5000, max_input=5000, max_output=65535)
+        RescaleFilter.filter_array(copy(images.data[0]), min_input=-5000, max_input=5000, max_output=65535)
     except ValueError:
         pass
     except Exception as e:

--- a/mantidimaging/core/operations/rescale/rescale_test.py
+++ b/mantidimaging/core/operations/rescale/rescale_test.py
@@ -4,7 +4,7 @@
 import math
 import numpy as np
 import pytest
-from numpy import testing as npt, int16, uint16, float32, finfo, copy
+from numpy import testing as npt, copy
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.rescale import RescaleFilter
@@ -65,22 +65,7 @@ def test_execute_wrapper_with_preset(type: str, expected_max: float):
     assert partial.keywords['max_output'] == expected_max
 
 
-@pytest.mark.parametrize('type, max_value', [(uint16, 65535), (float32, finfo(float32).max)])
-def test_type_changes_to_given_type(type, max_value):
-    images = th.generate_images((10, 100, 100))
-
-    expected_min_input = 0
-    images = RescaleFilter.filter_func(images,
-                                       min_input=expected_min_input,
-                                       max_input=images.data.max(),
-                                       max_output=max_value,
-                                       data_type=type)
-
-    npt.assert_equal(images.dtype, type)
-
-
-@pytest.mark.parametrize('type', [uint16, float32])
-def test_scale_single_image(type):
+def test_scale_single_image():
     images = th.generate_images((2, 100, 100))
 
     images.data[0:2] = np.arange(-1, 1, step=0.0002).reshape(100, 100)
@@ -88,22 +73,15 @@ def test_scale_single_image(type):
     scaled_image = RescaleFilter.filter_single_image(copy(images.data[0]),
                                                      min_input=images.data[0].min(),
                                                      max_input=images.data[0].max(),
-                                                     max_output=65535,
-                                                     data_type=type)
+                                                     max_output=65535)
     assert scaled_image.min() == 0
     assert scaled_image.max() == 65535
-    assert scaled_image.dtype != int16, \
-        "Ensure not using signed int16 - this will make all values over 32768 overflow to negative"
 
 
 def test_scale_single_image_bad_offset():
     images = th.generate_images((2, 100, 100))
     try:
-        RescaleFilter.filter_single_image(copy(images.data[0]),
-                                          min_input=-5000,
-                                          max_input=5000,
-                                          max_output=65535,
-                                          data_type=uint16)
+        RescaleFilter.filter_single_image(copy(images.data[0]), min_input=-5000, max_input=5000, max_output=65535)
     except ValueError:
         pass
     except Exception as e:

--- a/mantidimaging/eyes_tests/reconstruct_window_test.py
+++ b/mantidimaging/eyes_tests/reconstruct_window_test.py
@@ -2,6 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import numpy as np
+from PyQt5.QtTest import QTest
 from PyQt5.QtWidgets import QApplication
 
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
@@ -18,28 +19,33 @@ class ReconstructionWindowTest(BaseEyesTest):
         self.imaging.recon.close()
         super().tearDown()
 
-    def test_reconstruction_window_opens(self):
+    def _show_recon_window(self):
         self.imaging.show_recon_window()
+        QTest.qWaitForWindowExposed(self.imaging.recon)
+
+    def test_reconstruction_window_opens(self):
+        self._show_recon_window()
 
         self.check_target(widget=self.imaging.recon)
 
     def test_reconstruction_window_opens_with_data(self):
         self._load_data_set()
 
-        self.imaging.show_recon_window()
+        self._show_recon_window()
+
         wait_until(lambda: len(self.imaging.recon.presenter.async_tracker) == 0)
 
         self.check_target(widget=self.imaging.recon)
 
     def test_reconstruction_window_cor_and_tilt_tab(self):
-        self.imaging.show_recon_window()
+        self._show_recon_window()
 
         self.imaging.recon.tabWidget.setCurrentWidget(self.imaging.recon.resultsTab)
 
         self.check_target(widget=self.imaging.recon)
 
     def test_reconstruction_window_reconstruct_tab(self):
-        self.imaging.show_recon_window()
+        self._show_recon_window()
 
         self.imaging.recon.tabWidget.setCurrentWidget(self.imaging.recon.reconTab)
 
@@ -57,13 +63,13 @@ class ReconstructionWindowTest(BaseEyesTest):
         images.data[0:, 3:4] = -1
         images.data[0:, 0:1] = np.nan
 
-        self.imaging.show_recon_window()
+        self._show_recon_window()
         self.check_target(widget=self.imaging.recon)
 
     def test_reconstruction_window_colour_palette_dialog(self):
         self._load_data_set()
 
-        self.imaging.show_recon_window()
+        self._show_recon_window()
         self.imaging.recon.image_view.imageview_recon.setImage(np.zeros((512, 512)))
         self.imaging.recon.changeColourPaletteButton.click()
 


### PR DESCRIPTION
### Issue

Closes #1475

### Description

The scaling operation was using nanmax() of each slice in the scaling calculation. Change to to only depend on the function arguments, as this is what is really wanted.

Unify the 2 methods in the filter to reduce duplication.

Use numpy interp, because it does the scaling and clipping that we want in a single step

Note this does change the behaviour of the rescale operation, but in a way that makes it more sensible.

### Testing & Acceptance Criteria 

See bug report

### Documentation

Release_notes
