### PR TITLE
Add set_spectrum and set_image to SpectrumViewerWindowView

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -59,7 +59,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         return None if stack_id is None else self.main_window.get_dataset_id_from_stack_uuid(stack_id)
 
     def show_new_sample(self) -> None:
-        self.view.spectrum.image.setImage(self.model.get_averaged_image())
+        self.view.set_image(self.model.get_averaged_image())
         self.view.spectrum.spectrum.plot(self.model.get_spectrum("roi", self.spectrum_mode), clear=True)
         self.view.spectrum.add_range(*self.model.tof_range)
         self.view.spectrum.add_roi(self.model.get_roi("roi"))
@@ -67,7 +67,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
     def handle_range_slide_moved(self) -> None:
         tof_range = self.view.spectrum.get_tof_range()
         self.model.tof_range = tof_range
-        self.view.spectrum.image.setImage(self.model.get_averaged_image(), autoLevels=False)
+        self.view.set_image(self.model.get_averaged_image(), autoLevels=False)
 
     def handle_roi_moved(self) -> None:
         roi = self.view.spectrum.get_roi()

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -60,7 +60,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def show_new_sample(self) -> None:
         self.view.set_image(self.model.get_averaged_image())
-        self.view.spectrum.spectrum.plot(self.model.get_spectrum("roi", self.spectrum_mode), clear=True)
+        self.view.set_spectrum(self.model.get_spectrum("roi", self.spectrum_mode), clear_all=True)
         self.view.spectrum.add_range(*self.model.tof_range)
         self.view.spectrum.add_roi(self.model.get_roi("roi"))
 
@@ -72,8 +72,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
     def handle_roi_moved(self) -> None:
         roi = self.view.spectrum.get_roi()
         self.model.set_roi("roi", roi)
-        self.view.spectrum.spectrum.clearPlots()
-        self.view.spectrum.spectrum.plot(self.model.get_spectrum("roi", self.spectrum_mode))
+        self.view.set_spectrum(self.model.get_spectrum("roi", self.spectrum_mode), clear_plots=True)
 
     def handle_export_csv(self) -> None:
         path = self.view.get_csv_filename()

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -108,8 +108,6 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
     def test_show_sample(self):
         image_stack = generate_images([10, 11, 12])
-        self.view.spectrum.image = mock.Mock()
-        self.view.spectrum.spectrum = mock.Mock()
         self.presenter.model.set_stack(image_stack)
 
         self.presenter.show_new_sample()
@@ -118,7 +116,6 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     def test_gui_changes_tof_range(self):
         image_stack = generate_images([30, 11, 12])
         self.view.spectrum.get_tof_range = mock.Mock(return_value=(10, 20))
-        self.view.spectrum.image = mock.Mock()
         self.presenter.model.set_stack(image_stack)
         self.presenter.handle_range_slide_moved()
 

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -13,6 +13,7 @@ from .spectrum_widget import SpectrumWidget
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
     from uuid import UUID
+    import numpy as np
 
 
 class SpectrumViewerWindowView(BaseMainWindowView):
@@ -85,3 +86,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             return Path(path)
         else:
             return None
+
+    def set_image(self, image_data: Optional['np.ndarray'], autoLevels: bool = True):
+        self.spectrum.image.setImage(image_data, autoLevels=autoLevels)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -89,3 +89,8 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
     def set_image(self, image_data: Optional['np.ndarray'], autoLevels: bool = True):
         self.spectrum.image.setImage(image_data, autoLevels=autoLevels)
+
+    def set_spectrum(self, spectrum_data: 'np.ndarray', clear_all=False, clear_plots=False):
+        if clear_plots:
+            self.spectrum.spectrum.clearPlots()
+        self.spectrum.spectrum.plot(spectrum_data, clear=clear_all)


### PR DESCRIPTION
### Issue

Closes #1551

### Description

Avoid the presenter needing deep calls into the view.

### Testing & Acceptance Criteria 

In the Spectrum Viewer
Check that adjusting the ROI causes the spectrum to be updated
Check that adjusting ToF range on the spectrum causes the image to be updated.


### Documentation

Not needed
