### PR TITLE
Update tomopy and remove work arounds

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - scikit-image=0.19.*
     - numpy=1.20.*
     - algotom=1.0.*
-    - tomopy=1.10.*
+    - tomopy=1.12.*
     - cudatoolkit=10.2*
     - cupy=10.2.*
     - astra-toolbox=2.0.*

--- a/mantidimaging/core/operations/ring_removal/ring_removal.py
+++ b/mantidimaging/core/operations/ring_removal/ring_removal.py
@@ -130,7 +130,7 @@ class RingRemovalFilter(BaseFilter):
 
         _, theta = add_property_to_form('Theta',
                                         Type.INT,
-                                        valid_values=(-1000, 1000),
+                                        valid_values=(0, 179),
                                         form=form,
                                         on_change=on_change,
                                         tooltip="minimum angle in degrees to be considered ring artifact")

--- a/mantidimaging/core/operations/ring_removal/ring_removal.py
+++ b/mantidimaging/core/operations/ring_removal/ring_removal.py
@@ -64,20 +64,6 @@ class RingRemovalFilter(BaseFilter):
 
         h.check_data_stack(images)
 
-        # COMPAT tomopy <= 1.10.1
-        # tomopy 1.10.1 and older will crash with "large" values of theta
-        # Catch these here for now
-        # https://github.com/tomopy/tomopy/issues/551
-        if center_mode == "manual":
-            min_dist_to_edge = min([center_x, center_y, images.width - center_x, images.height - center_y])
-        else:
-            min_dist_to_edge = min([images.width / 2, images.height / 2])
-
-        if theta_min >= 180 or theta_min > min_dist_to_edge:
-            raise ValueError("Theta should be in the range [0 - 180) and larger than the min distance from"
-                             "from COR to edge.")
-        # end COMPAT
-
         with progress:
             progress.update(msg="Ring Removal")
             sample = images.data


### PR DESCRIPTION
### Issue
Closes #1597 

### Description

Update tomopy
Remove workaround
Limit Theta spinbox

### Testing & Acceptance Criteria 

With `tilt_simple_recon.tar.xz` from the Onedrive example data.
Open the Ring removal, use the values from the screenshot. There should be some reduction in ring artefacts (its a bit subtle).

![image](https://user-images.githubusercontent.com/74248560/194361529-3f4a363e-8bcc-438c-9042-65204786bc2b.png)

If you change Center of Rotation to manual, and put in some small values (e.g. 2,2) then there should no longer be an error message.

The Theta input should now be limited to 0-179

### Documentation

Not needed
