### PR TITLE
1623: Move tree view selection when tab changes

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -10,6 +10,7 @@ New Features and improvements
 - #1616 : Change selected stack with single click on tree widget
 - #1625 : Allow adding extra stacks to a dataset
 - #1625 : Load recons to an existing dataset
+- #1625 : Change selection in tree view when switching tabs
 
 Fixes
 -----

--- a/mantidimaging/eyes_tests/main_window_test.py
+++ b/mantidimaging/eyes_tests/main_window_test.py
@@ -91,8 +91,8 @@ class MainWindowTest(BaseEyesTest):
         self.check_target(widget=self.imaging.add_to_dataset_dialog)
 
     def test_clicking_tab_changes_tree_view_selection(self):
+        self._load_strict_data_set()
         sample_vis = self._load_strict_data_set()
         sample_vis.raise_()
-        self._load_strict_data_set()
 
         self.check_target()

--- a/mantidimaging/eyes_tests/main_window_test.py
+++ b/mantidimaging/eyes_tests/main_window_test.py
@@ -89,3 +89,10 @@ class MainWindowTest(BaseEyesTest):
         self._create_mixed_dataset()
         self.imaging.show_add_stack_to_existing_dataset_dialog(list(self.imaging.presenter.all_dataset_ids)[0])
         self.check_target(widget=self.imaging.add_to_dataset_dialog)
+
+    def test_clicking_tab_changes_tree_view_selection(self):
+        sample_vis = self._load_strict_data_set()
+        sample_vis._raise()
+        self._load_strict_data_set()
+
+        self.check_target()

--- a/mantidimaging/eyes_tests/main_window_test.py
+++ b/mantidimaging/eyes_tests/main_window_test.py
@@ -92,7 +92,7 @@ class MainWindowTest(BaseEyesTest):
 
     def test_clicking_tab_changes_tree_view_selection(self):
         sample_vis = self._load_strict_data_set()
-        sample_vis._raise()
+        sample_vis.raise_()
         self._load_strict_data_set()
 
         self.check_target()

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -31,13 +31,6 @@ class MainWindowModel(object):
                     return image
         return None
 
-    def get_images_by_name(self, images_name: uuid.UUID) -> Optional[ImageStack]:
-        for dataset in self.datasets.values():
-            for image in dataset.all:
-                if images_name == image.name:
-                    return image
-        return None
-
     def do_load_dataset(self, parameters: LoadingParameters, progress) -> StrictDataset:
         sample = loader.load_p(parameters.sample, parameters.dtype, progress)
         ds = StrictDataset(sample)

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -31,6 +31,13 @@ class MainWindowModel(object):
                     return image
         return None
 
+    def get_images_by_name(self, images_name: uuid.UUID) -> Optional[ImageStack]:
+        for dataset in self.datasets.values():
+            for image in dataset.all:
+                if images_name == image.name:
+                    return image
+        return None
+
     def do_load_dataset(self, parameters: LoadingParameters, progress) -> StrictDataset:
         sample = loader.load_p(parameters.sample, parameters.dtype, progress)
         ds = StrictDataset(sample)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -256,7 +256,7 @@ class MainWindowPresenter(BasePresenter):
         if n_stack_visualisers <= 1:
             return
 
-        tab_bar = self.view.findChildren(QTabBar)[-1]
+        tab_bar = self.view.findChild(QTabBar)
         if tab_bar is not None:
             last_stack_pos = n_stack_visualisers
             # make Qt process the addition of the dock onto the main window

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -530,7 +530,6 @@ class MainWindowPresenter(BasePresenter):
                         if recon_item.id == uuid_select:
                             self._select_tree_widget_item(recon_item)
                             return
-        # runtime error ?
 
     def _select_tree_widget_item(self, tree_widget_item: QTreeWidgetItem):
         """

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -486,7 +486,10 @@ class MainWindowPresenter(BasePresenter):
         self.view.show_recon_window()
 
     def remove_item_from_tree_view(self, uuid_remove: uuid.UUID) -> None:
-
+        """
+        Removes an item from the tree view using a given ID.
+        :param uuid_remove: The ID of the item to remove.
+        """
         for i in range(self.view.dataset_tree_widget.topLevelItemCount()):
             top_level_item = self.view.dataset_tree_widget.topLevelItem(i)
             if top_level_item.id == uuid_remove:
@@ -506,6 +509,10 @@ class MainWindowPresenter(BasePresenter):
                         return
 
     def _set_tree_view_selection_with_id(self, uuid_select: uuid.UUID):
+        """
+        Selects an item on the tree view using the given ID.
+        :param uuid_select: The ID of the item to select.
+        """
         for i in range(self.view.dataset_tree_widget.topLevelItemCount()):
             top_level_item = self.view.dataset_tree_widget.topLevelItem(i)
             if top_level_item.id == uuid_select:
@@ -519,13 +526,17 @@ class MainWindowPresenter(BasePresenter):
                     return
                 if child_item.childCount() > 0:
                     for k in range(child_item.childCount()):
-                        recon_item = top_level_item.child(k)
+                        recon_item = child_item.child(k)
                         if recon_item.id == uuid_select:
                             self._select_tree_widget_item(recon_item)
                             return
         # runtime error ?
 
     def _select_tree_widget_item(self, tree_widget_item: QTreeWidgetItem):
+        """
+        Clears the existing selection on the dataset tree view and selects a given item.
+        :param tree_widget_item: The item to select.
+        """
         self.view.dataset_tree_widget.clearSelection()
         tree_widget_item.setSelected(True)
 

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -875,6 +875,52 @@ class MainWindowPresenterTest(unittest.TestCase):
         tree_widget_item.setSelected.assert_called_once_with(True)
         self.view.dataset_tree_widget.clearSelection.assert_called_once()
 
+    def test_select_top_level_item(self):
+        self.view.dataset_tree_widget.topLevelItemCount.return_value = 1
+        self.view.dataset_tree_widget.topLevelItem.return_value = mock_top_level_item = mock.Mock()
+        mock_top_level_item.id = mock_id = "id"
+
+        self.presenter._set_tree_view_selection_with_id(mock_id)
+        self.view.dataset_tree_widget.clearSelection.assert_called_once()
+        mock_top_level_item.setSelected.assert_called_once_with(True)
+
+    def test_select_stack_item(self):
+        mock_stack_widget = mock.Mock()
+        mock_stack_widget.id = mock_id = "stack-id"
+
+        self.view.dataset_tree_widget.topLevelItemCount.return_value = 1
+        self.view.dataset_tree_widget.topLevelItem.return_value = mock_top_level_item = mock.Mock()
+        mock_top_level_item.id = "dataset-id"
+
+        mock_top_level_item.childCount.return_value = 1
+        mock_stack_item = mock_top_level_item.child.return_value
+        mock_stack_item.id = mock_id
+
+        self.presenter.notify(Notification.TAB_CLICKED, stack=mock_stack_widget)
+
+        self.view.dataset_tree_widget.clearSelection.assert_called_once()
+        mock_stack_item.setSelected.assert_called_once_with(True)
+
+    def test_select_recon_item(self):
+        mock_recon_widget = mock.Mock()
+        mock_recon_widget.id = mock_id = "recon-id"
+
+        self.view.dataset_tree_widget.topLevelItemCount.return_value = 1
+        self.view.dataset_tree_widget.topLevelItem.return_value = mock_top_level_item = mock.Mock()
+        mock_top_level_item.id = "dataset-id"
+
+        mock_top_level_item.childCount.return_value = 1
+        mock_recon_group = mock_top_level_item.child.return_value
+        mock_recon_group.childCount.return_value = 1
+        mock_recon_group.id = "recon-group-id"
+        mock_recon_item = mock_recon_group.child.return_value
+        mock_recon_item.id = mock_id
+
+        self.presenter.notify(Notification.TAB_CLICKED, stack=mock_recon_widget)
+
+        self.view.dataset_tree_widget.clearSelection.assert_called_once()
+        mock_recon_item.setSelected.assert_called_once_with(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -869,6 +869,12 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.assertIn(recon, self.dataset.recons.stacks)
         self.presenter.add_recon_item_to_tree_view.assert_called_once_with(self.dataset.id, recon.id, recon.name)
 
+    def test_select_tree_widget_item(self):
+        tree_widget_item = mock.Mock()
+        self.presenter._select_tree_widget_item(tree_widget_item)
+        tree_widget_item.setSelected.assert_called_once_with(True)
+        self.view.dataset_tree_widget.clearSelection.assert_called_once()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -497,3 +497,8 @@ class MainWindowViewTest(unittest.TestCase):
             self.view.show_add_stack_to_existing_dataset_dialog(mixed_dataset_id)
 
         add_images_mock.assert_called_once_with(self.view, mixed_dataset_id, False, mixed_dataset_name)
+
+    def test_tab_bar_clicked(self):
+        mock_stack = mock.Mock()
+        self.view._on_tab_bar_clicked(mock_stack)
+        self.presenter.notify.assert_called_once_with(Notification.TAB_CLICKED, stack=mock_stack)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -11,7 +11,7 @@ import numpy as np
 from PyQt5.QtCore import Qt, pyqtSignal, QUrl, QPoint
 from PyQt5.QtGui import QIcon, QDragEnterEvent, QDropEvent, QDesktopServices
 from PyQt5.QtWidgets import QAction, QDialog, QLabel, QMessageBox, QMenu, QFileDialog, QSplitter, \
-    QTreeWidgetItem, QTreeWidget, QTabBar
+    QTreeWidgetItem, QTreeWidget
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset
@@ -96,7 +96,6 @@ class MainWindowView(BaseMainWindowView):
     nexus_load_dialog: Optional[NexusLoadDialog] = None
     nexus_save_dialog: Optional[NexusSaveDialog] = None
     add_to_dataset_dialog: Optional[AddImagesToDatasetDialog] = None
-    tab_bar: Optional[QTabBar] = None
 
     def __init__(self, open_dialogs: bool = True):
         super().__init__(None, "gui/ui/main_window.ui")
@@ -158,8 +157,6 @@ class MainWindowView(BaseMainWindowView):
 
         self.tabifiedDockWidgetActivated.connect(self._on_tab_bar_clicked)
 
-        self.tab_connected = False
-
     def setup_shortcuts(self):
         self.actionLoadDataset.triggered.connect(self.show_image_load_dialog)
         self.actionLoadImages.triggered.connect(self.load_image_stack)
@@ -184,7 +181,6 @@ class MainWindowView(BaseMainWindowView):
         self.actionCompareImages.triggered.connect(self.show_stack_select_dialog)
 
         self.model_changed.connect(self.update_shortcuts)
-        self.model_changed.connect(self._update_tab_bar)
 
     def populate_image_menu(self):
         self.menuImage.clear()
@@ -211,11 +207,6 @@ class MainWindowView(BaseMainWindowView):
         self.actionLoadProjectionAngles.setEnabled(has_datasets)
         self.menuWorkflow.setEnabled(has_datasets)
         self.menuImage.setEnabled(has_datasets)
-
-    def _update_tab_bar(self):
-        if len(self.presenter.datasets) == 0:
-            self.tab_connected = False
-            self.tab_bar = None
 
     @staticmethod
     def open_online_documentation():


### PR DESCRIPTION
### Issue

Closes #1623 

### Description

Makes the tree view selection match the current tab.

### Testing 

Added a few tests for the main window and several for the main presenter.

### Acceptance Criteria 

Check that the tests pass. Check that changing the tab changes the tree view.

### Documentation

Updated release notes.
