### PR TITLE
1616: Change tab at front with single click

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -7,6 +7,7 @@ New Features and improvements
 -----------------------------
 
 - #1601 : arithmetic filter optimisation
+- #1616 : Change selected stack with single click on tree widget
 
 Fixes
 -----

--- a/mantidimaging/eyes_tests/main_window_test.py
+++ b/mantidimaging/eyes_tests/main_window_test.py
@@ -72,8 +72,9 @@ class MainWindowTest(BaseEyesTest):
         self._load_data_set()
         self._load_data_set()
 
-        second_stack = self.imaging.dataset_tree_widget.topLevelItem(1).child(0)
-        rect = self.imaging.dataset_tree_widget.visualItemRect(second_stack)
-        QTest.mouseClick(self.imaging.dataset_tree_widget.viewport(), Qt.LeftButton, Qt.NoModifier, rect.center())
+        second_stack_item = self.imaging.dataset_tree_widget.topLevelItem(1).child(0)
+        second_stack_rect = self.imaging.dataset_tree_widget.visualItemRect(second_stack_item)
+        QTest.mouseClick(self.imaging.dataset_tree_widget.viewport(), Qt.LeftButton, Qt.NoModifier,
+                         second_stack_rect.center())
 
         self.check_target()

--- a/mantidimaging/eyes_tests/main_window_test.py
+++ b/mantidimaging/eyes_tests/main_window_test.py
@@ -3,6 +3,9 @@
 
 from unittest import mock
 
+from PyQt5.QtCore import Qt
+from PyQt5.QtTest import QTest
+
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
 
 
@@ -62,5 +65,15 @@ class MainWindowTest(BaseEyesTest):
     def test_main_window_loaded_2_sets_of_data(self):
         self._load_data_set()
         self._load_data_set()
+
+        self.check_target()
+
+    def test_single_click_changes_tab(self):
+        self._load_data_set()
+        self._load_data_set()
+
+        second_stack = self.imaging.dataset_tree_widget.topLevelItem(1).child(0)
+        rect = self.imaging.dataset_tree_widget.visualItemRect(second_stack)
+        QTest.mouseClick(self.imaging.dataset_tree_widget.viewport(), Qt.LeftButton, Qt.NoModifier, rect.center())
 
         self.check_target()

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -141,7 +141,7 @@ class MainWindowView(BaseMainWindowView):
         self.dataset_tree_widget = QTreeWidget()
         self.dataset_tree_widget.setContextMenuPolicy(Qt.CustomContextMenu)
         self.dataset_tree_widget.customContextMenuRequested.connect(self._open_tree_menu)
-        self.dataset_tree_widget.itemDoubleClicked.connect(self._bring_stack_tab_to_front)
+        self.dataset_tree_widget.itemClicked.connect(self._bring_stack_tab_to_front)
 
         self.splitter = QSplitter(Qt.Horizontal, self)
         self.splitter.addWidget(self.dataset_tree_widget)


### PR DESCRIPTION
### Issue

Closes #1616

### Description

Allows changing the current tab with a single click on the dataset tree view.

### Testing 

Added an eyes test that uses `QTest.mouseClick` so now a pass looks like this:

![image](https://user-images.githubusercontent.com/43887608/195653774-8530fdd7-988a-40ea-b80f-90ee779f46e0.png)

### Acceptance Criteria 

Check that the test passes. Check that only a single click on the dataset tree view is required to change the tab.

### Documentation

Updated release notes.
