### PR TITLE
Prevent IndexErrors when selecting projections and slices in Reconstruction window

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -36,6 +36,7 @@ Fixes
 - #1351 : Double clicking reconstruct buttons can cause RunTimeError
 - #1562 : Stop reconstruction previews updating when window is closed
 - #1564 : 180 stack not removed from main window when projection stack is deleted
+- #1561 : IndexError in Reconstruction window if select a slice or projection index that's too high
 
 
 Developer Changes

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -25,10 +25,7 @@ class ReconImagesView(GraphicsLayoutWidget):
         self.imageview_sinogram = MIMiniImageView(name="Sinogram", parent=parent)
         self.imageview_recon = MIMiniImageView(name="Recon", parent=parent, recon_mode=True)
 
-        self.slice_line = InfiniteLine(pos=1024,
-                                       angle=0,
-                                       bounds=[0, self.imageview_projection.image_item.width()],
-                                       movable=True)
+        self.slice_line = InfiniteLine(pos=1024, angle=0, movable=True)
         self.imageview_projection.viewbox.addItem(self.slice_line)
         self.tilt_line = InfiniteLine(pos=1024, angle=90, pen=(255, 0, 0, 255), movable=True)
         self.recon_line_profile = LineProfilePlot(self.imageview_recon)
@@ -62,6 +59,7 @@ class ReconImagesView(GraphicsLayoutWidget):
         self.imageview_projection.setImage(image_data)
         self.imageview_projection.histogram.imageChanged(autoLevel=True, autoRange=True)
         self.slice_line.setPos(preview_slice_index)
+        self.slice_line.setBounds([0, int(self.imageview_projection.image_item.height()) - 1])
         if tilt_angle:
             self.set_tilt(tilt_angle, image_data.shape[1] // 2)
         else:

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -145,8 +145,15 @@ class ReconstructWindowPresenter(BasePresenter):
             self.view.reset_recon_line_profile()
             self.view.show_status_message("")
             return
+        self._set_max_preview_indexes()
         self.do_preview_reconstruct_slice(reset_roi=True)
         self._do_nan_zero_negative_check()
+
+    def _set_max_preview_indexes(self):
+        images = self.model.images
+        if images is not None:
+            self.view.set_max_projection_index(images.num_projections - 1)
+            self.view.set_max_slice_index(images.height - 1)
 
     def set_preview_projection_idx(self, idx):
         self.model.preview_projection_idx = idx
@@ -178,6 +185,7 @@ class ReconstructWindowPresenter(BasePresenter):
         if self.view.isVisible():
             self.model.reset_cor_model()
             self.do_update_projection()
+            self._set_max_preview_indexes()
             self.do_preview_reconstruct_slice(reset_roi=True)
         else:
             self.stack_changed_pending = True

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -61,6 +61,8 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.view.clear_cor_table.assert_called_once()
         self.view.update_projection.assert_called_once()
         self.view.update_sinogram.assert_called_once()
+        self.view.set_max_projection_index.assert_called_once_with(self.data.num_projections - 1)
+        self.view.set_max_slice_index.assert_called_once_with(self.data.height - 1)
 
         # calling again with the same stack shouldn't re-do everything
         self.presenter.set_stack_uuid(self.uuid)
@@ -87,6 +89,8 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.view.update_projection.assert_not_called()
         self.view.reset_recon_line_profile.assert_called_once()
         self.view.show_status_message.assert_called_once_with("")
+        self.view.set_max_projection_index.assert_not_called()
+        self.view.set_max_slice_index.assert_not_called()
 
     @mock.patch('mantidimaging.gui.windows.recon.presenter.start_async_task_view')
     def test_set_stack_uuid_updates_rotation_centre_and_pixel_size(self, mock_start_async: mock.Mock):
@@ -432,3 +436,13 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.presenter.handle_stack_changed()
 
         self.presenter.do_preview_reconstruct_slice.assert_called_once_with(reset_roi=True)
+
+    def test_handle_stack_changed_updates_preview_indexes(self):
+        self.view.isVisible.return_value = True
+        self.presenter.model.reset_cor_model = mock.Mock()
+        self.presenter.do_update_projection = mock.Mock()
+        self.presenter.do_preview_reconstruct_slice = mock.Mock()
+        self.presenter.handle_stack_changed()
+
+        self.view.set_max_projection_index.assert_called_once_with(self.data.num_projections - 1)
+        self.view.set_max_slice_index.assert_called_once_with(self.data.height - 1)

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -512,3 +512,9 @@ class ReconstructWindowView(BaseMainWindowView):
     def set_recon_buttons_enabled(self, enabled: bool):
         self.reconstructSlice.setEnabled(enabled)
         self.reconstructVolume.setEnabled(enabled)
+
+    def set_max_projection_index(self, max_index: int):
+        self.previewProjectionIndex.setMaximum(max_index)
+
+    def set_max_slice_index(self, max_index: int):
+        self.previewSliceIndex.setMaximum(max_index)


### PR DESCRIPTION
### Issue

Closes #1561

### Description

Sets maximum values on the preview projection and slice index spinboxes to prevent the user entering values outside the available range.

This PR also fixes a bug in setting the bounds for the slice line on the projection preview so that we're setting the maximum bound using the correct image dimension. I've also moved where we set the bounds, as no image data was available when it was being set in the original location, leading to no max value being applied. The new location also means the max bound will update as required when the image changes.

### Testing & Acceptance Criteria 

See steps given on issue. Check that it's not possible to select values outside the available range using either of the preview index spinboxes or the slice line on the projection preview. Check that the maximum permitted values change when the stack selection or dimensions change (i.e. by cropping to reduce the height of the currently selected stack). Check that no IndexErrors are encountered.

### Documentation

Issue number added to release notes.
