### PR TITLE
Auto sinogram for remaining stripe operations

### DIFF
--- a/mantidimaging/core/operations/arithmetic/arithmetic.py
+++ b/mantidimaging/core/operations/arithmetic/arithmetic.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from functools import partial
-from typing import Callable, Dict, List
+from typing import Callable, Dict
 
 import numpy as np
 from PyQt5.QtWidgets import QFormLayout, QWidget, QDoubleSpinBox
@@ -46,13 +46,13 @@ class ArithmeticFilter(BaseFilter):
             raise ValueError("Unable to proceed with operation because division/multiplication value is zero.")
 
         params = {'div': div_val, 'mult': mult_val, 'add': add_val, 'sub': sub_val}
-        ps.run_compute_func(cls.compute_function, images.data.shape[0], [images.shared_array], params, progress)
+        ps.run_compute_func(cls.compute_function, images.data.shape[0], images.shared_array, params, progress)
 
         return images
 
     @staticmethod
-    def compute_function(i: int, arrays: List[np.ndarray], params: Dict[str, float]):
-        arrays[0][i] = arrays[0][i] / params['div'] * params['mult'] + params['add'] - params['sub']
+    def compute_function(i: int, array: np.ndarray, params: Dict[str, float]):
+        array[i] = array[i] / params['div'] * params['mult'] + params['add'] - params['sub']
 
     @staticmethod
     def register_gui(form: 'QFormLayout', on_change: Callable, view: 'BaseMainWindowView') -> Dict[str, 'QWidget']:

--- a/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
+++ b/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
@@ -50,12 +50,10 @@ class RemoveAllStripesFilter(BaseFilter):
         params = {"snr": snr, "la_size": la_size, "sm_size": sm_size, "dim": dim}
         if images.is_sinograms:
             compute_func = RemoveAllStripesFilter.compute_function_sino
-            num_slices = images.data.shape[0]
         else:
             compute_func = RemoveAllStripesFilter.compute_function
-            num_slices = images.data.shape[1]
 
-        ps.run_compute_func(compute_func, num_slices, [images.shared_array], params, progress)
+        ps.run_compute_func(compute_func, images.num_sinograms, [images.shared_array], params, progress)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
+++ b/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial
-from typing import List, Dict, Any
+from typing import Dict, Any
 from mantidimaging.core.data.imagestack import ImageStack
 
 from PyQt5.QtWidgets import QSpinBox, QDoubleSpinBox
@@ -53,16 +53,16 @@ class RemoveAllStripesFilter(BaseFilter):
         else:
             compute_func = RemoveAllStripesFilter.compute_function
 
-        ps.run_compute_func(compute_func, images.num_sinograms, [images.shared_array], params, progress)
+        ps.run_compute_func(compute_func, images.num_sinograms, images.shared_array, params, progress)
         return images
 
     @staticmethod
-    def compute_function_sino(index: int, arrays: List[ndarray], params: Dict[str, Any]):
-        arrays[0][index] = remove_all_stripe(arrays[0][index], **params)
+    def compute_function_sino(index: int, array: ndarray, params: Dict[str, Any]):
+        array[index] = remove_all_stripe(array[index], **params)
 
     @staticmethod
-    def compute_function(index: int, arrays: List[ndarray], params: Dict[str, Any]):
-        arrays[0][:, index, :] = remove_all_stripe(arrays[0][:, index, :], **params)
+    def compute_function(index: int, array: ndarray, params: Dict[str, Any]):
+        array[:, index, :] = remove_all_stripe(array[:, index, :], **params)
 
     @staticmethod
     def register_gui(form, on_change, view):

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial
-from typing import List, Dict, Any
+from typing import Dict, Any
 
 from PyQt5.QtWidgets import QDoubleSpinBox, QSpinBox
 from algotom.prep.removal import remove_dead_stripe
@@ -47,16 +47,16 @@ class RemoveDeadStripesFilter(BaseFilter):
             compute_func = cls.compute_function_sino
         else:
             compute_func = cls.compute_function
-        ps.run_compute_func(compute_func, images.num_sinograms, [images.shared_array], params, progress)
+        ps.run_compute_func(compute_func, images.num_sinograms, images.shared_array, params, progress)
         return images
 
     @staticmethod
-    def compute_function_sino(index: int, arrays: List[ndarray], params: Dict[str, Any]):
-        arrays[0][index] = remove_dead_stripe(arrays[0][index], **params)
+    def compute_function_sino(index: int, array: ndarray, params: Dict[str, Any]):
+        array[index] = remove_dead_stripe(array[index], **params)
 
     @staticmethod
-    def compute_function(index: int, arrays: List[ndarray], params: Dict[str, Any]):
-        arrays[0][:, index, :] = remove_dead_stripe(arrays[0][:, index, :], **params)
+    def compute_function(index: int, array: ndarray, params: Dict[str, Any]):
+        array[:, index, :] = remove_dead_stripe(array[:, index, :], **params)
 
     @staticmethod
     def register_gui(form, on_change, view):

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -2,14 +2,16 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial
-from mantidimaging.core.data.imagestack import ImageStack
+from typing import List, Dict, Any
 
 from PyQt5.QtWidgets import QDoubleSpinBox, QSpinBox
 from algotom.prep.removal import remove_dead_stripe
+from numpy import ndarray
 
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.gui.utility.qt_helpers import Type
+from mantidimaging.core.data.imagestack import ImageStack
 
 
 class RemoveDeadStripesFilter(BaseFilter):
@@ -28,18 +30,35 @@ class RemoveDeadStripesFilter(BaseFilter):
     """
     filter_name = "Remove dead stripes"
     link_histograms = True
+    operate_on_sinograms = True
 
-    @staticmethod
-    def filter_func(images: ImageStack, snr=3, size=61, progress=None):
+    @classmethod
+    def filter_func(cls, images: ImageStack, snr=3, size=61, progress=None):
         """
         :param snr: The ratio value.
         :param size: The window size of the median filter to remove dead stripes.
 
         :return: The ImageStack object with the dead stripes removed.
         """
-        f = ps.create_partial(remove_dead_stripe, ps.return_to_self, snr=snr, size=size, residual=False)
-        ps.execute(f, [images.shared_array], images.data.shape[0], progress)
+        if images.num_projections < 2:
+            return images
+        params = {"snr": snr, "size": size, "residual": False}
+        if images.is_sinograms:
+            compute_func = cls.compute_function_sino
+            num_slices = images.data.shape[0]
+        else:
+            compute_func = cls.compute_function
+            num_slices = images.data.shape[1]
+        ps.run_compute_func(compute_func, num_slices, [images.shared_array], params, progress)
         return images
+
+    @staticmethod
+    def compute_function_sino(index: int, arrays: List[ndarray], params: Dict[str, Any]):
+        arrays[0][index] = remove_dead_stripe(arrays[0][index], **params)
+
+    @staticmethod
+    def compute_function(index: int, arrays: List[ndarray], params: Dict[str, Any]):
+        arrays[0][:, index, :] = remove_dead_stripe(arrays[0][:, index, :], **params)
 
     @staticmethod
     def register_gui(form, on_change, view):

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -45,11 +45,9 @@ class RemoveDeadStripesFilter(BaseFilter):
         params = {"snr": snr, "size": size, "residual": False}
         if images.is_sinograms:
             compute_func = cls.compute_function_sino
-            num_slices = images.data.shape[0]
         else:
             compute_func = cls.compute_function
-            num_slices = images.data.shape[1]
-        ps.run_compute_func(compute_func, num_slices, [images.shared_array], params, progress)
+        ps.run_compute_func(compute_func, images.num_sinograms, [images.shared_array], params, progress)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_dead_stripe/test/remove_dead_stripe_test.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/test/remove_dead_stripe_test.py
@@ -6,8 +6,10 @@ from unittest import mock
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.remove_dead_stripe import RemoveDeadStripesFilter
+from mantidimaging.test_helpers.start_qapplication import start_multiprocessing_pool
 
 
+@start_multiprocessing_pool
 class RemoveDeadStripesTest(unittest.TestCase):
     """
     Test stripe removal filter.

--- a/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
+++ b/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial
-from typing import TYPE_CHECKING, List, Dict, Any
+from typing import TYPE_CHECKING, Dict, Any
 
 from PyQt5.QtWidgets import QSpinBox, QDoubleSpinBox
 from algotom.prep.removal import remove_large_stripe
@@ -47,16 +47,16 @@ class RemoveLargeStripesFilter(BaseFilter):
             compute_func = cls.compute_function_sino
         else:
             compute_func = cls.compute_function
-        ps.run_compute_func(compute_func, images.num_sinograms, [images.shared_array], params, progress)
+        ps.run_compute_func(compute_func, images.num_sinograms, images.shared_array, params, progress)
         return images
 
     @staticmethod
-    def compute_function_sino(index: int, arrays: List['ndarray'], params: Dict[str, Any]):
-        arrays[0][index] = remove_large_stripe(arrays[0][index], **params)
+    def compute_function_sino(index: int, array: 'ndarray', params: Dict[str, Any]):
+        array[index] = remove_large_stripe(array[index], **params)
 
     @staticmethod
-    def compute_function(index: int, arrays: List['ndarray'], params: Dict[str, Any]):
-        arrays[0][:, index, :] = remove_large_stripe(arrays[0][:, index, :], **params)
+    def compute_function(index: int, array: 'ndarray', params: Dict[str, Any]):
+        array[:, index, :] = remove_large_stripe(array[:, index, :], **params)
 
     @staticmethod
     def register_gui(form, on_change, view):

--- a/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
+++ b/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
@@ -45,11 +45,9 @@ class RemoveLargeStripesFilter(BaseFilter):
         params = {"snr": snr, "size": la_size}
         if images.is_sinograms:
             compute_func = cls.compute_function_sino
-            num_slices = images.data.shape[0]
         else:
             compute_func = cls.compute_function
-            num_slices = images.data.shape[1]
-        ps.run_compute_func(compute_func, num_slices, [images.shared_array], params, progress)
+        ps.run_compute_func(compute_func, images.num_sinograms, [images.shared_array], params, progress)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
@@ -50,21 +50,19 @@ class RemoveStripeFilteringFilter(BaseFilter):
         """
         params = {"sigma": sigma, "size": size, "dim": window_dim}
         if images.is_sinograms:
-            num_slices = images.data.shape[0]
             if filtering_dim == 1:
                 params["sort"] = True
                 compute_func = cls.compute_function_sino
             else:
                 compute_func = cls.compute_function_2d_sino
         else:
-            num_slices = images.data.shape[1]
             if filtering_dim == 1:
                 params["sort"] = True
                 compute_func = cls.compute_function
             else:
                 compute_func = cls.compute_function_2d
 
-        ps.run_compute_func(compute_func, num_slices, [images.shared_array], params, progress)
+        ps.run_compute_func(compute_func, images.num_sinograms, [images.shared_array], params, progress)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial
-from typing import List, Dict, Any
+from typing import Dict, Any
 
 from PyQt5.QtWidgets import QSpinBox
 from algotom.prep.removal import remove_stripe_based_filtering, remove_stripe_based_2d_filtering_sorting
@@ -62,24 +62,24 @@ class RemoveStripeFilteringFilter(BaseFilter):
             else:
                 compute_func = cls.compute_function_2d
 
-        ps.run_compute_func(compute_func, images.num_sinograms, [images.shared_array], params, progress)
+        ps.run_compute_func(compute_func, images.num_sinograms, images.shared_array, params, progress)
         return images
 
     @staticmethod
-    def compute_function_sino(index: int, arrays: List[ndarray], params: Dict[str, Any]):
-        arrays[0][index] = remove_stripe_based_filtering(arrays[0][index], **params)
+    def compute_function_sino(index: int, array: ndarray, params: Dict[str, Any]):
+        array[index] = remove_stripe_based_filtering(array[index], **params)
 
     @staticmethod
-    def compute_function(index: int, arrays: List[ndarray], params: Dict[str, Any]):
-        arrays[0][:, index, :] = remove_stripe_based_filtering(arrays[0][:, index, :], **params)
+    def compute_function(index: int, array: ndarray, params: Dict[str, Any]):
+        array[:, index, :] = remove_stripe_based_filtering(array[:, index, :], **params)
 
     @staticmethod
-    def compute_function_2d_sino(index: int, arrays: List[ndarray], params: Dict[str, Any]):
-        arrays[0][index] = remove_stripe_based_2d_filtering_sorting(arrays[0][index], **params)
+    def compute_function_2d_sino(index: int, array: ndarray, params: Dict[str, Any]):
+        array[index] = remove_stripe_based_2d_filtering_sorting(array[index], **params)
 
     @staticmethod
-    def compute_function_2d(index: int, arrays: List[ndarray], params: Dict[str, Any]):
-        arrays[0][:, index, :] = remove_stripe_based_2d_filtering_sorting(arrays[0][:, index, :], **params)
+    def compute_function_2d(index: int, array: ndarray, params: Dict[str, Any]):
+        array[:, index, :] = remove_stripe_based_2d_filtering_sorting(array[:, index, :], **params)
 
     @staticmethod
     def register_gui(form, on_change, view):

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
@@ -47,11 +47,9 @@ class RemoveStripeSortingFittingFilter(BaseFilter):
         params = {'order': order, 'sigma': sigma, 'sort': True}
         if images.is_sinograms:
             compute_func = cls.compute_function_sino
-            num_slices = images.data.shape[0]
         else:
             compute_func = cls.compute_function
-            num_slices = images.data.shape[1]
-        ps.run_compute_func(compute_func, num_slices, [images.shared_array], params, progress)
+        ps.run_compute_func(compute_func, images.num_sinograms, [images.shared_array], params, progress)
 
         return images
 

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial
-from typing import List, Dict, Any
+from typing import Dict, Any
 
 from PyQt5.QtWidgets import QSpinBox
 from algotom.prep.removal import remove_stripe_based_fitting
@@ -49,17 +49,17 @@ class RemoveStripeSortingFittingFilter(BaseFilter):
             compute_func = cls.compute_function_sino
         else:
             compute_func = cls.compute_function
-        ps.run_compute_func(compute_func, images.num_sinograms, [images.shared_array], params, progress)
+        ps.run_compute_func(compute_func, images.num_sinograms, images.shared_array, params, progress)
 
         return images
 
     @staticmethod
-    def compute_function_sino(index: int, arrays: List[ndarray], params: Dict[str, Any]):
-        arrays[0][index] = remove_stripe_based_fitting(arrays[0][index], **params)
+    def compute_function_sino(index: int, array: ndarray, params: Dict[str, Any]):
+        array[index] = remove_stripe_based_fitting(array[index], **params)
 
     @staticmethod
-    def compute_function(index: int, arrays: List[ndarray], params: Dict[str, Any]):
-        arrays[0][:, index, :] = remove_stripe_based_fitting(arrays[0][:, index, :], **params)
+    def compute_function(index: int, array: ndarray, params: Dict[str, Any]):
+        array[:, index, :] = remove_stripe_based_fitting(array[:, index, :], **params)
 
     @staticmethod
     def register_gui(form, on_change, view):

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
@@ -2,14 +2,16 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from functools import partial
-from mantidimaging.core.data.imagestack import ImageStack
+from typing import List, Dict, Any
 
 from PyQt5.QtWidgets import QSpinBox
 from algotom.prep.removal import remove_stripe_based_fitting
+from numpy import ndarray
 
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.gui.utility.qt_helpers import Type
+from mantidimaging.core.data.imagestack import ImageStack
 
 
 class RemoveStripeSortingFittingFilter(BaseFilter):
@@ -28,9 +30,10 @@ class RemoveStripeSortingFittingFilter(BaseFilter):
     """
     filter_name = "Remove stripes with sorting and fitting"
     link_histograms = True
+    operate_on_sinograms = True
 
-    @staticmethod
-    def filter_func(images: ImageStack, order=1, sigma=3, progress=None):
+    @classmethod
+    def filter_func(cls, images: ImageStack, order=1, sigma=3, progress=None):
         """
         :param order: The polynomial fit order. Check algotom docs for more
                       information.
@@ -39,10 +42,26 @@ class RemoveStripeSortingFittingFilter(BaseFilter):
         :return: The ImageStack object with the stripes removed using the
                  sorting and fitting technique.
         """
-        f = ps.create_partial(remove_stripe_based_fitting, ps.return_to_self, order=order, sigma=sigma, sort=True)
+        if images.num_projections < 2:
+            return images
+        params = {'order': order, 'sigma': sigma, 'sort': True}
+        if images.is_sinograms:
+            compute_func = cls.compute_function_sino
+            num_slices = images.data.shape[0]
+        else:
+            compute_func = cls.compute_function
+            num_slices = images.data.shape[1]
+        ps.run_compute_func(compute_func, num_slices, [images.shared_array], params, progress)
 
-        ps.execute(f, [images.shared_array], images.data.shape[0], progress)
         return images
+
+    @staticmethod
+    def compute_function_sino(index: int, arrays: List[ndarray], params: Dict[str, Any]):
+        arrays[0][index] = remove_stripe_based_fitting(arrays[0][index], **params)
+
+    @staticmethod
+    def compute_function(index: int, arrays: List[ndarray], params: Dict[str, Any]):
+        arrays[0][:, index, :] = remove_stripe_based_fitting(arrays[0][:, index, :], **params)
 
     @staticmethod
     def register_gui(form, on_change, view):

--- a/mantidimaging/core/parallel/shared.py
+++ b/mantidimaging/core/parallel/shared.py
@@ -75,7 +75,8 @@ def execute(partial_func: partial,
     pu.execute_impl(num_operations, partial_func, all_data_in_shared_memory, progress, msg)
 
 
-ComputeFuncType = Callable[[int, List['ndarray'], Dict[str, Any]], None]
+ComputeFuncType = Union[Callable[[int, List['ndarray'], Dict[str, Any]], None],
+                        Callable[[int, 'ndarray', Dict[str, Any]], None]]
 
 
 class _Worker:
@@ -87,14 +88,18 @@ class _Worker:
 
     def __call__(self, index: int):
         ndarrays = [sa.array for sa in self.arrays]
+        if len(ndarrays) == 1:
+            ndarrays = ndarrays[0]
         self.func(index, ndarrays, self.params)
 
 
 def run_compute_func(func: ComputeFuncType,
                      num_operations: int,
-                     arrays: List[pu.SharedArray],
+                     arrays: Union[List[pu.SharedArray], pu.SharedArray],
                      params: Dict[str, Any],
                      progress=None):
+    if isinstance(arrays, pu.SharedArray):
+        arrays = [arrays]
     all_data_in_shared_memory, data = _check_shared_mem_and_get_data(arrays)
     worker_func = _Worker(func, data, params)
     pu.run_compute_func_impl(worker_func, num_operations, all_data_in_shared_memory, progress)

--- a/mantidimaging/core/parallel/shared.py
+++ b/mantidimaging/core/parallel/shared.py
@@ -34,10 +34,6 @@ def return_to_second_at_i(func, data: Union[List[pu.SharedArray], List[pu.Shared
     data[1].array[i] = func(data[0].array[i], **kwargs)
 
 
-def arithmetic(func, data: Union[List[pu.SharedArray], List[pu.SharedArrayProxy]], i, arg_list):
-    func(data[0].array[i], *arg_list)
-
-
 def create_partial(func, fwd_function, **kwargs):
     """
     Create a partial using functools.partial, to forward the kwargs to the


### PR DESCRIPTION
### Issue

Closes #1500 

### Description

This sets `operate_on_sinograms` on remaining algotom filters. StripeRemovalFilter is still to do, it has some complications (#1529).

Note that code is complicated due to having to handle both projection and sinogram ordered data. Hopefully this can be removed in the future once all tasks can be done while in projection ordering.

I looked at using numpy.take() to get slices along an axis defined by a value. Unfortunately this does not work for assignment.

I have also updated ArithmeticFilter to use ps.run_compute_func, to show that its sinogram axis requirements that make these more complex than they should be.

### Testing & Acceptance Criteria 

 See #1499


### Documentation

Previous release note comment is good enough
