### PR TITLE
Prevent multiple ROI selector windows in Operations window

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -10,8 +10,9 @@ New Features and improvements
 
 Fixes
 -----
-- #1589 : Recomend new update command
+- #1589 : Recommend new update command
 - #1330 : Initial ROI box is sometimes much larger than image for relevant filters
+- #1602 : Prevent multiple ROI selector windows opening from Operations window
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/operations/crop_coords/crop_coords.py
+++ b/mantidimaging/core/operations/crop_coords/crop_coords.py
@@ -79,11 +79,9 @@ class CropCoordinatesFilter(BaseFilter):
                                                 form=form,
                                                 on_change=on_change,
                                                 default_value="0, 0, 200, 200")
-        add_property_to_form("Select ROI",
-                             Type.BUTTON,
-                             form=form,
-                             on_change=on_change,
-                             run_on_press=lambda: view.roi_visualiser(roi_field))
+        roi_button, _ = add_property_to_form("Select ROI", Type.BUTTON, form=form, on_change=on_change)
+        roi_button.clicked.connect(lambda: view.roi_visualiser(roi_field, roi_button))
+
         return {'roi_field': roi_field}
 
     @staticmethod

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -93,11 +93,8 @@ class RoiNormalisationFilter(BaseFilter):
                                                 form=form,
                                                 on_change=on_change,
                                                 default_value="0, 0, 200, 200")
-        add_property_to_form("Select Air Region",
-                             "button",
-                             form=form,
-                             on_change=on_change,
-                             run_on_press=lambda: view.roi_visualiser(roi_field))
+        roi_button, _ = add_property_to_form("Select Air Region", "button", form=form, on_change=on_change)
+        roi_button.clicked.connect(lambda: view.roi_visualiser(roi_field, roi_button))
 
         _, mode_field = add_property_to_form('Normalise Mode',
                                              Type.CHOICE,

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -65,7 +65,6 @@ class FiltersWindowView(BaseMainWindowView):
         self.presenter = FiltersWindowPresenter(self, main_window)
         self.roi_view = None
         self.roi_view_averaged = False
-        self._roi_selector_window_count = 0
         self.splitter.setSizes([200, 9999])
         self.splitter.setStretchFactor(0, 1)
 
@@ -235,7 +234,7 @@ class FiltersWindowView(BaseMainWindowView):
         else:
             self.applyToAllButton.setEnabled(True)
 
-    def roi_visualiser(self, roi_field):
+    def roi_visualiser(self, roi_field, roi_button):
         # Start the stack visualiser and ensure that it uses the ROI from here in the rest of this
         try:
             images = self.presenter.stack.slice_as_image_stack(self.presenter.model.preview_image_idx)
@@ -243,8 +242,8 @@ class FiltersWindowView(BaseMainWindowView):
             # Happens if nothing has been loaded, so do nothing as nothing can't be visualised
             return
 
-        self._roi_selector_window_count += 1
         roi_field.setEnabled(False)
+        roi_button.setEnabled(False)
         window = QMainWindow(self)
         window.setWindowTitle("Select ROI")
         window.setMinimumHeight(600)
@@ -305,9 +304,8 @@ class FiltersWindowView(BaseMainWindowView):
         self.roi_view.button_stack_left.hide()
 
         def close_event(event):
-            self._roi_selector_window_count -= 1
-            if not self._roi_selector_window_count:
-                roi_field.setEnabled(True)
+            roi_field.setEnabled(True)
+            roi_button.setEnabled(True)
             event.accept()
 
         button = QPushButton("OK", window)


### PR DESCRIPTION
### Issue

Closes #1602

### Description

Disables the ROI button for the Crop Co-ordinates and ROI Normalisation operations when the ROI selector window has been opened, ensuring that only one window can be opened at a time. I've added a test for this. ~The opened window is not stored as a property on the `FiltersWindowView` class, so it doesn't seem straight-forward (if possible at all) to test that the button is re-enabled when the window is closed.~ I've found a way to do this but will include it in the PR for issue #1613.

I haven't refactored the code to store the window as a property because I think if we want to do that then it might be worth doing a larger refactor to separate the window into it's own class. If we want to do that, then I think it would be better done as a task in itself rather than as part of this issue.

### Testing &Acceptance Criteria 

Check that when the ROI selector window is opened on the Crop Co-ordinates and ROI Normalisation filters the button to open it is disabled, meaning that only one window can be open at a time. Closing the window should re-enable the button.

### Documentation

Issue number added to release notes.
