### PR TITLE
Add ToF Range label to Spectrum Viewer plot

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -91,8 +91,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.spectrum.add_roi(self.model.get_roi("roi"))
         self.view.auto_range_image()
 
-    def handle_range_slide_moved(self) -> None:
-        tof_range = self.view.spectrum.get_tof_range()
+    def handle_range_slide_moved(self, tof_range) -> None:
         self.model.tof_range = tof_range
         self.view.set_image(self.model.get_averaged_image(), autoLevels=False)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -70,9 +70,6 @@ class SpectrumWidget(GraphicsLayoutWidget):
         size = CloseEnoughPoint(self.roi.size())
         return SensibleROI.from_points(pos, size)
 
-    def remove_roi(self) -> None:
-        self.image.vb.removeItem(self.roi)
-
     def _set_tof_range_label(self, range_min: int, range_max: int) -> None:
         self._tof_range_label.setText(f'ToF range: {range_min} - {range_max}')
 
@@ -80,3 +77,9 @@ class SpectrumWidget(GraphicsLayoutWidget):
         tof_range = self.get_tof_range()
         self._set_tof_range_label(tof_range[0], tof_range[1])
         self.range_changed.emit(tof_range)
+
+    def clear_data(self):
+        self.image.clear()
+        self.spectrum.clear()
+        self.image.vb.removeItem(self.roi)
+        self._tof_range_label.setText('')

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -20,7 +20,7 @@ class SpectrumWidget(GraphicsLayoutWidget):
     range_control: LinearRegionItem
     roi: ROI
 
-    range_changed = pyqtSignal()
+    range_changed = pyqtSignal(object)
     roi_changed = pyqtSignal()
 
     def __init__(self, parent: 'SpectrumViewerWindowView'):
@@ -33,11 +33,14 @@ class SpectrumWidget(GraphicsLayoutWidget):
         self.nextRow()
         self.spectrum = self.addPlot()
 
+        self.nextRow()
+        self._tof_range_label = self.addLabel()
+
         self.ci.layout.setRowStretchFactor(0, 3)
         self.ci.layout.setRowStretchFactor(1, 1)
 
         self.range_control = LinearRegionItem()
-        self.range_control.sigRegionChanged.connect(self.range_changed.emit)
+        self.range_control.sigRegionChanged.connect(self._handle_tof_range_changed)
 
         self.roi = ROI(pos=(0, 0), rotatable=False, scaleSnap=True, translateSnap=True)
         self.roi.sigRegionChanged.connect(self.roi_changed.emit)
@@ -46,6 +49,7 @@ class SpectrumWidget(GraphicsLayoutWidget):
         self.range_control.setBounds((range_min, range_max))
         self.range_control.setRegion((range_min, range_max))
         self.spectrum.addItem(self.range_control)
+        self._set_tof_range_label(range_min, range_max)
 
     def get_tof_range(self) -> tuple[int, int]:
         r_min, r_max = self.range_control.getRegion()
@@ -68,3 +72,11 @@ class SpectrumWidget(GraphicsLayoutWidget):
 
     def remove_roi(self) -> None:
         self.image.vb.removeItem(self.roi)
+
+    def _set_tof_range_label(self, range_min: int, range_max: int) -> None:
+        self._tof_range_label.setText(f'ToF range: {range_min} - {range_max}')
+
+    def _handle_tof_range_changed(self) -> None:
+        tof_range = self.get_tof_range()
+        self._set_tof_range_label(tof_range[0], tof_range[1])
+        self.range_changed.emit(tof_range)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -116,11 +116,11 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
     def test_gui_changes_tof_range(self):
         image_stack = generate_images([30, 11, 12])
-        self.view.spectrum.get_tof_range = mock.Mock(return_value=(10, 20))
+        new_tof_range = (10, 20)
         self.presenter.model.set_stack(image_stack)
-        self.presenter.handle_range_slide_moved()
+        self.presenter.handle_range_slide_moved(new_tof_range)
 
-        self.assertEqual(self.presenter.model.tof_range, (10, 20))
+        self.assertEqual(self.presenter.model.tof_range, new_tof_range)
 
     @mock.patch("mantidimaging.gui.windows.spectrum_viewer.model.SpectrumViewerWindowModel.save_csv")
     def test_handle_export_csv_none(self, mock_save_csv: mock.Mock):

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -103,9 +103,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.spectrum.spectrum.plot(spectrum_data)
 
     def clear(self) -> None:
-        self.spectrum.image.clear()
-        self.spectrum.spectrum.clear()
-        self.spectrum.remove_roi()
+        self.spectrum.clear_data()
 
     def auto_range_image(self):
         self.spectrum.image.vb.autoRange()


### PR DESCRIPTION
### Issue

Closes #1574

### Description

Adds a label underneath the plot in the Spectrum Viewer window to give the min and max values of the currently selected range. The label is cleared when all stacks are deleted from the main window.

### Testing & Acceptance Criteria 

The label should appear with correct values under the plot and should update accurately as the range is changed. If all stacks are deleted from the main window while the Spectrum Viewer window is still open then the label should disappear.

### Documentation

Not required at this stage.
