### PR TITLE
Update documentation for Windows support

### DIFF
--- a/docs/developer_guide/index.rst
+++ b/docs/developer_guide/index.rst
@@ -4,7 +4,9 @@ Developer Guide
 Getting Started
 ---------------
 
-You will need conda/mamba, CUDA and gcc installed, see the :ref:`Installation` instructions.
+You will need conda/mamba, CUDA and gcc installed, see the :ref:`Installation` instructions. If you are a Linux user, you will also need to complete step 6 of the installation instructions.
+
+*Note that the Python commands given below are for Linux only. To run the commands on Windows, replace* :code:`python3` *with* :code:`python`.
 
 First download the Mantid Imaging source code using Git.
 

--- a/docs/developer_guide/testing.rst
+++ b/docs/developer_guide/testing.rst
@@ -3,13 +3,19 @@ Testing
 
 Mantid Imaging uses unit tests, static analysis and GUI approval testing
 
-The full test suite can be run using:
+The full test suite can be run using our makefile target.
+
+On Linux, run the following command:
 
 .. code ::
 
     make check
 
+On Windows, you will need to install a Windows version of GNU Make.
+There are a number of options available, so please speak to other developers on the team if you are struggling to find a suitable installation.
+
 Tests are run automatically on pull requests on GitHub using actions, but should also be run during development.
+The full suite of unit tests can run very slowly on a Windows machine. We recommend selecting only relevant tests to run locally when developing on Windows.
 
 Pre-commit
 ----------
@@ -41,31 +47,51 @@ GUI screenshot testing
 
 Mantid Imaging uses `Applitools Eyes <https://applitools.com/products-eyes/>`_ for GUI approval testing. Screenshots of windows are uploaded and compared to known good baseline images. This is run in the github action on pull requests.
 
-Appplitools requires an API key to use, which can be found on via a Applitools web interface. On a developer machine this can be passed as an environment variable. E.g.
+Applitools requires an API key to use, which can be found via the Applitools web interface. On a developer machine this can be passed as an environment variable. E.g.
+
+Linux:
 
 .. code::
 
     APPLITOOLS_API_KEY=XXXXXXXXXX xvfb-run --auto-servernum pytest -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests
 
+Windows:
+
+.. code::
+
+    set APPLITOOLS_API_KEY=XXXXXXXXXX&& python -m pytest -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests
+
+
 Differences between uploaded and baseline images can be examined and approved or rejected from the Applitools web interface.
 
 To run without a key or to prevent uploads, set ``APPLITOOLS_API_KEY`` to ``local`` and choose a directory to save the screenshots. Note that this does not check for changes, and will always pass. e.g.
+
+Linux:
 
 .. code::
 
     mkdir /tmp/gui_test
     APPLITOOLS_API_KEY=local APPLITOOLS_IMAGE_DIR=/tmp/gui_test xvfb-run --auto-servernum pytest -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests
 
+Windows:
+
+In the command below, replace :code:`[path_to_output_directory]` with the path to the directory that you would like to save the screenshots to.
+
+.. code::
+
+    set APPLITOOLS_API_KEY=local&& set APPLITOOLS_IMAGE_DIR=[path_to_output_directory]&& python -m pytest -p no:xdist -p no:randomly -p no:repeat -p no:cov mantidimaging/eyes_tests
+
+
 GUI system tests
 ----------------
 
-GUI system tests run work flows in Mantid Imaging in a 'realistic' way, where possible by using QTest methods to emulate mouse and keyboard actions. They use the same data files as the GUI screenshot tests. These take several minutes to run and so must be explicitly requested.
+GUI system tests run work flows in Mantid Imaging in a 'realistic' way, where possible by using QTest methods to emulate mouse and keyboard actions. They use the same data files as the GUI screenshot tests. These take several minutes to run (longer on Windows) and so must be explicitly requested.
 
 .. code::
 
     pytest -v --run-system-tests
 
-or in virtual X server xvfb-run
+or in virtual X server xvfb-run (Linux only)
 
 .. code::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,7 +7,8 @@ Requirements
 ------------
 
 Operating system
-   Linux. Tested on Ubuntu 18.04, 20.04 and CentOS 7
+ - Linux. Tested on Ubuntu 18.04, 20.04 and CentOS 7
+ - Windows. Tested on Windows 10
 
 Python 3.9
    This can be installed below using Conda if needed.
@@ -43,8 +44,23 @@ Please look for instructions specific to your OS on how to do that:
 (Specific versions can be installed by using the release url, e.g. `https://raw.githubusercontent.com/mantidproject/mantidimaging/release-2.2.0/environment.yml`)
 
 5. This creates an environment called :code:`mantidimaging` that you can activate via :code:`conda activate mantidimaging`
-6. [Optional] If you wish to run :code:`mantidimaging-ipython`, you will need to have :code:`ipython` installed. This can be done
-   with the command :code:`conda install ipython`.
+6. **This step is required for Linux users only.** To ensure that MantidImaging can make full use of the memory available on your Linux machine, we need to set the shared memory size to an appropriate value. Please follow the steps below to do this:
+
+  - Open the etc/fstab file on your computer. You can do this by opening a terminal and running this command (with sudo if needed to allow you to edit the file): :code:`gedit /etc/fstab`
+  - In the open fstab file, try to locate a line like this one: :code:`none /dev/shm tmpfs defaults,size=4G 0 0`.
+  - If the line exists:
+
+    - Modify the text after :code:`size=` to replace with :code:`size=90%`. After you have made the change, the line should look like this: :code:`none /dev/shm tmpfs defaults,size=90% 0 0`
+    - Save your changes and exit the text editor.
+    - In a terminal, run this command (with sudo if needed): :code:`mount -o remount /dev/shm`
+
+  - If the line does NOT exist:
+
+    - At the end of the file, add this line: :code:`none /dev/shm tmpfs defaults,size=90% 0 0`
+    - Save your changes and exit the text editor.
+    - In a terminal, run this command (with sudo if needed): :code:`mount /dev/shm`
+
+7. [Optional] If you wish to run :code:`mantidimaging-ipython`, you will need to have :code:`ipython` installed. This can be done with the command :code:`conda install ipython`.
 
 Running the package
 -------------------

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -5,7 +5,7 @@ Mantid Imaging contains tools for loading data from neutron imaging experiments,
 
 Mantid Imaging makes use of a range of algorithms, some from external tools including `Astra <http://www.astra-toolbox.com/>`_, `Tomopy <https://tomopy.readthedocs.io/en/latest/>`_, `Algotom <https://github.com/algotom/algotom>`_ and the `Core Imaging Library <https://github.com/TomographicImaging/CIL>`_. Many of these are optimised for multithreading and GPU computing.
 
-Mantid Imaging is written in Python and requires a CUDA capable GPU for full functionality. It runs on Linux. See :ref:`Installation` for more details.
+Mantid Imaging is written in Python and requires a CUDA capable GPU for full functionality. It runs on Linux and Windows. See :ref:`Installation` for more details.
 
 See the :ref:`User Guide` for an example taking data from a set of images to full reconstruction.
 


### PR DESCRIPTION
### Issue

Closes #1544

### Description

Updates our documentation to reflect Windows support. This PR doesn't include changes to documentation about compiler requirements, as that has been split out into a separate issue, but should cover all other required updates.

### Testing & Acceptance Criteria 

Documentation can be build locally using `python ./setup.py internal_docs`

