### PR TITLE
Add missing operation doccstrings

### DIFF
--- a/mantidimaging/core/operations/divide/divide.py
+++ b/mantidimaging/core/operations/divide/divide.py
@@ -28,6 +28,12 @@ class DivideFilter(BaseFilter):
 
     @staticmethod
     def filter_func(images: ImageStack, value: Union[int, float] = 0, unit="micron", progress=None) -> ImageStack:
+        """
+        :param value: The division value.
+        :param unit: The unit of the divisor.
+
+        :return: The ImageStack object which has been divided by a value.
+        """
         h.check_data_stack(images)
         if not value:
             raise ValueError('value parameter must not equal 0 or None')

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -31,6 +31,9 @@ class MonitorNormalisation(BaseFilter):
 
     @staticmethod
     def filter_func(images: ImageStack, progress=None) -> ImageStack:
+        """
+        :return: The ImageStack object which has been normalised.
+        """
         if images.num_projections == 1:
             # we can't really compute the preview as the image stack copy
             # passed in doesn't have the logfile in it

--- a/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
+++ b/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
@@ -34,6 +34,17 @@ class RemoveAllStripesFilter(BaseFilter):
 
     @staticmethod
     def filter_func(images: ImageStack, snr=3, la_size=61, sm_size=21, dim=1, progress=None):
+        """
+        :param snr: The ratio used to segment between useful information and
+                    noise. Greater is less sensitive.
+        :param la_size: The window size of the median filter to remove large
+                        stripes.
+        :param sm_size: The window size of the median filter to remove
+                        small-to-medium stripes.
+        :param dim: Whether to perform the median on 1D or 2D view of the data.
+
+        :return: Remove all types of stripe artifacts.
+        """
         if images.num_projections < 2:
             return images
         params = {"snr": snr, "la_size": la_size, "sm_size": sm_size, "dim": dim}

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -31,6 +31,12 @@ class RemoveDeadStripesFilter(BaseFilter):
 
     @staticmethod
     def filter_func(images: ImageStack, snr=3, size=61, progress=None):
+        """
+        :param snr: The ratio value.
+        :param size: The window size of the median filter to remove dead stripes.
+
+        :return: The ImageStack object with the dead stripes removed.
+        """
         f = ps.create_partial(remove_dead_stripe, ps.return_to_self, snr=snr, size=size, residual=False)
         ps.execute(f, [images.shared_array], images.data.shape[0], progress)
         return images

--- a/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
+++ b/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
@@ -34,6 +34,12 @@ class RemoveLargeStripesFilter(BaseFilter):
 
     @staticmethod
     def filter_func(images: 'ImageStack', snr=3, la_size=61, progress=None):
+        """
+        :param snr: The ratio value.
+        :param size: The window size of the median filter to remove large stripes.
+
+        :return: The ImageStack object with large stripes removed.
+        """
         f = ps.create_partial(
             remove_large_stripe,
             ps.return_to_self,

--- a/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
@@ -31,6 +31,20 @@ class RemoveStripeFilteringFilter(BaseFilter):
 
     @staticmethod
     def filter_func(images: ImageStack, sigma=3, size=21, window_dim=1, filtering_dim=1, progress=None):
+        """
+        :param sigma: The sigma of the Gaussian window used to separate the
+                      low-pass and high-pass components of the intensity profile
+                      of each column.
+        :param size: The window size of the median filter to remove large
+                     stripes.
+        :param window_dim: Whether to perform the median on 1D or 2D view of the
+                           data.
+        :param filtering_dim: Whether to use a 1D or 2D low-pass filter. This
+                              uses different Sarepy methods.
+
+        :return: The ImageStack object with the stripes removed using the
+                 filtering and sorting technique.
+        """
         if filtering_dim == 1:
             f = ps.create_partial(remove_stripe_based_filtering,
                                   ps.return_to_self,

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
@@ -31,6 +31,14 @@ class RemoveStripeSortingFittingFilter(BaseFilter):
 
     @staticmethod
     def filter_func(images: ImageStack, order=1, sigma=3, progress=None):
+        """
+        :param order: The polynomial fit order. Check algotom docs for more
+                      information.
+        :param sigma: The sigma of the Gaussian window in the x-direction.
+
+        :return: The ImageStack object with the stripes removed using the
+                 sorting and fitting technique.
+        """
         f = ps.create_partial(remove_stripe_based_fitting, ps.return_to_self, order=order, sigma=sigma, sort=True)
 
         ps.execute(f, [images.shared_array], images.data.shape[0], progress)

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -28,6 +28,16 @@ class RescaleFilter(BaseFilter):
                     max_input: float = 10000.0,
                     max_output: float = 256.0,
                     progress=None) -> ImageStack:
+        """
+        :param min_input: The Minimum value of the data that will be used.
+                          Anything below this will be clipped to 0.
+        :param max_input: Maximum value of the data that will be used. Anything
+                          above it will be clipped to 0.
+        :param max_output: Maximum value of the OUTPUT images. They will be
+                           rescaled to range [0, MAX OUTPUT].
+
+        :return: The ImageStack object scaled to a new range.
+        """
 
         RescaleFilter.filter_array(images.data, min_input, max_input, max_output)
         return images


### PR DESCRIPTION
### Issue

Closes #1160

### Description

Add missing operation doccstrings for `divide.py`, `monitor_normalisation.py`, `remove_dead_stripe.py`, `remove_large_stripe.py,` `remove_large_stripe.py`, `remove_stripe_filtering.py`, `remove_stripe_sorting_fitting.py`, `rescale.py`, `remove_all_stripe.py.

### Testing 

Built the docs to see if the param and return docstrings were included.

### Acceptance Criteria 

Build the docs and see if the added docstrings are there.

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*
