### PR TITLE
Use fixed flat fielding scale when lock scale is selected

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -20,6 +20,7 @@ New Features
 - #1483 : Add line profile to reconstruction window
 - #1480 : Automatic sinograms for sinogram operations
 - #1523 : Lock zoom and lock scale selected by default in operations window
+- #1524 : Flat fielding after histogram locks to appropriate range when using lock scale
 
 Fixes
 -----

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from itertools import chain, tee
-from typing import List, TYPE_CHECKING, Optional
+from typing import List, TYPE_CHECKING, Optional, Union
 from weakref import WeakSet
 
 from pyqtgraph import ImageItem, ViewBox
@@ -59,6 +59,14 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
     @property
     def histogram(self) -> HistogramLUTItem:
         return self.hist
+
+    @property
+    def histogram_region(self):
+        return self.hist.region.getRegion()
+
+    @histogram_region.setter
+    def histogram_region(self, new_region: tuple[Union[int, list[int]], Union[int, list[int]]]):
+        self.hist.region.setRegion(new_region)
 
     @property
     def image_data(self) -> 'np.ndarray':

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -190,14 +190,14 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.imageview_before.viewbox.autoRange()
 
     def record_histogram_regions(self):
-        self.before_region = self.imageview_before.histogram.region.getRegion()
-        self.diff_region = self.imageview_difference.histogram.region.getRegion()
-        self.after_region = self.imageview_after.histogram.region.getRegion()
+        self.before_region = self.imageview_before.histogram_region
+        self.diff_region = self.imageview_difference.histogram_region
+        self.after_region = self.imageview_after.histogram_region
 
     def restore_histogram_regions(self):
-        self.imageview_before.histogram.region.setRegion(self.before_region)
-        self.imageview_difference.histogram.region.setRegion(self.diff_region)
-        self.imageview_after.histogram.region.setRegion(self.after_region)
+        self.imageview_difference.histogram_region = self.diff_region
+        self.imageview_after.histogram_region = self.after_region
+        self.imageview_before.histogram_region = self.before_region
 
     def link_before_after_histogram_scales(self, create_link: bool):
         """
@@ -215,3 +215,8 @@ class FilterPreviews(GraphicsLayoutWidget):
         """
         set_histogram_log_scale(self.imageview_before.histogram)
         set_histogram_log_scale(self.imageview_after.histogram)
+
+    def autorange_histograms(self):
+        self.imageview_before.histogram.autoHistogramRange()
+        self.imageview_after.histogram.autoHistogramRange()
+        self.imageview_difference.histogram.autoHistogramRange()

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -12,7 +12,6 @@ from uuid import UUID
 
 import numpy as np
 from PyQt5.QtWidgets import QApplication, QLineEdit
-from pyqtgraph import ImageItem
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operation_history.const import OPERATION_HISTORY, OPERATION_DISPLAY_NAME
@@ -35,6 +34,7 @@ FLAT_FIELD_REGION = [-0.2, 1.2]
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # pragma: no cover
     from mantidimaging.gui.windows.operations import FiltersWindowView  # pragma: no cover
+    from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
 
 REPEAT_FLAT_FIELDING_MSG = "Do you want to run flat-fielding again? This could cause you to lose data."
 
@@ -403,7 +403,7 @@ class FiltersWindowPresenter(BasePresenter):
         self.view.previews.set_histogram_log_scale()
 
     @staticmethod
-    def _update_preview_image(image_data: Optional[np.ndarray], image: ImageItem):
+    def _update_preview_image(image_data: Optional[np.ndarray], image: 'MIMiniImageView'):
         image.clear()
         image.setImage(image_data)
 

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -30,6 +30,7 @@ APPLY_TO_180_MSG = "Operations applied to the sample are also automatically appl
       " degree projection?"
 
 FLAT_FIELDING = "Flat-fielding"
+FLAT_FIELD_HISTOGRAM_REGION = [-0.2, 1.2]
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # pragma: no cover
@@ -323,6 +324,7 @@ class FiltersWindowPresenter(BasePresenter):
             return
 
         is_new_data = self.view.preview_image_before.image_data is None
+        is_flat_fielding = self._flat_fielding_is_selected()
 
         self.view.clear_previews(clear_before=False)
 
@@ -330,6 +332,8 @@ class FiltersWindowPresenter(BasePresenter):
         lock_scale = self.view.lockScaleCheckBox.isChecked() and not is_new_data
         if lock_scale:
             self.view.previews.record_histogram_regions()
+            if is_flat_fielding:
+                self.view.previews.after_region = FLAT_FIELD_HISTOGRAM_REGION
 
         if not self.model.selected_filter.operate_on_sinograms:
             subset: ImageStack = self.stack.slice_as_image_stack(self.model.preview_image_idx)
@@ -387,6 +391,11 @@ class FiltersWindowPresenter(BasePresenter):
 
         if lock_scale:
             self.view.previews.restore_histogram_regions()
+            if is_flat_fielding:
+                self.view.preview_image_after.histogram.autoHistogramRange()
+        else:
+            self.view.previews.autorange_histograms()
+
         self.view.previews.set_histogram_log_scale()
 
     @staticmethod

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -30,7 +30,7 @@ APPLY_TO_180_MSG = "Operations applied to the sample are also automatically appl
       " degree projection?"
 
 FLAT_FIELDING = "Flat-fielding"
-FLAT_FIELD_HISTOGRAM_REGION = [-0.2, 1.2]
+FLAT_FIELD_REGION = [-0.2, 1.2]
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # pragma: no cover
@@ -333,7 +333,7 @@ class FiltersWindowPresenter(BasePresenter):
         if lock_scale:
             self.view.previews.record_histogram_regions()
             if is_flat_fielding:
-                self.view.previews.after_region = FLAT_FIELD_HISTOGRAM_REGION
+                self.view.previews.after_region = FLAT_FIELD_REGION
 
         if not self.model.selected_filter.operate_on_sinograms:
             subset: ImageStack = self.stack.slice_as_image_stack(self.model.preview_image_idx)
@@ -392,7 +392,11 @@ class FiltersWindowPresenter(BasePresenter):
         if lock_scale:
             self.view.previews.restore_histogram_regions()
             if is_flat_fielding:
-                self.view.preview_image_after.histogram.autoHistogramRange()
+                self.view.preview_image_after.histogram.setHistogramRange(mn=FLAT_FIELD_REGION[0],
+                                                                          mx=FLAT_FIELD_REGION[1])
+                # We must auto-range the before histogram as when the before and after histograms are linked the
+                # change to the after scale is also applied to the before scale
+                self.view.preview_image_before.histogram.autoHistogramRange()
         else:
             self.view.previews.autorange_histograms()
 

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -178,7 +178,7 @@ class FiltersWindowPresenter(BasePresenter):
         self.view.auto_update_triggered.emit()
 
     def do_register_active_filter(self):
-        filter_name = self.view.filterSelector.currentText()
+        filter_name = self.view.get_selected_filter()
 
         # Get registration function for new filter
         register_func = self.model.filter_registration_func(filter_name)
@@ -297,7 +297,7 @@ class FiltersWindowPresenter(BasePresenter):
                 self.view.clear_notification_dialog()
                 self.view.show_operation_cancelled(self.model.selected_filter.filter_name)
 
-            if use_new_data and self.view.filterSelector.currentText() == FLAT_FIELDING and negative_stacks:
+            if use_new_data and self._flat_fielding_is_selected() and negative_stacks:
                 self._show_negative_values_error(negative_stacks)
 
         finally:
@@ -325,6 +325,7 @@ class FiltersWindowPresenter(BasePresenter):
         is_new_data = self.view.preview_image_before.image_data is None
 
         self.view.clear_previews(clear_before=False)
+
         # Only apply the lock scale after image data has been set for the first time otherwise no region is shown
         lock_scale = self.view.lockScaleCheckBox.isChecked() and not is_new_data
         if lock_scale:
@@ -408,7 +409,7 @@ class FiltersWindowPresenter(BasePresenter):
         """
         :return: True if this is not the first time flat-fielding is being run, False otherwise.
         """
-        if self.view.filterSelector.currentText() != FLAT_FIELDING:
+        if not self._flat_fielding_is_selected():
             return False
         if OPERATION_HISTORY not in self.stack.metadata:
             return False
@@ -474,3 +475,6 @@ class FiltersWindowPresenter(BasePresenter):
         :param slice_idx: The index of the preview slice.
         """
         self.view.show_error_dialog(f"Negative values found in result preview for slice {slice_idx}.")
+
+    def _flat_fielding_is_selected(self):
+        return self.view.get_selected_filter() == FLAT_FIELDING

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -57,7 +57,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
 
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.filter_registration_func')
     def test_disconnect_before_after_histograms(self, _):
-        self.view.filterSelector.currentText.return_value = "Rescale"
+        self.view.get_selected_filter.return_value = "Rescale"
         with mock.patch("mantidimaging.gui.windows.operations.presenter.BlockQtSignals"):
             self.presenter.do_register_active_filter()
 
@@ -349,7 +349,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         """
         Test that a warning is displayed if the user is trying to run flat-fielding again.
         """
-        self.view.filterSelector.currentText.return_value = FLAT_FIELDING
+        self.view.get_selected_filter.return_value = FLAT_FIELDING
         self.presenter.stack = mock.MagicMock()
         self.presenter.stack.metadata = {OPERATION_HISTORY: [{OPERATION_DISPLAY_NAME: "Flat-fielding"}]}
         self.presenter._do_apply_filter = mock.MagicMock()
@@ -396,7 +396,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         """
         Test that pressing "Cancel" when the flat-fielding warning is displayed means that no operation is run.
         """
-        self.view.filterSelector.currentText.return_value = FLAT_FIELDING
+        self.view.get_selected_filter.return_value = FLAT_FIELDING
         self.presenter.stack = mock.MagicMock()
         self.presenter.stack.metadata = {OPERATION_HISTORY: [{OPERATION_DISPLAY_NAME: "Flat-fielding"}]}
         self.presenter._do_apply_filter = mock.MagicMock()
@@ -443,7 +443,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter._do_apply_filter_sync')
     def test_negative_values_found_in_twelve_or_less_ranges(self, do_apply_filter_sync_mock):
         self.presenter.view.safeApply.isChecked.return_value = False
-        self.presenter.view.filterSelector.currentText.return_value = FLAT_FIELDING
+        self.presenter.view.get_selected_filter.return_value = FLAT_FIELDING
         mock_task = mock.Mock()
         mock_task.error = None
         images = generate_images()
@@ -468,7 +468,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter._do_apply_filter_sync')
     def test_negative_values_in_all_slices(self, do_apply_filter_sync_mock):
         self.presenter.view.safeApply.isChecked.return_value = False
-        self.presenter.view.filterSelector.currentText.return_value = FLAT_FIELDING
+        self.presenter.view.get_selected_filter.return_value = FLAT_FIELDING
         mock_task = mock.Mock()
         mock_task.error = None
         images = generate_images()
@@ -489,7 +489,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter._do_apply_filter_sync')
     def test_negative_values_in_more_than_twelve_ranges(self, do_apply_filter_sync_mock):
         self.presenter.view.safeApply.isChecked.return_value = False
-        self.presenter.view.filterSelector.currentText.return_value = FLAT_FIELDING
+        self.presenter.view.get_selected_filter.return_value = FLAT_FIELDING
         mock_task = mock.Mock()
         mock_task.error = None
         images = generate_images(shape=(25, 8, 10))

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -16,7 +16,7 @@ from mantidimaging.core.operation_history.const import OPERATION_HISTORY, OPERAT
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.operations import FiltersWindowPresenter
 from mantidimaging.gui.windows.operations.presenter import REPEAT_FLAT_FIELDING_MSG, FLAT_FIELDING, _find_nan_change, \
-    _group_consecutive_values, FLAT_FIELD_HISTOGRAM_REGION
+    _group_consecutive_values, FLAT_FIELD_REGION
 from mantidimaging.test_helpers.unit_test_helper import assert_called_once_with, generate_images
 from mantidimaging.core.data import ImageStack
 
@@ -265,7 +265,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.view.previews.auto_range.assert_not_called()
         self.view.previews.record_histogram_regions.assert_called_once()
         self.view.previews.restore_histogram_regions.assert_called_once()
-        self.view.preview_image_after.histogram.autoHistogramRange.assert_not_called()
+        self.view.preview_image_after.histogram.setHistogramRange.assert_not_called()
         self.assertEqual(after_region, self.view.previews.after_region)
         self.view.previews.autorange_histograms.assert_not_called()
 
@@ -279,13 +279,15 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.presenter.stack = stack
         self.view.lockScaleCheckBox.isChecked.return_value = True
         self.presenter._flat_fielding_is_selected = mock.Mock(return_value=True)
-        self.view.previews.after_region = [FLAT_FIELD_HISTOGRAM_REGION[0] + 10, 10]
+        self.view.previews.after_region = [FLAT_FIELD_REGION[0] + 10, 10]
         self.presenter.do_update_previews()
 
         self.view.previews.record_histogram_regions.assert_called_once()
         self.view.previews.restore_histogram_regions.assert_called_once()
-        self.view.preview_image_after.histogram.autoHistogramRange.assert_called_once()
-        self.assertEqual(FLAT_FIELD_HISTOGRAM_REGION, self.view.previews.after_region)
+        self.view.preview_image_after.histogram.setHistogramRange.assert_called_once_with(mn=FLAT_FIELD_REGION[0],
+                                                                                          mx=FLAT_FIELD_REGION[1])
+        self.view.preview_image_before.histogram.autoHistogramRange.assert_called_once()
+        self.assertEqual(FLAT_FIELD_REGION, self.view.previews.after_region)
         self.view.previews.autorange_histograms.assert_not_called()
 
     @parameterized.expand([(True, True), (False, True), (True, False), (False, False)])

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -258,7 +258,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.presenter.stack = stack
         self.view.lockZoomCheckBox.isChecked.return_value = True
         self.view.lockScaleCheckBox.isChecked.return_value = True
-        self.presenter._flat_fielding_is_selected = mock.Mock(return_value=False)
+        self.view.get_selected_filter.return_value = "Test"
         self.view.previews.after_region = after_region = [10, 10]
         self.presenter.do_update_previews()
 
@@ -278,7 +278,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         stack.slice_as_image_stack.return_value = images
         self.presenter.stack = stack
         self.view.lockScaleCheckBox.isChecked.return_value = True
-        self.presenter._flat_fielding_is_selected = mock.Mock(return_value=True)
+        self.view.get_selected_filter.return_value = FLAT_FIELDING
         self.view.previews.after_region = [FLAT_FIELD_REGION[0] + 10, 10]
         self.presenter.do_update_previews()
 

--- a/mantidimaging/gui/windows/operations/test/view_test.py
+++ b/mantidimaging/gui/windows/operations/test/view_test.py
@@ -7,6 +7,7 @@ from unittest import mock
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.operations.view import FiltersWindowView
 from mantidimaging.test_helpers import start_qapplication, mock_versions
+from mantidimaging.gui.windows.operations.presenter import FLAT_FIELDING
 
 
 @mock_versions
@@ -72,9 +73,18 @@ class OperationsWindowsViewTest(unittest.TestCase):
 
         self.window.presenter.do_update_previews.assert_called_once()
 
-    def test_lock_scale_changed_selected(self):
+    def test_lock_scale_changed_selected_not_flat_fielding(self):
         self.window.lockScaleCheckBox.setChecked(True)
         self.window.presenter.do_update_previews = mock.Mock()
+        self.window.get_selected_filter = mock.Mock(return_value="Test")
         self.window.lock_scale_changed()
 
         self.window.presenter.do_update_previews.assert_not_called()
+
+    def test_lock_scale_changed_selected_flat_fielding(self):
+        self.window.lockScaleCheckBox.setChecked(True)
+        self.window.presenter.do_update_previews = mock.Mock()
+        self.window.get_selected_filter = mock.Mock(return_value=FLAT_FIELDING)
+        self.window.lock_scale_changed()
+
+        self.window.presenter.do_update_previews.assert_called_once()

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -7,7 +7,6 @@ import numpy as np
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import (QAction, QApplication, QCheckBox, QComboBox, QLabel, QMainWindow, QMenu, QMessageBox,
                              QPushButton, QSizePolicy, QSplitter, QStyle, QVBoxLayout)
-from pyqtgraph import ImageItem
 
 from mantidimaging.core.net.help_pages import open_user_operation_docs
 from mantidimaging.gui.mvp_base import BaseMainWindowView
@@ -21,6 +20,7 @@ from .presenter import Notification as PresNotification
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
+    from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
 
 
 def _strip_filter_name(filter_name: str):
@@ -184,15 +184,15 @@ class FiltersWindowView(BaseMainWindowView):
             self.previews.unlink_all_views()
 
     @property
-    def preview_image_before(self) -> ImageItem:
+    def preview_image_before(self) -> 'MIMiniImageView':
         return self.previews.imageview_before
 
     @property
-    def preview_image_after(self) -> ImageItem:
+    def preview_image_after(self) -> 'MIMiniImageView':
         return self.previews.imageview_after
 
     @property
-    def preview_image_difference(self) -> ImageItem:
+    def preview_image_difference(self) -> 'MIMiniImageView':
         return self.previews.imageview_difference
 
     def show_error_dialog(self, msg=""):

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -311,3 +311,6 @@ class FiltersWindowView(BaseMainWindowView):
     def lock_scale_changed(self):
         if not self.lockScaleCheckBox.isChecked():
             self.presenter.notify(PresNotification.UPDATE_PREVIEWS)
+
+    def get_selected_filter(self):
+        return self.filterSelector.currentText()

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -16,7 +16,7 @@ from mantidimaging.gui.widgets.mi_image_view.view import MIImageView
 from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
 
 from .filter_previews import FilterPreviews
-from .presenter import FiltersWindowPresenter
+from .presenter import FiltersWindowPresenter, FLAT_FIELDING
 from .presenter import Notification as PresNotification
 
 if TYPE_CHECKING:
@@ -309,7 +309,7 @@ class FiltersWindowView(BaseMainWindowView):
             self.previews.auto_range()
 
     def lock_scale_changed(self):
-        if not self.lockScaleCheckBox.isChecked():
+        if not self.lockScaleCheckBox.isChecked() or self.get_selected_filter() == FLAT_FIELDING:
             self.presenter.notify(PresNotification.UPDATE_PREVIEWS)
 
     def get_selected_filter(self):


### PR DESCRIPTION
### Issue

Closes #1524

### Description

Includes the following changes:

1) When lock scale is selected while using flat fielding, the after histogram level range and the histogram display range are set to -0.2 to 1.2. The preview histograms are auto-ranged if lock scale is not selected.

2) Fixes a bug where the after histogram level range was overwriting the before histogram level range when using lock scale.

3) Auto-ranges all histograms on re-drawing the previews if lock scale is not being used.

### Testing & Acceptance Criteria 

Ensure the following is behaving as expected:

1) Navigating between flat fielding and other filters
2) Changing parameters while on flat fielding
3) Selecting and de-selecting the lock scale checkbox while on flat fielding

### Documentation

Issue number added to release notes
