### PR TITLE
Use GITHUB_TOKEN for doc upload

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -79,4 +79,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: ./.github/actions/publish-docs
         with:
-          token: ${{ secrets.GHPAGES_API_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Issue

Avoid need to manually generate tokens for pushing the docs

### Description

Use GITHUB_TOKEN for doc upload

### Testing & Acceptance Criteria 

Tricky to test because we only upload docs once merged to main. So best to merge and then revert if there is an issue.

Based on working workflow in mslice ( https://github.com/mantidproject/mslice/blob/main/.github/workflows/online_doc_update.yml#L28 )

