### PR TITLE
Remove 180 stack from main window when projection stack is deleted

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -34,6 +34,7 @@ Fixes
 - #1496 : OutliersFilter IndexError when using sinograms
 - #1515 : Unlink axis in recon window
 - #1351 : Double clicking reconstruct buttons can cause RunTimeError
+- #1564 : 180 stack not removed from main window when projection stack is deleted
 
 
 Developer Changes

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -170,8 +170,13 @@ class MainWindowModel(object):
         else:
             for dataset in self.datasets.values():
                 if container_id in dataset:
+                    proj_180_id = None
+                    # If we're deleting a sample from a StrictDataset then any linked 180 projection will also be
+                    # deleted
+                    if isinstance(dataset, StrictDataset) and dataset.proj180deg and dataset.sample.id == container_id:
+                        proj_180_id = dataset.proj180deg.id
                     dataset.delete_stack(container_id)
-                    return [container_id]
+                    return [container_id, proj_180_id] if proj_180_id else [container_id]
                 if container_id == dataset.recons.id:
                     ids_to_remove = dataset.recons.ids
                     dataset.delete_recons()

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -535,11 +535,18 @@ class MainWindowPresenter(BasePresenter):
         Informs the model to delete a container, then updates the view elements.
         :param container_id: The ID of the container to delete.
         """
-        ids_to_remove = self.model.remove_container(container_id)
-        for stack_id in ids_to_remove:
+        # We need the ids of the stacks that have been deleted to tidy up the stack visualiser tabs
+        removed_stack_ids = self.model.remove_container(container_id)
+        for stack_id in removed_stack_ids:
             if stack_id in self.stack_visualisers:
                 self._delete_stack(stack_id)
-        self.remove_item_from_tree_view(container_id)
+
+        # If the container_id provided is not a stack id then we remove the entire container from the tree view,
+        # otherwise we remove the individual stacks that were deleted
+        tree_view_items_to_remove = [container_id] if container_id not in removed_stack_ids else removed_stack_ids
+        for item_id in tree_view_items_to_remove:
+            self.remove_item_from_tree_view(item_id)
+
         self.view.model_changed.emit()
 
     def _delete_stack(self, stack_id: uuid.UUID) -> None:

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -402,14 +402,24 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.remove_item_from_tree_view = mock.Mock()
         self.presenter._delete_container(id_to_remove)
 
-        self.assertNotIn(id_to_remove, self.presenter.stack_visualisers.keys())
-        self.assertNotIn(mock_stack, self.presenter.stack_visualisers.values())
-
-        mock_stack.image_view.close.assert_called_once()
-        mock_stack.presenter.delete_data.assert_called_once()
-        mock_stack.deleteLater.assert_called_once()
-
+        self._check_stack_visualiser_removed(id_to_remove, mock_stack)
         self.presenter.remove_item_from_tree_view.assert_called_once_with(id_to_remove)
+        self.view.model_changed.emit.assert_called_once()
+
+    def test_delete_sample_stack_with_180(self):
+        ids_to_remove = ["sample-to-remove", "proj_180_to_remove"]
+        self.model.remove_container = mock.Mock(return_value=ids_to_remove)
+        self.presenter.stack_visualisers[ids_to_remove[0]] = mock_sample = mock.Mock()
+        self.presenter.stack_visualisers[ids_to_remove[1]] = mock_180 = mock.Mock()
+        self.presenter.remove_item_from_tree_view = mock.Mock()
+
+        self.presenter._delete_container(ids_to_remove[0])
+
+        self._check_stack_visualiser_removed(ids_to_remove[0], mock_sample)
+        self._check_stack_visualiser_removed(ids_to_remove[1], mock_180)
+
+        calls = [call(ids_to_remove[0]), call(ids_to_remove[1])]
+        self.presenter.remove_item_from_tree_view.assert_has_calls(calls, any_order=True)
         self.view.model_changed.emit.assert_called_once()
 
     def test_delete_dataset_and_member_image_stacks(self):
@@ -758,6 +768,14 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         result = self.presenter.get_dataset(incorrect_id)
         self.assertIsNone(result)
+
+    def _check_stack_visualiser_removed(self, stack_id, mock_stack_visualiser):
+        self.assertNotIn(stack_id, self.presenter.stack_visualisers.keys())
+        self.assertNotIn(mock_stack_visualiser, self.presenter.stack_visualisers.values())
+
+        mock_stack_visualiser.image_view.close.assert_called_once()
+        mock_stack_visualiser.presenter.delete_data.assert_called_once()
+        mock_stack_visualiser.deleteLater.assert_called_once()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Issue

Closes #1564

### Description

This PR makes sure we're returning the ID of any 180 stacks that have been deleted along with the sample stack. This allows the main window tree view items and visualiser tabs to be tidied correctly.

I took a bit of time to look at whether we could split the code here up a little bit, as there seem to be a bit of a mix of things going on. However I concluded this could take a bit more time to refactor than I wanted to spend at this point in the release cycle, so I went with adding a small fix instead.

### Testing & Acceptance Criteria 

I've added a number of unit tests to try and cover various issues.
For manual testing, follow the steps given on the issue and also try loading and deleting stacks and/or datasets in different sequences to check that no errors arise.

### Documentation

Issue number added to release notes.
