### PR TITLE
Spectrum CSV normalised output

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -10,6 +10,8 @@ from mantidimaging.core.data import ImageStack
 from mantidimaging.core.io.csv_output import CSVOutput
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 
+ALL = "all"
+
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.spectrum_viewer.presenter import SpectrumViewerWindowPresenter
 
@@ -34,7 +36,7 @@ class SpectrumViewerWindowModel:
         self._stack = stack
         self.tof_range = (0, stack.data.shape[0] - 1)
         height, width = self.get_image_shape()
-        self.set_roi("all", SensibleROI.from_list([0, 0, width, height]))
+        self.set_roi(ALL, SensibleROI.from_list([0, 0, width, height]))
         self.set_roi("roi", SensibleROI.from_list([0, 0, width, height]))
 
     def set_normalise_stack(self, normalise_stack: ImageStack) -> None:
@@ -90,7 +92,7 @@ class SpectrumViewerWindowModel:
         csv_output = CSVOutput()
         csv_output.add_column("tof_index", np.arange(self._stack.data.shape[0]))
 
-        for roi_name in ("all", "roi"):
+        for roi_name in (ALL, "roi"):
             csv_output.add_column(roi_name, self.get_spectrum(roi_name, SpecType.SAMPLE))
             if normalized:
                 if self._normalise_stack is None:

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -19,7 +19,6 @@ class SpectrumViewerWindowModel:
     _normalise_stack: Optional[ImageStack] = None
     tof_range: tuple[int, int] = (0, 0)
     _roi_ranges: dict[str, SensibleROI] = {}
-    normalised: bool = False
 
     def __init__(self, presenter: 'SpectrumViewerWindowPresenter'):
         self.presenter = presenter
@@ -47,14 +46,14 @@ class SpectrumViewerWindowModel:
         else:
             return None
 
-    def get_spectrum(self, roi_name: str) -> Optional['np.ndarray']:
+    def get_spectrum(self, roi_name: str, normalised: bool) -> Optional['np.ndarray']:
         if self._stack is None:
             return None
 
         left, top, right, bottom = self.get_roi(roi_name)
         roi_data = self._stack.data[:, top:bottom, left:right]
         roi_spectrum = roi_data.mean(axis=(1, 2))
-        if self.normalised and self._normalise_stack is not None:
+        if normalised and self._normalise_stack is not None:
             roi_norm_data = self._normalise_stack.data[:, top:bottom, left:right]
             roi_norm_spectrum = roi_norm_data.mean(axis=(1, 2))
             return np.divide(roi_spectrum,
@@ -78,7 +77,7 @@ class SpectrumViewerWindowModel:
         csv_output.add_column("tof_index", np.arange(self._stack.data.shape[0]))
 
         for roi_name in ("all", "roi"):
-            csv_output.add_column(roi_name, self.get_spectrum(roi_name))
+            csv_output.add_column(roi_name, self.get_spectrum(roi_name, False))
 
         with path.open("w") as outfile:
             csv_output.write(outfile)

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -18,7 +18,7 @@ class SpectrumViewerWindowModel:
     _stack: Optional[ImageStack] = None
     _normalise_stack: Optional[ImageStack] = None
     tof_range: tuple[int, int] = (0, 0)
-    roi_range: SensibleROI = SensibleROI()
+    _roi_ranges: dict[str, SensibleROI] = {}
     normalised: bool = False
 
     def __init__(self, presenter: 'SpectrumViewerWindowPresenter'):
@@ -28,10 +28,17 @@ class SpectrumViewerWindowModel:
         self._stack = stack
         self.tof_range = (0, stack.data.shape[0] - 1)
         height, width = self.get_image_shape()
-        self.roi_range = SensibleROI.from_list([0, 0, width, height])
+        self.set_roi("all", SensibleROI.from_list([0, 0, width, height]))
+        self.set_roi("roi", SensibleROI.from_list([0, 0, width, height]))
 
     def set_normalise_stack(self, normalise_stack: ImageStack) -> None:
         self._normalise_stack = normalise_stack
+
+    def set_roi(self, roi_name: str, roi: SensibleROI):
+        self._roi_ranges[roi_name] = roi
+
+    def get_roi(self, roi_name: str):
+        return self._roi_ranges[roi_name]
 
     def get_averaged_image(self) -> Optional['np.ndarray']:
         if self._stack is not None:
@@ -44,7 +51,7 @@ class SpectrumViewerWindowModel:
         if self._stack is None:
             return None
 
-        left, top, right, bottom = self.roi_range
+        left, top, right, bottom = self.get_roi("roi")
         roi_data = self._stack.data[:, top:bottom, left:right]
         roi_spectrum = roi_data.mean(axis=(1, 2))
         if self.normalised and self._normalise_stack is not None:

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -83,7 +83,7 @@ class SpectrumViewerWindowModel:
         else:
             return 0, 0
 
-    def save_csv(self, path: Path) -> None:
+    def save_csv(self, path: Path, normalized: bool) -> None:
         if self._stack is None:
             raise ValueError("No stack selected")
 
@@ -92,6 +92,11 @@ class SpectrumViewerWindowModel:
 
         for roi_name in ("all", "roi"):
             csv_output.add_column(roi_name, self.get_spectrum(roi_name, SpecType.SAMPLE))
+            if normalized:
+                if self._normalise_stack is None:
+                    raise RuntimeError("No normalisation stack selected")
+                csv_output.add_column(roi_name + "_open", self.get_spectrum(roi_name, SpecType.OPEN))
+                csv_output.add_column(roi_name + "_norm", self.get_spectrum(roi_name, SpecType.SAMPLE_NORMED))
 
         with path.open("w") as outfile:
             csv_output.write(outfile)

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -47,11 +47,11 @@ class SpectrumViewerWindowModel:
         else:
             return None
 
-    def get_spectrum(self) -> Optional['np.ndarray']:
+    def get_spectrum(self, roi_name: str) -> Optional['np.ndarray']:
         if self._stack is None:
             return None
 
-        left, top, right, bottom = self.get_roi("roi")
+        left, top, right, bottom = self.get_roi(roi_name)
         roi_data = self._stack.data[:, top:bottom, left:right]
         roi_spectrum = roi_data.mean(axis=(1, 2))
         if self.normalised and self._normalise_stack is not None:
@@ -77,8 +77,8 @@ class SpectrumViewerWindowModel:
         csv_output = CSVOutput()
         csv_output.add_column("tof_index", np.arange(self._stack.data.shape[0]))
 
-        csv_output.add_column("all", self._stack.data.mean(axis=(1, 2)))
-        csv_output.add_column("roi", self.get_spectrum())
+        for roi_name in ("all", "roi"):
+            csv_output.add_column(roi_name, self.get_spectrum(roi_name))
 
         with path.open("w") as outfile:
             csv_output.write(outfile)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -61,7 +61,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.spectrum.image.setImage(self.model.get_averaged_image())
         self.view.spectrum.spectrum.plot(self.model.get_spectrum(), clear=True)
         self.view.spectrum.add_range(*self.model.tof_range)
-        self.view.spectrum.add_roi(self.model.roi_range)
+        self.view.spectrum.add_roi(self.model.get_roi("roi"))
 
     def handle_range_slide_moved(self) -> None:
         tof_range = self.view.spectrum.get_tof_range()
@@ -70,7 +70,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def handle_roi_moved(self) -> None:
         roi = self.view.spectrum.get_roi()
-        self.model.roi_range = roi
+        self.model.set_roi("roi", roi)
         self.view.spectrum.spectrum.clearPlots()
         self.view.spectrum.spectrum.plot(self.model.get_spectrum())
 

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Optional
 
 from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.gui.mvp_base import BasePresenter
-from mantidimaging.gui.windows.spectrum_viewer.model import SpectrumViewerWindowModel
+from mantidimaging.gui.windows.spectrum_viewer.model import SpectrumViewerWindowModel, SpecType
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.spectrum_viewer.view import SpectrumViewerWindowView  # pragma: no cover
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 class SpectrumViewerWindowPresenter(BasePresenter):
     view: 'SpectrumViewerWindowView'
     model: SpectrumViewerWindowModel
-    normalised: bool = False
+    spectrum_mode: SpecType = SpecType.SAMPLE
 
     def __init__(self, view: 'SpectrumViewerWindowView', main_window: 'MainWindowView'):
         super().__init__(view)
@@ -60,7 +60,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def show_new_sample(self) -> None:
         self.view.spectrum.image.setImage(self.model.get_averaged_image())
-        self.view.spectrum.spectrum.plot(self.model.get_spectrum("roi", self.normalised), clear=True)
+        self.view.spectrum.spectrum.plot(self.model.get_spectrum("roi", self.spectrum_mode), clear=True)
         self.view.spectrum.add_range(*self.model.tof_range)
         self.view.spectrum.add_roi(self.model.get_roi("roi"))
 
@@ -73,7 +73,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         roi = self.view.spectrum.get_roi()
         self.model.set_roi("roi", roi)
         self.view.spectrum.spectrum.clearPlots()
-        self.view.spectrum.spectrum.plot(self.model.get_spectrum("roi", self.normalised))
+        self.view.spectrum.spectrum.plot(self.model.get_spectrum("roi", self.spectrum_mode))
 
     def handle_export_csv(self) -> None:
         path = self.view.get_csv_filename()
@@ -86,5 +86,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.model.save_csv(path)
 
     def handle_enable_normalised(self, enabled: bool) -> None:
-        self.normalised = bool(enabled)
+        if enabled:
+            self.spectrum_mode = SpecType.SAMPLE_NORMED
+        else:
+            self.spectrum_mode = SpecType.SAMPLE
         self.handle_roi_moved()

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 class SpectrumViewerWindowPresenter(BasePresenter):
     view: 'SpectrumViewerWindowView'
     model: SpectrumViewerWindowModel
+    normalised: bool = False
 
     def __init__(self, view: 'SpectrumViewerWindowView', main_window: 'MainWindowView'):
         super().__init__(view)
@@ -59,7 +60,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def show_new_sample(self) -> None:
         self.view.spectrum.image.setImage(self.model.get_averaged_image())
-        self.view.spectrum.spectrum.plot(self.model.get_spectrum("roi"), clear=True)
+        self.view.spectrum.spectrum.plot(self.model.get_spectrum("roi", self.normalised), clear=True)
         self.view.spectrum.add_range(*self.model.tof_range)
         self.view.spectrum.add_roi(self.model.get_roi("roi"))
 
@@ -72,7 +73,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         roi = self.view.spectrum.get_roi()
         self.model.set_roi("roi", roi)
         self.view.spectrum.spectrum.clearPlots()
-        self.view.spectrum.spectrum.plot(self.model.get_spectrum("roi"))
+        self.view.spectrum.spectrum.plot(self.model.get_spectrum("roi", self.normalised))
 
     def handle_export_csv(self) -> None:
         path = self.view.get_csv_filename()
@@ -85,5 +86,5 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.model.save_csv(path)
 
     def handle_enable_normalised(self, enabled: bool) -> None:
-        self.model.normalised = bool(enabled)
+        self.normalised = bool(enabled)
         self.handle_roi_moved()

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -59,7 +59,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def show_new_sample(self) -> None:
         self.view.spectrum.image.setImage(self.model.get_averaged_image())
-        self.view.spectrum.spectrum.plot(self.model.get_spectrum(), clear=True)
+        self.view.spectrum.spectrum.plot(self.model.get_spectrum("roi"), clear=True)
         self.view.spectrum.add_range(*self.model.tof_range)
         self.view.spectrum.add_roi(self.model.get_roi("roi"))
 
@@ -72,7 +72,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         roi = self.view.spectrum.get_roi()
         self.model.set_roi("roi", roi)
         self.view.spectrum.spectrum.clearPlots()
-        self.view.spectrum.spectrum.plot(self.model.get_spectrum())
+        self.view.spectrum.spectrum.plot(self.model.get_spectrum("roi"))
 
     def handle_export_csv(self) -> None:
         path = self.view.get_csv_filename()

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -83,7 +83,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         if path.suffix != ".csv":
             path = path.with_suffix(".csv")
 
-        self.model.save_csv(path)
+        self.model.save_csv(path, self.spectrum_mode == SpecType.SAMPLE_NORMED)
 
     def handle_enable_normalised(self, enabled: bool) -> None:
         if enabled:

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -9,7 +9,7 @@ import numpy as np
 import numpy.testing as npt
 
 from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowPresenter, SpectrumViewerWindowModel
-from mantidimaging.gui.windows.spectrum_viewer.model import SpecType
+from mantidimaging.gui.windows.spectrum_viewer.model import SpecType, ALL
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.utility.sensible_roi import SensibleROI
@@ -112,11 +112,11 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     def test_set_stack_sets_roi(self):
         stack = ImageStack(np.ones([10, 11, 12]))
         self.model.set_stack(stack)
-        self.assertEqual(self.model.get_roi('all'), self.model.get_roi('roi'))
-        npt.assert_array_equal(self.model.get_roi('all').top, 0)
-        npt.assert_array_equal(self.model.get_roi('all').left, 0)
-        npt.assert_array_equal(self.model.get_roi('all').right, 12)
-        npt.assert_array_equal(self.model.get_roi('all').bottom, 11)
+        self.assertEqual(self.model.get_roi(ALL), self.model.get_roi('roi'))
+        npt.assert_array_equal(self.model.get_roi(ALL).top, 0)
+        npt.assert_array_equal(self.model.get_roi(ALL).left, 0)
+        npt.assert_array_equal(self.model.get_roi(ALL).right, 12)
+        npt.assert_array_equal(self.model.get_roi(ALL).bottom, 11)
 
     def test_get_spectrum_roi(self):
         stack = ImageStack(np.ones([10, 11, 12]))

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -101,10 +101,11 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     def test_set_stack_sets_roi(self):
         stack = ImageStack(np.ones([10, 11, 12]))
         self.model.set_stack(stack)
-        npt.assert_array_equal(self.model.roi_range.top, 0)
-        npt.assert_array_equal(self.model.roi_range.left, 0)
-        npt.assert_array_equal(self.model.roi_range.right, 12)
-        npt.assert_array_equal(self.model.roi_range.bottom, 11)
+        self.assertEqual(self.model.get_roi('all'), self.model.get_roi('roi'))
+        npt.assert_array_equal(self.model.get_roi('all').top, 0)
+        npt.assert_array_equal(self.model.get_roi('all').left, 0)
+        npt.assert_array_equal(self.model.get_roi('all').right, 12)
+        npt.assert_array_equal(self.model.get_roi('all').bottom, 11)
 
     def test_get_spectrum_roi(self):
         stack = ImageStack(np.ones([10, 11, 12]))
@@ -113,11 +114,11 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         stack.data[:, :, 6:] *= 2
         self.model.set_stack(stack)
 
-        self.model.roi_range = SensibleROI.from_list([0, 0, 3, 3])
+        self.model.set_roi('roi', SensibleROI.from_list([0, 0, 3, 3]))
         model_spec = self.model.get_spectrum()
         npt.assert_array_equal(model_spec, spectrum)
 
-        self.model.roi_range = SensibleROI.from_list([6, 0, 6 + 3, 3])
+        self.model.set_roi('roi', SensibleROI.from_list([6, 0, 6 + 3, 3]))
         model_spec = self.model.get_spectrum()
         npt.assert_array_equal(model_spec, spectrum * 2)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -63,7 +63,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         stack.data[:, :, :] = spectrum.reshape((10, 1, 1))
         self.model.set_stack(stack)
 
-        model_spec = self.model.get_spectrum("roi")
+        model_spec = self.model.get_spectrum("roi", False)
         self.assertEqual(model_spec.shape, (10, ))
         npt.assert_array_equal(model_spec, spectrum)
 
@@ -75,9 +75,8 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
         normalise_stack = ImageStack(np.ones([10, 11, 12]) * 2)
         self.model.set_normalise_stack(normalise_stack)
-        self.model.normalised = True
 
-        model_norm_spec = self.model.get_spectrum("roi")
+        model_norm_spec = self.model.get_spectrum("roi", True)
         self.assertEqual(model_norm_spec.shape, (10, ))
         npt.assert_array_equal(model_norm_spec, spectrum / 2)
 
@@ -90,9 +89,8 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         normalise_stack = ImageStack(np.ones([10, 11, 12]) * 2)
         normalise_stack.data[5] = 0
         self.model.set_normalise_stack(normalise_stack)
-        self.model.normalised = True
 
-        model_norm_spec = self.model.get_spectrum("roi")
+        model_norm_spec = self.model.get_spectrum("roi", True)
         expected_spec = spectrum / 2
         expected_spec[5] = 0
         self.assertEqual(model_norm_spec.shape, (10, ))
@@ -115,11 +113,11 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.model.set_stack(stack)
 
         self.model.set_roi('roi', SensibleROI.from_list([0, 0, 3, 3]))
-        model_spec = self.model.get_spectrum("roi")
+        model_spec = self.model.get_spectrum("roi", False)
         npt.assert_array_equal(model_spec, spectrum)
 
         self.model.set_roi('roi', SensibleROI.from_list([6, 0, 6 + 3, 3]))
-        model_spec = self.model.get_spectrum("roi")
+        model_spec = self.model.get_spectrum("roi", False)
         npt.assert_array_equal(model_spec, spectrum * 2)
 
     def test_save_csv(self):

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -9,6 +9,7 @@ import numpy as np
 import numpy.testing as npt
 
 from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowPresenter, SpectrumViewerWindowModel
+from mantidimaging.gui.windows.spectrum_viewer.model import SpecType
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.utility.sensible_roi import SensibleROI
@@ -63,7 +64,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         stack.data[:, :, :] = spectrum.reshape((10, 1, 1))
         self.model.set_stack(stack)
 
-        model_spec = self.model.get_spectrum("roi", False)
+        model_spec = self.model.get_spectrum("roi", SpecType.SAMPLE)
         self.assertEqual(model_spec.shape, (10, ))
         npt.assert_array_equal(model_spec, spectrum)
 
@@ -76,7 +77,11 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         normalise_stack = ImageStack(np.ones([10, 11, 12]) * 2)
         self.model.set_normalise_stack(normalise_stack)
 
-        model_norm_spec = self.model.get_spectrum("roi", True)
+        model_open_spec = self.model.get_spectrum("roi", SpecType.OPEN)
+        self.assertEqual(model_open_spec.shape, (10, ))
+        self.assertTrue(np.all(model_open_spec == 2))
+
+        model_norm_spec = self.model.get_spectrum("roi", SpecType.SAMPLE_NORMED)
         self.assertEqual(model_norm_spec.shape, (10, ))
         npt.assert_array_equal(model_norm_spec, spectrum / 2)
 
@@ -90,7 +95,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         normalise_stack.data[5] = 0
         self.model.set_normalise_stack(normalise_stack)
 
-        model_norm_spec = self.model.get_spectrum("roi", True)
+        model_norm_spec = self.model.get_spectrum("roi", SpecType.SAMPLE_NORMED)
         expected_spec = spectrum / 2
         expected_spec[5] = 0
         self.assertEqual(model_norm_spec.shape, (10, ))
@@ -113,11 +118,11 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.model.set_stack(stack)
 
         self.model.set_roi('roi', SensibleROI.from_list([0, 0, 3, 3]))
-        model_spec = self.model.get_spectrum("roi", False)
+        model_spec = self.model.get_spectrum("roi", SpecType.SAMPLE)
         npt.assert_array_equal(model_spec, spectrum)
 
         self.model.set_roi('roi', SensibleROI.from_list([6, 0, 6 + 3, 3]))
-        model_spec = self.model.get_spectrum("roi", False)
+        model_spec = self.model.get_spectrum("roi", SpecType.SAMPLE)
         npt.assert_array_equal(model_spec, spectrum * 2)
 
     def test_save_csv(self):

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -63,7 +63,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         stack.data[:, :, :] = spectrum.reshape((10, 1, 1))
         self.model.set_stack(stack)
 
-        model_spec = self.model.get_spectrum()
+        model_spec = self.model.get_spectrum("roi")
         self.assertEqual(model_spec.shape, (10, ))
         npt.assert_array_equal(model_spec, spectrum)
 
@@ -77,7 +77,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.model.set_normalise_stack(normalise_stack)
         self.model.normalised = True
 
-        model_norm_spec = self.model.get_spectrum()
+        model_norm_spec = self.model.get_spectrum("roi")
         self.assertEqual(model_norm_spec.shape, (10, ))
         npt.assert_array_equal(model_norm_spec, spectrum / 2)
 
@@ -92,7 +92,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.model.set_normalise_stack(normalise_stack)
         self.model.normalised = True
 
-        model_norm_spec = self.model.get_spectrum()
+        model_norm_spec = self.model.get_spectrum("roi")
         expected_spec = spectrum / 2
         expected_spec[5] = 0
         self.assertEqual(model_norm_spec.shape, (10, ))
@@ -115,11 +115,11 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.model.set_stack(stack)
 
         self.model.set_roi('roi', SensibleROI.from_list([0, 0, 3, 3]))
-        model_spec = self.model.get_spectrum()
+        model_spec = self.model.get_spectrum("roi")
         npt.assert_array_equal(model_spec, spectrum)
 
         self.model.set_roi('roi', SensibleROI.from_list([6, 0, 6 + 3, 3]))
-        model_spec = self.model.get_spectrum()
+        model_spec = self.model.get_spectrum("roi")
         npt.assert_array_equal(model_spec, spectrum * 2)
 
     def test_save_csv(self):

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -15,6 +15,14 @@ from mantidimaging.core.data import ImageStack
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 
 
+class CloseCheckStream(io.StringIO):
+    is_closed: bool = False
+
+    def close(self) -> None:
+        # don't call real close as it clears buffer
+        self.is_closed = True
+
+
 class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     def setUp(self) -> None:
         self.presenter = mock.create_autospec(SpectrumViewerWindowPresenter)
@@ -130,21 +138,44 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         spectrum = np.arange(0, 10) * 2
         stack.data[:, :, :] = spectrum.reshape((10, 1, 1))
         self.model.set_stack(stack)
-
-        class CloseCheckStream(io.StringIO):
-            self.is_closed: bool = False
-
-            def close(self) -> None:
-                # don't call real close as it clears buffer
-                self.is_closed = True
+        self.model.set_normalise_stack(None)
 
         mock_stream = CloseCheckStream()
         mock_path = mock.create_autospec(Path)
         mock_path.open.return_value = mock_stream
 
-        self.model.save_csv(mock_path)
+        self.model.save_csv(mock_path, False)
         mock_path.open.assert_called_once_with("w")
         self.assertIn("# tof_index,all,roi", mock_stream.getvalue())
         self.assertIn("0.0,0.0,0.0", mock_stream.getvalue())
         self.assertIn("1.0,2.0,2.0", mock_stream.getvalue())
+        self.assertTrue(mock_stream.is_closed)
+
+    def test_save_csv_norm_missing_stack(self):
+        stack = ImageStack(np.ones([10, 11, 12]))
+        spectrum = np.arange(0, 10) * 2
+        stack.data[:, :, :] = spectrum.reshape((10, 1, 1))
+        self.model.set_stack(stack)
+        self.model.set_normalise_stack(None)
+        with self.assertRaises(RuntimeError):
+            self.model.save_csv(mock.Mock(), True)
+
+    def test_save_csv_norm(self):
+        stack = ImageStack(np.ones([10, 11, 12]))
+        spectrum = np.arange(0, 10)
+        stack.data[:, :, :] = spectrum.reshape((10, 1, 1))
+
+        open_stack = ImageStack(np.ones([10, 11, 12]) * 2)
+        self.model.set_stack(stack)
+        self.model.set_normalise_stack(open_stack)
+
+        mock_stream = CloseCheckStream()
+        mock_path = mock.create_autospec(Path)
+        mock_path.open.return_value = mock_stream
+
+        self.model.save_csv(mock_path, True)
+        mock_path.open.assert_called_once_with("w")
+        self.assertIn("# tof_index,all,all_open,all_norm,roi,roi_open,roi_norm", mock_stream.getvalue())
+        self.assertIn("0.0,0.0,2.0,0.0,0.0,2.0,0.0", mock_stream.getvalue())
+        self.assertIn("1.0,1.0,2.0,0.5,1.0,2.0,0.5", mock_stream.getvalue())
         self.assertTrue(mock_stream.is_closed)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -143,4 +143,4 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.handle_export_csv()
 
         self.view.get_csv_filename.assert_called_once()
-        mock_save_csv.assert_called_once_with(Path("/fake/path.csv"))
+        mock_save_csv.assert_called_once_with(Path("/fake/path.csv"), False)


### PR DESCRIPTION
### Issue

closes #1545

### Description

This updates `save_csv()` to output the open beam and normalized values. `get_spectrum` is now controlled by the arguments instead of state in the model. The normalisation mode is now stored in the presenter as an Enum.

I also merged getting the whole spectrum with getting the RoI spectrum, by having the model keep a dict of RoIs, and creating and `all` roi. This should make it simple to support additional RoIs in the future.

I had an intermediate version d30204437bc904a1f522acc6c641070162a1eada, where `normalised` was still a bool, just moved to the presenter, but deceided an Enum was clearer (and allows some flexibility for additional normalisation modes).

I'm not completely happy with how the presenter maps back and forth between the bool of the normalised checkbox and the spectrum_mode. I.e. I'm not a fan of having to do `self.model.save_csv(path, self.spectrum_mode == SpecType.SAMPLE_NORMED)`. If the model holds a bool, then it makes the `get_spectrum()` calls more complicated. If it holds a bool and spectrum mode, then that is 2 values that could get out of sync. I'm open to ideas here.

### Testing & Acceptance Criteria 

Load up the 4 powders sample and open stacks
Open the Spectrum Viewer
Resize the ROI
Export the CSV
Check that the CSV file opens in a spreadsheet

Enable the Normalisation checkbox, and select the open beam stack
Export the CSV
Check that the CSV file opens in a spreadsheet, there should now be `open` and `norm` columns for all and roi.


### Documentation
Once all spectrum work is done
