### PR TITLE
Add publish step to windows workflow for testing

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -121,3 +121,11 @@ jobs:
         run: |
           python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests --durations=10
         timeout-minutes: 15
+
+      # For testing package building on Windows, which is why we upload with label 'windows-build-test'
+      - name: publish 'windows-build-test' package
+        if: github.event_name == 'release' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release')))
+        uses: ./.github/actions/publish-package
+        with:
+          label: windows-build-test
+          token: ${{ secrets.ANACONDA_API_TOKEN }}


### PR DESCRIPTION
### Issue

Refs #1430

### Description

Adds a publish step into the Windows workflow to test if the package builds OK using GitHub Actions on Windows. We're uploading using label `windows-build-test` as the packages are only for testing purposes. Do I need to create this label on Anaconda, or will it be created automatically on the first upload?

### Testing & Acceptance Criteria 

This PR can only be tested once it's been merged in. We will need to check the following:

1) The Windows package builds and is uploaded successfully.
2) The package can be downloaded and runs correctly on both Windows and Linux.

Once testing is complete, the issue can be closed and the label can be disabled.

### Documentation

Not required.
