### PR TITLE
Improve usability of ROI selectors and default sizes

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -11,6 +11,7 @@ New Features and improvements
 Fixes
 -----
 - #1589 : Recomend new update command
+- #1330 : Initial ROI box is sometimes much larger than image for relevant filters
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/widgets/mi_image_view/test/view_test.py
+++ b/mantidimaging/gui/widgets/mi_image_view/test/view_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from unittest import mock
 
 import numpy as np
 import unittest
@@ -18,3 +19,61 @@ class MIImageViewTest(unittest.TestCase):
 
         self.view.setImage(image)
         self.assertTrue(hasattr(self.view, 'tVals'), 'tVals attribute missing for small image size')
+
+    def test_set_image_calls_set_roi_for_new_image(self):
+        self.view.set_roi = mock.Mock()
+        image = np.zeros((1, 1, 1))
+
+        self.view.setImage(image)
+        self.view.set_roi.assert_called_once()
+
+    def test_set_image_calls_set_roi_for_changed_image_dimensions(self):
+        image = np.zeros((1, 1, 1))
+        self.view.setImage(image)
+        self.view.set_roi = mock.Mock()
+        new_image = np.zeros((1, 10, 10))
+
+        self.view.setImage(new_image)
+        self.view.set_roi.assert_called_once()
+
+    def test_set_image_does_not_call_set_roi_for_same_image_dimensions(self):
+        image = np.zeros((1, 1, 1))
+        self.view.setImage(image)
+        self.view.set_roi = mock.Mock()
+
+        self.view.setImage(image)
+        self.view.set_roi.assert_not_called()
+
+    def test_set_roi(self):
+        image = np.zeros((1, 10, 5))
+        self.view.setImage(image)
+        self.view.roi.setPos = mock.Mock()
+        self.view.roi.setSize = mock.Mock()
+        self.view._update_roi_region_avg = mock.Mock()
+        self.view._update_message = mock.Mock()
+        self.view.roi_changed_callback = mock.Mock()
+
+        left = top = 0
+        right = 10
+        bottom = 5
+        self.view.set_roi([left, top, right, bottom])
+
+        self.view.roi.setPos.assert_called_once_with(left, top, update=False)
+        self.view.roi.setSize.assert_called_once_with([right - left, bottom - top])
+        self.view._update_roi_region_avg.assert_called_once()
+        self.view.roi_changed_callback.assert_called_once()
+        self.view._update_message.assert_called_once()
+
+    def test_default_roi(self):
+        image = np.zeros((1, 50, 50))
+        self.view.setImage(image)
+        expected_roi = [0, 0, 25, 25]
+
+        self.assertListEqual(expected_roi, self.view.default_roi())
+
+    def test_default_roi_uses_min_value_for_small_images(self):
+        image = np.zeros((1, 5, 5))
+        self.view.setImage(image)
+        expected_roi = [0, 0, 20, 20]
+
+        self.assertListEqual(expected_roi, self.view.default_roi())

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -447,16 +447,16 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         assert self.presenter.prev_apply_single_state == prev_apply_single_state
         assert self.presenter.prev_apply_all_state == prev_apply_all_state
 
-    def test_init_crop_coords_does_nothing_when_stack_is_none(self):
+    def test_init_roi_field_does_nothing_when_stack_is_none(self):
         mock_roi_field = mock.Mock()
-        self.presenter.init_crop_coords(mock_roi_field)
+        self.presenter.init_roi_field(mock_roi_field)
         mock_roi_field.setText.assert_not_called()
 
-    def test_init_crop_coords_does_nothing_when_image_is_greater_than_200_by_200(self):
+    def test_init_roi_field_does_nothing_when_image_is_greater_than_200_by_200(self):
         mock_roi_field = mock.Mock()
         self.presenter.stack = mock.Mock()
         self.presenter.stack.data = np.ones((2, 201, 201))
-        self.presenter.init_crop_coords(mock_roi_field)
+        self.presenter.init_roi_field(mock_roi_field)
         mock_roi_field.setText.assert_not_called()
 
     @parameterized.expand([(190, 201, "0, 0, 200, 190"), (201, 80, "0, 0, 80, 200"), (200, 200, "0, 0, 200, 200")])
@@ -464,7 +464,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         mock_roi_field = mock.Mock()
         self.presenter.stack = mock.Mock()
         self.presenter.stack.data = np.ones((2, shape_x, shape_y))
-        self.presenter.init_crop_coords(mock_roi_field)
+        self.presenter.init_roi_field(mock_roi_field)
         mock_roi_field.setText.assert_called_once_with(expected)
 
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter._do_apply_filter_sync')

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -162,10 +162,8 @@ class StackVisualiserView(QDockWidget):
             flags=INPUT_DIALOG_FLAGS)
         if accepted:
             roi = [int(r.strip()) for r in roi.split(",")]
-            self.image_view.roi.setPos((roi[0], roi[1]), update=False)
-            self.image_view.roi.setSize((roi[2] - roi[0], roi[3] - roi[1]))
+            self.image_view.set_roi(roi)
             self.image_view.roi.show()
-            self.image_view.roiChanged()
 
     def copy_roi_to_clipboard(self):
         pos, size = self.image_view.get_roi()


### PR DESCRIPTION
### Issue

Closes #1330

### Description

Various fixes so that the default size of an ROI in the `MIImageView` should be equal to either the top left quadrant of the image or 20 x 20, whichever is larger. This is relevant for various stack visualisers through the application, including the main window.

For the ROI selectors on the operations window (used for Crop Co-ordinates and ROI Normalisation), the initial ROI is now set based on the value in the ROI field. If no valid value has been set then the selector uses the default for the `MIImageView`. After Crop Co-ordinates has been applied, the ROI field is reset to use the new image size and ensure the ROI size remains relevant.

I had a go at having the ROI selector dialog update in response to the user changing values in the ROI field while the dialog was open. This introduced some complexity to the code that seemed unnecessary given that I think it's reasonable to assume users will choose just one method of selecting the ROI (as they have to now). With this in mind, I've set the ROI field to be disabled when any ROI selector dialogs are opened and re-enabled when all are closed.

### Testing & Acceptance Criteria 

- Check the problems described on the issue.
- Additionally check that moving the ROI in a selector dialog updates the ROI field and also that moving the ROI updates the information at the bottom of the `MIImageView` image.
- Check that the ROI is adjusted correctly when a Crop Co-ordinates filter is applied, both in the Operations window and in the main window stack visualiser.

I'm expecting the Applitools ROI Normalisation test to fail because the value in the ROI field should now be set to the image size when the image size is less than 200 x 200.

### Documentation

Issue added to release notes.
