### PR TITLE
Spectrum view: disable norm checkbox when first opened

### DIFF
--- a/mantidimaging/gui/ui/spectrum_viewer.ui
+++ b/mantidimaging/gui/ui/spectrum_viewer.ui
@@ -124,7 +124,7 @@
         <item>
          <widget class="DatasetSelectorWidgetView" name="normaliseStackSelector">
           <property name="enabled">
-           <bool>true</bool>
+           <bool>false</bool>
           </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">


### PR DESCRIPTION
### Issue

Closes #1569 

### Description

Disable the normise stack selector by default

Needs rebasing

### Testing & Acceptance Criteria 

Open a stack, open the spectrum window
The normalisation stack selector should be disabled until the checkbox is ticked

### Documentation
Not needed
