### PR TITLE
Remove gcc from docker recipes

### DIFF
--- a/docker/CentOS7_base.Dockerfile
+++ b/docker/CentOS7_base.Dockerfile
@@ -5,7 +5,7 @@ FROM centos:centos7
 
 WORKDIR /opt/
 
-RUN yum install -y make wget git which xorg-x11-server-Xvfb libxkbcommon-x11 fontconfig qt5-qtbase-devel gcc &&\
+RUN yum install -y make wget git which xorg-x11-server-Xvfb libxkbcommon-x11 fontconfig qt5-qtbase-devel &&\
       yum clean all
 
 # Fixes "D-Bus library appears to be incorrectly set up;" error

--- a/docker/Ubuntu18_base.Dockerfile
+++ b/docker/Ubuntu18_base.Dockerfile
@@ -15,6 +15,5 @@ RUN apt-get update && apt-get install -y make wget curl git fontconfig \
       libxtst6 \
       libsm6 \
       qt5-default \
-      xvfb \
-      gcc &&\
+      xvfb &&\
       apt-get clean


### PR DESCRIPTION
### Issue

Follow-up for #1503 

### Description
No longer needed as jenkspy is installed from conda

### Testing & Acceptance Criteria 
I have tested this locally and successfully rebuilt the docker images

### Documentation

Not needed
