### PR TITLE
Auto sinograms

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -18,6 +18,7 @@ New Features
 - #1398 : Save recons to NeXus file
 - #1444 : CIL PDHG non-negativity constraint
 - #1483 : Add line profile to reconstruction window
+- #1480 : Automatic sinograms for sinogram operations
 
 Fixes
 -----

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -164,7 +164,7 @@ class ImageStack:
         mark_cropped(images, roi)
         return images
 
-    def index_as_image_stack(self, index) -> 'ImageStack':
+    def slice_as_image_stack(self, index) -> 'ImageStack':
         return ImageStack(np.asarray([self.data[index]]), metadata=deepcopy(self.metadata), sinograms=self.is_sinograms)
 
     @property

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -30,12 +30,13 @@ class ImageStack:
                  sinograms: bool = False,
                  name: Optional[str] = None):
         """
-
         :param data: a numpy array or SharedArray object containing the images of the Sample/Projection data
         :param filenames: All filenames that were matched for loading
         :param indices: Indices that were actually loaded
         :param metadata: Properties to copy when creating a new stack from an existing one
+        :param sinograms: Set data ordering, if false: [t,y,x] if true: [y,t,x]
         :param name: A name for the stack
+
         """
 
         if isinstance(data, pu.SharedArray):
@@ -165,7 +166,12 @@ class ImageStack:
         return images
 
     def slice_as_image_stack(self, index) -> 'ImageStack':
+        "A slice, either projection or sinogram depending on current ordering"
         return ImageStack(np.asarray([self.data[index]]), metadata=deepcopy(self.metadata), sinograms=self.is_sinograms)
+
+    def sino_as_image_stack(self, index) -> 'ImageStack':
+        "A single sinogram slice as an ImageStack in projection ordering"
+        return ImageStack(np.asarray([self.sino(index)]).swapaxes(0, 1), metadata=deepcopy(self.metadata))
 
     @property
     def height(self):

--- a/mantidimaging/core/data/test/image_stack_test.py
+++ b/mantidimaging/core/data/test/image_stack_test.py
@@ -240,3 +240,28 @@ class ImageStackTest(unittest.TestCase):
         imgs = ImageStack(np.asarray([1]), name="tomo")
         imgs.make_name_unique(existing)
         self.assertEqual(imgs.name, "tomo_2")
+
+    def test_slice_as_stack(self):
+        raw_pixels = np.arange(60, dtype=np.float32).reshape((3, 4, 5))
+        image = ImageStack(raw_pixels.copy(), name="tomo", sinograms=False)
+
+        np.testing.assert_array_equal(raw_pixels[[0], :, :], image.slice_as_image_stack(0).data)
+        np.testing.assert_array_equal(raw_pixels[[2], :, :], image.slice_as_image_stack(2).data)
+        self.assertRaises(IndexError, image.slice_as_image_stack, 3)
+
+        slice = image.slice_as_image_stack(0)
+        self.assertEqual(slice.height, image.height)
+        self.assertEqual(slice.width, image.width)
+        self.assertEqual(slice.num_projections, 1)
+
+        # check that modification do not affect original
+        copy = image.slice_as_image_stack(0)
+        copy.data += 1
+        np.testing.assert_array_equal(raw_pixels, image.data)
+
+        image = ImageStack(raw_pixels.copy(), name="tomo", sinograms=True)
+        slice = image.slice_as_image_stack(0)
+        self.assertEqual(slice.height, 1)
+        self.assertEqual(slice.width, image.width)
+        self.assertEqual(slice.num_projections, image.num_projections)
+        np.testing.assert_array_equal(raw_pixels[[0], :, :], slice.data)

--- a/mantidimaging/core/data/test/image_stack_test.py
+++ b/mantidimaging/core/data/test/image_stack_test.py
@@ -265,3 +265,24 @@ class ImageStackTest(unittest.TestCase):
         self.assertEqual(slice.width, image.width)
         self.assertEqual(slice.num_projections, image.num_projections)
         np.testing.assert_array_equal(raw_pixels[[0], :, :], slice.data)
+
+    def test_sino_as_stack(self):
+        raw_pixels = np.arange(60, dtype=np.float32).reshape((3, 4, 5))
+        image = ImageStack(raw_pixels.copy(), name="tomo", sinograms=False)
+
+        np.testing.assert_array_equal(raw_pixels[:, [0], :], image.sino_as_image_stack(0).data)
+        np.testing.assert_array_equal(raw_pixels[:, [3], :], image.sino_as_image_stack(3).data)
+        self.assertRaises(IndexError, image.sino_as_image_stack, 4)
+
+        slice = image.sino_as_image_stack(0)
+        self.assertEqual(slice.height, 1)
+        self.assertEqual(slice.width, image.width)
+        self.assertEqual(slice.num_projections, image.num_projections)
+
+        # check that modification do not affect original
+        copy = image.sino_as_image_stack(0)
+        copy.data += 1
+        np.testing.assert_array_equal(raw_pixels, image.data)
+
+        image = ImageStack(raw_pixels.copy(), name="tomo", sinograms=True)
+        np.testing.assert_array_equal(raw_pixels[[0], :, :].swapaxes(0, 1), image.sino_as_image_stack(0).data)

--- a/mantidimaging/core/operations/base_filter.py
+++ b/mantidimaging/core/operations/base_filter.py
@@ -25,6 +25,7 @@ class BaseFilter:
     filter_name = "Unnamed Filter"
     link_histograms = False
     show_negative_overlay = True
+    operate_on_sinograms = False
     __name__ = "BaseFilter"
     """
     The base class for filter algorithms, which should extend this class.

--- a/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
+++ b/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
@@ -30,17 +30,30 @@ class RemoveAllStripesFilter(BaseFilter):
     """
     filter_name = "Remove all stripes"
     link_histograms = True
+    operate_on_sinograms = True
 
     @staticmethod
     def filter_func(images: ImageStack, snr=3, la_size=61, sm_size=21, dim=1, progress=None):
+        if images.num_projections < 2:
+            return images
         params = {"snr": snr, "la_size": la_size, "sm_size": sm_size, "dim": dim}
-        ps.run_compute_func(RemoveAllStripesFilter.compute_function, images.data.shape[0], [images.shared_array],
-                            params, progress)
+        if images.is_sinograms:
+            compute_func = RemoveAllStripesFilter.compute_function_sino
+            num_slices = images.data.shape[0]
+        else:
+            compute_func = RemoveAllStripesFilter.compute_function
+            num_slices = images.data.shape[1]
+
+        ps.run_compute_func(compute_func, num_slices, [images.shared_array], params, progress)
         return images
 
     @staticmethod
-    def compute_function(index: int, arrays: List[ndarray], params: Dict[str, Any]):
+    def compute_function_sino(index: int, arrays: List[ndarray], params: Dict[str, Any]):
         arrays[0][index] = remove_all_stripe(arrays[0][index], **params)
+
+    @staticmethod
+    def compute_function(index: int, arrays: List[ndarray], params: Dict[str, Any]):
+        arrays[0][:, index, :] = remove_all_stripe(arrays[0][:, index, :], **params)
 
     @staticmethod
     def register_gui(form, on_change, view):

--- a/mantidimaging/core/operations/remove_all_stripe/test/remove_all_stripe_test.py
+++ b/mantidimaging/core/operations/remove_all_stripe/test/remove_all_stripe_test.py
@@ -6,8 +6,10 @@ from unittest import mock
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.remove_all_stripe import RemoveAllStripesFilter
+from mantidimaging.test_helpers.start_qapplication import start_multiprocessing_pool
 
 
+@start_multiprocessing_pool
 class RemoveAllStripesTest(unittest.TestCase):
     """
     Test stripe removal filter.
@@ -16,6 +18,14 @@ class RemoveAllStripesTest(unittest.TestCase):
     """
     def test_executed(self):
         images = th.generate_images()
+        control = images.copy()
+
+        result = RemoveAllStripesFilter.filter_func(images)
+
+        th.assert_not_equals(result.data, control.data)
+
+    def test_executed_mp(self):
+        images = th.generate_images(shape=(20, 20, 20))
         control = images.copy()
 
         result = RemoveAllStripesFilter.filter_func(images)

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -315,7 +315,7 @@ class FiltersWindowPresenter(BasePresenter):
         if lock_scale:
             self.view.previews.record_histogram_regions()
 
-        subset: ImageStack = self.stack.index_as_image_stack(self.model.preview_image_idx)
+        subset: ImageStack = self.stack.slice_as_image_stack(self.model.preview_image_idx)
         before_image = np.copy(subset.data[0])
 
         try:

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -329,15 +329,17 @@ class FiltersWindowPresenter(BasePresenter):
 
         if not self.model.selected_filter.operate_on_sinograms:
             subset: ImageStack = self.stack.slice_as_image_stack(self.model.preview_image_idx)
+            squeeze_axis = 0
         else:
             if self.stack.num_projections < 2:
                 self.show_error("This filter requires a stack with multiple projections", "")
                 self.view.clear_previews()
                 return
             subset = self.stack.sino_as_image_stack(self.model.preview_image_idx)
+            squeeze_axis = 1
 
         # Take copies for display to prevent issues when the shared memory is cleaned
-        before_image = np.copy(subset.data.squeeze())
+        before_image = np.copy(subset.data.squeeze(squeeze_axis))
 
         try:
             if self.model.filter_widget_kwargs:
@@ -352,7 +354,7 @@ class FiltersWindowPresenter(BasePresenter):
 
         # Update image after first in order to prevent wrong histogram ranges being shared
 
-        filtered_image_data = np.copy(subset.data.squeeze())
+        filtered_image_data = np.copy(subset.data.squeeze(squeeze_axis))
 
         if np.any(filtered_image_data < 0):
             self._show_preview_negative_values_error(self.model.preview_image_idx)

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -218,7 +218,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     def test_update_previews_apply_throws_exception(self, apply_mock: mock.Mock):
         apply_mock.side_effect = Exception
         stack = mock.Mock()
-        images = generate_images()
+        images = generate_images([1, 10, 10])
         stack.slice_as_image_stack.return_value = images
         self.presenter.stack = stack
 
@@ -232,7 +232,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.apply_to_images')
     def test_update_previews_with_no_lock_checked(self, apply_mock: mock.Mock, update_preview_image_mock: mock.Mock):
         stack = mock.Mock()
-        images = generate_images()
+        images = generate_images([1, 10, 10])
         stack.slice_as_image_stack.return_value = images
         self.presenter.stack = stack
         self.view.lockZoomCheckBox.isChecked.return_value = False
@@ -252,7 +252,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     def test_auto_range_called_when_locks_are_checked(self, apply_mock: mock.Mock,
                                                       update_preview_image_mock: mock.Mock):
         stack = mock.Mock()
-        images = generate_images()
+        images = generate_images([1, 10, 10])
         stack.slice_as_image_stack.return_value = images
         self.presenter.stack = stack
         self.view.lockZoomCheckBox.isChecked.return_value = True
@@ -513,7 +513,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.presenter.model.preview_image_idx = slice_idx = 14
         self.presenter.model.apply_to_images = mock.Mock()
         self.presenter.stack = mock.Mock()
-        self.presenter.stack.slice_as_image_stack.return_value.data = np.ones([3, 3]) * -1
+        self.presenter.stack.slice_as_image_stack.return_value.data = np.ones([1, 3, 3]) * -1
         self.presenter.do_update_previews()
 
         self.view.show_error_dialog.assert_called_once_with(
@@ -522,7 +522,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     def test_no_negative_values_preview_message(self):
         self.presenter.model.apply_to_images = mock.Mock()
         self.presenter.stack = mock.Mock()
-        self.presenter.stack.slice_as_image_stack.return_value.data = np.ones([3, 3])
+        self.presenter.stack.slice_as_image_stack.return_value.data = np.ones([1, 3, 3])
         self.presenter.do_update_previews()
 
         self.view.show_error_dialog.assert_not_called()

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -263,6 +263,26 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.view.previews.record_histogram_regions.assert_called_once()
         self.view.previews.restore_histogram_regions.assert_called_once()
 
+    @parameterized.expand([(True, True), (False, True), (True, False), (False, False)])
+    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter._update_preview_image')
+    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.apply_to_images')
+    def test_update_previews_shapes(self, sino_op, stack_sino, _, update_preview_image_mock: mock.Mock):
+        stack = mock.Mock(num_projections=10)
+        if not sino_op:
+            stack.slice_as_image_stack.return_value = generate_images([1, 10, 12])
+            stack.slice_as_image_stack.return_value._is_sinograms = stack_sino
+        else:
+            stack.sino_as_image_stack.return_value = generate_images([10, 1, 12])
+            stack.sino_as_image_stack.return_value._is_sinograms = stack_sino
+
+        self.presenter.model.selected_filter = mock.Mock(operate_on_sinograms=sino_op)
+        self.presenter.stack = stack
+
+        self.presenter.do_update_previews()
+
+        for args in update_preview_image_mock.call_args_list:
+            self.assertEqual(args[0][0].shape, (10, 12))
+
     def test_get_filter_module_name(self):
         self.presenter.model.filters = mock.MagicMock()
 

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -216,12 +216,12 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         apply_mock.side_effect = Exception
         stack = mock.Mock()
         images = generate_images()
-        stack.index_as_image_stack.return_value = images
+        stack.slice_as_image_stack.return_value = images
         self.presenter.stack = stack
 
         self.presenter.do_update_previews()
 
-        stack.index_as_image_stack.assert_called_once_with(self.presenter.model.preview_image_idx)
+        stack.slice_as_image_stack.assert_called_once_with(self.presenter.model.preview_image_idx)
         self.view.clear_previews.assert_called_once()
         apply_mock.assert_called_once()
 
@@ -230,13 +230,13 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     def test_update_previews_with_no_lock_checked(self, apply_mock: mock.Mock, update_preview_image_mock: mock.Mock):
         stack = mock.Mock()
         images = generate_images()
-        stack.index_as_image_stack.return_value = images
+        stack.slice_as_image_stack.return_value = images
         self.presenter.stack = stack
         self.view.lockZoomCheckBox.isChecked.return_value = False
         self.view.lockScaleCheckBox.isChecked.return_value = False
         self.presenter.do_update_previews()
 
-        stack.index_as_image_stack.assert_called_once_with(self.presenter.model.preview_image_idx)
+        stack.slice_as_image_stack.assert_called_once_with(self.presenter.model.preview_image_idx)
         self.view.clear_previews.assert_called_once()
         self.assertEqual(3, update_preview_image_mock.call_count)
         apply_mock.assert_called_once()
@@ -250,7 +250,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
                                                       update_preview_image_mock: mock.Mock):
         stack = mock.Mock()
         images = generate_images()
-        stack.index_as_image_stack.return_value = images
+        stack.slice_as_image_stack.return_value = images
         self.presenter.stack = stack
         self.view.lockZoomCheckBox.isChecked.return_value = True
         self.view.lockScaleCheckBox.isChecked.return_value = True
@@ -510,8 +510,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.presenter.model.preview_image_idx = slice_idx = 14
         self.presenter.model.apply_to_images = mock.Mock()
         self.presenter.stack = mock.Mock()
-        self.presenter.stack.index_as_image_stack.return_value.data = np.array([[-1 for _ in range(3)]
-                                                                                for _ in range(3)])
+        self.presenter.stack.slice_as_image_stack.return_value.data = np.ones([3, 3]) * -1
         self.presenter.do_update_previews()
 
         self.view.show_error_dialog.assert_called_once_with(
@@ -520,8 +519,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     def test_no_negative_values_preview_message(self):
         self.presenter.model.apply_to_images = mock.Mock()
         self.presenter.stack = mock.Mock()
-        self.presenter.stack.index_as_image_stack.return_value.data = np.array([[1 for _ in range(3)]
-                                                                                for _ in range(3)])
+        self.presenter.stack.slice_as_image_stack.return_value.data = np.ones([3, 3])
         self.presenter.do_update_previews()
 
         self.view.show_error_dialog.assert_not_called()

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -40,7 +40,8 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         reg_fun_mock = mock.Mock()
         filter_reg_mock.return_value = reg_fun_mock
         self.view.filterSelector.currentIndex.return_value = 0
-        self.presenter.do_register_active_filter()
+        with mock.patch("mantidimaging.gui.windows.operations.presenter.BlockQtSignals"):
+            self.presenter.do_register_active_filter()
 
         reg_fun_mock.assert_called_once()
         filter_reg_mock.assert_called_once()
@@ -49,14 +50,16 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.filter_registration_func')
     def test_link_before_after_histograms(self, _):
         self.view.filterSelector.currentText.return_value = "Clip Values"
-        self.presenter.do_register_active_filter()
+        with mock.patch("mantidimaging.gui.windows.operations.presenter.BlockQtSignals"):
+            self.presenter.do_register_active_filter()
 
         self.view.previews.link_before_after_histogram_scales.assert_called_once_with(True)
 
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.filter_registration_func')
     def test_disconnect_before_after_histograms(self, _):
         self.view.filterSelector.currentText.return_value = "Rescale"
-        self.presenter.do_register_active_filter()
+        with mock.patch("mantidimaging.gui.windows.operations.presenter.BlockQtSignals"):
+            self.presenter.do_register_active_filter()
 
         self.view.previews.link_before_after_histogram_scales.assert_called_once_with(False)
 

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -235,7 +235,7 @@ class FiltersWindowView(BaseMainWindowView):
     def roi_visualiser(self, roi_field):
         # Start the stack visualiser and ensure that it uses the ROI from here in the rest of this
         try:
-            images = self.presenter.stack.index_as_image_stack(self.presenter.model.preview_image_idx)
+            images = self.presenter.stack.slice_as_image_stack(self.presenter.model.preview_image_idx)
         except IndexError:
             # Happens if nothing has been loaded, so do nothing as nothing can't be visualised
             return


### PR DESCRIPTION
### Issue
Closes #1480 

### Description

Allow operations to declare that they `operate_on_sinograms`. If so they will receive a sinogram slice from the operations window. These operations will need to switch to a different way of calling multiprocessing so that they can control how they index the slices.

This will allow users to use sinogram operations without having to manualy convert to sinograms and back

This PR contains the new multiprocessing methods. Updates to the operations window. And a conversion for `RemoveAllStripesFilter`

To keep PR size down, the rest will be done in #1500

### Testing &  Acceptance Criteria 

Open a dataset.
Open operations window
Choose Remove all stripes

The before and after images should switch to sinogram view. (this can look a bit plain for on the first slice as that usually does not contain any of the object).

Use the z-slider to move to the middle of the stack

Z-slider limits should be number of sinograms (moving to the end should not give IndexErrors).

Switching back to another operation should restore projection view

### Documentation

release notes updated
