### PR TITLE
OperationsUserDoc record dependant files

### DIFF
--- a/docs/ext/operations_user_doc.py
+++ b/docs/ext/operations_user_doc.py
@@ -56,10 +56,14 @@ class OperationsUserDoc(Directive):
         except ImportError:
             raise ValueError("operations_user_doc could not import load_filter_packages")
 
+        env = self.state.document.settings.env
+        env.note_dependency(__file__)
+
         rst_lines = []
 
         operations = load_filter_packages()
         for op in operations:
+            env.note_dependency(inspect.getfile(op))
             # Title
             rst_lines += make_heading(op.filter_name, "-")
 


### PR DESCRIPTION
### Issue
Closes #1527 

### Description
Record files used to build the docs. This means that changes to them will trigger a rebuild of the appropriate page.

### Testing 

Follow steps on #1527

### Acceptance Criteria 

Edits to the operation class doc strings should cause the html page to be updated with sphinx is run again.

### Documentation
Not needed
