### PR TITLE
Reduce size of recon line profile relative to preview

### DIFF
--- a/mantidimaging/gui/widgets/line_profile_plot/test/view_test.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/test/view_test.py
@@ -80,9 +80,11 @@ class ImageViewLineROITest(unittest.TestCase):
     def test_reset(self):
         self._set_image()
         self.roi_line._roi_line_is_visible = True
+        self.roi_line._image_view.viewbox.autoRange = mock.Mock()
         self.roi_line.reset()
 
         check_state_and_bounds(self.roi_line)
+        self.roi_line._image_view.viewbox.autoRange.assert_called_once()
 
     def test_get_image_region_no_image_data(self):
         self.assertIsNone(self.roi_line.get_image_region())

--- a/mantidimaging/gui/widgets/line_profile_plot/view.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/view.py
@@ -73,6 +73,7 @@ class ImageViewLineROI(LineSegmentROI):
     def reset(self) -> None:
         if self._image_data_exists() and self._roi_line_is_visible:
             self._set_initial_state()
+            self._image_view.viewbox.autoRange()
             self.sigRegionChanged.emit(self)
 
     def reset_is_needed(self) -> bool:

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -37,9 +37,13 @@ class ReconImagesView(GraphicsLayoutWidget):
         self.recon_line_profile = LineProfilePlot(self.imageview_recon)
 
         self.addItem(self.imageview_projection, 0, 0)
-        self.addItem(self.imageview_recon, 0, 1)
         self.addItem(self.imageview_sinogram, 1, 0)
-        self.addItem(self.recon_line_profile, 1, 1)
+
+        self.recon_layout = self.ci.addLayout(0, 1, rowspan=2)
+        self.recon_layout.addItem(self.imageview_recon, 0, 0)
+        self.recon_layout.addItem(self.recon_line_profile, 1, 0)
+        # Set the recon preview to take up more vertical space than the line profile graph underneath it
+        self.recon_layout.layout.setRowStretchFactor(0, 2)
 
         self.imageview_projection.image_item.mouseClickEvent = lambda ev: self.mouse_click(ev, self.slice_line)
         self.slice_line.sigPositionChangeFinished.connect(self.slice_line_moved)


### PR DESCRIPTION
### Issue

Closes #1486

### Description

Reduces the size of the recon line profile to allow more space for the recon preview:

![ReconLineProfile](https://user-images.githubusercontent.com/38210467/173375290-12127c59-6f25-4da6-8ce8-eff07ff6acf1.PNG)

Also resets the image in the viewbox when the profile ROI line is reset. This fixes the behaviour where re-positioning the line when the image size changes (for example, when a new stack is selected) was previously causing the recon preview size to jump around. This change also means that if the user has zoomed in or out of the recon preview and then clicks the option to reset the ROI, it will also reset the zoom. This seems acceptable and like it could potentially be desirable in certain cases (i.e. when zoomed in, if you reset the ROI without resetting the zoom the line disappears off the image), however we can always tweak the behaviour if we get different feedback from users.

### Testing & Acceptance Criteria 

Recon preview size should be larger than the line profile - we can always adjust the relative sizes if the users prefer them to be different when they start testing/working with it.

Changing between different stack sizes doesn't change the size of the recon preview.

### Documentation

Not required - can be covered in release notes by entry for issue #1483.
