### PR TITLE
Clear ops and recon window previews when there is no data to display

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -26,6 +26,7 @@ Fixes
 - #1397 : Only use real NeXus projection angles
 - #1473 : Tomopy COR finder use -log
 - #1475 : Fix scaling when saving to int
+- #1484 : Clear image previews in open windows when there are no stacks to select
 
 
 Developer Changes

--- a/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
+++ b/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
@@ -43,9 +43,13 @@ class BadDataCheck:
         self.overlay.setZValue(11)
         self.overlay.setLevels([0, 1])
 
-    def clear(self):
+    def remove(self):
         self.overlay.getViewBox().removeItem(self.indicator)
         self.overlay.getViewBox().removeItem(self.overlay)
+        self.overlay.clear()
+
+    def clear(self):
+        self.indicator.setVisible(False)
         self.overlay.clear()
 
 
@@ -101,7 +105,7 @@ class BadDataOverlay:
 
     def disable_check(self, name: str):
         if name in self.enabled_checks:
-            self.enabled_checks[name].clear()
+            self.enabled_checks[name].remove()
             self.enabled_checks.pop(name, None)
 
     def _get_current_slice(self) -> Optional[np.ndarray]:
@@ -113,3 +117,7 @@ class BadDataOverlay:
         if current_slice is not None:
             for test in self.enabled_checks.values():
                 test.do_check(current_slice)
+
+    def clear_overlays(self):
+        for check in self.enabled_checks.values():
+            check.clear()

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -79,6 +79,7 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
     def clear(self):
         self.im.clear()
         self.set_auto_color_enabled(False)
+        self.clear_overlays()
 
     def setImage(self, *args, **kwargs):
         self.im.setImage(*args, **kwargs)

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -544,3 +544,8 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     def test_is_a_proj180deg_returns_false(self):
         self.main_window.get_all_180_projections.return_value = [generate_images() for _ in range(5)]
         assert not self.presenter.is_a_proj180deg(generate_images())
+
+    def test_do_update_previews_no_image_data(self):
+        self.presenter.do_update_previews()
+        self.view.clear_previews.assert_called_once()
+        self.view.clear_previews.assert_called_with()

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -89,6 +89,12 @@ class ReconImagesView(GraphicsLayoutWidget):
     def clear_recon(self):
         self.imageview_recon.clear()
 
+    def clear_sinogram(self):
+        self.imageview_sinogram.clear()
+
+    def clear_projection(self):
+        self.imageview_projection.clear()
+
     def reset_slice_and_tilt(self, slice_index):
         self.slice_line.setPos(slice_index)
         self.hide_tilt()

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -136,6 +136,7 @@ class ReconstructWindowPresenter(BasePresenter):
         self.do_update_projection()
         self.view.update_recon_hist_needed = True
         if images is None:
+            self.view.show_status_message("")
             return
         self.do_preview_reconstruct_slice()
         self._do_nan_zero_negative_check()

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -128,7 +128,7 @@ class ReconstructWindowPresenter(BasePresenter):
         if self.model.is_current_stack(uuid):
             return
 
-        self.view.reset_image_recon_preview()
+        self.view.reset_recon_and_sino_previews()
         self.view.clear_cor_table()
         self.model.initial_select_data(images)
         self.view.rotation_centre = self.model.last_cor.value
@@ -160,9 +160,11 @@ class ReconstructWindowPresenter(BasePresenter):
 
     def do_update_projection(self):
         images = self.model.images
-        if images is not None:
-            img_data = images.projection(self.model.preview_projection_idx)
-            self.view.update_projection(img_data, self.model.preview_slice_idx, self.model.tilt_angle)
+        if images is None:
+            self.view.reset_projection_preview()
+            return
+        img_data = images.projection(self.model.preview_projection_idx)
+        self.view.update_projection(img_data, self.model.preview_slice_idx, self.model.tilt_angle)
 
     def handle_stack_changed(self):
         if self.view.isVisible():
@@ -225,6 +227,7 @@ class ReconstructWindowPresenter(BasePresenter):
 
     def do_preview_reconstruct_slice(self, cor=None, slice_idx: Optional[int] = None, force_update: bool = False):
         if self.model.images is None:
+            self.view.reset_recon_and_sino_previews()
             return
 
         slice_idx = self._get_slice_index(slice_idx)

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -72,6 +72,20 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.view.update_sinogram.assert_called_once()
 
     @mock.patch('mantidimaging.gui.windows.recon.presenter.start_async_task_view')
+    @mock.patch('mantidimaging.gui.windows.recon.model.ReconstructWindowModel.is_current_stack')
+    def test_set_stack_uuid_no_image_data(self, mock_is_current_stack, mock_start_async_task_view):
+        self.presenter.model._images = None
+        self.view.get_stack.return_value = None
+        mock_is_current_stack.return_value = False
+
+        self.presenter.set_stack_uuid(None)
+        self.view.reset_recon_and_sino_previews.assert_called_once()
+        self.view.reset_projection_preview.assert_called_once()
+        mock_start_async_task_view.assert_not_called()
+        self.view.update_sinogram.assert_not_called()
+        self.view.update_projection.assert_not_called()
+
+    @mock.patch('mantidimaging.gui.windows.recon.presenter.start_async_task_view')
     def test_set_stack_uuid_updates_rotation_centre_and_pixel_size(self, mock_start_async: mock.Mock):
         self.presenter.model._images = None
         # first-time selecting this data after reset
@@ -97,6 +111,12 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.view.update_projection.assert_called_once()
         self.view.update_sinogram.assert_called_once()
 
+    def test_do_update_projection_no_image_data(self):
+        self.presenter.model._images = None
+        self.presenter.do_update_projection()
+        self.view.reset_projection_preview.assert_called_once()
+        self.view.update_projection.assert_not_called()
+
     @mock.patch('mantidimaging.gui.windows.recon.model.ReconstructWindowModel.get_me_a_cor', return_value=ScalarCoR(15))
     def test_do_add_manual_cor_table_row(self, mock_get_me_a_cor):
         self.presenter.model.selected_row = 0
@@ -121,6 +141,12 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.view.update_sinogram.assert_called_once()
         mock_start_async_task_view.assert_called_once()
         self.view.recon_params.assert_called_once()
+
+    def test_do_preview_reconstruct_slice_no_image_data(self):
+        self.presenter.model._images = None
+        self.presenter.do_preview_reconstruct_slice()
+        self.view.reset_recon_and_sino_previews.assert_called_once()
+        self.view.update_sinogram.assert_not_called()
 
     @mock.patch('mantidimaging.gui.windows.recon.presenter.ReconstructWindowPresenter._get_reconstruct_slice')
     def test_do_preview_reconstruct_slice_no_auto_update(self, mock_get_reconstruct_slice):

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -84,6 +84,7 @@ class ReconWindowPresenterTest(unittest.TestCase):
         mock_start_async_task_view.assert_not_called()
         self.view.update_sinogram.assert_not_called()
         self.view.update_projection.assert_not_called()
+        self.view.show_status_message.assert_called_once_with("")
 
     @mock.patch('mantidimaging.gui.windows.recon.presenter.start_async_task_view')
     def test_set_stack_uuid_updates_rotation_centre_and_pixel_size(self, mock_start_async: mock.Mock):

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -165,9 +165,10 @@ class ReconstructWindowViewTest(unittest.TestCase):
         self.image_view.update_recon.assert_called_once_with(image_data)
         self.image_view.update_recon_hist.assert_called_once_with()
 
-    def test_reset_image_recon_preview(self):
-        self.view.reset_image_recon_preview()
+    def test_reset_recon_and_sino_previews(self):
+        self.view.reset_recon_and_sino_previews()
         self.image_view.clear_recon.assert_called_once()
+        self.image_view.clear_sinogram.assert_called_once()
 
     def test_reset_slice_and_tilt(self):
         slice_index = 5

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -296,12 +296,16 @@ class ReconstructWindowView(BaseMainWindowView):
             self.image_view.update_recon_hist()
             self.update_recon_hist_needed = False
 
-    def reset_image_recon_preview(self):
+    def reset_recon_and_sino_previews(self):
         """
-        Resets the recon preview image, forcing a complete redraw next time it
-        is updated.
+        Resets the recon and sinogram preview images, forcing a complete redraw next time they
+        are updated.
         """
         self.image_view.clear_recon()
+        self.image_view.clear_sinogram()
+
+    def reset_projection_preview(self):
+        self.image_view.clear_projection()
 
     def reset_slice_and_tilt(self, slice_index):
         self.image_view.reset_slice_and_tilt(slice_index)


### PR DESCRIPTION
### Issue

Closes #1484

### Description

The source of the seg fault described on the issue was the `show_value` method in `MIMiniImageView` class. This is used to display the pixel value of the point that the mouse is hovering over on the image. In the reconstruction window, the projection and sinogram previews are backed by shared memory, so when the data was deleted this functionality would seg fault when the user hovered their mouse over either of these previews.

It feels a little bit confusing to be holding on to a view of data that the application no longer has available, so the solution in this PR is to clear the previews in the recon window when there is no data available to display. For consistency, I've also resolved this in the operations window, even though the previews there use copies of the data and so do not cause seg faults. I've also made some changes to make sure that bad data overlays are hidden when there is no data, and that status messages in the recon window are cleared.

### Testing & Acceptance Criteria 

The recon window seg fault should no longer occur - the updated steps to test this are in the comment on the issue (note the original steps given in the issue description turned out to be incorrect on further investigation).

Deleting all data from the tree view should clear all previews, bad data overlays and error messages from the operations and reconstruction windows, if they are open. When new data is loaded, these windows should update and function correctly.

### Documentation

Issue number added to release notes.
