### PR TITLE
Docs: add support page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ such as `Avizo
    installation
    user_guide/index
    developer_guide/index
+   support
    troubleshooting
    api
    release_notes/index

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -1,0 +1,7 @@
+Support
+=======
+
+Issues can be reported on the `Github project page <https://github.com/mantidproject/mantidimaging/issues>`_ or with the email below. Please check if there is an existing report for your issue.
+
+The developers can be contacted at
+mantidimagingsupport@stfc365.onmicrosoft.com

--- a/docs/user_guide/quick_start.rst
+++ b/docs/user_guide/quick_start.rst
@@ -5,8 +5,6 @@ Written: November 2020
 
 Author: Arianna Wintle (STFC)
 
-Please email any suggestions to mantidimagingsupport@stfc365.onmicrosoft.com
-
 Example data that can be used for this tutorial can be downloaded from `github.com/mantidproject/mantidimaging-data <https://github.com/mantidproject/mantidimaging-data/archive/refs/heads/main.zip>`_
 
 Loading Sample Stack


### PR DESCRIPTION
### Issue
Closes #1474

### Description

Add quick support page

### Testing & Acceptance Criteria 

To build docs locally:
`python ./setup.py docs`

### Documentation

No needed
