### PR TITLE
Spectrum viewer: handle changing stacks

### DIFF
--- a/mantidimaging/gui/ui/spectrum_viewer.ui
+++ b/mantidimaging/gui/ui/spectrum_viewer.ui
@@ -86,17 +86,40 @@
          </spacer>
         </item>
         <item>
-         <widget class="QCheckBox" name="normaliseCheckBox">
-          <property name="layoutDirection">
-           <enum>Qt::LeftToRight</enum>
-          </property>
-          <property name="text">
-           <string>Normalise to open beam</string>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
-          </property>
-         </widget>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QCheckBox" name="normaliseCheckBox">
+            <property name="layoutDirection">
+             <enum>Qt::LeftToRight</enum>
+            </property>
+            <property name="text">
+             <string>Normalise to open beam</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="normaliseErrorIcon">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>32</width>
+              <height>32</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item>
          <widget class="DatasetSelectorWidgetView" name="normaliseStackSelector">

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -32,8 +32,10 @@ class SpectrumViewerWindowModel:
     def __init__(self, presenter: 'SpectrumViewerWindowPresenter'):
         self.presenter = presenter
 
-    def set_stack(self, stack: ImageStack) -> None:
+    def set_stack(self, stack: Optional[ImageStack]) -> None:
         self._stack = stack
+        if stack is None:
+            return
         self.tof_range = (0, stack.data.shape[0] - 1)
         height, width = self.get_image_shape()
         self.set_roi(ALL, SensibleROI.from_list([0, 0, width, height]))

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -63,6 +63,15 @@ class SpectrumViewerWindowModel:
         roi_data = stack.data[:, top:bottom, left:right]
         return roi_data.mean(axis=(1, 2))
 
+    def normalise_issue(self) -> str:
+        if self._stack is None or self._normalise_stack is None:
+            return "Need 2 selected stacks"
+        if self._stack is self._normalise_stack:
+            return "Need 2 different stacks"
+        if self._stack.data.shape != self._normalise_stack.data.shape:
+            return "Stack shapes must match"
+        return ""
+
     def get_spectrum(self, roi_name: str, mode: SpecType) -> Optional['np.ndarray']:
         if self._stack is None:
             return None
@@ -77,6 +86,8 @@ class SpectrumViewerWindowModel:
         if mode == SpecType.OPEN:
             return self.get_stack_spectrum(self._normalise_stack, roi)
         elif mode == SpecType.SAMPLE_NORMED:
+            if self.normalise_issue():
+                return np.array([])
             roi_spectrum = self.get_stack_spectrum(self._stack, roi)
             roi_norm_spectrum = self.get_stack_spectrum(self._normalise_stack, roi)
         return np.divide(roi_spectrum, roi_norm_spectrum, out=np.zeros_like(roi_spectrum), where=roi_norm_spectrum != 0)

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -41,7 +41,7 @@ class SpectrumViewerWindowModel:
         self.set_roi(ALL, SensibleROI.from_list([0, 0, width, height]))
         self.set_roi("roi", SensibleROI.from_list([0, 0, width, height]))
 
-    def set_normalise_stack(self, normalise_stack: ImageStack) -> None:
+    def set_normalise_stack(self, normalise_stack: Optional[ImageStack]) -> None:
         self._normalise_stack = normalise_stack
 
     def set_roi(self, roi_name: str, roi: SensibleROI):

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -72,16 +72,16 @@ class SpectrumViewerWindowModel:
             return "Stack shapes must match"
         return ""
 
-    def get_spectrum(self, roi_name: str, mode: SpecType) -> Optional['np.ndarray']:
+    def get_spectrum(self, roi_name: str, mode: SpecType) -> 'np.ndarray':
         if self._stack is None:
-            return None
+            return np.array([])
 
         roi = self.get_roi(roi_name)
         if mode == SpecType.SAMPLE:
             return self.get_stack_spectrum(self._stack, roi)
 
         if self._normalise_stack is None:
-            raise RuntimeError("No normalisation stack selected")
+            return np.array([])
 
         if mode == SpecType.OPEN:
             return self.get_stack_spectrum(self._normalise_stack, roi)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -86,7 +86,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def show_new_sample(self) -> None:
         self.view.set_image(self.model.get_averaged_image())
-        self.view.set_spectrum(self.model.get_spectrum("roi", self.spectrum_mode), clear_all=True)
+        self.view.set_spectrum(self.model.get_spectrum("roi", self.spectrum_mode))
         self.view.spectrum.add_range(*self.model.tof_range)
         self.view.spectrum.add_roi(self.model.get_roi("roi"))
         self.view.auto_range_image()
@@ -99,7 +99,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
     def handle_roi_moved(self) -> None:
         roi = self.view.spectrum.get_roi()
         self.model.set_roi("roi", roi)
-        self.view.set_spectrum(self.model.get_spectrum("roi", self.spectrum_mode), clear_plots=True)
+        self.view.set_spectrum(self.model.get_spectrum("roi", self.spectrum_mode))
 
     def handle_export_csv(self) -> None:
         path = self.view.get_csv_filename()

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -89,6 +89,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.set_spectrum(self.model.get_spectrum("roi", self.spectrum_mode), clear_all=True)
         self.view.spectrum.add_range(*self.model.tof_range)
         self.view.spectrum.add_roi(self.model.get_roi("roi"))
+        self.view.auto_range_image()
 
     def handle_range_slide_moved(self) -> None:
         tof_range = self.view.spectrum.get_tof_range()

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -52,6 +52,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             except RuntimeError:
                 norm_stack = None
             self.model.set_normalise_stack(norm_stack)
+
+        self.view.display_normalise_error(self.model.normalise_issue())
         self.show_new_sample()
 
     def handle_normalise_stack_change(self, normalise_uuid: Optional['UUID']) -> None:
@@ -65,6 +67,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             return
 
         self.model.set_normalise_stack(self.main_window.get_stack(normalise_uuid))
+        self.view.display_normalise_error(self.model.normalise_issue())
         self.handle_roi_moved()
 
     def auto_find_flat_stack(self, new_dataset_id):

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -32,12 +32,16 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         else:
             self.view.current_dataset_id = None
 
-        if uuid is not None:
-            self.model.set_stack(self.main_window.get_stack(uuid))
-            normalise_uuid = self.view.get_normalise_stack()
-            if normalise_uuid is not None:
-                self.model.set_normalise_stack(self.main_window.get_stack(normalise_uuid))
-            self.show_new_sample()
+        if uuid is None:
+            self.model.set_stack(None)
+            self.view.clear()
+            return
+
+        self.model.set_stack(self.main_window.get_stack(uuid))
+        normalise_uuid = self.view.get_normalise_stack()
+        if normalise_uuid is not None:
+            self.model.set_normalise_stack(self.main_window.get_stack(normalise_uuid))
+        self.show_new_sample()
 
     def handle_normalise_stack_change(self, normalise_uuid: Optional['UUID']) -> None:
         if normalise_uuid is not None:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -53,7 +53,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                 norm_stack = None
             self.model.set_normalise_stack(norm_stack)
 
-        self.view.display_normalise_error(self.model.normalise_issue())
+        self.view.set_normalise_error(self.model.normalise_issue())
         self.show_new_sample()
 
     def handle_normalise_stack_change(self, normalise_uuid: Optional['UUID']) -> None:
@@ -67,7 +67,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             return
 
         self.model.set_normalise_stack(self.main_window.get_stack(normalise_uuid))
-        self.view.display_normalise_error(self.model.normalise_issue())
+        self.view.set_normalise_error(self.model.normalise_issue())
         self.handle_roi_moved()
 
     def auto_find_flat_stack(self, new_dataset_id):
@@ -116,3 +116,4 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         else:
             self.spectrum_mode = SpecType.SAMPLE
         self.handle_roi_moved()
+        self.view.display_normalise_error()

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -65,3 +65,6 @@ class SpectrumWidget(GraphicsLayoutWidget):
         pos = CloseEnoughPoint(self.roi.pos())
         size = CloseEnoughPoint(self.roi.size())
         return SensibleROI.from_points(pos, size)
+
+    def remove_roi(self) -> None:
+        self.image.vb.removeItem(self.roi)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -109,6 +109,30 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.assertEqual(model_norm_spec.shape, (10, ))
         npt.assert_array_equal(model_norm_spec, expected_spec)
 
+    def test_get_normalised_spectrum_different_size(self):
+        stack = ImageStack(np.ones([10, 11, 12]))
+        self.model.set_stack(stack)
+
+        normalise_stack = ImageStack(np.ones([10, 11, 13]))
+        self.model.set_normalise_stack(normalise_stack)
+
+        error_spectrum = self.model.get_spectrum("roi", SpecType.SAMPLE_NORMED)
+        np.testing.assert_array_equal(error_spectrum, np.array([]))
+
+    def test_normalise_issue(self):
+        self.assertIn("selected", self.model.normalise_issue())
+
+        stack = ImageStack(np.ones([10, 11, 12]))
+        self.model.set_stack(stack)
+        self.model.set_normalise_stack(stack)
+        self.assertIn("different", self.model.normalise_issue())
+
+        self.model.set_normalise_stack(ImageStack(np.ones([10, 11, 13])))
+        self.assertIn("shapes", self.model.normalise_issue())
+
+        self.model.set_normalise_stack(ImageStack(np.ones([10, 11, 12])))
+        self.assertEqual("", self.model.normalise_issue())
+
     def test_set_stack_sets_roi(self):
         stack = ImageStack(np.ones([10, 11, 12]))
         self.model.set_stack(stack)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -62,6 +62,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.show_new_sample.assert_called_once()
 
     def test_handle_sample_change_no_new_stack(self):
+        self.presenter.current_stack_uuid = uuid.uuid4()
         self.presenter.get_dataset_id_for_stack = mock.Mock(return_value=None)
         self.view.try_to_select_relevant_normalise_stack = mock.Mock()
         self.presenter.show_new_sample = mock.Mock()

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -98,10 +98,9 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     def set_image(self, image_data: Optional['np.ndarray'], autoLevels: bool = True):
         self.spectrum.image.setImage(image_data, autoLevels=autoLevels)
 
-    def set_spectrum(self, spectrum_data: 'np.ndarray', clear_all=False, clear_plots=False):
-        if clear_plots:
-            self.spectrum.spectrum.clearPlots()
-        self.spectrum.spectrum.plot(spectrum_data, clear=clear_all)
+    def set_spectrum(self, spectrum_data: 'np.ndarray'):
+        self.spectrum.spectrum.clearPlots()
+        self.spectrum.spectrum.plot(spectrum_data)
 
     def clear(self) -> None:
         self.spectrum.image.clear()

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -94,3 +94,8 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         if clear_plots:
             self.spectrum.spectrum.clearPlots()
         self.spectrum.spectrum.plot(spectrum_data, clear=clear_all)
+
+    def clear(self) -> None:
+        self.spectrum.image.clear()
+        self.spectrum.spectrum.clear()
+        self.spectrum.remove_roi()

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -27,6 +27,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     exportButton: QPushButton
     normaliseErrorIcon: QLabel
     _current_dataset_id: Optional['UUID']
+    normalise_error_issue: str = ""
 
     def __init__(self, main_window: 'MainWindowView'):
         super().__init__(main_window, 'gui/ui/spectrum_viewer.ui')
@@ -107,10 +108,15 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.spectrum.spectrum.clear()
         self.spectrum.remove_roi()
 
-    def display_normalise_error(self, norm_issue: str):
-        if norm_issue:
+    def set_normalise_error(self, norm_issue: str):
+        self.normalise_error_issue = norm_issue
+
+        self.display_normalise_error()
+
+    def display_normalise_error(self):
+        if self.normalise_error_issue and self.normaliseCheckBox.isChecked():
             self.normaliseErrorIcon.setPixmap(self.normalise_error_icon_pixmap)
-            self.normaliseErrorIcon.setToolTip(norm_issue)
+            self.normaliseErrorIcon.setToolTip(self.normalise_error_issue)
         else:
             self.normaliseErrorIcon.setPixmap(QPixmap())
             self.normaliseErrorIcon.setToolTip("")

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -108,6 +108,9 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.spectrum.spectrum.clear()
         self.spectrum.remove_roi()
 
+    def auto_range_image(self):
+        self.spectrum.image.vb.autoRange()
+
     def set_normalise_error(self, norm_issue: str):
         self.normalise_error_issue = norm_issue
 

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -3,8 +3,10 @@
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
-from PyQt5.QtWidgets import QCheckBox, QVBoxLayout, QFileDialog, QPushButton
+from PyQt5.QtGui import QPixmap
+from PyQt5.QtWidgets import QCheckBox, QVBoxLayout, QFileDialog, QPushButton, QLabel
 
+from mantidimaging.core.utility import finder
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
 from .presenter import SpectrumViewerWindowPresenter
@@ -23,12 +25,17 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     normaliseCheckBox: QCheckBox
     imageLayout: QVBoxLayout
     exportButton: QPushButton
+    normaliseErrorIcon: QLabel
     _current_dataset_id: Optional['UUID']
 
     def __init__(self, main_window: 'MainWindowView'):
         super().__init__(main_window, 'gui/ui/spectrum_viewer.ui')
 
         self.main_window = main_window
+
+        icon_path = finder.ROOT_PATH + "/gui/ui/images/exclamation-triangle-red.png"
+        self.normalise_error_icon_pixmap = QPixmap(icon_path)
+
         self.presenter = SpectrumViewerWindowPresenter(self, main_window)
 
         self.spectrum = SpectrumWidget(self)
@@ -99,3 +106,11 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.spectrum.image.clear()
         self.spectrum.spectrum.clear()
         self.spectrum.remove_roi()
+
+    def display_normalise_error(self, norm_issue: str):
+        if norm_issue:
+            self.normaliseErrorIcon.setPixmap(self.normalise_error_icon_pixmap)
+            self.normaliseErrorIcon.setToolTip(norm_issue)
+        else:
+            self.normaliseErrorIcon.setPixmap(QPixmap())
+            self.normaliseErrorIcon.setToolTip("")


### PR DESCRIPTION
### Issue

Closes #1550 

### Description

Handle some cases for changing stacks

- Make `SpectrumViewerWindowModel.set_stack()` handle None properly (Happens when stacks are closed in main window)
- Invert some `is not None` into `is None` guards
- Clear the view when setting stack to None
- Handle case where the `normalise_uuid` is not an open stack. Can happen momentarily while stacks are closing.
- Don't do anything in `handle_sample_change` and `handle_normalise_stack_change` if the stack has not actually changed.
- Implement a warning icon if normalisation cannot be done.
- Return an empty array for a normalisation spectrum if it can't be performed.

### Testing & Acceptance Criteria 

For all these cases the user should not see any exception messages

1)
Open dataset, open spectrum viewer.
With spectrum viewer still open, close the dataset in the main window.

2)
Open dataset, open spectrum viewer.
With spectrum viewer still open, close just the selected stack in the main window.

3)
Open dataset, open spectrum viewer.
With spectrum viewer still open, close just the normalise (flat/open) stack in the main window.

4)
Open 2 datasets with different dimensions
Open spectrum viewer, try setting the the normalisation stack to a stack from the other dataset
A warning icon should show, with a tool tip explaining the issue

5)
Open 2 datasets of different sizes.
Open spectrum viewer
Switch back and forth between different stacks for the sample
Check that the zoom is reset when the new stack is selected
Check that zoom does not get reset by changing the ToF range selector

### Documentation

Not needed
