### PR TITLE
Update pyqtgraph to 0.13

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - ccpi-regulariser=21.0.*
     - jenkspy=0.2.0
     - pyqt=5.15.*
-    - pyqtgraph>=0.12.1,<0.13
+    - pyqtgraph=0.13.*
 
 build:
   noarch: python

--- a/mantidimaging/eyes_tests/eyes_manager.py
+++ b/mantidimaging/eyes_tests/eyes_manager.py
@@ -90,6 +90,7 @@ class EyesManager:
             raise ValueError("widget is not a QWidget")
 
         QTest.qWaitForWindowExposed(widget)
+        QApplication.sendPostedEvents()
         QApplication.processEvents()
         window_image = widget.grab()
 

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -30,6 +30,10 @@ class UnrotateablePlotROI(ROI):
         self.addScaleHandle([1, 1], [0, 0])
 
 
+def clip(value, lower, upper):
+    return lower if value < lower else upper if value > upper else value
+
+
 # ImageView objects cannot always be safely garbage collected. To prevent this
 # we need keep a reference to the dead objects.
 graveyard = []
@@ -222,11 +226,17 @@ class MIImageView(ImageView, BadDataOverlay, AutoColorMenu):
         # event holds the coordinates in column-major coordinate
         # while the data is in row-major coordinate, hence why
         # the data access below is [y, x]
-        msg = f"x={pt.y}, y={pt.x}, "
+
         if self.image.ndim == 3:
-            msg += f"z={self.currentIndex}, value={self.image[self.currentIndex, pt.y, pt.x]:.6f}"
+            x = clip(pt.x, 0, self.image.shape[2] - 1)
+            y = clip(pt.y, 0, self.image.shape[1] - 1)
+            value = self.image[self.currentIndex, y, x]
+            msg = f"x={y}, y={x}, z={self.currentIndex}, value={value :.6f}"
         else:
-            msg += f"value={self.image[pt.y, pt.x]}"
+            x = clip(pt.x, 0, self.image.shape[1] - 1)
+            y = clip(pt.y, 0, self.image.shape[0] - 1)
+            value = self.image[y, x]
+            msg = f"x={y}, y={x}, value={value}"
         if self.roiString is not None:
             msg += f" | roi = {self.roiString}"
         self.details.setText(msg)

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -178,20 +178,6 @@ class MIImageView(ImageView, BadDataOverlay, AutoColorMenu):
         if self.roi_changed_callback and roi is not None:
             self.roi_changed_callback(roi)
 
-    def timeLineChanged(self):
-        """
-        Re-implements timeLineChanged function, and the only change
-        is that now self.updateImage will NOT auto range the histogram
-        """
-        if not self.ignorePlaying:
-            self.play(0)
-
-        (ind, time) = self.timeIndex(self.timeLine)
-        if ind != self.currentIndex:
-            self.currentIndex = ind
-            self.updateImage(autoHistogramRange=False)
-        self.sigTimeChanged.emit(ind, time)
-
     def _update_roi_region_avg(self) -> Optional[SensibleROI]:
         if self.image.ndim != 3:
             return None


### PR DESCRIPTION
### Issue
Closes #1604 

### Description

Update pyqtgraph.

This causes a few changes to how labels on axes are drawn. With the extra `sendPostedEvents()` the changes are fine.

ImageView.timeLineChanged has changed significantly in pyqtgraph 0.13, causing issues for the override in MIImageView. As its not needed, remove the override.

### Testing & Acceptance Criteria 

Create a new dev environment. Check that basics work

### Documentation

Not needed.
