### PR TITLE
Maintain lock scale after applying a filter to an image stack with a 180 projection

### DIFF
--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -272,7 +272,6 @@ class FiltersWindowPresenter(BasePresenter):
                         use_new_data = self._wait_for_stack_choice(stack, stack.id)
                     # if the stack that was kept happened to have a proj180 stack - then apply the filter to that too
                     if stack.has_proj180deg() and use_new_data and not self.applying_to_all:
-                        self.view.clear_previews()
                         # Apply to proj180 synchronously - this function is already running async
                         # and running another async instance causes a race condition in the parallel module
                         # where the shared data can be removed in the middle of the operation of another operation


### PR DESCRIPTION
### Issue

Closes #1554

### Description

Recent changes were made to set lock scale on by default in the operations window. However, locking the scale before there is a before preview results in unhelpful histogram level ranges, so the code in `do_update_previews()` was changed to check if the before preview is available and only apply the lock once it is.

The bug fixed by this PR occurs because when we apply a filter to a single stack and that stack has a 180 projection, we make a call to clear all the previews in the `_post_filter()` method. Later in `_post_filter()` we call `do_update_previews()`, and so at that point there is no before preview and the lock is therefore not maintained.

I can't see a good reason why we're making the call to clear the previews - there are no comments in the code and I haven't been able to find an explanation from the time that the change was introduced. I can't see any problems resulting from removing it and it seems to be an unnecessary step given that all relevant previews are refreshed as part of `do_update_previews()` anyway. If I'm missing something, though, then please shout and I can look into an alternative solution.

### Testing & Acceptance Criteria

Follow steps given on linked issue. Applying filters should always maintain the histogram level range if lock scale is ticked.

### Documentation

Not required - fixes a recent regression.
