### PR TITLE
Add line profile to reconstruction window

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -17,6 +17,7 @@ New Features
 - #1430 : Provide an Anaconda package that is compatible with Windows
 - #1398 : Save recons to NeXus file
 - #1444 : CIL PDHG non-negativity constraint
+- #1483 : Add line profile to reconstruction window
 
 Fixes
 -----

--- a/mantidimaging/gui/widgets/line_profile_plot/test/view_test.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/test/view_test.py
@@ -1,0 +1,143 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+import unittest
+from unittest import mock
+
+import numpy as np
+from PyQt5.QtCore import QRect
+from parameterized import parameterized
+
+from mantidimaging.gui.widgets.line_profile_plot.view import LineProfilePlot, MILineSegmentROI
+from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
+from mantidimaging.test_helpers import start_qapplication
+
+
+@start_qapplication
+class LineProfilePlotTest(unittest.TestCase):
+    IMAGE_WIDTH = 10
+    IMAGE_HEIGHT = 15
+    IMAGE = np.zeros((IMAGE_HEIGHT, IMAGE_WIDTH))
+    INITIAL_POS = [(0, 0), (IMAGE_WIDTH, 0)]
+    BOUNDS = QRect(0, 0, IMAGE_WIDTH, IMAGE_HEIGHT)
+
+    def setUp(self) -> None:
+        self.image_view = MIMiniImageView()
+        self.line_profile = LineProfilePlot(self.image_view)
+
+    def test_roi_bounds(self):
+        self._set_image()
+        bounds = self.line_profile._roi_bounds()
+        self.assertIsInstance(bounds, QRect)
+        self.assertEqual(bounds.x(), 0)
+        self.assertEqual(bounds.y(), 0)
+        self.assertEqual(bounds.height(), self.IMAGE_HEIGHT)
+        self.assertEqual(bounds.width(), self.IMAGE_WIDTH)
+
+    def test_roi_initial_pos_no_image(self):
+        self.assertIsNone(self.line_profile._roi_initial_pos())
+
+    def test_roi_initial_pos_with_image(self):
+        self._set_image()
+        initial_pos = self.line_profile._roi_initial_pos()
+        self.assertIsNotNone(initial_pos)
+        self.assertEqual(initial_pos, self.INITIAL_POS)
+
+    def test_roi_line_needs_resetting_no_image(self):
+        self.assertFalse(self.line_profile._roi_line_needs_resetting())
+
+    def test_roi_line_needs_resetting_no_roi_line(self):
+        self._set_image()
+        self.assertFalse(self.line_profile._roi_line_needs_resetting())
+
+    @parameterized.expand([("Diff width", IMAGE_WIDTH + 5, IMAGE_HEIGHT, True),
+                           ("Diff height", IMAGE_WIDTH, IMAGE_HEIGHT + 5, True),
+                           ("Same dimensions", IMAGE_WIDTH, IMAGE_HEIGHT, False)])
+    def test_roi_line_needs_resetting(self, _, width, height, expected_result):
+        self._set_image()
+        self.line_profile._roi_line = mock.Mock()
+        self.line_profile._roi_line.maxBounds.width.return_value = width
+        self.line_profile._roi_line.maxBounds.height.return_value = height
+
+        self.assertEqual(self.line_profile._roi_line_needs_resetting(), expected_result)
+
+    def test_try_add_roi_to_image_view_no_image(self):
+        self.assertFalse(self.line_profile._try_add_roi_to_image_view())
+
+    def test_try_add_roi_to_image_view(self):
+        self._set_image()
+        result = self.line_profile._try_add_roi_to_image_view()
+        self.assertTrue(result)
+        self.assertIsInstance(self.line_profile._roi_line, MILineSegmentROI)
+        self._check_state_and_bounds()
+        self.assertTrue(self.line_profile._roi_line in self.image_view.viewbox.addedItems)
+
+    def test_add_roi_reset_menu_option(self):
+        self.line_profile._add_roi_reset_menu_option()
+        self.assertIsNotNone(self.line_profile._reset_roi)
+        self.assertTrue(self.line_profile._reset_roi in self.image_view.viewbox.menu.actions())
+
+    def test_reset_roi_line_no_initial_state(self):
+        self.assertIsNone(self.line_profile._roi_initial_state)
+        self.line_profile._roi_initial_pos = mock.Mock()
+        self.line_profile.reset_roi_line(force_reset=True)
+        self.line_profile._roi_initial_pos.assert_not_called()
+
+    def test_reset_roi_line_no_need_for_reset(self):
+        self.line_profile._roi_initial_state = mock.Mock()
+        self.line_profile._roi_line_needs_resetting = mock.Mock()
+        self.line_profile._roi_line_needs_resetting.return_value = False
+        self.line_profile._roi_initial_pos = mock.Mock()
+        self.line_profile.reset_roi_line(force_reset=False)
+        self.line_profile._roi_initial_pos.assert_not_called()
+
+    def test_reset_roi_line(self):
+        self._set_image()
+        self.line_profile._try_add_roi_to_image_view()
+        self._check_state_and_bounds()
+
+        new_height = self.IMAGE_HEIGHT + 5
+        new_width = self.IMAGE_WIDTH + 5
+        reset_position = [(0, 0), (new_width, 0)]
+        reset_bounds = QRect(0, 0, new_width, new_height)
+        self.line_profile._roi_initial_pos = mock.Mock()
+        self.line_profile._roi_initial_pos.return_value = reset_position
+        self.line_profile._roi_bounds = mock.Mock()
+        self.line_profile._roi_bounds.return_value = reset_bounds
+        self.line_profile.reset_roi_line(force_reset=True)
+        self._check_state_and_bounds(reset_position, reset_bounds)
+
+    def test_update_plot_with_roi(self):
+        self.line_profile._roi_line = mock.Mock()
+        self.line_profile._roi_line.getArrayRegion = mock.Mock()
+        self.line_profile._line_profile.setData = mock.Mock()
+
+        self.line_profile.update_plot()
+        self.line_profile._roi_line.getArrayRegion.assert_called_once()
+        self.line_profile._line_profile.setData.assert_called_once()
+
+    def test_update_plot_no_roi_and_cannot_add(self):
+        self.assertIsNone(self.line_profile._roi_line)
+        self.line_profile._try_add_roi_to_image_view = mock.Mock()
+        self.line_profile._try_add_roi_to_image_view.return_value = False
+        self.line_profile._line_profile.setData = mock.Mock()
+
+        self.line_profile.update_plot()
+        self.line_profile._line_profile.setData.assert_not_called()
+
+    def test_update_plot_no_roi_and_can_add(self):
+        self.assertIsNone(self.line_profile._roi_line)
+        self.line_profile._line_profile.setData = mock.Mock()
+
+        self._set_image()
+        self.line_profile.update_plot()
+        self.line_profile._line_profile.setData.assert_called_once()
+
+    def _set_image(self, image=IMAGE):
+        self.image_view.setImage(image)
+
+    def _check_state_and_bounds(self, expected_points=INITIAL_POS, expected_bounds=BOUNDS):
+        self.assertIsNotNone(self.line_profile._roi_initial_state)
+        self.assertIsNotNone(self.line_profile._roi_line.maxBounds)
+        self.assertEqual(self.line_profile._roi_initial_state['points'], expected_points)
+        self.assertEqual(self.line_profile._roi_line.saveState()['points'], expected_points)
+        self.assertEqual(self.line_profile._roi_line.maxBounds, expected_bounds)

--- a/mantidimaging/gui/widgets/line_profile_plot/test/view_test.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/test/view_test.py
@@ -7,137 +7,146 @@ import numpy as np
 from PyQt5.QtCore import QRect
 from parameterized import parameterized
 
-from mantidimaging.gui.widgets.line_profile_plot.view import LineProfilePlot, MILineSegmentROI
+from mantidimaging.gui.widgets.line_profile_plot.view import LineProfilePlot, ImageViewLineROI
 from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
 from mantidimaging.test_helpers import start_qapplication
 
+IMAGE_WIDTH = 10
+IMAGE_HEIGHT = 15
+IMAGE = np.zeros((IMAGE_HEIGHT, IMAGE_WIDTH))
+INITIAL_POS = [(0, 0), (IMAGE_WIDTH, 0)]
+BOUNDS = QRect(0, 0, IMAGE_WIDTH, IMAGE_HEIGHT)
+
+
+def check_state_and_bounds(roi_line: ImageViewLineROI, initial_pos=INITIAL_POS, bounds=BOUNDS):
+    assert roi_line.maxBounds is not None
+    assert roi_line._initial_state['points'] == initial_pos
+    assert roi_line.saveState()['points'] == initial_pos
+    assert roi_line.maxBounds == bounds
+
 
 @start_qapplication
-class LineProfilePlotTest(unittest.TestCase):
-    IMAGE_WIDTH = 10
-    IMAGE_HEIGHT = 15
-    IMAGE = np.zeros((IMAGE_HEIGHT, IMAGE_WIDTH))
-    INITIAL_POS = [(0, 0), (IMAGE_WIDTH, 0)]
-    BOUNDS = QRect(0, 0, IMAGE_WIDTH, IMAGE_HEIGHT)
-
-    def setUp(self) -> None:
+class ImageViewLineROITest(unittest.TestCase):
+    def setUp(self):
         self.image_view = MIMiniImageView()
-        self.line_profile = LineProfilePlot(self.image_view)
+        self.roi_line = ImageViewLineROI(self.image_view)
 
-    def test_roi_bounds(self):
+    def test_reset_is_needed_no_image_data(self):
+        self.assertFalse(self.roi_line.reset_is_needed())
+
+    def test_reset_is_needed_roi_not_visible(self):
         self._set_image()
-        bounds = self.line_profile._roi_bounds()
-        self.assertIsInstance(bounds, QRect)
-        self.assertEqual(bounds.x(), 0)
-        self.assertEqual(bounds.y(), 0)
-        self.assertEqual(bounds.height(), self.IMAGE_HEIGHT)
-        self.assertEqual(bounds.width(), self.IMAGE_WIDTH)
 
-    def test_roi_initial_pos_no_image(self):
-        self.assertIsNone(self.line_profile._roi_initial_pos())
-
-    def test_roi_initial_pos_with_image(self):
-        self._set_image()
-        initial_pos = self.line_profile._roi_initial_pos()
-        self.assertIsNotNone(initial_pos)
-        self.assertEqual(initial_pos, self.INITIAL_POS)
-
-    def test_roi_line_needs_resetting_no_image(self):
-        self.assertFalse(self.line_profile._roi_line_needs_resetting())
-
-    def test_roi_line_needs_resetting_no_roi_line(self):
-        self._set_image()
-        self.assertFalse(self.line_profile._roi_line_needs_resetting())
+        self.assertFalse(self.roi_line.reset_is_needed())
 
     @parameterized.expand([("Diff width", IMAGE_WIDTH + 5, IMAGE_HEIGHT, True),
                            ("Diff height", IMAGE_WIDTH, IMAGE_HEIGHT + 5, True),
                            ("Same dimensions", IMAGE_WIDTH, IMAGE_HEIGHT, False)])
-    def test_roi_line_needs_resetting(self, _, width, height, expected_result):
+    def test_reset_is_needed(self, _, width, height, expected_result):
+        self._set_image(np.zeros((height, width)))
+        self.roi_line._roi_line_is_visible = True
+        self.roi_line.maxBounds = BOUNDS
+
+        self.assertEqual(self.roi_line.reset_is_needed(), expected_result)
+
+    def test_add_reset_menu_option(self):
+        self.roi_line._add_reset_menu_option()
+
+        self.assertIsNotNone(self.roi_line._reset_option)
+        self.assertTrue(self.roi_line._reset_option in self.image_view.viewbox.menu.actions())
+
+    def test_add_roi_to_image(self):
         self._set_image()
-        self.line_profile._roi_line = mock.Mock()
-        self.line_profile._roi_line.maxBounds.width.return_value = width
-        self.line_profile._roi_line.maxBounds.height.return_value = height
+        self.assertFalse(self.roi_line._roi_line_is_visible)
+        self.roi_line._add_roi_to_image()
 
-        self.assertEqual(self.line_profile._roi_line_needs_resetting(), expected_result)
+        check_state_and_bounds(self.roi_line)
+        self.assertTrue(self.roi_line in self.image_view.viewbox.addedItems)
+        self.assertTrue(self.roi_line._roi_line_is_visible)
 
-    def test_try_add_roi_to_image_view_no_image(self):
-        self.assertFalse(self.line_profile._try_add_roi_to_image_view())
+    def test_reset_no_image_data(self):
+        self.roi_line._set_initial_state = mock.Mock()
+        self.roi_line.reset()
 
-    def test_try_add_roi_to_image_view(self):
+        self.roi_line._set_initial_state.assert_not_called()
+
+    def test_reset_roi_not_visible(self):
         self._set_image()
-        result = self.line_profile._try_add_roi_to_image_view()
-        self.assertTrue(result)
-        self.assertIsInstance(self.line_profile._roi_line, MILineSegmentROI)
-        self._check_state_and_bounds()
-        self.assertTrue(self.line_profile._roi_line in self.image_view.viewbox.addedItems)
+        self.roi_line._set_initial_state = mock.Mock()
+        self.roi_line.reset()
 
-    def test_add_roi_reset_menu_option(self):
-        self.line_profile._add_roi_reset_menu_option()
-        self.assertIsNotNone(self.line_profile._reset_roi)
-        self.assertTrue(self.line_profile._reset_roi in self.image_view.viewbox.menu.actions())
+        self.roi_line._set_initial_state.assert_not_called()
 
-    def test_reset_roi_line_no_initial_state(self):
-        self.assertIsNone(self.line_profile._roi_initial_state)
-        self.line_profile._roi_initial_pos = mock.Mock()
-        self.line_profile.reset_roi_line(force_reset=True)
-        self.line_profile._roi_initial_pos.assert_not_called()
-
-    def test_reset_roi_line_no_need_for_reset(self):
-        self.line_profile._roi_initial_state = mock.Mock()
-        self.line_profile._roi_line_needs_resetting = mock.Mock()
-        self.line_profile._roi_line_needs_resetting.return_value = False
-        self.line_profile._roi_initial_pos = mock.Mock()
-        self.line_profile.reset_roi_line(force_reset=False)
-        self.line_profile._roi_initial_pos.assert_not_called()
-
-    def test_reset_roi_line(self):
+    def test_reset(self):
         self._set_image()
-        self.line_profile._try_add_roi_to_image_view()
-        self._check_state_and_bounds()
+        self.roi_line._roi_line_is_visible = True
+        self.roi_line.reset()
 
-        new_height = self.IMAGE_HEIGHT + 5
-        new_width = self.IMAGE_WIDTH + 5
-        reset_position = [(0, 0), (new_width, 0)]
-        reset_bounds = QRect(0, 0, new_width, new_height)
-        self.line_profile._roi_initial_pos = mock.Mock()
-        self.line_profile._roi_initial_pos.return_value = reset_position
-        self.line_profile._roi_bounds = mock.Mock()
-        self.line_profile._roi_bounds.return_value = reset_bounds
-        self.line_profile.reset_roi_line(force_reset=True)
-        self._check_state_and_bounds(reset_position, reset_bounds)
+        check_state_and_bounds(self.roi_line)
 
-    def test_update_plot_with_roi(self):
-        self.line_profile._roi_line = mock.Mock()
-        self.line_profile._roi_line.getArrayRegion = mock.Mock()
-        self.line_profile._line_profile.setData = mock.Mock()
+    def test_get_image_region_no_image_data(self):
+        self.assertIsNone(self.roi_line.get_image_region())
 
-        self.line_profile.update_plot()
-        self.line_profile._roi_line.getArrayRegion.assert_called_once()
-        self.line_profile._line_profile.setData.assert_called_once()
-
-    def test_update_plot_no_roi_and_cannot_add(self):
-        self.assertIsNone(self.line_profile._roi_line)
-        self.line_profile._try_add_roi_to_image_view = mock.Mock()
-        self.line_profile._try_add_roi_to_image_view.return_value = False
-        self.line_profile._line_profile.setData = mock.Mock()
-
-        self.line_profile.update_plot()
-        self.line_profile._line_profile.setData.assert_not_called()
-
-    def test_update_plot_no_roi_and_can_add(self):
-        self.assertIsNone(self.line_profile._roi_line)
-        self.line_profile._line_profile.setData = mock.Mock()
-
+    def test_get_image_region_no_visible_roi(self):
         self._set_image()
-        self.line_profile.update_plot()
-        self.line_profile._line_profile.setData.assert_called_once()
+        self.assertIsNotNone(self.roi_line.get_image_region())
+
+    def test_get_image_region_visible_roi(self):
+        self._set_image()
+        self.roi_line._add_roi_to_image()
+        self.assertIsNotNone(self.roi_line.get_image_region())
 
     def _set_image(self, image=IMAGE):
         self.image_view.setImage(image)
 
-    def _check_state_and_bounds(self, expected_points=INITIAL_POS, expected_bounds=BOUNDS):
-        self.assertIsNotNone(self.line_profile._roi_initial_state)
-        self.assertIsNotNone(self.line_profile._roi_line.maxBounds)
-        self.assertEqual(self.line_profile._roi_initial_state['points'], expected_points)
-        self.assertEqual(self.line_profile._roi_line.saveState()['points'], expected_points)
-        self.assertEqual(self.line_profile._roi_line.maxBounds, expected_bounds)
+
+@start_qapplication
+class LineProfilePlotTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.image_view = MIMiniImageView()
+        self.line_profile = LineProfilePlot(self.image_view)
+
+    def test_update_no_image_data(self):
+        self.line_profile._line_profile.setData = mock.Mock()
+        self.line_profile.clear_plot = mock.Mock()
+        self.line_profile.update()
+
+        self.line_profile._line_profile.setData.assert_not_called()
+        self.line_profile.clear_plot.assert_called_once()
+
+    def test_update(self):
+        self.line_profile._line_profile.setData = mock.Mock()
+        self._set_image()
+        self.line_profile.update()
+
+        self.line_profile._line_profile.setData.assert_called_once()
+
+    def test_reset_with_roi_reset(self):
+        self.line_profile._line_profile.setData = mock.Mock()
+        self._set_image()
+        self.line_profile._roi_line._add_roi_to_image()
+
+        # Update the image data so that an ROI reset would be needed
+        new_width = IMAGE_WIDTH + 5
+        self._set_image(np.zeros((IMAGE_HEIGHT, new_width)))
+        self.line_profile._roi_line.reset_is_needed = mock.Mock()
+        self.line_profile._roi_line.reset_is_needed.return_value = True
+
+        self.line_profile.reset()
+
+        check_state_and_bounds(self.line_profile._roi_line, [(0, 0), (new_width, 0)],
+                               QRect(0, 0, new_width, IMAGE_HEIGHT))
+        self.line_profile._line_profile.setData.assert_called_once()
+
+    def test_reset_without_roi_reset(self):
+        self.line_profile._line_profile.setData = mock.Mock()
+        self._set_image()
+        self.line_profile._roi_line._add_roi_to_image()
+        self.line_profile._roi_line.reset_is_needed = mock.Mock()
+        self.line_profile._roi_line.reset_is_needed.return_value = False
+        self.line_profile.reset()
+
+        self.line_profile._line_profile.setData.assert_called_once()
+
+    def _set_image(self, image=IMAGE):
+        self.image_view.setImage(image)

--- a/mantidimaging/gui/widgets/line_profile_plot/view.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/view.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Union, Optional
 
 from PyQt5.QtCore import QRect
 from pyqtgraph import GraphicsLayout, LineSegmentROI
@@ -18,7 +18,7 @@ class LineProfilePlot(GraphicsLayout):
 
         self._plot = self.addPlot()
         self._line_profile = self._plot.plot()
-        self._roi_line = ImageViewLineROI(image_view)
+        self._roi_line = ImageViewLineROI(image_view, reset_menu_name="Reset Profile Line")
         self._roi_line.sigRegionChanged.connect(self.update)
 
     def update(self) -> None:
@@ -42,11 +42,11 @@ class LineProfilePlot(GraphicsLayout):
 
 
 class ImageViewLineROI(LineSegmentROI):
-    def __init__(self, image_view: Union['MIMiniImageView', 'MIImageView']):
+    def __init__(self, image_view: Union['MIMiniImageView', 'MIImageView'], reset_menu_name: Optional[str] = None):
         super().__init__(positions=[(0, 0), (0, 0)], pen='r')
 
         self._image_view = image_view
-        self._add_reset_menu_option()
+        self._add_reset_menu_option(reset_menu_name)
         self._initial_state = self.saveState()
         self._roi_line_is_visible = False
 
@@ -98,7 +98,8 @@ class ImageViewLineROI(LineSegmentROI):
         self._image_view.viewbox.addItem(self)
         self._roi_line_is_visible = True
 
-    def _add_reset_menu_option(self) -> None:
-        self._reset_option = self._image_view.viewbox.menu.addAction("Reset Profile Line")
+    def _add_reset_menu_option(self, reset_menu_name: Optional[str] = None) -> None:
+        menu_name = reset_menu_name if reset_menu_name is not None else "Reset ROI line"
+        self._reset_option = self._image_view.viewbox.menu.addAction(menu_name)
         self._image_view.viewbox.menu.insertSeparator(self._reset_option)
         self._reset_option.triggered.connect(lambda: self.reset())

--- a/mantidimaging/gui/widgets/line_profile_plot/view.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/view.py
@@ -48,7 +48,7 @@ class LineProfilePlot(GraphicsLayout):
         return True
 
     def _add_roi_reset_menu_option(self) -> None:
-        self._reset_roi = self._image_view.viewbox.menu.addAction("Reset ROI")
+        self._reset_roi = self._image_view.viewbox.menu.addAction("Reset Profile Line")
         self._image_view.viewbox.menu.insertSeparator(self._reset_roi)
         self._reset_roi.triggered.connect(lambda: self.reset_roi_line(True))
 

--- a/mantidimaging/gui/widgets/line_profile_plot/view.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/view.py
@@ -1,0 +1,81 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from typing import TYPE_CHECKING, Union
+
+from PyQt5.QtCore import QRect
+from pyqtgraph import GraphicsLayout, LineSegmentROI
+
+if TYPE_CHECKING:
+    from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
+    from mantidimaging.gui.widgets.mi_image_view.view import MIImageView
+
+
+class LineProfilePlot(GraphicsLayout):
+    def __init__(self, image_view: Union['MIMiniImageView', 'MIImageView'], enable_roi_reset: bool = True):
+        super().__init__()
+
+        self._line_profile = self.addPlot().plot()
+        self._image_view = image_view
+        self._roi_line = None
+        self._roi_initial_state = None
+
+        self.update_plot()
+        if enable_roi_reset:
+            self._add_roi_reset_menu_option()
+
+    def update_plot(self):
+        if self._roi_line is not None or self._try_add_roi_to_image_view():
+            roi_slice = self._roi_line.getArrayRegion(self._image_view.image_data,
+                                                      self._image_view.image_item,
+                                                      axes=(1, 0))
+            self._line_profile.setData(roi_slice)
+
+    def reset_roi_line(self, force_reset: bool = False):
+        if self._roi_initial_state is not None and (force_reset or self._roi_line_needs_resetting()):
+            self._roi_initial_state['points'] = self._roi_initial_pos()
+            self._roi_line.setState(self._roi_initial_state)
+            self._roi_line.maxBounds = self._roi_bounds()
+
+    def _try_add_roi_to_image_view(self):
+        initial_position = self._roi_initial_pos()
+        if initial_position is None:
+            return False
+
+        self._roi_line = MILineSegmentROI(positions=initial_position, pen='r', maxBounds=self._roi_bounds())
+        self._image_view.viewbox.addItem(self._roi_line)
+        self._roi_line.sigRegionChanged.connect(self.update_plot)
+        self._roi_initial_state = self._roi_line.saveState()
+        return True
+
+    def _add_roi_reset_menu_option(self):
+        self._reset_roi = self._image_view.viewbox.menu.addAction("Reset ROI")
+        self._image_view.viewbox.menu.insertSeparator(self._reset_roi)
+        self._reset_roi.triggered.connect(lambda: self.reset_roi_line(True))
+
+    def _roi_line_needs_resetting(self):
+        image_width = self._image_view.image_item.width()
+        if image_width is None:
+            return False
+
+        roi_bound_width = self._roi_line.maxBounds.width()
+        roi_bound_height = self._roi_line.maxBounds.height()
+        return roi_bound_width != image_width or roi_bound_height != self._image_view.image_item.height()
+
+    def _roi_initial_pos(self):
+        image_width = self._image_view.image_item.width()
+        return [(0, 0), (image_width, 0)] if image_width is not None else None
+
+    def _roi_bounds(self):
+        return QRect(0, 0, self._image_view.image_item.width(), self._image_view.image_item.height())
+
+
+class MILineSegmentROI(LineSegmentROI):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def checkPointMove(self, handle, pos, modifiers):
+        if self.maxBounds is None:
+            return True
+
+        new_point = self.getViewBox().mapSceneToView(pos)
+        return self.maxBounds.contains(new_point.x(), new_point.y())

--- a/mantidimaging/gui/widgets/line_profile_plot/view.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/view.py
@@ -1,9 +1,11 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-from typing import TYPE_CHECKING, Union, Tuple, Optional
+from typing import TYPE_CHECKING, Union
 
 from PyQt5.QtCore import QRect
 from pyqtgraph import GraphicsLayout, LineSegmentROI
+
+from mantidimaging.gui.utility import BlockQtSignals
 
 if TYPE_CHECKING:
     from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
@@ -11,67 +13,46 @@ if TYPE_CHECKING:
 
 
 class LineProfilePlot(GraphicsLayout):
-    def __init__(self, image_view: Union['MIMiniImageView', 'MIImageView'], enable_roi_reset: bool = True):
+    def __init__(self, image_view: Union['MIMiniImageView', 'MIImageView']):
         super().__init__()
 
-        self._line_profile = self.addPlot().plot()
+        self._plot = self.addPlot()
+        self._line_profile = self._plot.plot()
+        self._roi_line = ImageViewLineROI(image_view)
+        self._roi_line.sigRegionChanged.connect(self.update)
+
+    def update(self) -> None:
+        image_region = self._roi_line.get_image_region()
+        if image_region is None:
+            self.clear_plot()
+        else:
+            self._line_profile.setData(image_region)
+
+    def reset(self) -> None:
+        if self._roi_line.reset_is_needed():
+            self._roi_line.reset()
+        else:
+            # Even if we don't need to move the ROI line, we may have new image data to plot
+            self.update()
+
+    def clear_plot(self):
+        # Calling self._line_profile.clear() seems to be very slow, so we use this approach instead
+        self._plot.clear()
+        self._line_profile = self._plot.plot()
+
+
+class ImageViewLineROI(LineSegmentROI):
+    def __init__(self, image_view: Union['MIMiniImageView', 'MIImageView']):
+        super().__init__(positions=[(0, 0), (0, 0)], pen='r')
+
         self._image_view = image_view
-        self._roi_line: Optional[MILineSegmentROI] = None
-        self._roi_initial_state = None
+        self._add_reset_menu_option()
+        self._initial_state = self.saveState()
+        self._roi_line_is_visible = False
 
-        self.update_plot()
-        if enable_roi_reset:
-            self._add_roi_reset_menu_option()
-
-    def update_plot(self):
-        if self._roi_line is not None or self._try_add_roi_to_image_view():
-            roi_slice = self._roi_line.getArrayRegion(self._image_view.image_data,
-                                                      self._image_view.image_item,
-                                                      axes=(1, 0))
-            self._line_profile.setData(roi_slice)
-
-    def reset_roi_line(self, force_reset: bool = False) -> None:
-        if self._roi_initial_state is not None and (force_reset or self._roi_line_needs_resetting()):
-            self._roi_initial_state['points'] = self._roi_initial_pos()
-            self._roi_line.setState(self._roi_initial_state)
-            self._roi_line.maxBounds = self._roi_bounds()
-
-    def _try_add_roi_to_image_view(self) -> bool:
-        initial_position = self._roi_initial_pos()
-        if initial_position is None:
-            return False
-
-        self._roi_line = MILineSegmentROI(positions=initial_position, pen='r', maxBounds=self._roi_bounds())
-        self._image_view.viewbox.addItem(self._roi_line)
-        self._roi_line.sigRegionChanged.connect(self.update_plot)
-        self._roi_initial_state = self._roi_line.saveState()
-        return True
-
-    def _add_roi_reset_menu_option(self) -> None:
-        self._reset_roi = self._image_view.viewbox.menu.addAction("Reset Profile Line")
-        self._image_view.viewbox.menu.insertSeparator(self._reset_roi)
-        self._reset_roi.triggered.connect(lambda: self.reset_roi_line(True))
-
-    def _roi_line_needs_resetting(self) -> bool:
-        image_width = self._image_view.image_item.width()
-        if image_width is None or self._roi_line is None:
-            return False
-
-        roi_bound_width = self._roi_line.maxBounds.width()
-        roi_bound_height = self._roi_line.maxBounds.height()
-        return roi_bound_width != image_width or roi_bound_height != self._image_view.image_item.height()
-
-    def _roi_initial_pos(self) -> Optional[list[Tuple[int, int]]]:
-        image_width = self._image_view.image_item.width()
-        return [(0, 0), (image_width, 0)] if image_width is not None else None
-
-    def _roi_bounds(self) -> QRect:
-        return QRect(0, 0, self._image_view.image_item.width(), self._image_view.image_item.height())
-
-
-class MILineSegmentROI(LineSegmentROI):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        # We can't add the ROI line until we have some image data dimensions to position it
+        if self._image_data_exists():
+            self._add_roi_to_image()
 
     def checkPointMove(self, handle, pos, modifiers) -> bool:
         if self.maxBounds is None:
@@ -79,3 +60,45 @@ class MILineSegmentROI(LineSegmentROI):
 
         new_point = self.getViewBox().mapSceneToView(pos)
         return self.maxBounds.contains(new_point.x(), new_point.y())
+
+    def get_image_region(self):
+        if not self._image_data_exists():
+            return None
+
+        if not self._roi_line_is_visible:
+            self._add_roi_to_image()
+
+        return self.getArrayRegion(self._image_view.image_data, self._image_view.image_item, axes=(1, 0))
+
+    def reset(self) -> None:
+        if self._image_data_exists() and self._roi_line_is_visible:
+            self._set_initial_state()
+            self.sigRegionChanged.emit(self)
+
+    def reset_is_needed(self) -> bool:
+        if not self._image_data_exists() or not self._roi_line_is_visible:
+            return False
+
+        image_width = self._image_view.image_item.width()
+        image_height = self._image_view.image_item.height()
+        return self.maxBounds.width() != image_width or self.maxBounds.height() != image_height
+
+    def _image_data_exists(self) -> bool:
+        return self._image_view.image_data is not None
+
+    def _set_initial_state(self) -> None:
+        # Prevent emitting a RegionChanged signal from setting the state programmatically
+        with BlockQtSignals(self):
+            self._initial_state['points'] = [(0, 0), (self._image_view.image_item.width(), 0)]
+            self.setState(self._initial_state)
+            self.maxBounds = QRect(0, 0, self._image_view.image_item.width(), self._image_view.image_item.height())
+
+    def _add_roi_to_image(self) -> None:
+        self._set_initial_state()
+        self._image_view.viewbox.addItem(self)
+        self._roi_line_is_visible = True
+
+    def _add_reset_menu_option(self) -> None:
+        self._reset_option = self._image_view.viewbox.menu.addAction("Reset Profile Line")
+        self._image_view.viewbox.menu.insertSeparator(self._reset_option)
+        self._reset_option.triggered.connect(lambda: self.reset())

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -78,8 +78,9 @@ class ReconImagesView(GraphicsLayoutWidget):
         self.imageview_recon.setImage(image_data, autoLevels=False)
         set_histogram_log_scale(self.imageview_recon.histogram)
         if reset_roi:
-            self.recon_line_profile.reset_roi_line()
-        self.recon_line_profile.update_plot()
+            self.recon_line_profile.reset()
+        else:
+            self.recon_line_profile.update()
 
     def update_recon_hist(self):
         self.imageview_recon.histogram.imageChanged(autoLevel=True, autoRange=True)
@@ -94,6 +95,9 @@ class ReconImagesView(GraphicsLayoutWidget):
 
     def clear_recon(self):
         self.imageview_recon.clear()
+
+    def clear_recon_line_profile(self):
+        self.recon_line_profile.clear_plot()
 
     def clear_sinogram(self):
         self.imageview_sinogram.clear()

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -10,6 +10,7 @@ from pyqtgraph import GraphicsLayoutWidget, InfiniteLine
 from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint
 from mantidimaging.core.utility.data_containers import Degrees
 from mantidimaging.core.utility.histogram import set_histogram_log_scale
+from mantidimaging.gui.widgets.line_profile_plot.view import LineProfilePlot
 from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
 
 
@@ -33,10 +34,12 @@ class ReconImagesView(GraphicsLayoutWidget):
                                        movable=True)
         self.imageview_projection.viewbox.addItem(self.slice_line)
         self.tilt_line = InfiniteLine(pos=1024, angle=90, pen=(255, 0, 0, 255), movable=True)
+        self.recon_line_profile = LineProfilePlot(self.imageview_recon)
 
         self.addItem(self.imageview_projection, 0, 0)
-        self.addItem(self.imageview_recon, 0, 1, rowspan=2)
+        self.addItem(self.imageview_recon, 0, 1)
         self.addItem(self.imageview_sinogram, 1, 0)
+        self.addItem(self.recon_line_profile, 1, 1)
 
         self.imageview_projection.image_item.mouseClickEvent = lambda ev: self.mouse_click(ev, self.slice_line)
         self.slice_line.sigPositionChangeFinished.connect(self.slice_line_moved)
@@ -70,10 +73,13 @@ class ReconImagesView(GraphicsLayoutWidget):
         self.imageview_sinogram.histogram.imageChanged(autoLevel=True, autoRange=True)
         set_histogram_log_scale(self.imageview_sinogram.histogram)
 
-    def update_recon(self, image_data):
+    def update_recon(self, image_data, reset_roi: bool = False):
         self.imageview_recon.clear()
         self.imageview_recon.setImage(image_data, autoLevels=False)
         set_histogram_log_scale(self.imageview_recon.histogram)
+        if reset_roi:
+            self.recon_line_profile.reset_roi_line()
+        self.recon_line_profile.update_plot()
 
     def update_recon_hist(self):
         self.imageview_recon.histogram.imageChanged(autoLevel=True, autoRange=True)

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -137,6 +137,7 @@ class ReconstructWindowPresenter(BasePresenter):
         self.do_update_projection()
         self.view.update_recon_hist_needed = True
         if images is None:
+            self.view.reset_recon_line_profile()
             self.view.show_status_message("")
             return
         self.do_preview_reconstruct_slice(reset_roi=True)

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -84,6 +84,7 @@ class ReconWindowPresenterTest(unittest.TestCase):
         mock_start_async_task_view.assert_not_called()
         self.view.update_sinogram.assert_not_called()
         self.view.update_projection.assert_not_called()
+        self.view.reset_recon_line_profile.assert_called_once()
         self.view.show_status_message.assert_called_once_with("")
 
     @mock.patch('mantidimaging.gui.windows.recon.presenter.start_async_task_view')

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -166,7 +166,7 @@ class ReconWindowPresenterTest(unittest.TestCase):
 
         self.presenter._on_preview_reconstruct_slice_done(task_mock)
 
-        self.view.update_recon_preview.assert_called_once_with(image_mock)
+        self.view.update_recon_preview.assert_called_once_with(image_mock, False)
 
     def test_do_preview_reconstruct_slice_raises(self):
         task_mock = mock.Mock(error=ValueError())

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -155,14 +155,14 @@ class ReconstructWindowViewTest(unittest.TestCase):
         self.view.update_recon_hist_needed = False
 
         self.view.update_recon_preview(image_data)
-        self.image_view.update_recon.assert_called_once_with(image_data)
+        self.image_view.update_recon.assert_called_once_with(image_data, False)
 
     def test_update_recon_preview_and_hist(self):
         image_data = mock.Mock()
         self.view.update_recon_hist_needed = True
 
         self.view.update_recon_preview(image_data)
-        self.image_view.update_recon.assert_called_once_with(image_data)
+        self.image_view.update_recon.assert_called_once_with(image_data, False)
         self.image_view.update_recon_hist.assert_called_once_with()
 
     def test_reset_recon_and_sino_previews(self):

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -286,12 +286,12 @@ class ReconstructWindowView(BaseMainWindowView):
         if self.previewAutoUpdate.isChecked():
             self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE)
 
-    def update_recon_preview(self, image_data: numpy.ndarray):
+    def update_recon_preview(self, image_data: numpy.ndarray, reset_roi: bool = False):
         """
         Updates the reconstruction preview image with new data.
         """
         # Plot image
-        self.image_view.update_recon(image_data)
+        self.image_view.update_recon(image_data, reset_roi)
         if self.update_recon_hist_needed:
             self.image_view.update_recon_hist()
             self.update_recon_hist_needed = False

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -304,6 +304,9 @@ class ReconstructWindowView(BaseMainWindowView):
         self.image_view.clear_recon()
         self.image_view.clear_sinogram()
 
+    def reset_recon_line_profile(self):
+        self.image_view.clear_recon_line_profile()
+
     def reset_projection_preview(self):
         self.image_view.clear_projection()
 


### PR DESCRIPTION
### Issue

Closes #1483

### Description

Line profile added to the reconstruction window to allow users to select a line segment from the recon preview to be plotted in the graph below.

Still to do towards this (under a separate issue) is re-sizing the plot so that it is smaller than the three image views in the grid layout. This will help keep the recon preview from getting too small. I've also noticed that if you switch between stacks from the drop-down on Linux, the sizing of the recon preview doesn't seem to be re-adjusting very well. This behaviour doesn't seem to occur on Windows. We should look at this as part of the stage 2 re-sizing work for this issue.

### Testing & Acceptance Criteria 

All tests pass (some eyes test baselines will need to be updated).
The ROI line can be used to select line sections from the image, which are correctly plotted on the graph below. These update correctly when the recon preview is updated and reset automatically when a new stack with different dimensions is selected from the drop-down.
The line profile plot is cleared when all data is deleted from the main window tree view.
The "Reset Profile Line" option appears on the image view right click menu for the recon preview. When clicked, this should reset the position of the ROI line and update the graph.
The ROI line handles can be used to select line segments at any angle.

### Documentation

Issue number added to release notes
