### PR TITLE
Remove Outliers: use correct axes for num_operations

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -28,6 +28,7 @@ Fixes
 - #1473 : Tomopy COR finder use -log
 - #1475 : Fix scaling when saving to int
 - #1484 : Clear image previews in open windows when there are no stacks to select
+- #1496 : OutliersFilter IndexError when using sinograms
 
 
 Developer Changes

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -66,7 +66,7 @@ class OutliersFilter(BaseFilter):
 
         func = ps.create_partial(OutliersFilter._execute, ps.return_to_self, diff=diff, radius=radius, mode=mode)
         ps.execute(func, [images.shared_array],
-                   images.num_projections,
+                   images.data.shape[0],
                    progress=progress,
                    msg=f"Outliers with threshold {diff} and kernel {radius}")
         return images

--- a/mantidimaging/core/operations/outliers/test/outliers_test.py
+++ b/mantidimaging/core/operations/outliers/test/outliers_test.py
@@ -48,6 +48,12 @@ class OutliersTest(unittest.TestCase):
 
         th.assert_not_equals(result.data, sample)
 
+    def test_executed_sino_preview(self):
+        images = th.generate_images([1, 10, 10])
+        images._is_sinograms = True
+
+        OutliersFilter.filter_func(images, 0.1, 2)
+
     def test_execute_wrapper_return_is_runnable(self):
         """
         Test that the partial returned by execute_wrapper can be executed (kwargs are named correctly)


### PR DESCRIPTION
### Issue

Closes #1496 

### Description
ps.execute always operates over the zeroth index, so use that length

### Testing 

Follow steps on #1496 

### Acceptance Criteria 

Should be able to use preview most filters with sinogram data.
Error messages ok for:
Crop - if the images dimensions are less that 200x200
Flat fielding - because the flat and dark to match the dimensions of the sinogram


### Documentation

Release notes
