### PR TITLE
Update cil

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -33,8 +33,7 @@ requirements:
     - h5py=3.6.*
     - sarepy=2020.07
     - psutil=5.9.*
-    - cil=21.4.*
-    - cil-astra=21.4.*
+    - cil=22.1.*
     - ccpi-regulariser=21.0.*
     - jenkspy=0.2.0
     - pyqt=5.15.*

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - sarepy=2020.07
     - psutil=5.9.*
     - cil=22.1.*
-    - ccpi-regulariser=21.0.*
+    - ccpi-regulariser
     - jenkspy=0.2.0
     - pyqt=5.15.*
     - pyqtgraph=0.13.*


### PR DESCRIPTION
### Issue

Closes #1609

### Description

Update CIL to 22.1.

This allows dropping the cil-astra package and the interface is now included in the main cil package,

Also drop the version number for ccpi-regulariser as this is constrained by the cil package.

### Testing & Acceptance Criteria 

Create a new environment
`python ./setup.py create_dev_env`

Reconstruction of a slice and volume should still work with CIL

### Documentation

Not needed
