### PR TITLE
Change nametuples to use NamedTuples from typing

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -49,3 +49,4 @@ Developer Changes
 - #1402 : Add GitHub Actions tests for Windows
 - #1449 : Update CIL to 21.4, Astra to 2.0
 - #1341 : Update to python 3.9, numpy 1.20
+- #1509 : Change nametuples to use NamedTuples from typing

--- a/mantidimaging/core/rotation/data_model.py
+++ b/mantidimaging/core/rotation/data_model.py
@@ -1,9 +1,8 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-from collections import namedtuple
 from logging import getLogger
-from typing import Optional, List, Iterator
+from typing import Optional, List, Iterator, NamedTuple
 
 import numpy as np
 import scipy as sp
@@ -12,7 +11,7 @@ from mantidimaging.core.operation_history import const
 from ..utility.data_containers import ScalarCoR, Degrees, Slope
 
 LOG = getLogger(__name__)
-Point = namedtuple('Point', ['slice_index', 'cor'])
+Point = NamedTuple("Point", [("slice_index", int), ("cor", float)])
 
 
 class CorTiltDataModel:

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -8,9 +8,8 @@ The biggest benefit is explicitly marking what the value represents (e.g. Degree
 and helps the type hints to tell you that you might be passing the wrong value (e.g. ScalarCoR to a VectorCoR),
 while they're both Float underneath and the value can be used, it just will produce nonsense.
 """
-from collections import namedtuple
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, NamedTuple
 
 import numpy
 
@@ -117,7 +116,7 @@ class ReconstructionParameters:
         }
 
 
-Indices = namedtuple('Indices', ['start', 'end', 'step'])
+Indices = NamedTuple("Indices", [("start", int), ("end", int), ("step", int)])
 
 
 @dataclass

--- a/mantidimaging/core/utility/progress_reporting/progress.py
+++ b/mantidimaging/core/utility/progress_reporting/progress.py
@@ -3,13 +3,12 @@
 
 import threading
 import time
-from collections import namedtuple
 from logging import getLogger
-from typing import List, Optional
+from typing import List, NamedTuple, Optional
 
 from mantidimaging.core.utility.memory_usage import get_memory_usage_linux_str
 
-ProgressHistory = namedtuple('ProgressHistory', ['time', 'step', 'msg'])
+ProgressHistory = NamedTuple('ProgressHistory', [('time', float), ('step', int), ('msg', str)])
 
 
 class ProgressHandler(object):

--- a/mantidimaging/eyes_tests/image_save_dialog_test.py
+++ b/mantidimaging/eyes_tests/image_save_dialog_test.py
@@ -1,8 +1,9 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from unittest import mock
+from uuid import UUID, uuid4
 
-from collections import namedtuple
+from typing import NamedTuple
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
 
 
@@ -12,9 +13,9 @@ class ImageSaveDialogTest(BaseEyesTest):
 
         self.check_target(widget=self.imaging.image_save_dialog)
 
-    def test_save_dialog_opens_with_dataset(self):
-        TestTuple = namedtuple('TestTuple', ['id', 'name'])
-        stack_list = [TestTuple('', 'Test Stack')]
+    def test_save_dialog_opens_with_dataset(self) -> None:
+        TestTuple = NamedTuple('TestTuple', [('id', UUID), ('name', str)])
+        stack_list = [TestTuple(uuid4(), 'Test Stack')]
         with mock.patch("mantidimaging.gui.windows.main.MainWindowView.stack_list",
                         new_callable=mock.PropertyMock) as mock_stack_list:
             mock_stack_list.return_value = stack_list

--- a/mantidimaging/eyes_tests/nexus_save_dialog_test.py
+++ b/mantidimaging/eyes_tests/nexus_save_dialog_test.py
@@ -1,16 +1,17 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-from collections import namedtuple
+from typing import NamedTuple
 from unittest import mock
+from uuid import UUID, uuid4
 
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
 
 
 class NexusSaveDialogTest(BaseEyesTest):
     def test_save_dialog_opens_with_dataset(self):
-        TestTuple = namedtuple('TestTuple', ['id', 'name'])
-        dataset_list = [TestTuple('', 'Test Dataset')]
+        TestTuple = NamedTuple('TestTuple', [('id', UUID), ('name', str)])
+        dataset_list = [TestTuple(uuid4(), 'Test Dataset')]
         with mock.patch("mantidimaging.gui.windows.main.MainWindowView.strict_dataset_list",
                         new_callable=mock.PropertyMock) as mock_dataset_list:
             mock_dataset_list.return_value = dataset_list


### PR DESCRIPTION
### Issue

Closes #1509 

### Description

Changed Python files using `nametuples` to use `NamedTuples` from `typing` to allow for type hinting.

### Testing 

Ran `make mypy` to see if any type errors were flagged.

### Acceptance Criteria 

*How should the reviewer test your changes*?

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*
