### PR TITLE
GUI work for sPDHG

### DIFF
--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -203,4 +203,4 @@ class CILRecon(BaseRecon):
 
 
 def allowed_recon_kwargs() -> dict:
-    return {'CIL: PDHG-TV': ['alpha', 'num_iter', 'non_negative']}
+    return {'CIL: PDHG-TV': ['alpha', 'num_iter', 'non_negative', 'stochastic', 'subsets']}

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -69,6 +69,8 @@ class CILRecon(BaseRecon):
         Should return a numpy array,
         """
 
+        print(f"SPDHG params: {recon_params.stochastic=} {recon_params.subsets=}")
+
         if progress:
             progress.add_estimated_steps(recon_params.num_iter + 1)
             progress.update(steps=1, msg='CIL: Setting up reconstruction', force_continue=False)

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -103,6 +103,8 @@ class ReconstructionParameters:
     non_negative: bool = False
     max_projection_angle: float = 360.0
     beam_hardening_coefs: Optional[List[float]] = None
+    stochastic: bool = False
+    subsets: int = 1
 
     def to_dict(self) -> dict:
         return {
@@ -112,7 +114,9 @@ class ReconstructionParameters:
             'cor': str(self.cor),
             'tilt': str(self.tilt),
             'pixel_size': self.pixel_size,
-            'alpha': self.alpha
+            'alpha': self.alpha,
+            'stochastic': self.stochastic,
+            'subsets': self.subsets,
         }
 
 

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -628,7 +628,7 @@
                  </widget>
                 </item>
                 <item row="4" column="1">
-                 <widget class="QDoubleSpinBox" name="alphaSpinbox">
+                 <widget class="QDoubleSpinBox" name="alphaSpinBox">
                   <property name="decimals">
                    <number>6</number>
                   </property>

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -707,6 +707,9 @@
                 </item>
                 <item row="7" column="0">
                  <widget class="QLabel" name="subsetsLabel">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
                   <property name="text">
                    <string>Subsets</string>
                   </property>
@@ -714,6 +717,9 @@
                 </item>
                 <item row="7" column="1">
                  <widget class="QSpinBox" name="subsetsSpinBox">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
                   <property name="minimum">
                    <number>1</number>
                   </property>

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -538,43 +538,32 @@
              <layout class="QVBoxLayout" name="verticalLayout_6">
               <item>
                <layout class="QGridLayout" name="optionsLayout">
-                <item row="6" column="1">
-                 <widget class="QDoubleSpinBox" name="pixelSize">
-                  <property name="maximum">
-                   <double>99999.000000000000000</double>
-                  </property>
-                 </widget>
-                </item>
-                <item row="2" column="0">
-                 <widget class="QLabel" name="filterNameLabel">
-                  <property name="text">
-                   <string>Reconstruction filter:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="3" column="0">
-                 <widget class="QLabel" name="numIterLabel">
-                  <property name="text">
-                   <string>Number of iterations:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="4" column="1">
-                 <widget class="QDoubleSpinBox" name="alphaSpinbox">
-                  <property name="decimals">
-                   <number>6</number>
-                  </property>
+                <item row="3" column="1">
+                 <widget class="QSpinBox" name="numIter">
                   <property name="minimum">
-                   <double>0.000001000000000</double>
+                   <number>1</number>
                   </property>
                   <property name="maximum">
-                   <double>1000000.000000000000000</double>
+                   <number>99999</number>
                   </property>
-                  <property name="singleStep">
-                   <double>0.010000000000000</double>
+                 </widget>
+                </item>
+                <item row="1" column="1">
+                 <widget class="QComboBox" name="algorithmName">
+                  <property name="enabled">
+                   <bool>false</bool>
                   </property>
-                  <property name="value">
-                   <double>1.000000000000000</double>
+                  <item>
+                   <property name="text">
+                    <string>gridrec</string>
+                   </property>
+                  </item>
+                 </widget>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QLabel" name="algorithmNameLabel">
+                  <property name="text">
+                   <string>Algorithm:</string>
                   </property>
                  </widget>
                 </item>
@@ -617,36 +606,10 @@
                   </item>
                  </widget>
                 </item>
-                <item row="1" column="1">
-                 <widget class="QComboBox" name="algorithmName">
-                  <property name="enabled">
-                   <bool>false</bool>
-                  </property>
-                  <item>
-                   <property name="text">
-                    <string>gridrec</string>
-                   </property>
-                  </item>
-                 </widget>
-                </item>
-                <item row="0" column="0">
-                 <widget class="QLabel" name="maxProjAngleLabel">
-                  <property name="text">
-                   <string>Maximum projection angle</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="6" column="0">
+                <item row="8" column="0">
                  <widget class="QLabel" name="pixelSizeLabel">
                   <property name="text">
                    <string>Pixel size (microns)</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="1" column="0">
-                 <widget class="QLabel" name="algorithmNameLabel">
-                  <property name="text">
-                   <string>Algorithm:</string>
                   </property>
                  </widget>
                 </item>
@@ -657,13 +620,29 @@
                   </property>
                  </widget>
                 </item>
-                <item row="3" column="1">
-                 <widget class="QSpinBox" name="numIter">
+                <item row="8" column="1">
+                 <widget class="QDoubleSpinBox" name="pixelSize">
+                  <property name="maximum">
+                   <double>99999.000000000000000</double>
+                  </property>
+                 </widget>
+                </item>
+                <item row="4" column="1">
+                 <widget class="QDoubleSpinBox" name="alphaSpinbox">
+                  <property name="decimals">
+                   <number>6</number>
+                  </property>
                   <property name="minimum">
-                   <number>1</number>
+                   <double>0.000001000000000</double>
                   </property>
                   <property name="maximum">
-                   <number>99999</number>
+                   <double>1000000.000000000000000</double>
+                  </property>
+                  <property name="singleStep">
+                   <double>0.010000000000000</double>
+                  </property>
+                  <property name="value">
+                   <double>1.000000000000000</double>
                   </property>
                  </widget>
                 </item>
@@ -674,6 +653,20 @@
                   </property>
                   <property name="value">
                    <double>360.000000000000000</double>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="0">
+                 <widget class="QLabel" name="numIterLabel">
+                  <property name="text">
+                   <string>Number of iterations:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="0">
+                 <widget class="QLabel" name="maxProjAngleLabel">
+                  <property name="text">
+                   <string>Maximum projection angle</string>
                   </property>
                  </widget>
                 </item>
@@ -688,6 +681,44 @@
                  <widget class="QCheckBox" name="nonNegativeCheckBox">
                   <property name="text">
                    <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="0">
+                 <widget class="QLabel" name="filterNameLabel">
+                  <property name="text">
+                   <string>Reconstruction filter:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="6" column="0">
+                 <widget class="QLabel" name="stochasticLabel">
+                  <property name="text">
+                   <string>Stochastic</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="6" column="1">
+                 <widget class="QCheckBox" name="stochasticCheckBox">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="0">
+                 <widget class="QLabel" name="subsetsLabel">
+                  <property name="text">
+                   <string>Subsets</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="1">
+                 <widget class="QSpinBox" name="subsetsSpinBox">
+                  <property name="minimum">
+                   <number>1</number>
+                  </property>
+                  <property name="maximum">
+                   <number>1024</number>
                   </property>
                  </widget>
                 </item>

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -63,6 +63,8 @@ class ReconstructWindowPresenter(BasePresenter):
             'num_iter': [self.view.numIter, self.view.numIterLabel],
             'alpha': [self.view.alphaSpinbox, self.view.alphaLabel],
             'non_negative': [self.view.nonNegativeCheckBox, self.view.nonNegativeLabel],
+            'stochastic': [self.view.stochasticCheckBox, self.view.stochasticLabel],
+            'subsets': [self.view.subsetsSpinBox, self.view.subsetsLabel],
         }
         self.main_window = main_window
 

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -61,7 +61,7 @@ class ReconstructWindowPresenter(BasePresenter):
         self.restricted_arg_widgets: Dict[str, List[QWidget]] = {
             'filter_name': [self.view.filterName, self.view.filterNameLabel],
             'num_iter': [self.view.numIter, self.view.numIterLabel],
-            'alpha': [self.view.alphaSpinbox, self.view.alphaLabel],
+            'alpha': [self.view.alphaSpinBox, self.view.alphaLabel],
             'non_negative': [self.view.nonNegativeCheckBox, self.view.nonNegativeLabel],
             'stochastic': [self.view.stochasticCheckBox, self.view.stochasticLabel],
             'subsets': [self.view.subsetsSpinBox, self.view.subsetsLabel],

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -37,7 +37,7 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.view.numIter = mock.Mock()
         self.view.numIterLabel = mock.Mock()
         self.view.image_view = mock.Mock()
-        self.view.alphaSpinbox = mock.Mock()
+        self.view.alphaSpinBox = mock.Mock()
         self.view.alphaLabel = mock.Mock()
         self.view.nonNegativeCheckBox = mock.Mock()
         self.view.nonNegativeLabel = mock.Mock()

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -41,6 +41,10 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.view.alphaLabel = mock.Mock()
         self.view.nonNegativeCheckBox = mock.Mock()
         self.view.nonNegativeLabel = mock.Mock()
+        self.view.stochasticCheckBox = mock.Mock()
+        self.view.stochasticLabel = mock.Mock()
+        self.view.subsetsLabel = mock.Mock()
+        self.view.subsetsSpinBox = mock.Mock()
 
     @mock.patch('mantidimaging.gui.windows.recon.presenter.start_async_task_view')
     def test_set_stack_uuid(self, mock_start_async: mock.Mock):

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -10,7 +10,7 @@ from mantidimaging.core.net.help_pages import SECTION_USER_GUIDE
 from mantidimaging.core.utility.data_containers import ScalarCoR, Degrees, Slope
 from mantidimaging.gui.utility.qt_helpers import INPUT_DIALOG_FLAGS
 from mantidimaging.gui.windows.recon import ReconstructWindowView
-from mantidimaging.gui.windows.recon.presenter import AutoCorMethod
+from mantidimaging.gui.windows.recon.presenter import AutoCorMethod, Notifications
 from mantidimaging.test_helpers import start_qapplication
 
 
@@ -388,3 +388,14 @@ class ReconstructWindowViewTest(unittest.TestCase):
         self.view.stochasticCheckBox.setChecked(False)
         self.assertFalse(self.view.subsetsSpinBox.isEnabled())
         self.assertFalse(self.view.subsetsLabel.isEnabled())
+
+    def test_WHEN_param_change_THEN_preview_called(self):
+        for func, val in [
+            (self.view.numIter.setValue, 2),
+            (self.view.alphaSpinBox.setValue, 2),
+            (self.view.stochasticCheckBox.setChecked, True),
+            (self.view.subsetsSpinBox.setValue, 2),
+        ]:
+            self.presenter.notify.reset_mock()
+            func(val)
+            self.presenter.notify.assert_called_once_with(Notifications.RECONSTRUCT_PREVIEW_SLICE)

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -23,18 +23,6 @@ class ReconstructWindowViewTest(unittest.TestCase):
         self.view.presenter = self.presenter = mock.Mock()
         self.view.image_view = self.image_view = mock.Mock()
         self.view.tableView = self.tableView = mock.Mock()
-        self.view.resultCor = self.resultCor = mock.Mock()
-        self.view.resultTilt = self.resultTilt = mock.Mock()
-        self.view.resultSlope = self.resultSlope = mock.Mock()
-        self.view.numIter = self.numIter = mock.Mock()
-        self.view.pixelSize = self.pixelSize = mock.Mock()
-        self.view.alphaSpinBox = self.alpha = mock.Mock()
-        self.view.nonNegativeCheckBox = self.non_negative = mock.Mock()
-        self.view.stochasticCheckBox = self.stochastic = mock.Mock()
-        self.view.subsetsSpinBox = self.subsets = mock.Mock()
-        self.view.algorithmName = self.algorithmName = mock.Mock()
-        self.view.filterName = self.filterName = mock.Mock()
-        self.view.maxProjAngle = self.maxProjAngle = mock.Mock()
         self.view.autoFindMethod = self.autoFindMethod = mock.Mock()
 
     @mock.patch("mantidimaging.gui.windows.recon.view.QMessageBox")
@@ -113,11 +101,12 @@ class ReconstructWindowViewTest(unittest.TestCase):
         tilt = Degrees(tilt_val)
         slope = Slope(slope_val)
 
-        self.view.set_results(cor, tilt, slope)
-        self.resultCor.setValue.assert_called_once_with(cor_val)
-        self.resultTilt.setValue.assert_called_once_with(tilt_val)
-        self.resultSlope.setValue.assert_called_once_with(slope_val)
-        self.image_view.set_tilt.assert_called_once_with(tilt)
+        with mock.patch.object(self.image_view, "set_tilt") as set_tilt:
+            self.view.set_results(cor, tilt, slope)
+            self.assertEqual(self.view.rotation_centre, cor_val)
+            self.assertEqual(self.view.tilt, tilt_val)
+            self.assertEqual(self.view.slope, slope_val)
+            set_tilt.assert_called_once_with(tilt)
 
     def test_preview_image_on_button_press(self):
         event_mock = mock.Mock()
@@ -197,55 +186,54 @@ class ReconstructWindowViewTest(unittest.TestCase):
         self.tableView.selectRow.assert_called_once_with(row)
 
     def test_rotation_centre_property(self):
-        assert self.view.rotation_centre == self.resultCor.value.return_value
+        self.assertEqual(self.view.rotation_centre, 0)
 
     def test_tilt_property(self):
-        assert self.view.tilt == self.resultTilt.value.return_value
+        self.assertEqual(self.view.tilt, 0)
 
     def test_slope_property(self):
-        assert self.view.slope == self.resultSlope.value.return_value
+        self.assertEqual(self.view.slope, 0)
 
     def test_max_proj_angle(self):
-        assert self.view.max_proj_angle == self.maxProjAngle.value.return_value
+        self.assertEqual(self.view.max_proj_angle, 360)
 
     def test_algorithm_name(self):
-        assert self.view.algorithm_name == self.algorithmName.currentText.return_value
+        self.assertIn(self.view.algorithm_name, ["gridrec", "FBP_CUDA"])
 
     def test_filter_name(self):
-        assert self.view.filter_name == self.filterName.currentText.return_value
+        self.assertIn(self.view.filter_name, ["ramlak", "ram-lak"])
 
     def test_num_iter_property(self):
-        assert self.view.num_iter == self.numIter.value.return_value
+        self.assertEqual(self.view.num_iter, 1)
+
+    def test_stochastic_property(self):
+        self.assertEqual(self.view.stochastic, False)
+
+    def test_subsets_property(self):
+        self.assertEqual(self.view.subsets, 1)
 
     def test_num_iter_setter(self):
         iters = 123
         self.view.num_iter = iters
-        self.numIter.setValue.assert_called_once_with(iters)
+        self.assertEqual(self.view.num_iter, iters)
 
     def test_pixel_size_property(self):
-        assert self.view.pixel_size == self.pixelSize.value.return_value
+        self.assertEqual(self.view.pixel_size, 0)
 
     @mock.patch("mantidimaging.gui.windows.recon.view.QSignalBlocker")
     def test_pixel_size_setter(self, _):
         value = 123
         self.view.pixel_size = value
-        self.pixelSize.setValue.assert_called_once_with(value)
+        self.assertEqual(self.view.pixel_size, value)
 
-    @mock.patch("mantidimaging.gui.windows.recon.view.ReconstructionParameters")
-    def test_recon_params(self, recon_params_mock):
-        self.view.recon_params()
-        recon_params_mock.assert_called_once_with(algorithm=self.algorithmName.currentText.return_value,
-                                                  filter_name=self.filterName.currentText.return_value,
-                                                  num_iter=self.numIter.value.return_value,
-                                                  cor=ScalarCoR(self.resultCor.value.return_value),
-                                                  tilt=Degrees(self.resultTilt.value.return_value),
-                                                  pixel_size=self.pixelSize.value.return_value,
-                                                  alpha=self.alpha.value.return_value,
-                                                  non_negative=self.non_negative.isChecked.return_value,
-                                                  stochastic=self.stochastic.isChecked.return_value,
-                                                  subsets=self.subsets.value.return_value,
-                                                  max_projection_angle=self.maxProjAngle.value.return_value,
-                                                  beam_hardening_coefs=self.view.beam_hardening_coefs)
+    def test_recon_params(self):
+        rp = self.view.recon_params()
+        self.assertIn(rp.algorithm, self.view.algorithm_name)
+        self.assertEqual(rp.num_iter, self.view.num_iter)
+        self.assertEqual(rp.alpha, self.view.alpha)
+        self.assertEqual(rp.non_negative, self.view.non_negative)
+        self.assertEqual(rp.stochastic, self.view.stochastic)
+        self.assertEqual(rp.subsets, self.view.subsets)
 
     def test_set_table_point(self):
         idx = 12
@@ -278,9 +266,10 @@ class ReconstructWindowViewTest(unittest.TestCase):
 
     def test_set_filters_for_recon_tool(self):
         filters = ["abc" for _ in range(3)]
-        self.view.set_filters_for_recon_tool(filters)
-        self.filterName.clear.assert_called_once()
-        self.filterName.insertItems.assert_called_once_with(0, filters)
+        with mock.patch.object(self.view, "filterName") as fn:
+            self.view.set_filters_for_recon_tool(filters)
+            fn.clear.assert_called_once()
+            fn.insertItems.assert_called_once_with(0, filters)
 
     @mock.patch("mantidimaging.gui.windows.recon.view.QInputDialog")
     def test_get_number_of_cors_when_accepted_is_true(self, qinputdialog_mock):

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -19,6 +19,8 @@ class MockMainWindow(QWidget):
         super().__init__()
         self.stack_changed = mock.Mock()
         self.model_changed = mock.Mock()
+        self.model_changed = mock.Mock()
+        self.presenter = mock.Mock(datasets=dict())
 
 
 @start_qapplication
@@ -374,3 +376,15 @@ class ReconstructWindowViewTest(unittest.TestCase):
 
         self.view.set_recon_buttons_enabled(True)
         assert_button_state_is_correct(is_enabled=True)
+
+    def test_WHEN_stochastic_ticked_THEN_subsets_enabled(self):
+        self.assertFalse(self.view.subsetsSpinBox.isEnabled())
+        self.assertFalse(self.view.subsetsLabel.isEnabled())
+
+        self.view.stochasticCheckBox.setChecked(True)
+        self.assertTrue(self.view.subsetsSpinBox.isEnabled())
+        self.assertTrue(self.view.subsetsLabel.isEnabled())
+
+        self.view.stochasticCheckBox.setChecked(False)
+        self.assertFalse(self.view.subsetsSpinBox.isEnabled())
+        self.assertFalse(self.view.subsetsLabel.isEnabled())

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -4,22 +4,29 @@
 import unittest
 from unittest import mock
 
+from PyQt5.QtWidgets import QWidget
+
 from mantidimaging.core.net.help_pages import SECTION_USER_GUIDE
 from mantidimaging.core.utility.data_containers import ScalarCoR, Degrees, Slope
 from mantidimaging.gui.utility.qt_helpers import INPUT_DIALOG_FLAGS
-from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.recon import ReconstructWindowView
 from mantidimaging.gui.windows.recon.presenter import AutoCorMethod
-from mantidimaging.test_helpers import start_qapplication, mock_versions
+from mantidimaging.test_helpers import start_qapplication
 
 
-@mock_versions
+class MockMainWindow(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.stack_changed = mock.Mock()
+        self.model_changed = mock.Mock()
+
+
 @start_qapplication
 class ReconstructWindowViewTest(unittest.TestCase):
     def setUp(self) -> None:
-        with mock.patch("mantidimaging.gui.windows.main.view.WelcomeScreenPresenter"):
-            self.main_window = MainWindowView()
+        self.main_window = MockMainWindow()
         self.view = ReconstructWindowView(self.main_window)
+
         self.view.presenter = self.presenter = mock.Mock()
         self.view.image_view = self.image_view = mock.Mock()
         self.view.tableView = self.tableView = mock.Mock()

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -30,6 +30,8 @@ class ReconstructWindowViewTest(unittest.TestCase):
         self.view.pixelSize = self.pixelSize = mock.Mock()
         self.view.alphaSpinbox = self.alpha = mock.Mock()
         self.view.nonNegativeCheckBox = self.non_negative = mock.Mock()
+        self.view.stochasticCheckBox = self.stochastic = mock.Mock()
+        self.view.subsetsSpinBox = self.subsets = mock.Mock()
         self.view.algorithmName = self.algorithmName = mock.Mock()
         self.view.filterName = self.filterName = mock.Mock()
         self.view.maxProjAngle = self.maxProjAngle = mock.Mock()
@@ -240,6 +242,8 @@ class ReconstructWindowViewTest(unittest.TestCase):
                                                   pixel_size=self.pixelSize.value.return_value,
                                                   alpha=self.alpha.value.return_value,
                                                   non_negative=self.non_negative.isChecked.return_value,
+                                                  stochastic=self.stochastic.isChecked.return_value,
+                                                  subsets=self.subsets.value.return_value,
                                                   max_projection_angle=self.maxProjAngle.value.return_value,
                                                   beam_hardening_coefs=self.view.beam_hardening_coefs)
 

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -28,7 +28,7 @@ class ReconstructWindowViewTest(unittest.TestCase):
         self.view.resultSlope = self.resultSlope = mock.Mock()
         self.view.numIter = self.numIter = mock.Mock()
         self.view.pixelSize = self.pixelSize = mock.Mock()
-        self.view.alphaSpinbox = self.alpha = mock.Mock()
+        self.view.alphaSpinBox = self.alpha = mock.Mock()
         self.view.nonNegativeCheckBox = self.non_negative = mock.Mock()
         self.view.stochasticCheckBox = self.stochastic = mock.Mock()
         self.view.subsetsSpinBox = self.subsets = mock.Mock()

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -408,6 +408,14 @@ class ReconstructWindowView(BaseMainWindowView):
         return self.nonNegativeCheckBox.isChecked()
 
     @property
+    def stochastic(self):
+        return self.stochasticCheckBox.isChecked()
+
+    @property
+    def subsets(self):
+        return self.subsetsSpinBox.value()
+
+    @property
     def beam_hardening_coefs(self) -> Optional[List[float]]:
         if not self.lbhc_enabled.isChecked():
             return None
@@ -428,6 +436,8 @@ class ReconstructWindowView(BaseMainWindowView):
                                         pixel_size=self.pixel_size,
                                         alpha=self.alpha,
                                         non_negative=self.non_negative,
+                                        stochastic=self.stochastic,
+                                        subsets=self.subsets,
                                         max_projection_angle=self.max_proj_angle,
                                         beam_hardening_coefs=self.beam_hardening_coefs)
 

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -57,7 +57,7 @@ class ReconstructWindowView(BaseMainWindowView):
     numIter: QSpinBox
     maxProjAngle: QDoubleSpinBox
     pixelSize: QDoubleSpinBox
-    alphaSpinbox: QDoubleSpinBox
+    alphaSpinBox: QDoubleSpinBox
     nonNegativeCheckBox: QCheckBox
     stochasticCheckBox: QCheckBox
     subsetsSpinBox: QSpinBox
@@ -182,7 +182,7 @@ class ReconstructWindowView(BaseMainWindowView):
             lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))  # type: ignore
 
         self.pixelSize.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
-        self.alphaSpinbox.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
+        self.alphaSpinBox.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
         self.nonNegativeCheckBox.stateChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
         self.reconHelpButton.clicked.connect(lambda: self.open_help_webpage("reconstructions/index"))
         self.corHelpButton.clicked.connect(lambda: self.open_help_webpage("reconstructions/center_of_rotation"))
@@ -397,11 +397,11 @@ class ReconstructWindowView(BaseMainWindowView):
 
     @property
     def alpha(self):
-        return self.alphaSpinbox.value()
+        return self.alphaSpinBox.value()
 
     @alpha.setter
     def alpha(self, value: float):
-        self.alphaSpinbox.setValue(value)
+        self.alphaSpinBox.setValue(value)
 
     @property
     def non_negative(self):

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -59,6 +59,8 @@ class ReconstructWindowView(BaseMainWindowView):
     pixelSize: QDoubleSpinBox
     alphaSpinbox: QDoubleSpinBox
     nonNegativeCheckBox: QCheckBox
+    stochasticCheckBox: QCheckBox
+    subsetsSpinBox: QSpinBox
     resultCor: QDoubleSpinBox
     resultTilt: QDoubleSpinBox
     resultSlope: QDoubleSpinBox

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -343,76 +343,72 @@ class ReconstructWindowView(BaseMainWindowView):
         return [row.row() for row in rows]
 
     @property
-    def rotation_centre(self):
+    def rotation_centre(self) -> float:
         return self.resultCor.value()
 
     @rotation_centre.setter
-    def rotation_centre(self, value: float):
+    def rotation_centre(self, value: float) -> None:
         self.resultCor.setValue(value)
 
     @property
-    def tilt(self):
+    def tilt(self) -> float:
         return self.resultTilt.value()
 
     @tilt.setter
-    def tilt(self, value: float):
+    def tilt(self, value: float) -> None:
         self.resultTilt.setValue(value)
 
     @property
-    def slope(self):
+    def slope(self) -> float:
         return self.resultSlope.value()
 
     @slope.setter
-    def slope(self, value: float):
+    def slope(self, value: float) -> None:
         self.resultSlope.setValue(value)
 
     @property
-    def max_proj_angle(self):
+    def max_proj_angle(self) -> float:
         return self.maxProjAngle.value()
 
     @property
-    def algorithm_name(self):
+    def algorithm_name(self) -> str:
         return self.algorithmName.currentText()
 
     @property
-    def filter_name(self):
+    def filter_name(self) -> str:
         return self.filterName.currentText()
 
     @property
-    def num_iter(self):
+    def num_iter(self) -> int:
         return self.numIter.value()
 
     @num_iter.setter
-    def num_iter(self, iters: int):
+    def num_iter(self, iters: int) -> None:
         self.numIter.setValue(iters)
 
     @property
-    def pixel_size(self):
+    def pixel_size(self) -> float:
         return self.pixelSize.value()
 
     @pixel_size.setter
-    def pixel_size(self, value: int):
+    def pixel_size(self, value: int) -> None:
         with QSignalBlocker(self.pixelSize):
             self.pixelSize.setValue(value)
 
     @property
-    def alpha(self):
+    def alpha(self) -> float:
         return self.alphaSpinBox.value()
 
-    @alpha.setter
-    def alpha(self, value: float):
-        self.alphaSpinBox.setValue(value)
-
     @property
-    def non_negative(self):
+    def non_negative(self) -> bool:
         return self.nonNegativeCheckBox.isChecked()
 
     @property
-    def stochastic(self):
+    def stochastic(self) -> bool:
         return self.stochasticCheckBox.isChecked()
 
     @property
-    def subsets(self):
+    def subsets(self) -> int:
         return self.subsetsSpinBox.value()
 
     @property

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -184,6 +184,8 @@ class ReconstructWindowView(BaseMainWindowView):
         self.pixelSize.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
         self.alphaSpinBox.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
         self.nonNegativeCheckBox.stateChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
+        self.stochasticCheckBox.stateChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
+        self.subsetsSpinBox.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
         self.reconHelpButton.clicked.connect(lambda: self.open_help_webpage("reconstructions/index"))
         self.corHelpButton.clicked.connect(lambda: self.open_help_webpage("reconstructions/center_of_rotation"))
 

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -187,6 +187,9 @@ class ReconstructWindowView(BaseMainWindowView):
         self.reconHelpButton.clicked.connect(lambda: self.open_help_webpage("reconstructions/index"))
         self.corHelpButton.clicked.connect(lambda: self.open_help_webpage("reconstructions/center_of_rotation"))
 
+        self.stochasticCheckBox.stateChanged.connect(self.subsetsSpinBox.setEnabled)
+        self.stochasticCheckBox.stateChanged.connect(self.subsetsLabel.setEnabled)
+
         self.previewAutoUpdate.stateChanged.connect(self.handle_auto_update_preview_selection)
         self.updatePreviewButton.clicked.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_USER_CLICK))
 


### PR DESCRIPTION
### Issue

Closes #1508 

### Description
This adds the input fields for stochastic PDHG, ready for them to be used in `CILRecon`.

This also contains some changes to the tests. The individual commit names should explain the changes.

### Testing & Acceptance Criteria 

The "Stochastic" and "Subsets" field should show in the recon window only for CIL: PHDG-TV.

Subsets should be disabled unless Stochastic is checked.

Changing either should trigger a new preview, unless Auto Update is unchecked. (though the values have no effect on the recon yet).

The values should be printed to the terminal on preview. e.g.
`SPDHG params: recon_params.stochastic=True recon_params.subsets=2`

### Documentation
Will add release notes once the CIL side is implemented.
