### PR TITLE
SpectrumWidget

### DIFF
--- a/mantidimaging/gui/ui/spectrum_viewer.ui
+++ b/mantidimaging/gui/ui/spectrum_viewer.ui
@@ -14,168 +14,181 @@
    <string>Spectrum Viewer</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <widget class="QSplitter" name="splitter">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>0</y>
-      <width>900</width>
-      <height>733</height>
-     </rect>
-    </property>
-    <property name="orientation">
-     <enum>Qt::Horizontal</enum>
-    </property>
-    <widget class="QWidget" name="verticalLayoutWidget">
-     <layout class="QVBoxLayout" name="optionsLayout" stretch="0,0,0,0,0,0,0,0">
-      <property name="sizeConstraint">
-       <enum>QLayout::SetDefaultConstraint</enum>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QSplitter" name="splitter">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
       </property>
-      <property name="leftMargin">
-       <number>9</number>
-      </property>
-      <property name="topMargin">
-       <number>9</number>
-      </property>
-      <property name="rightMargin">
-       <number>9</number>
-      </property>
-      <property name="bottomMargin">
-       <number>9</number>
-      </property>
-      <item>
-       <widget class="QLabel" name="sampleLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+      <widget class="QWidget" name="optionsLayout" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <property name="leftMargin">
+         <number>20</number>
         </property>
-        <property name="text">
-         <string>Sample:</string>
+        <property name="topMargin">
+         <number>20</number>
         </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="DatasetSelectorWidgetView" name="sampleStackSelector"/>
-      </item>
-      <item>
-       <spacer name="dropdownSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
+        <property name="rightMargin">
+         <number>20</number>
         </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Maximum</enum>
+        <property name="bottomMargin">
+         <number>20</number>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="normaliseCheckBox">
-        <property name="layoutDirection">
-         <enum>Qt::LeftToRight</enum>
-        </property>
-        <property name="text">
-         <string>Normalise to open beam</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="DatasetSelectorWidgetView" name="normaliseStackSelector">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="frame">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="buttonSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Maximum</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>50</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="sampleLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Sample:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="DatasetSelectorWidgetView" name="sampleStackSelector">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>200</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="dropdownSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="normaliseCheckBox">
+          <property name="layoutDirection">
+           <enum>Qt::LeftToRight</enum>
+          </property>
+          <property name="text">
+           <string>Normalise to open beam</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="DatasetSelectorWidgetView" name="normaliseStackSelector">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>200</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="frame">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="buttonSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
         <item>
          <widget class="QPushButton" name="exportButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
           <property name="text">
            <string>Export spectrum</string>
           </property>
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer">
+         <spacer name="verticalSpacer">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Vertical</enum>
           </property>
           <property name="sizeType">
-           <enum>QSizePolicy::Preferred</enum>
+           <enum>QSizePolicy::MinimumExpanding</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>200</width>
+            <width>20</width>
             <height>20</height>
            </size>
           </property>
          </spacer>
         </item>
        </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Preferred</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>600</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-    <widget class="QWidget" name="verticalLayoutWidget_2">
-     <layout class="QVBoxLayout" name="imageLayout">
-      <property name="leftMargin">
-       <number>9</number>
-      </property>
-      <property name="topMargin">
-       <number>9</number>
-      </property>
-      <property name="rightMargin">
-       <number>9</number>
-      </property>
-      <property name="bottomMargin">
-       <number>9</number>
-      </property>
-     </layout>
-    </widget>
-   </widget>
+      </widget>
+      <widget class="QWidget" name="rightWidget" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <item>
+         <layout class="QVBoxLayout" name="imageLayout"/>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </item>
+   </layout>
   </widget>
  </widget>
  <customwidgets>

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -36,5 +36,17 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                 elif new_dataset.flat_after is not None:
                     self.view.try_to_select_relevant_normalise_stack(new_dataset.flat_after.name)
 
+        if uuid is not None:
+            self.show_new_sample(uuid)
+
     def get_dataset_id_for_stack(self, stack_id: Optional['UUID']) -> Optional['UUID']:
         return None if stack_id is None else self.main_window.get_dataset_id_from_stack_uuid(stack_id)
+
+    def show_new_sample(self, uuid: 'UUID'):
+        stack = self.main_window.get_stack(uuid)
+
+        stack_averaged = stack.data.mean(axis=0)
+        stack_spectrum = stack.data.mean(axis=(1, 2))
+
+        self.view.spectrum.image.setImage(stack_averaged)
+        self.view.spectrum.spectrum.plot(stack_spectrum, clear=True)

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+from typing import TYPE_CHECKING
+
+from pyqtgraph import GraphicsLayoutWidget, PlotItem
+
+from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
+
+if TYPE_CHECKING:
+    from .view import SpectrumViewerWindowView
+
+
+class SpectrumWidget(GraphicsLayoutWidget):
+    image: MIMiniImageView
+    spectrum: PlotItem
+
+    def __init__(self, parent: 'SpectrumViewerWindowView'):
+        super().__init__(parent)
+        self.parent = parent
+
+        self.image = MIMiniImageView(name="Projection", parent=parent)
+        self.addItem(self.image, 0, 0)
+
+        self.nextRow()
+        self.spectrum = self.addPlot()
+
+        self.ci.layout.setRowStretchFactor(0, 3)
+        self.ci.layout.setRowStretchFactor(1, 1)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -37,10 +37,12 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         new_dataset.flat_before.name = 'Flat_before'
         self.presenter.main_window.get_dataset = mock.Mock()
         self.presenter.main_window.get_dataset.return_value = new_dataset
+        self.presenter.show_new_sample = mock.Mock()
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
 
         self.presenter.handle_sample_change(uuid.uuid4())
         self.view.try_to_select_relevant_normalise_stack.assert_called_once_with('Flat_before')
+        self.presenter.show_new_sample.assert_called_once()
 
     def test_handle_sample_change_has_flat_after(self):
         self.presenter.get_dataset_id_for_stack = mock.Mock()
@@ -49,25 +51,30 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         new_dataset.flat_after.name = 'Flat_after'
         self.presenter.main_window.get_dataset = mock.Mock()
         self.presenter.main_window.get_dataset.return_value = new_dataset
+        self.presenter.show_new_sample = mock.Mock()
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
 
         self.presenter.handle_sample_change(uuid.uuid4())
         self.view.try_to_select_relevant_normalise_stack.assert_called_once_with('Flat_after')
+        self.presenter.show_new_sample.assert_called_once()
 
     def test_handle_sample_change_no_new_stack(self):
         self.presenter.get_dataset_id_for_stack = mock.Mock()
         self.presenter.get_dataset_id_for_stack.return_value = None
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
+        self.presenter.show_new_sample = mock.Mock()
 
         self.presenter.handle_sample_change(None)
         self.view.try_to_select_relevant_normalise_stack.assert_not_called()
         self.assertIsNone(self.view.current_dataset_id)
+        self.presenter.show_new_sample.assert_not_called()
 
     def test_handle_sample_change_dataset_unchanged(self):
         initial_dataset_id = self.view.current_dataset_id
         self.presenter.get_dataset_id_for_stack = mock.Mock()
         self.presenter.get_dataset_id_for_stack.return_value = initial_dataset_id
         self.presenter.main_window.get_dataset = mock.Mock()
+        self.presenter.show_new_sample = mock.Mock()
 
         self.presenter.handle_sample_change(uuid.uuid4())
         self.presenter.main_window.get_dataset.assert_not_called()
@@ -79,6 +86,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         new_dataset = MixedDataset([generate_images()])
         self.presenter.main_window.get_dataset = mock.Mock()
         self.presenter.main_window.get_dataset.return_value = new_dataset
+        self.presenter.show_new_sample = mock.Mock()
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
 
         self.presenter.handle_sample_change(uuid.uuid4())
@@ -91,6 +99,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         new_dataset = StrictDataset(generate_images())
         self.presenter.main_window.get_dataset = mock.Mock()
         self.presenter.main_window.get_dataset.return_value = new_dataset
+        self.presenter.show_new_sample = mock.Mock()
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
 
         self.presenter.handle_sample_change(uuid.uuid4())

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -2,11 +2,12 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from typing import TYPE_CHECKING, Optional
 
-from PyQt5.QtWidgets import QCheckBox
+from PyQt5.QtWidgets import QCheckBox, QVBoxLayout
 
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
 from .presenter import SpectrumViewerWindowPresenter
+from .spectrum_widget import SpectrumWidget
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
@@ -18,6 +19,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     normaliseStackSelector: DatasetSelectorWidgetView
 
     normaliseCheckBox: QCheckBox
+    imageLayout: QVBoxLayout
 
     def __init__(self, main_window: 'MainWindowView'):
         super().__init__(main_window, 'gui/ui/spectrum_viewer.ui')
@@ -34,6 +36,9 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self._current_dataset_id = self.presenter.get_dataset_id_for_stack(self.sampleStackSelector.current())
         self.sampleStackSelector.stack_selected_uuid.connect(self.presenter.handle_sample_change)
         self.normaliseCheckBox.stateChanged.connect(self.set_normalise_dropdown_state)
+
+        self.spectrum = SpectrumWidget(self)
+        self.imageLayout.addWidget(self.spectrum)
 
     def cleanup(self):
         self.sampleStackSelector.unsubscribe_from_main_window()


### PR DESCRIPTION
### Issue

Closes #1512

### Description

Add SpectrumWidget with an image and plot region.

Simple display of the mean of the image values and the spectrum.

Tweaks to layout

There is no testing of show_new_sample(), because I expect that functionality will move into a model class soon.

### Testing & Acceptance Criteria 

See #1510 to enable the spectrum menu entry

Load a dataset. Open spectrum window. Select sample.

The image should show the image averaged through the 3rd axis. The spectrum view should show a line.

e.g. for the flower dataset it would look something like:
![image](https://user-images.githubusercontent.com/74248560/175051223-b1c6bae2-e9ca-4442-ae08-f104e1680680.png)
(Note this has angle as the third axis, so is not showing a spectrum)


### Documentation

Wait until whole feature is done
