### PR TITLE
Prevent Reconstruction window previews updating while the window is closed

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -34,6 +34,7 @@ Fixes
 - #1496 : OutliersFilter IndexError when using sinograms
 - #1515 : Unlink axis in recon window
 - #1351 : Double clicking reconstruct buttons can cause RunTimeError
+- #1562 : Stop reconstruction previews updating when window is closed
 
 
 Developer Changes

--- a/mantidimaging/eyes_tests/reconstruct_window_test.py
+++ b/mantidimaging/eyes_tests/reconstruct_window_test.py
@@ -22,6 +22,8 @@ class ReconstructionWindowTest(BaseEyesTest):
     def _show_recon_window(self):
         self.imaging.show_recon_window()
         QTest.qWaitForWindowExposed(self.imaging.recon)
+        # If a recon preview is running then we need to wait until it has completed
+        wait_until(lambda: len(self.imaging.recon.presenter.async_tracker) == 0)
 
     def test_reconstruction_window_opens(self):
         self._show_recon_window()
@@ -32,8 +34,6 @@ class ReconstructionWindowTest(BaseEyesTest):
         self._load_data_set()
 
         self._show_recon_window()
-
-        wait_until(lambda: len(self.imaging.recon.presenter.async_tracker) == 0)
 
         self.check_target(widget=self.imaging.recon)
 
@@ -64,6 +64,7 @@ class ReconstructionWindowTest(BaseEyesTest):
         images.data[0:, 0:1] = np.nan
 
         self._show_recon_window()
+
         self.check_target(widget=self.imaging.recon)
 
     def test_reconstruction_window_colour_palette_dialog(self):

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -71,6 +71,7 @@ class ReconstructWindowPresenter(BasePresenter):
 
         self.main_window.stack_changed.connect(self.handle_stack_changed)
         self.stack_changed_pending = False
+        self.stack_selection_change_pending = False
 
     def notify(self, notification, slice_idx=None):
         try:
@@ -125,6 +126,10 @@ class ReconstructWindowPresenter(BasePresenter):
         self.view.change_refine_iterations()
 
     def set_stack_uuid(self, uuid):
+        if not self.view.isVisible():
+            self.stack_selection_change_pending = True
+            return
+
         images = self.view.get_stack(uuid)
         if self.model.is_current_stack(uuid):
             return

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -98,6 +98,16 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.assertEqual(64.0, self.view.rotation_centre)
         self.assertEqual(TEST_PIXEL_SIZE, self.view.pixel_size)
 
+    def test_set_stack_uuid_no_preview_redraw_when_window_closed(self):
+        self.view.isVisible = mock.Mock(return_value=False)
+        self.presenter.do_preview_reconstruct_slice = mock.Mock()
+        # reset the model data
+        self.presenter.model.initial_select_data(None)
+
+        self.presenter.set_stack_uuid(self.uuid)
+
+        self.presenter.do_preview_reconstruct_slice.assert_not_called()
+
     def test_set_projection_preview_index(self):
         self.presenter.set_preview_projection_idx(5)
         self.assertEqual(self.presenter.model.preview_projection_idx, 5)

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -194,7 +194,11 @@ class ReconstructWindowView(BaseMainWindowView):
         self.lbhc_enabled.toggled.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
 
     def showEvent(self, e):
-        if self.presenter.stack_changed_pending:
+        if self.presenter.stack_selection_change_pending:
+            self.presenter.set_stack_uuid(self.stackSelector.current())
+            self.presenter.stack_selection_change_pending = False
+            self.presenter.stack_changed_pending = False
+        elif self.presenter.stack_changed_pending:
             self.presenter.handle_stack_changed()
             self.presenter.stack_changed_pending = False
 


### PR DESCRIPTION
### Issue

Closes #1562

### Description

The problem was being caused because when a stack is loaded it causes a `model_changed` signal to be emitted. This triggers the DatasetSelectorWidget to reload it's dataset, which in turn emits a `stack_selected_uuid` signal. In the recon window, this triggers a call to method `set_stack_uuid`, which wasn't checking if the window was visible before refreshing the previews. This PR adds that check using the same approach as we already use when a stack is changed. If both the `stack_changed` and `model_changed` signals have been emitted while the reconstruction window was closed then it's the change in the selected stack (i.e. the `model_changed` signal) that will be applied.

### Testing & Acceptance Criteria 

See steps given on issue.
Check that the preview is still updating when needed.

### Documentation

Issue number added to release notes.
