### PR TITLE
Move ROI selector window to a separate class

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -16,6 +16,6 @@ Fixes
 
 Developer Changes
 -----------------
-
 - #1472 : Investigate issues reported by flake8-bugbear
 - #1607 : Add flake8-bugbear to environment, github actions and precommit
+- #1613 : Refactor Operations window ROI selector to be in its own class

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -167,11 +167,14 @@ class ImageStack:
 
     def slice_as_image_stack(self, index) -> 'ImageStack':
         "A slice, either projection or sinogram depending on current ordering"
-        return ImageStack(np.asarray([self.data[index]]), metadata=deepcopy(self.metadata), sinograms=self.is_sinograms)
+        return ImageStack(self.slice_as_array(index), metadata=deepcopy(self.metadata), sinograms=self.is_sinograms)
 
     def sino_as_image_stack(self, index) -> 'ImageStack':
         "A single sinogram slice as an ImageStack in projection ordering"
         return ImageStack(np.asarray([self.sino(index)]).swapaxes(0, 1), metadata=deepcopy(self.metadata))
+
+    def slice_as_array(self, index) -> np.ndarray:
+        return np.asarray([self.data[index]])
 
     @property
     def height(self):

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -118,3 +118,9 @@ class BaseEyesTest(unittest.TestCase):
         QApplication.sendPostedEvents()
 
         return vis
+
+    def _get_top_level_widget(cls, widget_type):
+        for widget in cls.app.topLevelWidgets():
+            if isinstance(widget, widget_type):
+                return widget
+        raise ValueError(f"Could not find top level widget of type {widget_type.__name__}")

--- a/mantidimaging/eyes_tests/operations_window_test.py
+++ b/mantidimaging/eyes_tests/operations_window_test.py
@@ -1,9 +1,10 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-from PyQt5.QtWidgets import QApplication
+from PyQt5.QtWidgets import QApplication, QWidget, QPushButton
 from unittest import mock
 
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
+from mantidimaging.gui.widgets.roi_selector.view import ROISelectorView
 
 
 class OperationsWindowTest(BaseEyesTest):
@@ -225,3 +226,31 @@ class OperationsWindowTest(BaseEyesTest):
         QApplication.processEvents()
 
         self.check_target(widget=self.imaging.filters)
+
+    def test_operations_roi_visualiser_window(self):
+        self._load_data_set()
+
+        self.imaging.show_filters_window()
+        self.imaging.filters.filterSelector.setCurrentText("Crop Coordinates")
+        QApplication.processEvents()
+
+        roi_button = self._get_operation_button_widget("Select ROI")
+        roi_button.click()
+        QApplication.processEvents()
+
+        roi_window = self._get_top_level_widget(ROISelectorView)
+        self.check_target(widget=roi_window)
+
+        roi_window.close()
+
+    def _get_operation_button_widget(self, button_name: str) -> QWidget:
+        form = self.imaging.filters.filterPropertiesLayout
+        for i in range(form.rowCount()):
+            widget_item = form.itemAt(i * 2)
+
+            if widget_item is not None:
+                button = widget_item.widget()
+                if isinstance(button, QPushButton) and button.text() == button_name:
+                    return button
+
+        raise ValueError(f"Could not find '{button_name}' in form")

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -109,3 +109,11 @@ class GuiSystemBase(unittest.TestCase):
         while self.main_window.dataset_tree_widget.topLevelItemCount():
             self.main_window.dataset_tree_widget.topLevelItem(0).setSelected(True)
             self.main_window._delete_container()
+
+    @classmethod
+    def _close_window(cls, window_type):
+        cls._wait_for_widget_visible(window_type)
+        for widget in cls.app.topLevelWidgets():
+            if isinstance(widget, window_type):
+                QTest.qWait(SHORT_DELAY)
+                widget.close()

--- a/mantidimaging/gui/test/gui_system_operations_test.py
+++ b/mantidimaging/gui/test/gui_system_operations_test.py
@@ -208,17 +208,9 @@ class TestGuiSystemOperations(GuiSystemBase):
         self.assertFalse(roi_field.isEnabled())
 
         # Check the relevant controls are enabled again when the window is closed
-        self._close_roi_window()
+        self._close_window(ROISelectorView)
         self.assertTrue(roi_button.isEnabled())
         self.assertTrue(roi_field.isEnabled())
 
         self.main_window.filters.close()
         QTest.qWait(SHOW_DELAY)
-
-    @classmethod
-    def _close_roi_window(cls):
-        cls._wait_for_widget_visible(ROISelectorView)
-        for widget in cls.app.topLevelWidgets():
-            if isinstance(widget, ROISelectorView):
-                QTest.qWait(SHORT_DELAY)
-                widget.close()

--- a/mantidimaging/gui/test/gui_system_operations_test.py
+++ b/mantidimaging/gui/test/gui_system_operations_test.py
@@ -10,6 +10,7 @@ from PyQt5.QtTest import QTest
 from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtWidgets import QFormLayout, QLabel, QWidget, QPushButton
 
+from mantidimaging.gui.widgets.roi_selector.view import ROISelectorView
 from mantidimaging.gui.windows.stack_choice.presenter import StackChoicePresenter
 from mantidimaging.core.data import ImageStack
 from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHOW_DELAY, SHORT_DELAY
@@ -189,18 +190,35 @@ class TestGuiSystemOperations(GuiSystemBase):
         self.main_window.filters.close()
         QTest.qWait(SHOW_DELAY)
 
-    @parameterized.expand([(OP_LIST[3][0], "Select ROI"), (OP_LIST[13][0], "Select Air Region")])
-    def test_opening_roi_selector_window_disables_button(self, op_name, button_name):
+    @parameterized.expand([(OP_LIST[3][0], "Select ROI", "ROI"), (OP_LIST[13][0], "Select Air Region", "Air Region")])
+    def test_opening_roi_selector_window_toggles_controls_correctly(self, op_name, button_name, field_name):
         QTest.qWait(SHOW_DELAY)
         index = self.op_window.filterSelector.findText(op_name)
         self.op_window.filterSelector.setCurrentIndex(index)
         QTest.qWait(SHOW_DELAY)
 
+        # Check the relevant controls are disabled when the window is opened
         roi_button = self._get_operation_button_widget(self.op_window.filterPropertiesLayout, button_name)
+        roi_field = self._get_operation_parameter_widget(self.op_window.filterPropertiesLayout, field_name)
         self.assertTrue(roi_button.isEnabled())
+        self.assertTrue(roi_field.isEnabled())
         QTest.mouseClick(roi_button, Qt.MouseButton.LeftButton)
         QTest.qWait(SHOW_DELAY)
         self.assertFalse(roi_button.isEnabled())
+        self.assertFalse(roi_field.isEnabled())
+
+        # Check the relevant controls are enabled again when the window is closed
+        self._close_roi_window()
+        self.assertTrue(roi_button.isEnabled())
+        self.assertTrue(roi_field.isEnabled())
 
         self.main_window.filters.close()
         QTest.qWait(SHOW_DELAY)
+
+    @classmethod
+    def _close_roi_window(cls):
+        cls._wait_for_widget_visible(ROISelectorView)
+        for widget in cls.app.topLevelWidgets():
+            if isinstance(widget, ROISelectorView):
+                QTest.qWait(SHORT_DELAY)
+                widget.close()

--- a/mantidimaging/gui/widgets/roi_selector/__init__.py
+++ b/mantidimaging/gui/widgets/roi_selector/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/widgets/roi_selector/test/__init__.py
+++ b/mantidimaging/gui/widgets/roi_selector/test/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later

--- a/mantidimaging/gui/widgets/roi_selector/test/view_test.py
+++ b/mantidimaging/gui/widgets/roi_selector/test/view_test.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+import unittest
+from unittest import mock
+
+from PyQt5.QtWidgets import QMainWindow
+from parameterized import parameterized
+
+from mantidimaging.core.utility.sensible_roi import SensibleROI
+from mantidimaging.gui.widgets.roi_selector.view import ROISelectorView
+from mantidimaging.test_helpers import start_qapplication
+from mantidimaging.test_helpers.unit_test_helper import generate_images
+
+
+@start_qapplication
+class ROISelectorViewTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.parent = QMainWindow()
+        self.image_stack = generate_images()
+        self.slice_idx = 0
+
+    def test_toggle_average_images(self):
+        view = ROISelectorView(self.parent, self.image_stack, self.slice_idx)
+        view.roi_view.setImage = mock.Mock()
+
+        self.assertTrue(view.roi_view_averaged)
+        view.toggle_average_images()
+        self.assertFalse(view.roi_view_averaged)
+        view.roi_view.setImage.assert_called_with(view.main_image)
+        view.toggle_average_images()
+        self.assertTrue(view.roi_view_averaged)
+        view.roi_view.setImage.assert_called_with(view.averaged_image)
+
+    @parameterized.expand([("Too_few", [1, 2, 10]), ("Too_many", [1, 2, 10, 20, 30]), ("None", None), ("Empty", [])])
+    def test_invalid_roi_values_use_default(self, _, roi_values):
+        view = ROISelectorView(self.parent, self.image_stack, self.slice_idx, roi_values)
+        self._check_roi_set_correctly(view, view.roi_view.default_roi())
+
+    def test_roi_values_set_correctly(self):
+        roi_values = [1, 2, 10, 30]
+        view = ROISelectorView(self.parent, self.image_stack, self.slice_idx, roi_values)
+        self._check_roi_set_correctly(view, roi_values)
+
+    def _check_roi_set_correctly(self, view, roi_values):
+        roi = SensibleROI.from_list(roi_values)
+        position = view.roi_view.roi.pos()
+        size = view.roi_view.roi.size()
+
+        self.assertEqual(roi.left, position[0])
+        self.assertEqual(roi.top, position[1])
+        self.assertEqual(roi.width, size[0])
+        self.assertEqual(roi.height, size[1])

--- a/mantidimaging/gui/widgets/roi_selector/view.py
+++ b/mantidimaging/gui/widgets/roi_selector/view.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from typing import TYPE_CHECKING, Optional
+
+import numpy as np
+from PyQt5.QtWidgets import QMainWindow, QMenu, QAction, QPushButton
+
+from mantidimaging.gui.widgets.mi_image_view.view import MIImageView
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
+
+
+class ROISelectorView(QMainWindow):
+    def __init__(self,
+                 parent,
+                 image_stack: 'ImageStack',
+                 slice_idx: int,
+                 roi_values: Optional[list[int]] = None,
+                 roi_changed_callback=None) -> None:
+        super().__init__(parent)
+
+        self.main_image = image_stack.slice_as_array(slice_idx)
+        averaged_images = np.sum(image_stack.data, axis=0)
+        self.averaged_image = averaged_images.reshape((1, averaged_images.shape[0], averaged_images.shape[1]))
+
+        self.setWindowTitle("Select ROI")
+        self.setMinimumHeight(600)
+        self.setMinimumWidth(600)
+        self.roi_view = MIImageView(self)
+        self.setCentralWidget(self.roi_view)
+
+        # Add context menu bits:
+        menu = QMenu(self.roi_view)
+        toggle_show_averaged_image = QAction("Toggle show averaged image", menu)
+        toggle_show_averaged_image.triggered.connect(lambda: self.toggle_average_images())
+        menu.addAction(toggle_show_averaged_image)
+        menu.addSeparator()
+        self.roi_view.imageItem.menu = menu
+
+        self.roi_view.setImage(self.averaged_image)
+        self.roi_view_averaged = True
+
+        if roi_changed_callback:
+            self.roi_view.roi_changed_callback = lambda callback: roi_changed_callback(callback)
+
+        # prep the MIImageView to display in this context
+        self.roi_view.ui.roiBtn.hide()
+        self.roi_view.ui.histogram.hide()
+        self.roi_view.ui.menuBtn.hide()
+        self.roi_view.ui.roiPlot.hide()
+        self.roi_view.set_roi(roi_values if roi_values and len(roi_values) == 4 else self.roi_view.default_roi())
+        self.roi_view.roi.show()
+        self.roi_view.ui.gridLayout.setRowStretch(1, 5)
+        self.roi_view.ui.gridLayout.setRowStretch(0, 95)
+        self.roi_view.button_stack_right.hide()
+        self.roi_view.button_stack_left.hide()
+
+        button = QPushButton("OK", self)
+        button.clicked.connect(lambda: self.close())
+        self.roi_view.ui.gridLayout.addWidget(button)
+
+    def toggle_average_images(self) -> None:
+        self.roi_view.setImage(self.main_image if self.roi_view_averaged else self.averaged_image)
+        self.roi_view_averaged = not self.roi_view_averaged
+        self.roi_view.roi.show()
+        self.roi_view.ui.roiPlot.hide()

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -3,20 +3,19 @@
 import functools
 from typing import TYPE_CHECKING
 
-import numpy as np
 from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtWidgets import (QAction, QApplication, QCheckBox, QComboBox, QLabel, QMainWindow, QMenu, QMessageBox,
-                             QPushButton, QSizePolicy, QSplitter, QStyle, QVBoxLayout)
+from PyQt5.QtWidgets import (QApplication, QCheckBox, QComboBox, QLabel, QMessageBox, QPushButton, QSizePolicy,
+                             QSplitter, QStyle, QVBoxLayout)
 
 from mantidimaging.core.net.help_pages import open_user_operation_docs
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.utility import delete_all_widgets_from_layout
-from mantidimaging.gui.widgets.mi_image_view.view import MIImageView
 from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
 
 from .filter_previews import FilterPreviews
 from .presenter import FiltersWindowPresenter, FLAT_FIELDING
 from .presenter import Notification as PresNotification
+from ...widgets.roi_selector.view import ROISelectorView
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
@@ -235,84 +234,32 @@ class FiltersWindowView(BaseMainWindowView):
             self.applyToAllButton.setEnabled(True)
 
     def roi_visualiser(self, roi_field, roi_button):
-        # Start the stack visualiser and ensure that it uses the ROI from here in the rest of this
-        try:
-            images = self.presenter.stack.slice_as_image_stack(self.presenter.model.preview_image_idx)
-        except IndexError:
-            # Happens if nothing has been loaded, so do nothing as nothing can't be visualised
+        if self.presenter.stack is None:
+            # If nothing has been loaded then we can't visualise anything
             return
 
         roi_field.setEnabled(False)
         roi_button.setEnabled(False)
-        window = QMainWindow(self)
-        window.setWindowTitle("Select ROI")
-        window.setMinimumHeight(600)
-        window.setMinimumWidth(600)
-        self.roi_view = MIImageView(window)
-        window.setCentralWidget(self.roi_view)
-        self.roi_view.setWindowTitle("Select ROI for operation")
-
-        def set_averaged_image():
-            averaged_images = np.sum(self.presenter.stack.data, axis=0)
-            self.roi_view.setImage(averaged_images.reshape((1, averaged_images.shape[0], averaged_images.shape[1])))
-            self.roi_view_averaged = True
-
-        def toggle_average_images(images_):
-            if self.roi_view_averaged:
-                self.roi_view.setImage(images_.data)
-                self.roi_view_averaged = False
-            else:
-                set_averaged_image()
-            self.roi_view.roi.show()
-            self.roi_view.ui.roiPlot.hide()
-
-        # Add context menu bits:
-        menu = QMenu(self.roi_view)
-        toggle_show_averaged_image = QAction("Toggle show averaged image", menu)
-        toggle_show_averaged_image.triggered.connect(lambda: toggle_average_images(images))
-        menu.addAction(toggle_show_averaged_image)
-        menu.addSeparator()
-        self.roi_view.imageItem.menu = menu
-
-        set_averaged_image()
 
         def roi_changed_callback(callback):
             roi_field.setText(callback.to_list_string())
             roi_field.editingFinished.emit()
 
-        self.roi_view.roi_changed_callback = lambda callback: roi_changed_callback(callback)
+        # Get the ROI values from the input field
+        try:
+            roi_values = [int(value) for value in roi_field.text().strip().split(',')]
+        except ValueError:
+            roi_values = None
 
-        def find_roi_values_from_field():
-            try:
-                values = [int(value) for value in roi_field.text().strip().split(',')]
-                if len(values) == 4:
-                    return values
-            except ValueError:
-                pass
-            return self.roi_view.default_roi()
-
-        # prep the MIImageView to display in this context
-        self.roi_view.ui.roiBtn.hide()
-        self.roi_view.ui.histogram.hide()
-        self.roi_view.ui.menuBtn.hide()
-        self.roi_view.ui.roiPlot.hide()
-        self.roi_view.set_roi(find_roi_values_from_field())
-        self.roi_view.roi.show()
-        self.roi_view.ui.gridLayout.setRowStretch(1, 5)
-        self.roi_view.ui.gridLayout.setRowStretch(0, 95)
-        self.roi_view.button_stack_right.hide()
-        self.roi_view.button_stack_left.hide()
+        window = ROISelectorView(self, self.presenter.stack, self.presenter.model.preview_image_idx, roi_values,
+                                 roi_changed_callback)
 
         def close_event(event):
             roi_field.setEnabled(True)
             roi_button.setEnabled(True)
             event.accept()
 
-        button = QPushButton("OK", window)
-        button.clicked.connect(lambda: window.close())
         window.closeEvent = functools.partial(close_event)
-        self.roi_view.ui.gridLayout.addWidget(button)
-
         window.show()
 
     def toggle_filters_section(self):


### PR DESCRIPTION
### Issue

Closes #1613

### Description

Pulls the generic parts of the ROI selector window into a separate class and adds extra tests for it.
Ensures that the window is being closed when the GUI tests no longer need it.

### Testing & Acceptance Criteria 

All tests pass.
The window can be used as before.

### Documentation

Issue number added to release notes.
