### PR TITLE
Add ToF range control to spectrum window

### DIFF
--- a/mantidimaging/gui/ui/main_window.ui
+++ b/mantidimaging/gui/ui/main_window.ui
@@ -225,9 +225,6 @@
    </property>
   </action>
   <action name="actionSpectrumViewer">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
    <property name="text">
     <string>Spectrum Viewer (Beta)</string>
    </property>

--- a/mantidimaging/gui/windows/spectrum_viewer/__init__.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/__init__.py
@@ -3,3 +3,4 @@
 
 from .view import SpectrumViewerWindowView  # noqa: F401
 from .presenter import SpectrumViewerWindowPresenter  # noqa: F401
+from .model import SpectrumViewerWindowModel  # noqa: F401

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Optional
 from mantidimaging.core.data import ImageStack
 
 if TYPE_CHECKING:
+    import numpy as np
     from mantidimaging.gui.windows.spectrum_viewer.presenter import SpectrumViewerWindowPresenter
 
 
@@ -23,3 +24,10 @@ class SpectrumViewerWindowModel:
 
     def set_open_stack(self, open_stack: ImageStack):
         self._open_stack = open_stack
+
+    def get_averaged_image(self) -> 'np.ndarray':
+        if self._stack is not None:
+            tof_slice = slice(self.tof_range[0], self.tof_range[1] + 1)
+            return self._stack.data[tof_slice].mean(axis=0)
+        else:
+            return None

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from typing import TYPE_CHECKING, Optional
+
+from mantidimaging.core.data import ImageStack
+
+if TYPE_CHECKING:
+    from mantidimaging.gui.windows.spectrum_viewer.presenter import SpectrumViewerWindowPresenter
+
+
+class SpectrumViewerWindowModel:
+    presenter: 'SpectrumViewerWindowPresenter'
+    _stack: Optional[ImageStack]
+    _open_stack: Optional[ImageStack]
+
+    def __init__(self, presenter):
+        self.presenter = presenter
+
+    def set_stack(self, stack: ImageStack):
+        self._stack = stack
+
+    def set_open_stack(self, open_stack: ImageStack):
+        self._open_stack = open_stack

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 class SpectrumViewerWindowModel:
     presenter: 'SpectrumViewerWindowPresenter'
     _stack: Optional[ImageStack]
-    _open_stack: Optional[ImageStack]
+    _normalise_stack: Optional[ImageStack]
     tof_range: tuple[int, int] = (0, 0)
 
     def __init__(self, presenter):
@@ -22,8 +22,8 @@ class SpectrumViewerWindowModel:
         self._stack = stack
         self.tof_range = (0, stack.data.shape[0] - 1)
 
-    def set_open_stack(self, open_stack: ImageStack):
-        self._open_stack = open_stack
+    def set_normalise_stack(self, normalise_stack: ImageStack):
+        self._normalise_stack = normalise_stack
 
     def get_averaged_image(self) -> 'np.ndarray':
         if self._stack is not None:

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -12,12 +12,14 @@ class SpectrumViewerWindowModel:
     presenter: 'SpectrumViewerWindowPresenter'
     _stack: Optional[ImageStack]
     _open_stack: Optional[ImageStack]
+    tof_range: tuple[int, int] = (0, 0)
 
     def __init__(self, presenter):
         self.presenter = presenter
 
     def set_stack(self, stack: ImageStack):
         self._stack = stack
+        self.tof_range = (0, stack.data.shape[0] - 1)
 
     def set_open_stack(self, open_stack: ImageStack):
         self._open_stack = open_stack

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -31,3 +31,9 @@ class SpectrumViewerWindowModel:
             return self._stack.data[tof_slice].mean(axis=0)
         else:
             return None
+
+    def get_spectrum(self) -> 'np.ndarray':
+        if self._stack is not None:
+            return self._stack.data.mean(axis=(1, 2))
+        else:
+            return None

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Optional
 
 from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.gui.mvp_base import BasePresenter
+from mantidimaging.gui.windows.spectrum_viewer.model import SpectrumViewerWindowModel
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.spectrum_viewer.view import SpectrumViewerWindowView  # pragma: no cover
@@ -13,12 +14,14 @@ if TYPE_CHECKING:
 
 class SpectrumViewerWindowPresenter(BasePresenter):
     view: 'SpectrumViewerWindowView'
+    model: SpectrumViewerWindowModel
 
     def __init__(self, view: 'SpectrumViewerWindowView', main_window: 'MainWindowView'):
         super().__init__(view)
 
         self.view = view
         self.main_window = main_window
+        self.model = SpectrumViewerWindowModel(self)
 
     def handle_sample_change(self, uuid: Optional['UUID']) -> None:
         new_dataset_id = self.get_dataset_id_for_stack(uuid)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -50,3 +50,4 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
         self.view.spectrum.image.setImage(stack_averaged)
         self.view.spectrum.spectrum.plot(stack_spectrum, clear=True)
+        self.view.spectrum.add_range(0, stack_spectrum.shape[0] - 1)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -36,7 +36,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             normalise_uuid = self.view.get_normalise_stack()
             if normalise_uuid is not None:
                 self.model.set_open_stack(self.main_window.get_stack(normalise_uuid))
-            self.show_new_sample(uuid)
+            self.show_new_sample()
 
     def auto_find_flat_stack(self, new_dataset_id):
         if self.view.current_dataset_id != new_dataset_id:
@@ -52,11 +52,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
     def get_dataset_id_for_stack(self, stack_id: Optional['UUID']) -> Optional['UUID']:
         return None if stack_id is None else self.main_window.get_dataset_id_from_stack_uuid(stack_id)
 
-    def show_new_sample(self, uuid: 'UUID'):
-        stack = self.main_window.get_stack(uuid)
-
-        stack_spectrum = stack.data.mean(axis=(1, 2))
-
+    def show_new_sample(self) -> None:
         self.view.spectrum.image.setImage(self.model.get_averaged_image())
-        self.view.spectrum.spectrum.plot(stack_spectrum, clear=True)
+        self.view.spectrum.spectrum.plot(self.model.get_spectrum(), clear=True)
         self.view.spectrum.add_range(*self.model.tof_range)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -35,7 +35,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             self.model.set_stack(self.main_window.get_stack(uuid))
             normalise_uuid = self.view.get_normalise_stack()
             if normalise_uuid is not None:
-                self.model.set_open_stack(self.main_window.get_stack(normalise_uuid))
+                self.model.set_normalise_stack(self.main_window.get_stack(normalise_uuid))
             self.show_new_sample()
 
     def auto_find_flat_stack(self, new_dataset_id):

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -55,9 +55,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
     def show_new_sample(self, uuid: 'UUID'):
         stack = self.main_window.get_stack(uuid)
 
-        stack_averaged = stack.data.mean(axis=0)
         stack_spectrum = stack.data.mean(axis=(1, 2))
 
-        self.view.spectrum.image.setImage(stack_averaged)
+        self.view.spectrum.image.setImage(self.model.get_averaged_image())
         self.view.spectrum.spectrum.plot(stack_spectrum, clear=True)
         self.view.spectrum.add_range(*self.model.tof_range)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -25,10 +25,20 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def handle_sample_change(self, uuid: Optional['UUID']) -> None:
         new_dataset_id = self.get_dataset_id_for_stack(uuid)
-        if new_dataset_id is None:
-            self.view.current_dataset_id = None
-            return
 
+        if new_dataset_id:
+            self.auto_find_flat_stack(new_dataset_id)
+        else:
+            self.view.current_dataset_id = None
+
+        if uuid is not None:
+            self.model.set_stack(self.main_window.get_stack(uuid))
+            normalise_uuid = self.view.get_normalise_stack()
+            if normalise_uuid is not None:
+                self.model.set_open_stack(self.main_window.get_stack(normalise_uuid))
+            self.show_new_sample(uuid)
+
+    def auto_find_flat_stack(self, new_dataset_id):
         if self.view.current_dataset_id != new_dataset_id:
             self.view.current_dataset_id = new_dataset_id
 
@@ -38,9 +48,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                     self.view.try_to_select_relevant_normalise_stack(new_dataset.flat_before.name)
                 elif new_dataset.flat_after is not None:
                     self.view.try_to_select_relevant_normalise_stack(new_dataset.flat_after.name)
-
-        if uuid is not None:
-            self.show_new_sample(uuid)
 
     def get_dataset_id_for_stack(self, stack_id: Optional['UUID']) -> Optional['UUID']:
         return None if stack_id is None else self.main_window.get_dataset_id_from_stack_uuid(stack_id)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -60,4 +60,4 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
         self.view.spectrum.image.setImage(stack_averaged)
         self.view.spectrum.spectrum.plot(stack_spectrum, clear=True)
-        self.view.spectrum.add_range(0, stack_spectrum.shape[0] - 1)
+        self.view.spectrum.add_range(*self.model.tof_range)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -56,3 +56,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.spectrum.image.setImage(self.model.get_averaged_image())
         self.view.spectrum.spectrum.plot(self.model.get_spectrum(), clear=True)
         self.view.spectrum.add_range(*self.model.tof_range)
+
+    def handle_range_slide_moved(self) -> None:
+        tof_range = self.view.spectrum.get_tof_range()
+        self.model.tof_range = tof_range
+        self.view.spectrum.image.setImage(self.model.get_averaged_image(), autoLevels=False)

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -3,6 +3,7 @@
 
 from typing import TYPE_CHECKING
 
+from PyQt5.QtCore import pyqtSignal
 from pyqtgraph import GraphicsLayoutWidget, PlotItem, LinearRegionItem
 
 from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
@@ -15,6 +16,8 @@ class SpectrumWidget(GraphicsLayoutWidget):
     image: MIMiniImageView
     spectrum: PlotItem
     range_control: LinearRegionItem
+
+    range_changed = pyqtSignal()
 
     def __init__(self, parent: 'SpectrumViewerWindowView'):
         super().__init__(parent)
@@ -30,8 +33,13 @@ class SpectrumWidget(GraphicsLayoutWidget):
         self.ci.layout.setRowStretchFactor(1, 1)
 
         self.range_control = LinearRegionItem()
+        self.range_control.sigRegionChanged.connect(self.range_changed.emit)
 
     def add_range(self, range_min: int, range_max: int):
         self.range_control.setBounds((range_min, range_max))
         self.range_control.setRegion((range_min, range_max))
         self.spectrum.addItem(self.range_control)
+
+    def get_tof_range(self) -> tuple[int, int]:
+        r_min, r_max = self.range_control.getRegion()
+        return int(r_min), int(r_max)

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -3,7 +3,7 @@
 
 from typing import TYPE_CHECKING
 
-from pyqtgraph import GraphicsLayoutWidget, PlotItem
+from pyqtgraph import GraphicsLayoutWidget, PlotItem, LinearRegionItem
 
 from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
 
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 class SpectrumWidget(GraphicsLayoutWidget):
     image: MIMiniImageView
     spectrum: PlotItem
+    range_control: LinearRegionItem
 
     def __init__(self, parent: 'SpectrumViewerWindowView'):
         super().__init__(parent)
@@ -27,3 +28,10 @@ class SpectrumWidget(GraphicsLayoutWidget):
 
         self.ci.layout.setRowStretchFactor(0, 3)
         self.ci.layout.setRowStretchFactor(1, 1)
+
+        self.range_control = LinearRegionItem()
+
+    def add_range(self, range_min: int, range_max: int):
+        self.range_control.setBounds((range_min, range_max))
+        self.range_control.setRegion((range_min, range_max))
+        self.spectrum.addItem(self.range_control)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+import unittest
+from unittest import mock
+from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowPresenter, SpectrumViewerWindowModel
+
+
+class SpectrumViewerWindowPresenterTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.presenter = mock.create_autospec(SpectrumViewerWindowPresenter)
+        self.model = SpectrumViewerWindowModel(self.presenter)
+
+    def test_set_stacks(self):
+        stack = mock.Mock()
+        open_stack = mock.Mock()
+        self.model.set_stack(stack)
+        self.model.set_open_stack(open_stack)
+
+        self.assertEqual(self.model._stack, stack)
+        self.assertEqual(self.model._open_stack, open_stack)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -4,6 +4,7 @@ import unittest
 from unittest import mock
 
 import numpy as np
+import numpy.testing as npt
 
 from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowPresenter, SpectrumViewerWindowModel
 from mantidimaging.test_helpers.unit_test_helper import generate_images
@@ -43,3 +44,13 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         av_img = self.model.get_averaged_image()
         self.assertEqual(av_img.data.shape, (11, 12))
         self.assertEqual(av_img.data[0, 0], 6.5)
+
+    def test_get_spectrum(self):
+        stack = ImageStack(np.ones([10, 11, 12]))
+        spectrum = np.arange(0, 10)
+        stack.data[:, :, :] = spectrum.reshape((10, 1, 1))
+        self.model.set_stack(stack)
+
+        model_spec = self.model.get_spectrum()
+        self.assertEqual(model_spec.shape, (10, ))
+        npt.assert_array_equal(model_spec, spectrum)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -16,15 +16,18 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter = mock.create_autospec(SpectrumViewerWindowPresenter)
         self.model = SpectrumViewerWindowModel(self.presenter)
 
-    def test_set_stacks(self):
+    def test_set_stack(self):
         stack = generate_images([10, 11, 12])
-        normalise_stack = generate_images([10, 11, 12])
         self.model.set_stack(stack)
-        self.model.set_normalise_stack(normalise_stack)
 
         self.assertEqual(self.model._stack, stack)
-        self.assertEqual(self.model._normalise_stack, normalise_stack)
         self.assertEqual(self.model.tof_range, (0, 9))
+
+    def test_set_normalise_stack(self):
+        normalise_stack = generate_images([10, 11, 12])
+        self.model.set_normalise_stack(normalise_stack)
+
+        self.assertEqual(self.model._normalise_stack, normalise_stack)
 
     def test_get_averaged_image(self):
         stack = ImageStack(np.ones([10, 11, 12]))

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -2,8 +2,12 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 import unittest
 from unittest import mock
+
+import numpy as np
+
 from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowPresenter, SpectrumViewerWindowModel
 from mantidimaging.test_helpers.unit_test_helper import generate_images
+from mantidimaging.core.data import ImageStack
 
 
 class SpectrumViewerWindowPresenterTest(unittest.TestCase):
@@ -20,3 +24,22 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.assertEqual(self.model._stack, stack)
         self.assertEqual(self.model._open_stack, open_stack)
         self.assertEqual(self.model.tof_range, (0, 9))
+
+    def test_get_averaged_image(self):
+        stack = ImageStack(np.ones([10, 11, 12]))
+        stack.data[:5, :, :] = 2
+        self.model.set_stack(stack)
+
+        av_img = self.model.get_averaged_image()
+        self.assertEqual(av_img.data.shape, (11, 12))
+        self.assertEqual(av_img.data[0, 0], (1.5))
+
+    def test_get_averaged_image_range(self):
+        stack = ImageStack(np.ones([10, 11, 12]))
+        stack.data[:, :, :] = np.arange(0, 10).reshape((10, 1, 1))
+        self.model.set_stack(stack)
+        self.model.tof_range = (6, 7)
+
+        av_img = self.model.get_averaged_image()
+        self.assertEqual(av_img.data.shape, (11, 12))
+        self.assertEqual(av_img.data[0, 0], 6.5)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -18,12 +18,12 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
     def test_set_stacks(self):
         stack = generate_images([10, 11, 12])
-        open_stack = generate_images([10, 11, 12])
+        normalise_stack = generate_images([10, 11, 12])
         self.model.set_stack(stack)
-        self.model.set_open_stack(open_stack)
+        self.model.set_normalise_stack(normalise_stack)
 
         self.assertEqual(self.model._stack, stack)
-        self.assertEqual(self.model._open_stack, open_stack)
+        self.assertEqual(self.model._normalise_stack, normalise_stack)
         self.assertEqual(self.model.tof_range, (0, 9))
 
     def test_get_averaged_image(self):

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -3,6 +3,7 @@
 import unittest
 from unittest import mock
 from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowPresenter, SpectrumViewerWindowModel
+from mantidimaging.test_helpers.unit_test_helper import generate_images
 
 
 class SpectrumViewerWindowPresenterTest(unittest.TestCase):
@@ -11,10 +12,11 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.model = SpectrumViewerWindowModel(self.presenter)
 
     def test_set_stacks(self):
-        stack = mock.Mock()
-        open_stack = mock.Mock()
+        stack = generate_images([10, 11, 12])
+        open_stack = generate_images([10, 11, 12])
         self.model.set_stack(stack)
         self.model.set_open_stack(open_stack)
 
         self.assertEqual(self.model._stack, stack)
         self.assertEqual(self.model._open_stack, open_stack)
+        self.assertEqual(self.model.tof_range, (0, 9))

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -35,6 +35,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         new_dataset = StrictDataset(generate_images(), flat_before=generate_images())
         new_dataset.flat_before.name = 'Flat_before'
         self.presenter.main_window.get_dataset = mock.Mock(return_value=new_dataset)
+        self.presenter.main_window.get_stack = mock.Mock()
         self.presenter.show_new_sample = mock.Mock()
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
 
@@ -47,6 +48,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         new_dataset = StrictDataset(generate_images(), flat_after=generate_images())
         new_dataset.flat_after.name = 'Flat_after'
         self.presenter.main_window.get_dataset = mock.Mock(return_value=new_dataset)
+        self.presenter.main_window.get_stack = mock.Mock()
         self.presenter.show_new_sample = mock.Mock()
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
 
@@ -68,6 +70,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         initial_dataset_id = self.view.current_dataset_id
         self.presenter.get_dataset_id_for_stack = mock.Mock(return_value=initial_dataset_id)
         self.presenter.main_window.get_dataset = mock.Mock()
+        self.presenter.main_window.get_stack = mock.Mock()
         self.presenter.show_new_sample = mock.Mock()
 
         self.presenter.handle_sample_change(uuid.uuid4())
@@ -78,6 +81,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.get_dataset_id_for_stack = mock.Mock(return_value=uuid.uuid4())
         new_dataset = MixedDataset([generate_images()])
         self.presenter.main_window.get_dataset = mock.Mock(return_value=new_dataset)
+        self.presenter.main_window.get_stack = mock.Mock()
         self.presenter.show_new_sample = mock.Mock()
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
 
@@ -89,6 +93,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.get_dataset_id_for_stack = mock.Mock(return_value=uuid.uuid4())
         new_dataset = StrictDataset(generate_images())
         self.presenter.main_window.get_dataset = mock.Mock(return_value=new_dataset)
+        self.presenter.main_window.get_stack = mock.Mock()
         self.presenter.show_new_sample = mock.Mock()
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
 

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -105,10 +105,9 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
     def test_show_sample(self):
         image_stack = generate_images([10, 11, 12])
-        self.presenter.main_window.get_stack = mock.Mock(return_value=image_stack)
         self.view.spectrum.image = mock.Mock()
         self.view.spectrum.spectrum = mock.Mock()
         self.presenter.model.set_stack(image_stack)
 
-        self.presenter.show_new_sample(uuid.uuid4())
+        self.presenter.show_new_sample()
         self.view.spectrum.add_range.assert_called_once_with(0, 9)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -7,6 +7,7 @@ from unittest import mock
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowView, SpectrumViewerWindowPresenter
+from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumWidget
 from mantidimaging.test_helpers import mock_versions, start_qapplication
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
@@ -19,6 +20,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
             self.main_window = MainWindowView()
         self.view = mock.create_autospec(SpectrumViewerWindowView)
         self.view.current_dataset_id = uuid.uuid4()
+        self.view.spectrum = mock.create_autospec(SpectrumWidget)
         self.presenter = SpectrumViewerWindowPresenter(self.view, self.main_window)
 
     def test_get_dataset_id_for_stack_no_stack_id(self):
@@ -32,10 +34,10 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
     def test_handle_sample_change_has_flat_before(self):
         self.presenter.get_dataset_id_for_stack = mock.Mock(return_value=uuid.uuid4())
-        new_dataset = StrictDataset(generate_images(), flat_before=generate_images())
+        new_dataset = StrictDataset(generate_images([10, 11, 12]), flat_before=generate_images())
         new_dataset.flat_before.name = 'Flat_before'
         self.presenter.main_window.get_dataset = mock.Mock(return_value=new_dataset)
-        self.presenter.main_window.get_stack = mock.Mock()
+        self.presenter.main_window.get_stack = mock.Mock(return_value=generate_images())
         self.presenter.show_new_sample = mock.Mock()
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
 
@@ -48,7 +50,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         new_dataset = StrictDataset(generate_images(), flat_after=generate_images())
         new_dataset.flat_after.name = 'Flat_after'
         self.presenter.main_window.get_dataset = mock.Mock(return_value=new_dataset)
-        self.presenter.main_window.get_stack = mock.Mock()
+        self.presenter.main_window.get_stack = mock.Mock(return_value=generate_images())
         self.presenter.show_new_sample = mock.Mock()
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
 
@@ -70,7 +72,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         initial_dataset_id = self.view.current_dataset_id
         self.presenter.get_dataset_id_for_stack = mock.Mock(return_value=initial_dataset_id)
         self.presenter.main_window.get_dataset = mock.Mock()
-        self.presenter.main_window.get_stack = mock.Mock()
+        self.presenter.main_window.get_stack = mock.Mock(return_value=generate_images())
         self.presenter.show_new_sample = mock.Mock()
 
         self.presenter.handle_sample_change(uuid.uuid4())
@@ -81,7 +83,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.get_dataset_id_for_stack = mock.Mock(return_value=uuid.uuid4())
         new_dataset = MixedDataset([generate_images()])
         self.presenter.main_window.get_dataset = mock.Mock(return_value=new_dataset)
-        self.presenter.main_window.get_stack = mock.Mock()
+        self.presenter.main_window.get_stack = mock.Mock(return_value=generate_images())
         self.presenter.show_new_sample = mock.Mock()
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
 
@@ -93,10 +95,20 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.get_dataset_id_for_stack = mock.Mock(return_value=uuid.uuid4())
         new_dataset = StrictDataset(generate_images())
         self.presenter.main_window.get_dataset = mock.Mock(return_value=new_dataset)
-        self.presenter.main_window.get_stack = mock.Mock()
+        self.presenter.main_window.get_stack = mock.Mock(return_value=generate_images())
         self.presenter.show_new_sample = mock.Mock()
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
 
         self.presenter.handle_sample_change(uuid.uuid4())
         self.presenter.main_window.get_dataset.assert_called_once()
         self.view.try_to_select_relevant_normalise_stack.assert_not_called()
+
+    def test_show_sample(self):
+        image_stack = generate_images([10, 11, 12])
+        self.presenter.main_window.get_stack = mock.Mock(return_value=image_stack)
+        self.view.spectrum.image = mock.Mock()
+        self.view.spectrum.spectrum = mock.Mock()
+        self.presenter.model.set_stack(image_stack)
+
+        self.presenter.show_new_sample(uuid.uuid4())
+        self.view.spectrum.add_range.assert_called_once_with(0, 9)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -111,3 +111,12 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
         self.presenter.show_new_sample()
         self.view.spectrum.add_range.assert_called_once_with(0, 9)
+
+    def test_gui_changes_tof_range(self):
+        image_stack = generate_images([30, 11, 12])
+        self.view.spectrum.get_tof_range = mock.Mock(return_value=(10, 20))
+        self.view.spectrum.image = mock.Mock()
+        self.presenter.model.set_stack(image_stack)
+        self.presenter.handle_range_slide_moved()
+
+        self.assertEqual(self.presenter.model.tof_range, (10, 20))

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -31,12 +31,10 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.main_window.get_dataset_id_from_stack_uuid.assert_called_once()
 
     def test_handle_sample_change_has_flat_before(self):
-        self.presenter.get_dataset_id_for_stack = mock.Mock()
-        self.presenter.get_dataset_id_for_stack.return_value = uuid.uuid4()
+        self.presenter.get_dataset_id_for_stack = mock.Mock(return_value=uuid.uuid4())
         new_dataset = StrictDataset(generate_images(), flat_before=generate_images())
         new_dataset.flat_before.name = 'Flat_before'
-        self.presenter.main_window.get_dataset = mock.Mock()
-        self.presenter.main_window.get_dataset.return_value = new_dataset
+        self.presenter.main_window.get_dataset = mock.Mock(return_value=new_dataset)
         self.presenter.show_new_sample = mock.Mock()
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
 
@@ -45,12 +43,10 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.show_new_sample.assert_called_once()
 
     def test_handle_sample_change_has_flat_after(self):
-        self.presenter.get_dataset_id_for_stack = mock.Mock()
-        self.presenter.get_dataset_id_for_stack.return_value = uuid.uuid4()
+        self.presenter.get_dataset_id_for_stack = mock.Mock(return_value=uuid.uuid4())
         new_dataset = StrictDataset(generate_images(), flat_after=generate_images())
         new_dataset.flat_after.name = 'Flat_after'
-        self.presenter.main_window.get_dataset = mock.Mock()
-        self.presenter.main_window.get_dataset.return_value = new_dataset
+        self.presenter.main_window.get_dataset = mock.Mock(return_value=new_dataset)
         self.presenter.show_new_sample = mock.Mock()
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
 
@@ -59,8 +55,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.show_new_sample.assert_called_once()
 
     def test_handle_sample_change_no_new_stack(self):
-        self.presenter.get_dataset_id_for_stack = mock.Mock()
-        self.presenter.get_dataset_id_for_stack.return_value = None
+        self.presenter.get_dataset_id_for_stack = mock.Mock(return_value=None)
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
         self.presenter.show_new_sample = mock.Mock()
 
@@ -71,8 +66,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
     def test_handle_sample_change_dataset_unchanged(self):
         initial_dataset_id = self.view.current_dataset_id
-        self.presenter.get_dataset_id_for_stack = mock.Mock()
-        self.presenter.get_dataset_id_for_stack.return_value = initial_dataset_id
+        self.presenter.get_dataset_id_for_stack = mock.Mock(return_value=initial_dataset_id)
         self.presenter.main_window.get_dataset = mock.Mock()
         self.presenter.show_new_sample = mock.Mock()
 
@@ -81,11 +75,9 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.assertEqual(self.view.current_dataset_id, initial_dataset_id)
 
     def test_handle_sample_change_to_MixedDataset(self):
-        self.presenter.get_dataset_id_for_stack = mock.Mock()
-        self.presenter.get_dataset_id_for_stack.return_value = uuid.uuid4()
+        self.presenter.get_dataset_id_for_stack = mock.Mock(return_value=uuid.uuid4())
         new_dataset = MixedDataset([generate_images()])
-        self.presenter.main_window.get_dataset = mock.Mock()
-        self.presenter.main_window.get_dataset.return_value = new_dataset
+        self.presenter.main_window.get_dataset = mock.Mock(return_value=new_dataset)
         self.presenter.show_new_sample = mock.Mock()
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
 
@@ -94,11 +86,9 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view.try_to_select_relevant_normalise_stack.assert_not_called()
 
     def test_handle_sample_change_no_flat(self):
-        self.presenter.get_dataset_id_for_stack = mock.Mock()
-        self.presenter.get_dataset_id_for_stack.return_value = uuid.uuid4()
+        self.presenter.get_dataset_id_for_stack = mock.Mock(return_value=uuid.uuid4())
         new_dataset = StrictDataset(generate_images())
-        self.presenter.main_window.get_dataset = mock.Mock()
-        self.presenter.main_window.get_dataset.return_value = new_dataset
+        self.presenter.main_window.get_dataset = mock.Mock(return_value=new_dataset)
         self.presenter.show_new_sample = mock.Mock()
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
 

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -40,6 +40,8 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.spectrum = SpectrumWidget(self)
         self.imageLayout.addWidget(self.spectrum)
 
+        self.spectrum.range_changed.connect(self.presenter.handle_range_slide_moved)
+
     def cleanup(self):
         self.sampleStackSelector.unsubscribe_from_main_window()
         self.normaliseStackSelector.unsubscribe_from_main_window()

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -65,3 +65,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
     def try_to_select_relevant_normalise_stack(self, name: str) -> None:
         self.normaliseStackSelector.try_to_select_relevant_stack(name)
+
+    def get_normalise_stack(self) -> Optional['UUID']:
+        return self.normaliseStackSelector.current()


### PR DESCRIPTION
### Issue

Closes #1521 

### Description

Add a ToF range slider to the spectrum widget. Moving the slider updates the region that the main view is averaged over.

Also enables the Spectrum Viewer menu item.

### Testing 

- Open the 4_powders_tof_tiffs dataset (There is an `open` directory that can be loaded as the Flat Before)
- Workflow -> Spectrum Viewer
- Select the tbin_0 stack for the sample (you might need to select a different stack, then switch back)
- Adjust the scale so that you can see the powders
- Use the yellow bars on the spectrum to adjust the displayed range

### Acceptance Criteria 

Everything should work, no error messages or crashes

### Documentation

Not yet, will add to the release notes when feature complete
