### PR TITLE
Switch to using pyqt from conda-forge

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     - cil-astra=21.4.*
     - ccpi-regulariser=21.0.*
     - jenkspy=0.2.0
+    - pyqt=5.15.*
 
 build:
   noarch: python

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - ccpi-regulariser=21.0.*
     - jenkspy=0.2.0
     - pyqt=5.15.*
+    - pyqtgraph>=0.12.1,<0.13
 
 build:
   noarch: python

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -11,9 +11,6 @@ dependencies:
   - mantidimaging
   - pip
   - pip:
-      # For running
-      - pyqtgraph>=0.12.1,<0.13
-      # For development
       - coveralls==3.3.*
       - yapf==0.31.*
       - mypy==0.910
@@ -27,7 +24,6 @@ dependencies:
       - eyes-images==4.25.*
       - parameterized==0.8.*
       - pre-commit==2.15.*
-  # For development
   - pytest==7.1.*
   - pytest-cov==3.0.*
   - pytest-randomly==3.12.*

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -12,7 +12,6 @@ dependencies:
   - pip
   - pip:
       # For running
-      - pyqt5==5.15.*
       - pyqtgraph>=0.12.1,<0.13
       # For development
       - coveralls==3.3.*

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,3 @@ channels:
 # Dependencies that can be installed with conda should be in conda/meta.yaml
 dependencies:
   - mantidimaging
-  - pip
-  - pip:
-      - pyqtgraph>=0.12.1,<0.13

--- a/environment.yml
+++ b/environment.yml
@@ -12,5 +12,4 @@ dependencies:
   - mantidimaging
   - pip
   - pip:
-      - pyqt5==5.15.*
       - pyqtgraph>=0.12.1,<0.13


### PR DESCRIPTION
### Issue

Closes #1598

### Description

Move pyqt and pyqtgraph from being installed with pip to conda-forge.

This should reduce the risk of ABI compatibility issues.

~Also update pyqtgraph to 0.13~ Causes some small screen shot changes so will make a separate PR.

### Testing & Acceptance Criteria 

Tests should all still pass.

To make a new dev environment
`python ./setup.py create_dev_env` 

### Documentation

Not needed
