### PR TITLE
1503 jenks package

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - cil=21.4.*
     - cil-astra=21.4.*
     - ccpi-regulariser=21.0.*
+    - jenkspy=0.2.0
 
 build:
   noarch: python

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -14,7 +14,6 @@ dependencies:
       # For running
       - pyqt5==5.15.*
       - pyqtgraph>=0.12.1,<0.13
-      - jenkspy==0.2.0
       # For developement
       - pytest==6.2.*
       - pytest-cov==2.12.*

--- a/environment.yml
+++ b/environment.yml
@@ -14,4 +14,3 @@ dependencies:
   - pip:
       - pyqt5==5.15.*
       - pyqtgraph>=0.12.1,<0.13
-      - jenkspy==0.2.0

--- a/mantidimaging/gui/widgets/palette_changer/test/presenter_test.py
+++ b/mantidimaging/gui/widgets/palette_changer/test/presenter_test.py
@@ -151,3 +151,16 @@ class PaletteChangerPresenterTest(unittest.TestCase):
     def test_recon_mode_doesnt_call_choice(self, choice_mock):
         PaletteChangerPresenter(self.view, self.histograms, self.recon_histogram, np.random.random((20, 20)), True)
         choice_mock.assert_not_called()
+
+    def test_jenks_break_values(self):
+        self.view.num_materials = 5
+        rng = np.random.Generator(np.random.PCG64(2022))
+        values = np.hstack([rng.normal(loc, 0.03, [500]) for loc in [0.1, 0.2, 0.3, 0.7, 0.9]])
+        values.clip(0, 1)
+        self.presenter.flattened_image = values
+        self.presenter.image = values
+
+        expected = [0.0, 0.1425191163809132, 0.2472192292490485, 0.40716533222825024, 0.7850138036900619, 1.0]
+        actual = self.presenter._generate_jenks_tick_points()
+
+        np.testing.assert_almost_equal(expected, actual, decimal=5)


### PR DESCRIPTION
### Issue

Closes #1503 

### Description

Use jenkspy package from conda instead of pip. Should avoid having to build from source.

### Testing & Acceptance Criteria 

I have added a test that check that jenkspy gives the same results on some example data

Confirm in the "List versions" section of the conda and windows github actions runs, that jenkspy is listed as from `conda-forge` not `pypi`. (Note the docker environments will still have the pypi version until those are rebuilt).

Once this is merged I can remove `gcc` from the docker images.

### Documentation

Once this is merged we can confirm that gcc/msvc is no longer needed and update the installation docs.
