### PR TITLE
1610 disable enable spectrum export button

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -14,6 +14,7 @@ Fixes
 - #1589 : Recommend new update command
 - #1330 : Initial ROI box is sometimes much larger than image for relevant filters
 - #1602 : Prevent multiple ROI selector windows opening from Operations window
+- #1610 : Apply bug fix to disable Spectrum Viewer export button when no data is loaded
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -98,6 +98,13 @@ class SpectrumViewerWindowModel:
         else:
             return 0, 0
 
+    def can_export(self) -> bool:
+        """
+        Check if data is available to export
+        @return: True if data is available to export and False otherwise
+        """
+        return self._stack is not None
+
     def save_csv(self, path: Path, normalized: bool) -> None:
         if self._stack is None:
             raise ValueError("No stack selected")

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -42,6 +42,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         if uuid is None:
             self.model.set_stack(None)
             self.view.clear()
+            self.handle_export_button_enabled()
             return
 
         self.model.set_stack(self.main_window.get_stack(uuid))
@@ -55,6 +56,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
         self.view.set_normalise_error(self.model.normalise_issue())
         self.show_new_sample()
+        self.handle_export_button_enabled()
 
     def handle_normalise_stack_change(self, normalise_uuid: Optional['UUID']) -> None:
         if normalise_uuid == self.current_norm_stack_uuid:
@@ -99,6 +101,12 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         roi = self.view.spectrum.get_roi()
         self.model.set_roi("roi", roi)
         self.view.set_spectrum(self.model.get_spectrum("roi", self.spectrum_mode))
+
+    def handle_export_button_enabled(self) -> None:
+        """
+        Enable the export button if the current stack is not None
+        """
+        self.view.set_export_button_enabled(self.model.can_export())
 
     def handle_export_csv(self) -> None:
         path = self.view.get_csv_filename()

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -7,6 +7,7 @@ import io
 
 import numpy as np
 import numpy.testing as npt
+from parameterized import parameterized
 
 from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowPresenter, SpectrumViewerWindowModel
 from mantidimaging.gui.windows.spectrum_viewer.model import SpecType, ALL
@@ -203,3 +204,11 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.assertIn("0.0,0.0,2.0,0.0,0.0,2.0,0.0", mock_stream.getvalue())
         self.assertIn("1.0,1.0,2.0,0.5,1.0,2.0,0.5", mock_stream.getvalue())
         self.assertTrue(mock_stream.is_closed)
+
+    @parameterized.expand([
+        ("False", None, False),
+        ("True", ImageStack(np.ones([10, 11, 12])), True),
+    ])
+    def test_WHEN_stack_value_set_THEN_can_export_returns_(self, _, image_stack, expected):
+        self.model.set_stack(image_stack)
+        self.assertEqual(self.model.can_export(), expected)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -71,6 +71,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view.try_to_select_relevant_normalise_stack.assert_not_called()
         self.assertIsNone(self.view.current_dataset_id)
         self.presenter.show_new_sample.assert_not_called()
+        self.view.set_export_button_enabled.assert_called_once_with(False)
 
     def test_handle_sample_change_dataset_unchanged(self):
         initial_dataset_id = self.view.current_dataset_id
@@ -82,6 +83,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.handle_sample_change(uuid.uuid4())
         self.presenter.main_window.get_dataset.assert_not_called()
         self.assertEqual(self.view.current_dataset_id, initial_dataset_id)
+        self.view.set_export_button_enabled.assert_called_once_with(True)
 
     def test_handle_sample_change_to_MixedDataset(self):
         self.presenter.get_dataset_id_for_stack = mock.Mock(return_value=uuid.uuid4())

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-from faulthandler import disable
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from faulthandler import disable
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
@@ -120,3 +121,11 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         else:
             self.normaliseErrorIcon.setPixmap(QPixmap())
             self.normaliseErrorIcon.setToolTip("")
+
+    def set_export_button_enabled(self, enabled: bool):
+        """
+        Toggle enabled state of the export button
+
+        :param enabled: True to enable the button, False to disable it
+        """
+        self.exportButton.setEnabled(enabled)


### PR DESCRIPTION
### Issue

Toggle state of spectrum viewer export button determined by stack being populated or not: #1610 

### Description

*Add a description of the changes made*.

The export button in the spectrum viewer was enabled when here was no active stack which caused a Value error if trying to export data. To resolve this:
* `set_export_button_enabled()` created in [view.py](https://github.dev/mantidproject/mantidimaging/blob/main/mantidimaging/gui/windows/spectrum_viewer/view.py) to toggle button enable state
* `handle_export_button_enabled()` created in [presenter.py](https://github.dev/mantidproject/mantidimaging/blob/main/mantidimaging/gui/windows/spectrum_viewer/presenter.py) to call `set_export_button_enabled()` with state when changes are made to stack in `handle_sample_change()`
* `can_export()` created in [model.py](https://github.dev/mantidproject/mantidimaging/blob/main/mantidimaging/gui/windows/spectrum_viewer/model.py) to return a boolean state based on whether there is an active stack loaded

### Testing 

*Describe the tests that were used to verify your changes*.

*  `test_WHEN_stack_value_set_THEN_can_export_returns_` created in [model_test.py](https://github.dev/mantidproject/mantidimaging/blob/main/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py) which tests correct boolean state is returned by `can_export()` based on whether the stack is populated or None
* Tests checking stack changes (`test_handle_sample_change_no_new_stack()`,  `test_handle_sample_change_dataset_unchanged()`) in [presenter_test.py](https://github.dev/mantidproject/mantidimaging/blob/main/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py) updated to include assertion to ensure that `set_export_button_enabled()` called with expected boolean argument if stack populated or not

### Acceptance Criteria 

*What is the acceptance criteria?*

- [ ] Export spectrum button is disabled if there not active stack in the spectrum viewer window.
- [ ] Export spectrum button enabled if there is an active stack in the spectrum viewer window.
- [ ] Export spectrum button when clicked does not trigger a ValueError when there is no active stack in the spectrum viewer window.

## How to Test

*verbose instructions for the reviewer to test changes*

- [ ] Open up GUI and Load Dataset `File > Load dataset > Sample`
- [ ] Open Spectrum Viewer `Workflow > Spectrum Viewer (Beta)
- [ ] Click the Export button and export a spectrum
- [ ] While keeping Spectrum Viewer window open, in the main window, delete the active stack by right clicking and selecting delete
- [ ] Go back to Spectrum Viewer window and validate export button is disabled
- [ ] While keeping Spectrum Viewer window open, in the main window, repeat steps one to three to validate that export button is enabled again and has expected behaviour. 

