### PR TITLE
1504 disable windows publish

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -122,9 +122,10 @@ jobs:
           python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests --durations=10
         timeout-minutes: 15
 
-      # Label as 'windows-build-test' for testing purposes. To use, remove 'false &&' from the 'if' condition and change label to 'unstable' after testing
+      # Label as 'windows-build-test' for testing purposes.
+      # To re-enable, use the if rule from the conda workflow and change label to 'unstable' after testing
       - name: publish package
-        if: false && github.event_name == 'release' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release')))
+        if: false
         uses: ./.github/actions/publish-package
         with:
           label: windows-build-test


### PR DESCRIPTION
### Issue

Closes #1504

### Description

I'm not sure why `if false && ...` was not sufficient to stop it running. But hopefully `if: false` should.

`if: false` worked for other rules on ef5566f2b57395b36112dcf2691c339967299af2