### PR TITLE
Lock zoom by default in operations window

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -19,6 +19,7 @@ New Features
 - #1444 : CIL PDHG non-negativity constraint
 - #1483 : Add line profile to reconstruction window
 - #1480 : Automatic sinograms for sinogram operations
+- #1523 : Lock zoom selected by default in operations window
 
 Fixes
 -----

--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -426,6 +426,9 @@
             <property name="text">
              <string>Lock zoom</string>
             </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
            </widget>
           </item>
          </layout>

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -322,6 +322,8 @@ class FiltersWindowPresenter(BasePresenter):
             self.view.clear_previews()
             return
 
+        is_new_data = self.view.preview_image_before.image_data is None
+
         self.view.clear_previews(clear_before=False)
         lock_scale = self.view.lockScaleCheckBox.isChecked()
         if lock_scale:
@@ -378,7 +380,7 @@ class FiltersWindowPresenter(BasePresenter):
             self._update_preview_image(diff, self.view.preview_image_difference)
 
         # Ensure all of it is visible if the lock zoom isn't checked
-        if not self.view.lockZoomCheckBox.isChecked():
+        if not self.view.lockZoomCheckBox.isChecked() or is_new_data:
             self.view.previews.auto_range()
 
         if lock_scale:

--- a/mantidimaging/gui/windows/operations/test/view_test.py
+++ b/mantidimaging/gui/windows/operations/test/view_test.py
@@ -50,3 +50,17 @@ class OperationsWindowsViewTest(unittest.TestCase):
                 as mock_do_update_previews:
             self.window.on_auto_update_triggered()
             mock_do_update_previews.assert_not_called()
+
+    def test_lock_zoom_changed_deselected(self):
+        self.window.lockZoomCheckBox.setChecked(False)
+        self.window.previews.auto_range = mock.Mock()
+        self.window.lock_zoom_changed()
+
+        self.window.previews.auto_range.assert_called_once()
+
+    def test_lock_zoom_changed_selected(self):
+        self.window.lockZoomCheckBox.setChecked(True)
+        self.window.previews.auto_range = mock.Mock()
+        self.window.lock_zoom_changed()
+
+        self.window.previews.auto_range.assert_not_called()

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -92,6 +92,7 @@ class FiltersWindowView(BaseMainWindowView):
         self.linkImages.setChecked(True)
         self.invertDifference.stateChanged.connect(lambda: self.presenter.notify(PresNotification.UPDATE_PREVIEWS))
         self.overlayDifference.stateChanged.connect(lambda: self.presenter.notify(PresNotification.UPDATE_PREVIEWS))
+        self.lockZoomCheckBox.stateChanged.connect(self.lock_zoom_changed)
 
         # Handle preview index selection
         self.previewImageIndex.valueChanged[int].connect(self.presenter.set_preview_image_index)
@@ -301,3 +302,7 @@ class FiltersWindowView(BaseMainWindowView):
         else:
             self.splitter.setSizes([200, 9999])
             self.collapseToggleButton.setText("<<")
+
+    def lock_zoom_changed(self):
+        if not self.lockZoomCheckBox.isChecked():
+            self.previews.auto_range()


### PR DESCRIPTION
### Issue

Refs #1523

### Description

Selects the lock zoom checkbox by default when the operations window first opens. This is just one part of the referenced issue as further information is required to implement the lock scale side. I've set the previews to auto-range when data is first loaded as, although all the datasets I tested with had visible previews without auto-ranging, we seem to get some slight jumping around in size without it.

This PR also includes a change so that the operations window previews will auto-range (the zoom will reset) when the lock zoom checkbox is de-selected.

### Testing & Acceptance Criteria 

Operations window opens with lock zoom selected by default.
De-selecting lock zoom causes the zoom to reset (all three previews auto-range).

### Documentation

Lock zoom part of the issue is added to the release notes.
