### PR TITLE
Unlink axis between views in recon window

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -30,6 +30,7 @@ Fixes
 - #1475 : Fix scaling when saving to int
 - #1484 : Clear image previews in open windows when there are no stacks to select
 - #1496 : OutliersFilter IndexError when using sinograms
+- #1515 : Unlink axis in recon window
 
 
 Developer Changes

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -24,9 +24,6 @@ class ReconImagesView(GraphicsLayoutWidget):
         self.imageview_projection = MIMiniImageView(name="Projection", parent=parent)
         self.imageview_sinogram = MIMiniImageView(name="Sinogram", parent=parent)
         self.imageview_recon = MIMiniImageView(name="Recon", parent=parent, recon_mode=True)
-        # Set the three images as axis siblings so that auto colour palette changes will be applied to them all
-        MIMiniImageView.set_siblings([self.imageview_projection, self.imageview_sinogram, self.imageview_recon],
-                                     axis=True)
 
         self.slice_line = InfiniteLine(pos=1024,
                                        angle=0,

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -487,9 +487,10 @@ class ReconstructWindowView(BaseMainWindowView):
         """
         Opens the Palette Changer window when the "Auto" button has been clicked.
         """
-        self.change_colour_palette_dialog = PaletteChangerView(
-            self, self.image_view.imageview_recon.histogram, self.image_view.imageview_recon.image_data,
-            [self.image_view.imageview_sinogram.histogram, self.image_view.imageview_projection.histogram], True)
+        self.change_colour_palette_dialog = PaletteChangerView(self,
+                                                               self.image_view.imageview_recon.histogram,
+                                                               self.image_view.imageview_recon.image_data,
+                                                               recon_mode=True)
         self.change_colour_palette_dialog.show()
 
     def show_status_message(self, msg: str):


### PR DESCRIPTION
### Issue

Closes #1515 

### Description

Don't make the views in ReconImagesView axis siblings.
This prevents values under the images being updated as the mouse moves over other images.
It also means that the auto colour option does not apply to all the views, which was odd because they have different value scales.

### Testing & Acceptance Criteria 

Mousing over images in recon window should display the value and coords for that image, and not update the other images.

### Documentation

release_notes
