### PR TITLE
1631: Load recons to an existing dataset

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -9,6 +9,7 @@ New Features and improvements
 - #1601 : arithmetic filter optimisation
 - #1616 : Change selected stack with single click on tree widget
 - #1625 : Allow adding extra stacks to a dataset
+- #1625 : Load recons to an existing dataset
 
 Fixes
 -----

--- a/docs/user_guide/gui/loading_saving.rst
+++ b/docs/user_guide/gui/loading_saving.rst
@@ -133,7 +133,7 @@ When a dataset has been successfully loaded, it will be possible to see its elem
 Adding / Replacing Data
 ***********************
 
-The stacks that comprise an existing dataset can be deleted or (in the case of *strict* datasets) replaced. This can be
+The stacks that comprise an existing dataset can be deleted or -- in the case of *strict* datasets only -- replaced. This can be
 done by right clicking an item in the dataset tree view and choosing the Add / Replace Stack option.
 
 .. image:: ../../_static/add_to_dataset_dialog.png
@@ -143,10 +143,11 @@ As in the case of loading images from the main menu, selecting a single file wil
 images in the same directory.
 
 The type of images that you wish to load can be selected from the drop-down menu. If this image type already exists in
-the dataset then the new images will replace it and the previous data will be deleted.
+the dataset then the new images will replace it and the previous data will be deleted. If Recon is chosen then the
+images will be added to the dataset's recons list.
 
-For "simple" datasets that do not have Projections, Flat Before, etc there is only the option of adding data through
-this dialog.
+For "simple" datasets that do not have Projections, Flat Before, etc there is only the option of adding additional
+stacks or recons.
 
 Deleting Data
 *************

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -59,6 +59,9 @@ class BaseDataset:
     def all_image_ids(self) -> List[uuid.UUID]:
         return [image_stack.id for image_stack in self.all if image_stack is not None]
 
+    def add_recon(self, recon: ImageStack):
+        self.recons.append(recon)
+
     def delete_recons(self):
         self.recons.clear()
 

--- a/mantidimaging/gui/ui/add_to_dataset.ui
+++ b/mantidimaging/gui/ui/add_to_dataset.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>485</width>
-    <height>156</height>
+    <width>452</width>
+    <height>140</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -61,68 +61,8 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QStackedWidget" name="stackedWidget">
-       <property name="currentIndex">
-        <number>1</number>
-       </property>
-       <widget class="QWidget" name="page_3">
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QComboBox" name="strictDatasetComboBox">
-           <item>
-            <property name="text">
-             <string>Sample</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Flat Before</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Flat After</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Dark Before</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Dark After</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Recon</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="page_4">
-        <layout class="QVBoxLayout" name="verticalLayout_2">
-         <item>
-          <widget class="QComboBox" name="mixedDatasetComboBox">
-           <item>
-            <property name="text">
-             <string>Images</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Recon</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </widget>
+     <item row="1" column="1" colspan="2">
+      <widget class="QComboBox" name="imageTypeComboBox"/>
      </item>
     </layout>
    </item>

--- a/mantidimaging/gui/ui/add_to_dataset.ui
+++ b/mantidimaging/gui/ui/add_to_dataset.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>360</width>
-    <height>149</height>
+    <width>485</width>
+    <height>156</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,13 +16,10 @@
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
-     <item row="1" column="0">
-      <widget class="QLabel" name="imageTypeLabel">
+     <item row="2" column="2">
+      <widget class="QPushButton" name="chooseFileButton">
        <property name="text">
-        <string>Image Type:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        <string>Choose File</string>
        </property>
       </widget>
      </item>
@@ -33,46 +30,13 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="2">
-      <widget class="QPushButton" name="chooseFileButton">
+     <item row="1" column="0">
+      <widget class="QLabel" name="imageTypeLabel">
        <property name="text">
-        <string>Choose File</string>
+        <string>Image Type:</string>
        </property>
-      </widget>
-     </item>
-     <item row="1" column="1" colspan="2">
-      <widget class="QComboBox" name="imageTypeComboBox">
-       <item>
-        <property name="text">
-         <string>Sample</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Flat Before</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Flat After</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Dark Before</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Dark After</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="filePathLabel">
-       <property name="text">
-        <string>File Path:</string>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
        </property>
       </widget>
      </item>
@@ -88,6 +52,76 @@
        <property name="text">
         <string/>
        </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="filePathLabel">
+       <property name="text">
+        <string>File Path:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QStackedWidget" name="stackedWidget">
+       <property name="currentIndex">
+        <number>1</number>
+       </property>
+       <widget class="QWidget" name="page_3">
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <widget class="QComboBox" name="strictDatasetComboBox">
+           <item>
+            <property name="text">
+             <string>Sample</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Flat Before</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Flat After</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Dark Before</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Dark After</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Recon</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="page_4">
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <widget class="QComboBox" name="mixedDatasetComboBox">
+           <item>
+            <property name="text">
+             <string>Images</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Recon</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </widget>
      </item>
     </layout>

--- a/mantidimaging/gui/windows/add_images_to_dataset_dialog/test/view_test.py
+++ b/mantidimaging/gui/windows/add_images_to_dataset_dialog/test/view_test.py
@@ -33,10 +33,6 @@ class AddImagesToDatasetDialogTest(unittest.TestCase):
     def test_combo_box_enabled_for_strict_dataset(self):
         assert self.view.imageTypeComboBox.isEnabled()
 
-    def test_combo_box_disabled_for_mixed_dataset(self):
-        view = AddImagesToDatasetDialog(self.main_window, "id", False, "dataset-name")
-        assert not view.imageTypeComboBox.isEnabled()
-
     def test_file_path_empty_and_ok_disabled_without_file_choice(self):
         assert not self.view.buttonBox.button(QDialogButtonBox.Ok).isEnabled()
         self.assertEqual(self.view.filePathLineEdit.text(), "")

--- a/mantidimaging/gui/windows/add_images_to_dataset_dialog/view.py
+++ b/mantidimaging/gui/windows/add_images_to_dataset_dialog/view.py
@@ -21,8 +21,13 @@ class AddImagesToDatasetDialog(BaseDialogView):
         self.presenter = AddImagesToDatasetPresenter(self)
         self._dataset_id = dataset_id
 
+        if strict_dataset:
+            self.imageTypeComboBox.addItems(
+                ["Sample", "Flat Before", "Flat After", "Dark Before", "Dark After", "Recon"])
+        else:
+            self.imageTypeComboBox.addItems(["Images", "Recon"])
+
         self.datasetNameText.setText(dataset_name)
-        self.imageTypeComboBox.setEnabled(strict_dataset)
         self.chooseFileButton.clicked.connect(self.choose_file_path)
         self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(False)
         self.accepted.connect(self._on_accepted)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -662,6 +662,7 @@ class MainWindowPresenter(BasePresenter):
         :param dataset: The MixedDataset to update.
         :param new_images: The new images to add.
         """
+        assert self.view.add_to_dataset_dialog is not None
         if self.view.add_to_dataset_dialog.images_type == RECON_TEXT:
             dataset.add_recon(new_images)
             self.add_recon_item_to_tree_view(dataset.id, new_images.id, new_images.name)

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -16,7 +16,7 @@ from mantidimaging.core.utility.data_containers import ProjectionAngles
 from mantidimaging.gui.dialogs.async_task import TaskWorkerThread
 from mantidimaging.gui.windows.image_load_dialog import ImageLoadDialog
 from mantidimaging.gui.windows.main import MainWindowView, MainWindowPresenter
-from mantidimaging.gui.windows.main.presenter import Notification
+from mantidimaging.gui.windows.main.presenter import Notification, RECON_TEXT
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
 
@@ -845,6 +845,29 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.assertIn(new_images, mixed_dataset.all)
         self.presenter.add_child_item_to_tree_view.assert_called_once_with(mixed_dataset.id, new_images.id,
                                                                            new_images.name)
+
+    def test_add_recon_to_mixed_dataset(self):
+        mixed_dataset = MixedDataset([generate_images()])
+        recon = generate_images()
+        recon.name = "recon-name"
+
+        self.view.add_to_dataset_dialog.images_type = RECON_TEXT
+        self.presenter.add_recon_item_to_tree_view = mock.Mock()
+        self.presenter._add_images_to_existing_mixed_dataset(mixed_dataset, recon)
+
+        self.assertIn(recon, mixed_dataset.recons.stacks)
+        self.presenter.add_recon_item_to_tree_view.assert_called_once_with(mixed_dataset.id, recon.id, recon.name)
+
+    def test_add_recon_to_strict_dataset(self):
+        self.presenter.add_recon_item_to_tree_view = mock.Mock()
+        self.view.add_to_dataset_dialog.images_type = RECON_TEXT
+
+        recon = generate_images()
+        recon.name = "recon-name"
+        self.presenter._add_images_to_existing_strict_dataset(self.dataset, recon)
+
+        self.assertIn(recon, self.dataset.recons.stacks)
+        self.presenter.add_recon_item_to_tree_view.assert_called_once_with(self.dataset.id, recon.id, recon.name)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Issue

Closes #1631

### Description

Allows recons to be loaded to an existing dataset.

### Testing 

Wrote two tests for adding recons to a strict or mixed dataset.

### Acceptance Criteria 

Check that loading works and the tree view is updated.

### Documentation

Updated documentation and release notes.
