### PR TITLE
Recon line profile improvements

### DIFF
--- a/mantidimaging/gui/widgets/line_profile_plot/test/view_test.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/test/view_test.py
@@ -14,8 +14,9 @@ from mantidimaging.test_helpers import start_qapplication
 IMAGE_WIDTH = 10
 IMAGE_HEIGHT = 15
 IMAGE = np.zeros((IMAGE_HEIGHT, IMAGE_WIDTH))
-INITIAL_POS = [(0, 0), (IMAGE_WIDTH, 0)]
-BOUNDS = QRect(0, 0, IMAGE_WIDTH, IMAGE_HEIGHT)
+INITIAL_POS_Y = IMAGE_HEIGHT // 2
+INITIAL_POS = [(0, INITIAL_POS_Y), (IMAGE_WIDTH, INITIAL_POS_Y)]
+BOUNDS = QRect(0, 0 - INITIAL_POS_Y, IMAGE_WIDTH, IMAGE_HEIGHT)
 
 
 def check_state_and_bounds(roi_line: ImageViewLineROI, initial_pos=INITIAL_POS, bounds=BOUNDS):
@@ -136,8 +137,10 @@ class LineProfilePlotTest(unittest.TestCase):
 
         self.line_profile.reset()
 
-        check_state_and_bounds(self.line_profile._roi_line, [(0, 0), (new_width, 0)],
-                               QRect(0, 0, new_width, IMAGE_HEIGHT))
+        new_y_pos = IMAGE_HEIGHT // 2
+        new_position = [(0, new_y_pos), (new_width, new_y_pos)]
+        new_bounds = QRect(0, 0 - new_y_pos, new_width, IMAGE_HEIGHT)
+        check_state_and_bounds(self.line_profile._roi_line, new_position, new_bounds)
         self.line_profile._line_profile.setData.assert_called_once()
 
     def test_reset_without_roi_reset(self):

--- a/mantidimaging/gui/widgets/line_profile_plot/test/view_test.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/test/view_test.py
@@ -88,16 +88,24 @@ class ImageViewLineROITest(unittest.TestCase):
         self.roi_line._image_view.viewbox.autoRange.assert_called_once()
 
     def test_get_image_region_no_image_data(self):
-        self.assertIsNone(self.roi_line.get_image_region())
+        image_region, coords = self.roi_line.get_image_region()
+        self.assertIsNone(image_region)
+        self.assertIsNone(coords)
 
     def test_get_image_region_no_visible_roi(self):
         self._set_image()
-        self.assertIsNotNone(self.roi_line.get_image_region())
+
+        image_region, coords = self.roi_line.get_image_region()
+        self.assertIsNotNone(image_region)
+        self.assertIsNotNone(coords)
 
     def test_get_image_region_visible_roi(self):
         self._set_image()
         self.roi_line._add_roi_to_image()
-        self.assertIsNotNone(self.roi_line.get_image_region())
+
+        image_region, coords = self.roi_line.get_image_region()
+        self.assertIsNotNone(image_region)
+        self.assertIsNotNone(coords)
 
     def _set_image(self, image=IMAGE):
         self.image_view.setImage(image)
@@ -123,6 +131,9 @@ class LineProfilePlotTest(unittest.TestCase):
         self.line_profile.update()
 
         self.line_profile._line_profile.setData.assert_called_once()
+        info_label_test = self.line_profile._info_label.text
+        self.assertIsNotNone(info_label_test)
+        self.assertNotEqual(' ', info_label_test)
 
     def test_reset_with_roi_reset(self):
         self.line_profile._line_profile.setData = mock.Mock()

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -80,6 +80,7 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
         self.im.clear()
         self.set_auto_color_enabled(False)
         self.clear_overlays()
+        self.details.setText("")
 
     def setImage(self, *args, **kwargs):
         self.im.setImage(*args, **kwargs)
@@ -108,16 +109,16 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
             return
         pos = CloseEnoughPoint(ev.pos())
 
-        self.show_value(pos)
+        self.show_details(pos)
         for img_view in self.axis_siblings:
-            img_view.show_value(pos)
+            img_view.show_details(pos)
 
-    def show_value(self, pos):
+    def show_details(self, pos):
         image = self.im.image
         if image is not None and pos.y < image.shape[0] and pos.x < image.shape[1]:
             pixel_value = image[pos.y, pos.x]
             value_string = ("%.6f" % pixel_value)[:8]
-            self.details.setText(f"{self.name}: {value_string}")
+            self.details.setText(f"{self.name}: x={pos.x}, y={pos.y}, value={value_string}")
 
     def link_sibling_axis(self):
         # Linking multiple viewboxes with locked aspect ratios causes


### PR DESCRIPTION
### Issue

Closes #1506

### Description

The initial position of the ROI line is now in the centre of the recon preview. This highlighted that the bounds for dragging the ROI seem to be being applied relative to the start position of the ROI line. I had a look through the PyQtGraph code and did some experimenting with converting between the different co-ordinate systems, but concluded it would take quite a bit of digging to find the underlying cause. I also noticed that whenever `autoRange()` is called (which happens on resetting the ROI line or when "View All" is clicked from the right click menu) it changes the way the bounds behave - see comment in the PR. Again, due to limited time at the moment, I've found a quick solution for this but have included comments so that this could be investigated in future to either try and bug fix the PyQtGraph widgets or implement our own version of the line segment ROI, if preferred.

This PR also adds ROI line start and end co-ordinates and line length information to the bottom of the recon line profile graph. As per the suggestion on the issue, I've also included x and y co-ordinates with the value information that is displayed on mouse over of MIMiniImageView previews. This means this information is displayed for all previews on the recon and operations windows, however I'm happy to change this and just limit it to the recon preview if preferred.

### Testing & Acceptance Criteria 

1) ROI line starts off in the centre of the recon preview and resets to that position when reset is selected from the right click menu.
1) All mini image previews in the recon and operations windows now display x and y co-ordinates as well as value on mouse over.
1) The start and end-point x and y co-ordinates and the ROI line length are displayed underneath the recon line profile graph.

All of the values should update live.  They should be checked for accuracy as part of testing this PR.

### Documentation

Not required.
