### PR TITLE
Update sinogram filter info wording in Operations window

### DIFF
--- a/mantidimaging/core/operations/base_filter.py
+++ b/mantidimaging/core/operations/base_filter.py
@@ -26,6 +26,9 @@ class BaseFilter:
     link_histograms = False
     show_negative_overlay = True
     operate_on_sinograms = False
+
+    SINOGRAM_FILTER_INFO = "This filter will work on a\nsinogram view of the data."
+
     __name__ = "BaseFilter"
     """
     The base class for filter algorithms, which should extend this class.

--- a/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
+++ b/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
@@ -68,10 +68,7 @@ class RemoveAllStripesFilter(BaseFilter):
     def register_gui(form, on_change, view):
         from mantidimaging.gui.utility import add_property_to_form
 
-        label, _ = add_property_to_form("This filter requires sinograms\nto produce a sensible result.",
-                                        Type.LABEL,
-                                        form=form,
-                                        on_change=on_change)
+        label, _ = add_property_to_form(BaseFilter.SINOGRAM_FILTER_INFO, Type.LABEL, form=form, on_change=on_change)
         # defaults taken from TomoPy integration
         # https://tomopy.readthedocs.io/en/latest/api/tomopy.prep.stripe.html#tomopy.prep.stripe.remove_all_stripe
         _, snr = add_property_to_form('Stripe ratio',

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -62,10 +62,7 @@ class RemoveDeadStripesFilter(BaseFilter):
     def register_gui(form, on_change, view):
         from mantidimaging.gui.utility import add_property_to_form
 
-        label, _ = add_property_to_form("This filter requires sinograms\nto produce a sensible result.",
-                                        Type.LABEL,
-                                        form=form,
-                                        on_change=on_change)
+        label, _ = add_property_to_form(BaseFilter.SINOGRAM_FILTER_INFO, Type.LABEL, form=form, on_change=on_change)
         # defaults taken from TomoPy integration
         # https://tomopy.readthedocs.io/en/latest/api/tomopy.prep.stripe.html#tomopy.prep.stripe.remove_all_stripe
         _, snr = add_property_to_form('Stripe ratio',

--- a/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
+++ b/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
@@ -61,10 +61,7 @@ class RemoveLargeStripesFilter(BaseFilter):
     @staticmethod
     def register_gui(form, on_change, view):
         from mantidimaging.gui.utility import add_property_to_form
-        label, _ = add_property_to_form("This filter requires sinograms\nto produce a sensible result.",
-                                        Type.LABEL,
-                                        form=form,
-                                        on_change=on_change)
+        label, _ = add_property_to_form(BaseFilter.SINOGRAM_FILTER_INFO, Type.LABEL, form=form, on_change=on_change)
 
         # defaults taken from TomoPy integration
         # https://tomopy.readthedocs.io/en/latest/api/tomopy.prep.stripe.html#tomopy.prep.stripe.remove_all_stripe

--- a/mantidimaging/core/operations/remove_stripe/stripe_removal.py
+++ b/mantidimaging/core/operations/remove_stripe/stripe_removal.py
@@ -90,10 +90,7 @@ class StripeRemovalFilter(BaseFilter):
     def register_gui(form, on_change, view):
         from mantidimaging.gui.utility import add_property_to_form
 
-        label, _ = add_property_to_form("This filter requires sinograms\nto produce a sensible result.",
-                                        Type.LABEL,
-                                        form=form,
-                                        on_change=on_change)
+        label, _ = add_property_to_form(BaseFilter.SINOGRAM_FILTER_INFO, Type.LABEL, form=form, on_change=on_change)
         # Filter type option
         _, value_filter_type = add_property_to_form('Filter Type',
                                                     Type.CHOICE,

--- a/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
@@ -85,10 +85,7 @@ class RemoveStripeFilteringFilter(BaseFilter):
     def register_gui(form, on_change, view):
         from mantidimaging.gui.utility import add_property_to_form
 
-        label, _ = add_property_to_form("This filter requires sinograms\nto produce a sensible result.",
-                                        Type.LABEL,
-                                        form=form,
-                                        on_change=on_change)
+        label, _ = add_property_to_form(BaseFilter.SINOGRAM_FILTER_INFO, Type.LABEL, form=form, on_change=on_change)
         _, sigma = add_property_to_form('Sigma',
                                         Type.INT,
                                         default_value=3,

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
@@ -65,10 +65,7 @@ class RemoveStripeSortingFittingFilter(BaseFilter):
     def register_gui(form, on_change, view):
         from mantidimaging.gui.utility import add_property_to_form
 
-        label, _ = add_property_to_form("This filter requires sinograms\nto produce a sensible result.",
-                                        Type.LABEL,
-                                        form=form,
-                                        on_change=on_change)
+        label, _ = add_property_to_form(BaseFilter.SINOGRAM_FILTER_INFO, Type.LABEL, form=form, on_change=on_change)
         _, order = add_property_to_form('Polynomial fit order',
                                         Type.INT,
                                         default_value=1,


### PR DESCRIPTION
### Issue

Closes #1557

### Description

Updates the wording for the sinogram filters following recent changes. The wording was duplicated across all of the sinogram filters, so I created a constant on the base class to hold the text in one place and make future updates easier.

I've updated the wording for the stripe removal filter even though that filter hasn't been updated to use auto sinograms yet (due in #1529). It seemed OK to update the wording in this PR as I know this is intended to go into the same release. However, if preferred, I can always leave that one out of these changes.

### Testing & Acceptance Criteria 

The new text given on the issue should appear when sinogram filters are selected in the Operations window.

### Documentation

Not needed as the changes contribute to the auto sinogram work.