### PR TITLE
Remove name from MIMiniImageView show_details

### DIFF
--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -126,7 +126,7 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
         if image is not None and pos.y < image.shape[0] and pos.x < image.shape[1]:
             pixel_value = image[pos.y, pos.x]
             value_string = ("%.6f" % pixel_value)[:8]
-            self.details.setText(f"{self.name}: x={pos.x}, y={pos.y}, value={value_string}")
+            self.details.setText(f"x={pos.x}, y={pos.y}, value={value_string}")
 
     def link_sibling_axis(self):
         # Linking multiple viewboxes with locked aspect ratios causes


### PR DESCRIPTION
### Issue

Closes #1573

### Description

Removes the name information from the details shown at the bottom of the MIMiniImageView widget when you hover over the image.

### Testing & Acceptance Criteria 

Check that hovering over the images in the Operations and Reconstruction windows shows only x, y, and value information. Name information should no longer be included.

### Documentation

No need to add this to the release notes for such a small change?
