### PR TITLE
Select lock scale in Operations window by default

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -19,7 +19,7 @@ New Features
 - #1444 : CIL PDHG non-negativity constraint
 - #1483 : Add line profile to reconstruction window
 - #1480 : Automatic sinograms for sinogram operations
-- #1523 : Lock zoom selected by default in operations window
+- #1523 : Lock zoom and lock scale selected by default in operations window
 
 Fixes
 -----

--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -419,6 +419,9 @@
             <property name="text">
              <string>Lock scale</string>
             </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
            </widget>
           </item>
           <item>

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -215,3 +215,8 @@ class FilterPreviews(GraphicsLayoutWidget):
         """
         set_histogram_log_scale(self.imageview_before.histogram)
         set_histogram_log_scale(self.imageview_after.histogram)
+
+    def autorange_histograms(self):
+        self.imageview_before.histogram.autoHistogramRange()
+        self.imageview_after.histogram.autoHistogramRange()
+        self.imageview_difference.histogram.autoHistogramRange()

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -215,8 +215,3 @@ class FilterPreviews(GraphicsLayoutWidget):
         """
         set_histogram_log_scale(self.imageview_before.histogram)
         set_histogram_log_scale(self.imageview_after.histogram)
-
-    def autorange_histograms(self):
-        self.imageview_before.histogram.autoHistogramRange()
-        self.imageview_after.histogram.autoHistogramRange()
-        self.imageview_difference.histogram.autoHistogramRange()

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -325,7 +325,8 @@ class FiltersWindowPresenter(BasePresenter):
         is_new_data = self.view.preview_image_before.image_data is None
 
         self.view.clear_previews(clear_before=False)
-        lock_scale = self.view.lockScaleCheckBox.isChecked()
+        # Only apply the lock scale after image data has been set for the first time otherwise no region is shown
+        lock_scale = self.view.lockScaleCheckBox.isChecked() and not is_new_data
         if lock_scale:
             self.view.previews.record_histogram_regions()
 
@@ -386,6 +387,10 @@ class FiltersWindowPresenter(BasePresenter):
         if lock_scale:
             self.view.previews.restore_histogram_regions()
         self.view.previews.set_histogram_log_scale()
+        if is_new_data:
+            # Needed for the case where we've deleted all the tree view data with the window
+            # still open and then loaded some new data
+            self.view.previews.autorange_histograms()
 
     @staticmethod
     def _update_preview_image(image_data: Optional[np.ndarray], image: ImageItem):

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -387,10 +387,6 @@ class FiltersWindowPresenter(BasePresenter):
         if lock_scale:
             self.view.previews.restore_histogram_regions()
         self.view.previews.set_histogram_log_scale()
-        if is_new_data:
-            # Needed for the case where we've deleted all the tree view data with the window
-            # still open and then loaded some new data
-            self.view.previews.autorange_histograms()
 
     @staticmethod
     def _update_preview_image(image_data: Optional[np.ndarray], image: ImageItem):

--- a/mantidimaging/gui/windows/operations/test/view_test.py
+++ b/mantidimaging/gui/windows/operations/test/view_test.py
@@ -64,3 +64,17 @@ class OperationsWindowsViewTest(unittest.TestCase):
         self.window.lock_zoom_changed()
 
         self.window.previews.auto_range.assert_not_called()
+
+    def test_lock_scale_changed_deselected(self):
+        self.window.lockScaleCheckBox.setChecked(False)
+        self.window.presenter.do_update_previews = mock.Mock()
+        self.window.lock_scale_changed()
+
+        self.window.presenter.do_update_previews.assert_called_once()
+
+    def test_lock_scale_changed_selected(self):
+        self.window.lockScaleCheckBox.setChecked(True)
+        self.window.presenter.do_update_previews = mock.Mock()
+        self.window.lock_scale_changed()
+
+        self.window.presenter.do_update_previews.assert_not_called()

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -93,6 +93,7 @@ class FiltersWindowView(BaseMainWindowView):
         self.invertDifference.stateChanged.connect(lambda: self.presenter.notify(PresNotification.UPDATE_PREVIEWS))
         self.overlayDifference.stateChanged.connect(lambda: self.presenter.notify(PresNotification.UPDATE_PREVIEWS))
         self.lockZoomCheckBox.stateChanged.connect(self.lock_zoom_changed)
+        self.lockScaleCheckBox.stateChanged.connect(self.lock_scale_changed)
 
         # Handle preview index selection
         self.previewImageIndex.valueChanged[int].connect(self.presenter.set_preview_image_index)
@@ -306,3 +307,7 @@ class FiltersWindowView(BaseMainWindowView):
     def lock_zoom_changed(self):
         if not self.lockZoomCheckBox.isChecked():
             self.previews.auto_range()
+
+    def lock_scale_changed(self):
+        if not self.lockScaleCheckBox.isChecked():
+            self.presenter.notify(PresNotification.UPDATE_PREVIEWS)


### PR DESCRIPTION
### Issue

Closes #1523

### Description

Selects the lock scale checkbox by default when the operations window opens.

Also triggers an update of the previews when the checkbox is de-selected. I spent a bit of time looking into options for resetting the histogram levels in a more light-weight way but, while I could find ways to get close to what we have when the previews re-draw, I couldn't replicate it exactly without doing the full re-draw.

We're aware that there are a number of odd behaviours that can occur with lock scales switched on by default, depending on what the user chooses to do. For example, selecting a Gaussian filter with the flowers dataset displays a slightly odd difference preview. For now this can be manually corrected, but we intend to follow up with the users to ask them to identify any corrections they would like automated.

### Testing & Acceptance Criteria 

The window should open with lock scale selected by default.
Un-ticking the lock scale checkbox should re-draw the previews so that the histograms levels are reset to their auto levels.

### Documentation

Updated release notes entry for the issue number.
