### PR TITLE
1607: bugbear in environment, actions, and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
     rev: 3.9.2
     hooks:
     -   id: flake8
+        additional_dependencies: [flake8-bugbear==22.9.*]
 -   repo: local
     hooks:
     -   id: check-licenses

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -18,3 +18,4 @@ Developer Changes
 -----------------
 
 - #1472 : Investigate issues reported by flake8-bugbear
+- #1607 : Add flake8-bugbear to environment, github actions and precommit

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -24,6 +24,7 @@ dependencies:
       - eyes-images==4.25.*
       - parameterized==0.8.*
       - pre-commit==2.15.*
+      - flake8-bugbear==22.9.*
   - pytest==7.1.*
   - pytest-cov==3.0.*
   - pytest-randomly==3.12.*


### PR DESCRIPTION
### Issue

Closes #1607 

### Description

Adds bugbear to environment, actions, and pre-commit.

### Testing 

Used `flake8 --version` to check that updating the dev environment added bugbear. Made some bad changes to check that pre-commit refused them. Created a bad commit to check that flake8 showed a warning: https://github.com/mantidproject/mantidimaging/pull/1614/commits/3080e0d8ea8e4a4b8ca93bc3d256d9fca9576c7c

### Acceptance Criteria 

Go through the tests and check that bugbear is added.

### Documentation

Updated release notes.
