### PR TITLE
Fix reconstruction double click error

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -32,6 +32,7 @@ Fixes
 - #1484 : Clear image previews in open windows when there are no stacks to select
 - #1496 : OutliersFilter IndexError when using sinograms
 - #1515 : Unlink axis in recon window
+- #1351 : Double clicking reconstruct buttons can cause RunTimeError
 
 
 Developer Changes

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -50,7 +50,7 @@ class Notification(Enum):
 
 
 def _generate_recon_item_name(recon_no: int) -> str:
-    return f"Recon {recon_no}"
+    return "Recon" if recon_no == 1 else f"Recon {recon_no}"
 
 
 class MainWindowPresenter(BasePresenter):
@@ -524,12 +524,15 @@ class MainWindowPresenter(BasePresenter):
         :param recon_count: The number of the recon in the dataset. One indicates the first recon that has been added.
         """
         dataset_item = self.view.get_dataset_tree_view_item(parent_id)
-        if recon_count == 1:
+        recon_group = None if recon_count == 1 else self.view.get_recon_group(dataset_item)
+
+        if not recon_group:
             recon_group = self.view.add_recon_group(dataset_item, self.model.get_recon_list_id(parent_id))
-            name = "Recon"
+            recon_num = 1
         else:
-            recon_group = self.view.get_recon_group(dataset_item)
-            name = _generate_recon_item_name(recon_count)
+            recon_num = recon_count
+
+        name = _generate_recon_item_name(recon_num)
         self.view.create_child_tree_item(recon_group, child_id, name)
 
     def add_stack_to_dictionary(self, stack: StackVisualiserView) -> None:

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -49,10 +49,6 @@ class Notification(Enum):
     ADD_RECON = auto()
 
 
-def _generate_recon_item_name(recon_no: int) -> str:
-    return "Recon" if recon_no == 1 else f"Recon {recon_no}"
-
-
 class MainWindowPresenter(BasePresenter):
     LOAD_ERROR_STRING = "Failed to load stack. Error: {}"
     SAVE_ERROR_STRING = "Failed to save data. Error: {}"
@@ -516,23 +512,19 @@ class MainWindowPresenter(BasePresenter):
         dataset_item = self.view.get_dataset_tree_view_item(parent_id)
         self.view.create_child_tree_item(dataset_item, child_id, child_name)
 
-    def add_recon_item_to_tree_view(self, parent_id: uuid.UUID, child_id: uuid.UUID, recon_count: int):
+    def add_recon_item_to_tree_view(self, parent_id: uuid.UUID, child_id: uuid.UUID, name: str):
         """
         Adds a recon item to the tree view.
         :param parent_id: The ID of the parent dataset.
         :param child_id: The ID of the corresponding ImageStack object.
-        :param recon_count: The number of the recon in the dataset. One indicates the first recon that has been added.
+        :param name: The name to display for the recon in the tree view.
         """
         dataset_item = self.view.get_dataset_tree_view_item(parent_id)
-        recon_group = None if recon_count == 1 else self.view.get_recon_group(dataset_item)
 
+        recon_group = self.view.get_recon_group(dataset_item)
         if not recon_group:
             recon_group = self.view.add_recon_group(dataset_item, self.model.get_recon_list_id(parent_id))
-            recon_num = 1
-        else:
-            recon_num = recon_count
 
-        name = _generate_recon_item_name(recon_num)
         self.view.create_child_tree_item(recon_group, child_id, name)
 
     def add_stack_to_dictionary(self, stack: StackVisualiserView) -> None:
@@ -583,7 +575,7 @@ class MainWindowPresenter(BasePresenter):
         """
         parent_id = self.model.add_recon_to_dataset(recon_data, stack_id)
         self.view.create_new_stack(recon_data)
-        self.add_recon_item_to_tree_view(parent_id, recon_data.id, len(self.model.datasets[parent_id].recons))
+        self.add_recon_item_to_tree_view(parent_id, recon_data.id, recon_data.name)
         self.view.model_changed.emit()
 
     def add_sinograms_to_dataset_and_update_view(self, sino_stack: ImageStack, original_stack_id: uuid.UUID):

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -9,7 +9,6 @@ from unittest import mock
 from unittest.mock import patch, call
 
 import numpy as np
-from parameterized import parameterized
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
@@ -17,13 +16,8 @@ from mantidimaging.core.utility.data_containers import ProjectionAngles
 from mantidimaging.gui.dialogs.async_task import TaskWorkerThread
 from mantidimaging.gui.windows.image_load_dialog import ImageLoadDialog
 from mantidimaging.gui.windows.main import MainWindowView, MainWindowPresenter
-from mantidimaging.gui.windows.main.presenter import Notification, _generate_recon_item_name
+from mantidimaging.gui.windows.main.presenter import Notification
 from mantidimaging.test_helpers.unit_test_helper import generate_images
-
-
-@parameterized.expand([("First", 1, "Recon"), ("Addition", 4, "Recon 4")])
-def test_generate_recon_item_name(_, recon_num, expected_result):
-    assert _generate_recon_item_name(recon_num) == expected_result
 
 
 def generate_images_with_filenames(n_images: int) -> List[ImageStack]:
@@ -462,17 +456,14 @@ class MainWindowPresenterTest(unittest.TestCase):
 
     def test_add_recon(self):
         recon = generate_images()
-        self.dataset.recons.append(recon)
         stack_id = "stack-id"
         parent_id = "parent-id"
-        self.model.datasets = dict()
-        self.model.datasets[parent_id] = self.dataset
         self.model.add_recon_to_dataset.return_value = parent_id
         self.presenter.add_recon_item_to_tree_view = mock.Mock()
 
         self.presenter.notify(Notification.ADD_RECON, recon_data=recon, stack_id=stack_id)
         self.model.add_recon_to_dataset.assert_called_once_with(recon, stack_id)
-        self.presenter.add_recon_item_to_tree_view.assert_called_with(parent_id, recon.id, 1)
+        self.presenter.add_recon_item_to_tree_view.assert_called_with(parent_id, recon.id, recon.name)
         self.view.create_new_stack.assert_called_once_with(recon)
         self.view.model_changed.emit.assert_called_once()
 
@@ -571,36 +562,39 @@ class MainWindowPresenterTest(unittest.TestCase):
         dataset_item_mock = self.view.get_dataset_tree_view_item.return_value
         dataset_item_mock.id = parent_id = "parent-id"
         child_id = "child-id"
+        name = "Recon"
         recon_group_mock = self.view.add_recon_group.return_value
         self.model.get_recon_list_id.return_value = recons_id = "recons-id"
+        self.view.get_recon_group.return_value = None
 
-        self.presenter.add_recon_item_to_tree_view(parent_id, child_id, 1)
+        self.presenter.add_recon_item_to_tree_view(parent_id, child_id, name)
         self.view.get_dataset_tree_view_item.assert_called_once_with(parent_id)
         self.model.get_recon_list_id.assert_called_once_with(parent_id)
         self.view.add_recon_group.assert_called_once_with(dataset_item_mock, recons_id)
-        self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, "Recon")
+        self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, name)
 
     def test_add_recon_item_to_tree_view_additional_item(self):
         parent_id = "parent-id"
         dataset_item_mock = self.view.get_dataset_tree_view_item.return_value
         child_id = "child-id"
         recon_group_mock = self.view.get_recon_group.return_value
-        recon_count = 2
+        name = "Recon_2"
 
-        self.presenter.add_recon_item_to_tree_view(parent_id, child_id, recon_count)
+        self.presenter.add_recon_item_to_tree_view(parent_id, child_id, name)
         self.view.get_dataset_tree_view_item.assert_called_once_with(parent_id)
         self.view.get_recon_group.assert_called_once_with(dataset_item_mock)
-        self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, "Recon 2")
+        self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, name)
 
     def test_add_recon_item_to_tree_view_first_item_with_multiple_recons(self):
         child_id = "child-id"
+        name = "Recon"
         recon_group_mock = self.view.add_recon_group.return_value
         self.view.get_recon_group.return_value = None
 
-        self.presenter.add_recon_item_to_tree_view("parent-id", child_id, 2)
+        self.presenter.add_recon_item_to_tree_view("parent-id", child_id, name)
 
         self.view.add_recon_group.assert_called_once()
-        self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, "Recon")
+        self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, name)
 
     def test_created_mixed_dataset_tree_view_items(self):
         n_images = 3

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -9,6 +9,7 @@ from unittest import mock
 from unittest.mock import patch, call
 
 import numpy as np
+from parameterized import parameterized
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
@@ -20,8 +21,9 @@ from mantidimaging.gui.windows.main.presenter import Notification, _generate_rec
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
 
-def test_generate_recon_item_name():
-    assert _generate_recon_item_name(4) == "Recon 4"
+@parameterized.expand([("First", 1, "Recon"), ("Addition", 4, "Recon 4")])
+def test_generate_recon_item_name(_, recon_num, expected_result):
+    assert _generate_recon_item_name(recon_num) == expected_result
 
 
 def generate_images_with_filenames(n_images: int) -> List[ImageStack]:
@@ -565,7 +567,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.create_child_tree_item.assert_has_calls([s_call, fb_call, fa_call, db_call, da_call, _180_call])
         self.view.add_item_to_tree_view.assert_called_once_with(dataset_tree_item_mock)
 
-    def test_add_first_recon_item_to_tree_view(self):
+    def test_add_recon_item_to_tree_view_first_item(self):
         dataset_item_mock = self.view.get_dataset_tree_view_item.return_value
         dataset_item_mock.id = parent_id = "parent-id"
         child_id = "child-id"
@@ -578,7 +580,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.add_recon_group.assert_called_once_with(dataset_item_mock, recons_id)
         self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, "Recon")
 
-    def test_add_additional_recon_item_to_tree_view(self):
+    def test_add_recon_item_to_tree_view_additional_item(self):
         parent_id = "parent-id"
         dataset_item_mock = self.view.get_dataset_tree_view_item.return_value
         child_id = "child-id"
@@ -589,6 +591,16 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.get_dataset_tree_view_item.assert_called_once_with(parent_id)
         self.view.get_recon_group.assert_called_once_with(dataset_item_mock)
         self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, "Recon 2")
+
+    def test_add_recon_item_to_tree_view_first_item_with_multiple_recons(self):
+        child_id = "child-id"
+        recon_group_mock = self.view.add_recon_group.return_value
+        self.view.get_recon_group.return_value = None
+
+        self.presenter.add_recon_item_to_tree_view("parent-id", child_id, 2)
+
+        self.view.add_recon_group.assert_called_once()
+        self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, "Recon")
 
     def test_created_mixed_dataset_tree_view_items(self):
         n_images = 3

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -411,8 +411,7 @@ class MainWindowViewTest(unittest.TestCase):
         item_mocks[1].text.return_value = "Flat Before"
         item_mocks[2].text.return_value = "Flat After"
 
-        with self.assertRaises(RuntimeError):
-            self.view.get_recon_group(dataset_item_mock)
+        self.assertIsNone(self.view.get_recon_group(dataset_item_mock))
 
     def test_get_all_180_projections(self):
         self.assertIs(self.view.get_all_180_projections(), self.presenter.get_all_180_projections.return_value)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -565,7 +565,7 @@ class MainWindowView(BaseMainWindowView):
         return recon_group
 
     @staticmethod
-    def get_recon_group(dataset_item: QTreeDatasetWidgetItem) -> QTreeDatasetWidgetItem:
+    def get_recon_group(dataset_item: QTreeDatasetWidgetItem) -> Optional[QTreeDatasetWidgetItem]:
         """
         Looks for an existing recon group in a dataset tree view item.
         :param dataset_item: The dataset item to look for the recon group in.
@@ -574,7 +574,7 @@ class MainWindowView(BaseMainWindowView):
         for i in range(dataset_item.childCount()):
             if dataset_item.child(i).text(0) == RECON_GROUP_TEXT:
                 return dataset_item.child(i)
-        raise RuntimeError(f"Unable to find recon group in dataset tree item for dataset {dataset_item.id}")
+        return None
 
     def get_dataset_tree_view_item(self, dataset_id: uuid.UUID) -> QTreeDatasetWidgetItem:
         """

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -361,3 +361,16 @@ class ReconstructWindowViewTest(unittest.TestCase):
 
         self.view.change_refine_iterations()
         refine_iterations_button_mock.setEnabled.assert_called_once_with(False)
+
+    def test_set_recon_buttons_enabled(self):
+        def assert_button_state_is_correct(is_enabled):
+            self.assertEqual(self.view.reconstructSlice.isEnabled(), is_enabled)
+            self.assertEqual(self.view.reconstructVolume.isEnabled(), is_enabled)
+
+        assert_button_state_is_correct(is_enabled=True)
+
+        self.view.set_recon_buttons_enabled(False)
+        assert_button_state_is_correct(is_enabled=False)
+
+        self.view.set_recon_buttons_enabled(True)
+        assert_button_state_is_correct(is_enabled=True)

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -504,3 +504,7 @@ class ReconstructWindowView(BaseMainWindowView):
             self.messageIcon.setPixmap(QApplication.style().standardPixmap(QStyle.SP_MessageBoxCritical))
         else:
             self.messageIcon.clear()
+
+    def set_recon_buttons_enabled(self, enabled: bool):
+        self.reconstructSlice.setEnabled(enabled)
+        self.reconstructVolume.setEnabled(enabled)


### PR DESCRIPTION
### Issue

Closes #1351

### Description

Previously the system expected that if a dataset had multiple recon stacks then a recon tree view group would already have been created, and threw an error if it couldn't find one. This PR alters that behaviour to handle the edge case where a user double clicks the recon button and multiple stacks are then created before the tree view group. In that scenario, the system will now create the recon group and display all the stacks.

Clicking the reconstruction button a second time after the recon has started creates duplicate stacks that aren't needed and could cause a long-running reconstruction to unintentionally be run twice. Therefore this PR also implements enabling and disabling the reconstruction buttons so that only one reconstruction can be triggered at a time. This appears to work well on Linux, however on Windows it still seems possible to click the disabled button and end up with a duplicate for very short reconstructions. I've spent a long time looking into this and haven't managed to find a solution, so I will open a separate issue to document what I've found. It still seemed worth leaving the functionality in, as preventing duplicate runs of long reconstructions seems desirable. I suspect it's unlikely that Windows users will notice the problem very regularly, if at all.

### Testing & Acceptance Criteria 

See steps on issue for replicating the original problem. Double clicking either of the reconstruction buttons should now either display all recon data that was created or, depending on timings, may result in only one recon stack being created. There should be no errors.

Depending on the reconstruction length and the OS, you should see both reconstruction buttons disable when the reconstruction is running and then enable again when it has finished. For very fast reconstruction algorithms on Linux (i.e. gridrec) the effect may be barely noticeable.

### Documentation

Issue number added to release notes
