### PR TITLE
Reset ROI line on recon preview image after changes to stack

### DIFF
--- a/mantidimaging/gui/widgets/line_profile_plot/view.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/view.py
@@ -130,4 +130,4 @@ class ImageViewLineROI(LineSegmentROI):
         menu_name = reset_menu_name if reset_menu_name is not None else "Reset ROI line"
         self._reset_option = self._image_view.viewbox.menu.addAction(menu_name)
         self._image_view.viewbox.menu.insertSeparator(self._reset_option)
-        self._reset_option.triggered.connect(lambda: self.reset())
+        self._reset_option.triggered.connect(self.reset)

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -173,7 +173,7 @@ class ReconstructWindowPresenter(BasePresenter):
         if self.view.isVisible():
             self.model.reset_cor_model()
             self.do_update_projection()
-            self.do_preview_reconstruct_slice()
+            self.do_preview_reconstruct_slice(reset_roi=True)
         else:
             self.stack_changed_pending = True
 

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -413,3 +413,12 @@ class ReconWindowPresenterTest(unittest.TestCase):
 
         self.presenter._on_volume_recon_done(task)
         self.view.set_recon_buttons_enabled.assert_called_once_with(True)
+
+    def test_handle_stack_changed_requests_roi_reset(self):
+        self.view.isVisible.return_value = True
+        self.presenter.model.reset_cor_model = mock.Mock()
+        self.presenter.do_update_projection = mock.Mock()
+        self.presenter.do_preview_reconstruct_slice = mock.Mock()
+        self.presenter.handle_stack_changed()
+
+        self.presenter.do_preview_reconstruct_slice.assert_called_once_with(reset_roi=True)


### PR DESCRIPTION
### Issue

Closes #1555

### Description

Triggers a reset of the ROI line profile when the selected stack has been updated. This makes sure the recon preview image takes up all the available viewbox space, even after the selected image stack has changed size following an operation.

### Testing & Acceptance Criteria 

See steps on linked issue. The recon preview image should always appear at full size with the ROI line correctly positioned across the middle of the image. This should be the case regardless of changes between stacks, or changes in image size resulting from operations being applied after the Reconstruction window has already been opened.

### Documentation

Not required - fixes a recent regression.
