### PR TITLE
Add some debug output to CIL

### DIFF
--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -156,6 +156,10 @@ class CILRecon(BaseRecon):
             LOG.warning("CIL recon already in progress")
 
         with cil_mutex:
+            LOG.info(f"Starting 3D PDHG-TV reconstruction: input shape {images.data.shape}"
+                     f"output shape {recon_volume_shape}\n"
+                     f"Num iter {recon_params.num_iter}, alpha {recon_params.alpha}, "
+                     f"Non-negative {recon_params.non_negative}")
             progress.update(steps=1, msg='CIL: Setting up reconstruction', force_continue=False)
             angles = images.projection_angles(recon_params.max_projection_angle).value
 


### PR DESCRIPTION
### Issue

Closes #1518 

### Description

Output the size and some of the processing params to aid with debugging

### Testing & Acceptance Criteria 
Run mantid imaging with log level INFO
`python -m mantidimaging --log-level INFO`
Open dataset
Open Recon window
Click "Use tilt/COR from above"
On recon tab select CIL:PDHG-TV
Click Reconstruct volume

Check for output like
`2022-06-27 14:35:59,473 [mantidimaging.core.reconstruct.cil_recon:L159] INFO: Starting 3D PDHG-TV reconstruction: input shape (402, 256, 362)output shape (362, 362, 256)
Num iter 1, alpha 1.0, Non-negative False`

Note: You might also see a `Logging error` about `TypeError: not all arguments converted during string formatting` and `Initialised GradientOperator with C backend running with`. This is from CIL and can be ignored.

### Documentation
Not needed.
