### PR TITLE
Fix module import error for line profile plot widget

### DIFF
--- a/mantidimaging/gui/widgets/line_profile_plot/__init__.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/widgets/line_profile_plot/test/__init__.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/test/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later


### PR DESCRIPTION
### Issue

Closes #1501

### Description

Add missing `__init__.py` files for recon line profile.

### Testing & Acceptance Criteria 

All tests should pass and should still work correctly locally. Will need to manually test on IDAaaS to check if the change has resolved the issue.

### Documentation

Not required.
