### PR TITLE
Use pyfakefs and cleanup log loading

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -30,3 +30,4 @@ dependencies:
   - pytest-randomly==3.12.*
   - pytest-xdist==2.5.*
   - coverage==6.4.*
+  - pyfakefs==5.0.*

--- a/mantidimaging/core/data/test/fake_logfile.py
+++ b/mantidimaging/core/data/test/fake_logfile.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from pathlib import Path
 
 from mantidimaging.core.utility.imat_log_file_parser import CSVLogParser, IMATLogFile, TextLogParser
 
@@ -20,7 +21,7 @@ def generate_txt_logfile() -> IMATLogFile:
         "Sun Feb 10 00:26:29 2019   Projection:  8  angle: 2.5216   Monitor 3 before:  5786535   Monitor 3 after:  5929002",  # noqa: E501
         "Sun Feb 10 00:27:02 2019   Projection:  9  angle: 2.8368   Monitor 3 before:  5938142   Monitor 3 after:  6078866",  # noqa: E501
     ]
-    return IMATLogFile(data, "/tmp/fake")
+    return IMATLogFile(data, Path("/tmp/fake"))
 
 
 def generate_csv_logfile() -> IMATLogFile:
@@ -37,4 +38,4 @@ def generate_csv_logfile() -> IMATLogFile:
         "Sun Feb 10 00:26:29 2019,Projection,8,angle: 2.5216,Monitor 3 before: 5786535,Monitor 3 after:  5929002",
         "Sun Feb 10 00:27:02 2019,Projection,9,angle: 2.8368,Monitor 3 before: 5938142,Monitor 3 after:  6078866",
     ]
-    return IMATLogFile(data, "/tmp/fake")
+    return IMATLogFile(data, Path("/tmp/fake"))

--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -3,7 +3,7 @@
 
 from pathlib import Path
 import re
-from typing import List, Iterator, Optional
+from typing import List, Iterator, Optional, Union
 from logging import getLogger
 
 LOG = getLogger(__name__)
@@ -81,7 +81,8 @@ class FilenameGroup:
         self.log_path: Optional[Path] = None
 
     @classmethod
-    def from_file(cls, path: Path) -> "FilenameGroup":
+    def from_file(cls, path: Union[Path, str]) -> "FilenameGroup":
+        path = Path(path)
         if path.is_dir():
             raise ValueError(f"path is a directory: {path}")
         directory = path.parent

--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -108,7 +108,7 @@ class FilenameGroup:
                 self.metadata_path = filename
         self.all_indexes.sort()
 
-    def find_log_file(self):
+    def find_log_file(self) -> None:
         parent_directory = self.directory.parent
         log_pattern = self.directory.name + "*" + ".txt"
         log_paths = list(parent_directory.glob(log_pattern))

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -105,7 +105,7 @@ def load_p(parameters: ImageParameters, dtype: 'npt.DTypeLike', progress: Progre
 def load_stack(file_path: str, progress: Optional[Progress] = None) -> ImageStack:
     image_format = get_file_extension(file_path)
     prefix = get_prefix(file_path)
-    file_names = get_file_names(path=os.path.dirname(file_path), img_format=image_format, prefix=prefix)  # type: ignore
+    file_names = get_file_names(path=os.path.dirname(file_path), img_format=image_format, prefix=prefix)
 
     return load(file_names=file_names, progress=progress)
 

--- a/mantidimaging/core/io/loader/test/loader_test.py
+++ b/mantidimaging/core/io/loader/test/loader_test.py
@@ -46,8 +46,8 @@ class LoaderTest(TestCase):
             self.fs.create_file(output_directory / filename)
 
         for stack_type in ["Flat_Before", "Flat_After", "Dark_Before", "Dark_After", "Tomo"]:
-            for ii in range(0, 5):
-                filename = Path(output_directory / stack_type / f"{stack_type}_{ii:04d}.tif")
+            for image_number in range(0, 5):
+                filename = Path(output_directory / stack_type / f"{stack_type}_{image_number:04d}.tif")
                 self.fs.create_file(filename)
 
         self.fs.create_file(output_directory / "180deg" / "180deg_000.tif")

--- a/mantidimaging/core/io/loader/test/loader_test.py
+++ b/mantidimaging/core/io/loader/test/loader_test.py
@@ -72,36 +72,36 @@ class LoaderTest(TestCase):
         flat_before = lp.flat_before
         self.assertEqual(image_format, flat_before.format)
         self.assertEqual(None, flat_before.indices)
-        self.assertEqual("/b/Flat_Before_log.txt", flat_before.log_file)
-        self.assertEqual("/b/Flat_Before", flat_before.input_path)
-        self.assertEqual("/b/Flat_Before/Flat_Before", flat_before.prefix)
+        self._files_equal("/b/Flat_Before_log.txt", flat_before.log_file)
+        self._files_equal("/b/Flat_Before", flat_before.input_path)
+        self._files_equal("/b/Flat_Before/Flat_Before", flat_before.prefix)
 
         # Flat after checking
         flat_after = lp.flat_after
         self.assertEqual(image_format, flat_after.format)
         self.assertEqual(None, flat_after.indices)
-        self.assertEqual("/b/Flat_After_log.txt", flat_after.log_file)
-        self.assertEqual("/b/Flat_After", flat_after.input_path)
-        self.assertEqual("/b/Flat_After/Flat_After", flat_after.prefix)
+        self._files_equal("/b/Flat_After_log.txt", flat_after.log_file)
+        self._files_equal("/b/Flat_After", flat_after.input_path)
+        self._files_equal("/b/Flat_After/Flat_After", flat_after.prefix)
 
         # Dark before checking
         dark_before = lp.dark_before
         self.assertEqual(image_format, dark_before.format)
         self.assertEqual(None, dark_before.indices)
-        self.assertEqual("/b/Dark_Before", dark_before.input_path)
-        self.assertEqual("/b/Dark_Before/Dark_Before", dark_before.prefix)
+        self._files_equal("/b/Dark_Before", dark_before.input_path)
+        self._files_equal("/b/Dark_Before/Dark_Before", dark_before.prefix)
 
         # Dark after checking
         dark_after = lp.dark_after
         self.assertEqual(image_format, dark_after.format)
         self.assertEqual(None, dark_after.indices)
-        self.assertEqual("/b/Dark_After", dark_after.input_path)
-        self.assertEqual("/b/Dark_After/Dark_After", dark_after.prefix)
+        self._files_equal("/b/Dark_After", dark_after.input_path)
+        self._files_equal("/b/Dark_After/Dark_After", dark_after.prefix)
 
         # 180 degree checking
         proj180 = lp.proj_180deg
         self.assertEqual(image_format, proj180.format)
         self.assertEqual(None, proj180.indices)
-        self.assertEqual("/b/180deg/180deg_000.tif", proj180.input_path)
+        self._files_equal("/b/180deg/180deg_000.tif", proj180.input_path)
         self.assertEqual(None, proj180.log_file)
-        self.assertEqual("/b/180deg/180deg", proj180.prefix)
+        self._files_equal("/b/180deg/180deg", proj180.prefix)

--- a/mantidimaging/core/io/loader/test/loader_test.py
+++ b/mantidimaging/core/io/loader/test/loader_test.py
@@ -1,104 +1,61 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-import os
 from unittest import mock
+from pathlib import Path
 
 from mantidimaging.core.io import loader
 from mantidimaging.core.io.loader import load_stack
 from mantidimaging.core.io.loader.loader import create_loading_parameters_for_file_path, DEFAULT_PIXEL_DEPTH, \
     DEFAULT_PIXEL_SIZE, DEFAULT_IS_SINOGRAM
-from mantidimaging.test_helpers import FileOutputtingTestCase
+from pyfakefs.fake_filesystem_unittest import TestCase
 
 
-class LoaderTest(FileOutputtingTestCase):
+class LoaderTest(TestCase):
+    def setUp(self) -> None:
+        self.setUpPyfakefs()
+
+    def _files_equal(self, file1, file2):
+        self.assertEqual(Path(file1).absolute(), Path(file2).absolute())
+
+    def _file_list_count_equal(self, list1, list2):
+        """Check that 2 lists of paths refer to the same files. Order independent"""
+        self.assertCountEqual((Path(s).absolute() for s in list1), (Path(s).absolute() for s in list2))
+
     def test_raise_on_invalid_format(self):
         self.assertRaises(NotImplementedError, loader.load, "/some/path", file_names=["/somefile"], in_format='txt')
 
     @mock.patch("mantidimaging.core.io.loader.loader.load")
-    @mock.patch("mantidimaging.core.io.loader.loader.get_file_names")
-    def test_load_stack(self, get_file_names_mock: mock.Mock, load_mock: mock.Mock):
-        file_names = mock.Mock()
+    def test_load_stack_finds_files(self, load_mock: mock.Mock):
         progress = mock.Mock()
-        file_path = "/path/to/file/that/is/fake.tif"
-        get_file_names_mock.return_value = file_names
+        file_paths_tomo = [f"/a/tomo_{x:04d}.tiff" for x in range(5)]
+        file_paths_other = [f"/a/flat_{x:04d}.tiff" for x in range(5)] + ["/a/tomo.log"]
+        for filename in file_paths_tomo + file_paths_other:
+            self.fs.create_file(filename)
 
-        load_stack(file_path, progress)
+        load_stack(file_paths_tomo[0], progress)
 
-        load_mock.assert_called_once_with(file_names=file_names, progress=progress)
-        get_file_names_mock.assert_called_once_with(path="/path/to/file/that/is",
-                                                    img_format="tif",
-                                                    prefix="/path/to/file/that/is/fake.ti")
+        load_mock.assert_called_once()
+        found_files = load_mock.call_args.kwargs['file_names']
+        self._file_list_count_equal(file_paths_tomo, found_files)
 
-    def _create_test_sample(self):
-        # Logs
-        with open(os.path.join(self.output_directory, "Tomo_log.txt"), "w") as f:
-            f.write("log")
-        with open(os.path.join(self.output_directory, "Flat_After_log.txt"), "w") as f:
-            f.write("log")
-        with open(os.path.join(self.output_directory, "Flat_Before_log.txt"), "w") as f:
-            f.write("log")
-
-        # Flat
-        os.mkdir(os.path.join(self.output_directory, "Flat_Before"))
-        os.mkdir(os.path.join(self.output_directory, "Flat_After"))
-        for ii in range(0, 10):
-            with open(os.path.join(self.output_directory, "Flat_Before", f"Flat_Before_00{ii}.tif"), "wb") as f:
-                f.write(b"\0")
-
-            with open(os.path.join(self.output_directory, "Flat_After", f"Flat_After_00{ii}.tif"), "wb") as f:
-                f.write(b"\0")
-
-        # Dark
-        os.mkdir(os.path.join(self.output_directory, "Dark_Before"))
-        os.mkdir(os.path.join(self.output_directory, "Dark_After"))
-        for ii in range(0, 10):
-            with open(os.path.join(self.output_directory, "Dark_Before", f"Dark_Before_00{ii}.tif"), "wb") as f:
-                f.write(b"\0")
-
-            with open(os.path.join(self.output_directory, "Dark_After", f"Dark_After_00{ii}.tif"), "wb") as f:
-                f.write(b"\0")
-
-        # Tomo
-        os.mkdir(os.path.join(self.output_directory, "Tomo"))
-        for ii in range(0, 200):
-            with open(os.path.join(self.output_directory, "Tomo", f"Tomo_00{ii}.tif"), "wb") as f:
-                f.write(b"\0")
-
-        # 180 degree projection
-        os.mkdir(os.path.join(self.output_directory, "180deg"))
-        with open(os.path.join(self.output_directory, "180deg", "180deg_000.tif"), "wb") as f:
-            f.write(b"\0")
-
-    @mock.patch("mantidimaging.core.io.loader.loader.find_and_verify_sample_log")
+    @mock.patch("mantidimaging.core.io.loader.loader.load_log")
     @mock.patch("mantidimaging.core.io.loader.loader.read_in_file_information")
-    def test_create_loading_parameters_for_file_path(self, mock_read_in_file_information,
-                                                     mock_find_and_verify_sample_log):
-        self._create_test_sample()
-        tomo_dir = os.path.join(self.output_directory, "Tomo")
-        tomo_prefix = os.path.join(tomo_dir, "Tomo")
+    def test_create_loading_parameters_for_file_path(self, _load_log, _read_in_file_information):
+        output_directory = Path("/b")
+        for filename in ["Tomo_log.txt", "Flat_After_log.txt", "Flat_Before_log.txt"]:
+            self.fs.create_file(output_directory / filename)
+
+        for stack_type in ["Flat_Before", "Flat_After", "Dark_Before", "Dark_After", "Tomo"]:
+            for ii in range(0, 5):
+                filename = Path(output_directory / stack_type / f"{stack_type}_{ii:04d}.tif")
+                self.fs.create_file(filename)
+
+        self.fs.create_file(output_directory / "180deg" / "180deg_000.tif")
+
         image_format = "tif"
-        flat_before_dir = os.path.join(self.output_directory, "Flat_Before")
-        flat_before_prefix = os.path.join(flat_before_dir, "Flat_Before")
-        flat_before_log = os.path.join(self.output_directory, "Flat_Before_log.txt")
 
-        flat_after_dir = os.path.join(self.output_directory, "Flat_After")
-        flat_after_prefix = os.path.join(flat_after_dir, "Flat_After")
-        flat_after_log = os.path.join(self.output_directory, "Flat_After_log.txt")
+        lp = create_loading_parameters_for_file_path(output_directory)
 
-        dark_before_dir = os.path.join(self.output_directory, "Dark_Before")
-        dark_before_prefix = os.path.join(dark_before_dir, "Dark_Before")
-
-        dark_after_dir = os.path.join(self.output_directory, "Dark_After")
-        dark_after_prefix = os.path.join(dark_after_dir, "Dark_After")
-
-        proj_180_file_prefix = os.path.join(self.output_directory, "180deg", "180deg")
-        proj_180_file = proj_180_file_prefix + "_000.tif"
-
-        lp = create_loading_parameters_for_file_path(self.output_directory)
-
-        mock_read_in_file_information.assert_called_once_with(tomo_dir, in_prefix=tomo_prefix, in_format=image_format)
-        mock_find_and_verify_sample_log.assert_called_once_with(tomo_dir,
-                                                                mock_read_in_file_information.return_value.filenames)
         self.assertEqual(DEFAULT_PIXEL_DEPTH, lp.dtype)
         self.assertEqual(DEFAULT_PIXEL_SIZE, lp.pixel_size)
         self.assertEqual(DEFAULT_IS_SINOGRAM, lp.sinograms)
@@ -107,44 +64,44 @@ class LoaderTest(FileOutputtingTestCase):
         sample = lp.sample
         self.assertEqual(image_format, sample.format)
         self.assertEqual(None, sample.indices)
-        self.assertEqual(tomo_dir, sample.input_path)
-        self.assertEqual(mock_find_and_verify_sample_log.return_value, sample.log_file)
-        self.assertEqual(tomo_prefix, sample.prefix)
+        self._files_equal("/b/Tomo", sample.input_path)
+        self._files_equal("/b/Tomo_log.txt", sample.log_file)
+        self._files_equal("/b/Tomo/Tomo", sample.prefix)
 
         # Flat before checking
         flat_before = lp.flat_before
         self.assertEqual(image_format, flat_before.format)
         self.assertEqual(None, flat_before.indices)
-        self.assertEqual(flat_before_log, flat_before.log_file)
-        self.assertEqual(flat_before_dir, flat_before.input_path)
-        self.assertEqual(flat_before_prefix, flat_before.prefix)
+        self.assertEqual("/b/Flat_Before_log.txt", flat_before.log_file)
+        self.assertEqual("/b/Flat_Before", flat_before.input_path)
+        self.assertEqual("/b/Flat_Before/Flat_Before", flat_before.prefix)
 
         # Flat after checking
         flat_after = lp.flat_after
         self.assertEqual(image_format, flat_after.format)
         self.assertEqual(None, flat_after.indices)
-        self.assertEqual(flat_after_log, flat_after.log_file)
-        self.assertEqual(flat_after_dir, flat_after.input_path)
-        self.assertEqual(flat_after_prefix, flat_after.prefix)
+        self.assertEqual("/b/Flat_After_log.txt", flat_after.log_file)
+        self.assertEqual("/b/Flat_After", flat_after.input_path)
+        self.assertEqual("/b/Flat_After/Flat_After", flat_after.prefix)
 
         # Dark before checking
         dark_before = lp.dark_before
         self.assertEqual(image_format, dark_before.format)
         self.assertEqual(None, dark_before.indices)
-        self.assertEqual(dark_before_dir, dark_before.input_path)
-        self.assertEqual(dark_before_prefix, dark_before.prefix)
+        self.assertEqual("/b/Dark_Before", dark_before.input_path)
+        self.assertEqual("/b/Dark_Before/Dark_Before", dark_before.prefix)
 
         # Dark after checking
         dark_after = lp.dark_after
         self.assertEqual(image_format, dark_after.format)
         self.assertEqual(None, dark_after.indices)
-        self.assertEqual(dark_after_dir, dark_after.input_path)
-        self.assertEqual(dark_after_prefix, dark_after.prefix)
+        self.assertEqual("/b/Dark_After", dark_after.input_path)
+        self.assertEqual("/b/Dark_After/Dark_After", dark_after.prefix)
 
         # 180 degree checking
         proj180 = lp.proj_180deg
         self.assertEqual(image_format, proj180.format)
         self.assertEqual(None, proj180.indices)
-        self.assertEqual(proj_180_file, proj180.input_path)
+        self.assertEqual("/b/180deg/180deg_000.tif", proj180.input_path)
         self.assertEqual(None, proj180.log_file)
-        self.assertEqual(proj_180_file_prefix, proj180.prefix)
+        self.assertEqual("/b/180deg/180deg", proj180.prefix)

--- a/mantidimaging/core/io/test/utility_test.py
+++ b/mantidimaging/core/io/test/utility_test.py
@@ -11,6 +11,10 @@ class UtilityTest(TestCase):
     def setUp(self) -> None:
         self.setUpPyfakefs()
 
+    def _file_list_count_equal(self, list1, list2):
+        """Check that 2 lists of paths refer to the same files. Order independent"""
+        self.assertCountEqual((Path(s).absolute() for s in list1), (Path(s).absolute() for s in list2))
+
     def test_get_candidate_file_extensions(self):
         self.assertEqual(['tif', 'tiff'], utility.get_candidate_file_extensions('tif'))
 
@@ -20,17 +24,21 @@ class UtilityTest(TestCase):
 
     def test_get_file_names(self):
         # Create test file with .tiff extension
-        tiff_filename = '/dirname/test.tiff'
+        tiff_filename = Path('/dirname/test.tiff')
         self.fs.create_file(tiff_filename)
 
         # Search for files with .tif extension
         found_files = utility.get_file_names("/dirname", 'tif')
 
         # Expect to find the .tiff file
-        self.assertEqual([tiff_filename], found_files)
+        self._file_list_count_equal([tiff_filename], found_files)
 
-    def test_find_log(self):
-        log_name = "/a/sample_log.txt"
+    def test_find_log_for_image(self):
+        log_name = Path("/a/b/TomoIMAT00010675_FlowerFine_log.txt")
+        image_name = Path("/a/b/Tomo/IMAT_Flower_Tomo_000000.tif")
         self.fs.create_file(log_name)
+        self.fs.create_file(image_name)
 
-        self.assertEqual(log_name, utility.find_log(Path("/a/b"), "sample"))
+        log_found = utility.find_log_for_image(image_name)
+
+        self.assertEqual(log_name, log_found)

--- a/mantidimaging/core/io/test/utility_test.py
+++ b/mantidimaging/core/io/test/utility_test.py
@@ -22,18 +22,15 @@ class UtilityTest(TestCase):
 
         self.assertEqual(['png'], utility.get_candidate_file_extensions('png'))
 
-    def test_get_file_names(self):
-        # Create test file with .tiff extension
+    def test_WHEN_tif_file_exists_THEN_tif_file_found_in_list(self):
         tiff_filename = Path('/dirname/test.tiff')
         self.fs.create_file(tiff_filename)
 
-        # Search for files with .tif extension
         found_files = utility.get_file_names("/dirname", 'tif')
 
-        # Expect to find the .tiff file
         self._file_list_count_equal([tiff_filename], found_files)
 
-    def test_find_log_for_image(self):
+    def test_WHEN_image_has_logfile_THEN_logfile_found_(self):
         log_name = Path("/a/b/TomoIMAT00010675_FlowerFine_log.txt")
         image_name = Path("/a/b/Tomo/IMAT_Flower_Tomo_000000.tif")
         self.fs.create_file(log_name)

--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -10,6 +10,10 @@ from logging import getLogger, Logger
 from pathlib import Path
 from typing import List, Optional, Union, Tuple
 
+from mantidimaging.core.io.filenames import FilenameGroup
+
+log = getLogger(__name__)
+
 DEFAULT_IO_FILE_FORMAT = 'tif'
 
 SIMILAR_FILE_EXTENSIONS = (('tif', 'tiff'), ('fit', 'fits'))
@@ -69,7 +73,6 @@ def get_file_names(path: Optional[Union[Path, str]],
 
     :return: All the file names, sorted by ascending
     """
-    log = getLogger(__name__)
 
     # Return no found files on None path
     if path is None:
@@ -163,21 +166,13 @@ def find_images(sample_dirname: Path,
     return []
 
 
-def find_log(dirname: Path, log_name: str, logger: Logger = None) -> str:
-    """
-
-    :param dirname: The directory in which the sample images were found
-    :param log_name: The log name is typically the directory name of the sample
-    :param logger: The logger that find_log should report back via, should an error occur.
-    :return:
-    """
-    expected_path = dirname / '..'
-    try:
-        return get_file_names(expected_path.absolute(), "txt", prefix=log_name)[0]
-    except RuntimeError:
-        if logger is not None:
-            logger.info(f"Could not find a log file for {log_name} in {dirname}")
-    return ""
+def find_log_for_image(image_file_name: Path) -> Optional[Path]:
+    fg = FilenameGroup.from_file(image_file_name)
+    fg.find_log_file()
+    if fg.log_path is None:
+        log.info(f"Could not find a log file for {image_file_name}")
+        return None
+    return fg.log_path
 
 
 def find_180deg_proj(sample_dirname: Path, image_format: str, logger: Optional[Logger] = None) -> str:

--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -167,12 +167,12 @@ def find_images(sample_dirname: Path,
 
 
 def find_log_for_image(image_file_name: Path) -> Optional[Path]:
-    fg = FilenameGroup.from_file(image_file_name)
-    fg.find_log_file()
-    if fg.log_path is None:
+    filename_group = FilenameGroup.from_file(image_file_name)
+    filename_group.find_log_file()
+    if filename_group.log_path is None:
         log.info(f"Could not find a log file for {image_file_name}")
         return None
-    return fg.log_path
+    return filename_group.log_path
 
 
 def find_180deg_proj(sample_dirname: Path, image_format: str, logger: Optional[Logger] = None) -> str:

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -9,6 +9,7 @@ and helps the type hints to tell you that you might be passing the wrong value (
 while they're both Float underneath and the value can be used, it just will produce nonsense.
 """
 from dataclasses import dataclass
+from pathlib import Path
 from typing import List, Optional, NamedTuple
 
 import numpy
@@ -129,7 +130,7 @@ class ImageParameters:
     format: str
     prefix: str
     indices: Optional[Indices] = None
-    log_file: Optional[str] = None
+    log_file: Optional[Path] = None
 
 
 class LoadingParameters:

--- a/mantidimaging/core/utility/imat_log_file_parser.py
+++ b/mantidimaging/core/utility/imat_log_file_parser.py
@@ -5,6 +5,7 @@ import csv
 import re
 from enum import Enum, auto
 from itertools import zip_longest
+from pathlib import Path
 from typing import Dict, List, Optional
 
 import numpy
@@ -107,7 +108,7 @@ class CSVLogParser:
 
 
 class IMATLogFile:
-    def __init__(self, data: List[str], source_file: str):
+    def __init__(self, data: List[str], source_file: Path):
         self._source_file = source_file
 
         self.parser = self.find_parser(data)
@@ -123,7 +124,7 @@ class IMATLogFile:
             raise RuntimeError("The format of the log file is not recognised.")
 
     @property
-    def source_file(self) -> str:
+    def source_file(self) -> Path:
         return self._source_file
 
     def projection_numbers(self):

--- a/mantidimaging/gui/windows/image_load_dialog/field.py
+++ b/mantidimaging/gui/windows/image_load_dialog/field.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from pathlib import Path
+
 import numpy as np
 import os
 from typing import Optional, List, Union, Tuple, TYPE_CHECKING
@@ -61,10 +63,11 @@ class Field:
         return self._path
 
     @path.setter
-    def path(self, value: str):
-        assert isinstance(value,
-                          str), f"The object passed as path for this field is not a string. " \
-                                f"Instead got {type(value)}"
+    def path(self, value: Union[Path, str]):
+        if isinstance(value, Path):
+            value = str(value)
+        elif not isinstance(value, str):
+            raise RuntimeError(f"The object passed as path for this field is not a string. Instead got {type(value)}")
         if value != "":
             self.path.setText(1, value)
             self.widget.setText(1, self.file())

--- a/mantidimaging/gui/windows/image_load_dialog/field.py
+++ b/mantidimaging/gui/windows/image_load_dialog/field.py
@@ -23,6 +23,8 @@ class Field:
     _stop_spinbox: Optional[QSpinBox] = None
     _increment_spinbox: Optional[QSpinBox] = None
     _shape_widget: Optional[QTreeWidgetItem] = None
+    _tree: QTreeWidget
+    _path: Optional[QTreeWidgetItem]
 
     def __init__(self, tree: QTreeWidget, widget: QTreeWidgetItem, use: QCheckBox, select_button: QPushButton,
                  file_info: 'TypeInfo'):
@@ -33,7 +35,7 @@ class Field:
         self.select_button = select_button
         self.file_info = file_info
 
-    def set_images(self, image_files: List[str]):
+    def set_images(self, image_files: List[str]) -> None:
         if len(image_files) > 0:
             self.path = image_files[0]
             self.update_shape(len(image_files))
@@ -52,18 +54,18 @@ class Field:
         return self._use
 
     @use.setter
-    def use(self, value: bool):
+    def use(self, value: bool) -> None:
         self._use.setChecked(value)
 
     @property
-    def path(self):
+    def path(self) -> QTreeWidgetItem:
         if self._path is None:
             self._path = QTreeWidgetItem(self._widget)
             self._path.setText(0, "Path")
         return self._path
 
     @path.setter
-    def path(self, value: Union[Path, str]):
+    def path(self, value: Union[Path, str]) -> None:
         if isinstance(value, Path):
             value = str(value)
         elif not isinstance(value, str):
@@ -91,7 +93,7 @@ class Field:
         """
         return str(self.path.text(1))
 
-    def _init_indices(self):
+    def _init_indices(self) -> None:
         indices_item = QTreeWidgetItem(self._widget)
         indices_item.setText(0, "File indices")
         _spinbox_layout = QHBoxLayout()
@@ -123,7 +125,7 @@ class Field:
         return self._start_spinbox
 
     @_start.setter
-    def _start(self, value: int):
+    def _start(self, value: int) -> None:
         self._start.setValue(value)
 
     @property
@@ -135,7 +137,7 @@ class Field:
         return self._stop_spinbox
 
     @_stop.setter
-    def _stop(self, value: int):
+    def _stop(self, value: int) -> None:
         self._stop.setValue(value)
 
     @property
@@ -147,7 +149,7 @@ class Field:
         return self._increment_spinbox
 
     @_increment.setter
-    def _increment(self, value: int):
+    def _increment(self, value: int) -> None:
         self._increment.setValue(value)
 
     @property
@@ -158,14 +160,14 @@ class Field:
         return self._shape_widget
 
     @_shape.setter
-    def _shape(self, value: str):
+    def _shape(self, value: str) -> None:
         self._shape.setText(1, value)
 
     @property
     def indices(self) -> Indices:
         return Indices(self._start.value(), self._stop.value(), self._increment.value())
 
-    def update_indices(self, number_of_images):
+    def update_indices(self, number_of_images: int) -> None:
         """
         :param number_of_images: Number of images that will be loaded in from
                                  the current selection
@@ -182,7 +184,7 @@ class Field:
         # Enforce the maximum step (ensure a minimum of 1)
         self._increment.setMaximum(max(number_of_images, 1))
 
-    def set_step(self, value: int):
+    def set_step(self, value: int) -> None:
         if self._increment_spinbox is not None:
             self._increment_spinbox.setValue(value)
 
@@ -195,7 +197,7 @@ class Field:
         exp_mem = round(single_mem * num_images, 2)
         return num_images, exp_mem
 
-    def update_shape(self, shape: Union[int, Tuple[int, int]]):
+    def update_shape(self, shape: Union[int, Tuple[int, int]]) -> None:
         if isinstance(shape, int):
             self._shape = f"{str(shape)} images"
         else:

--- a/mantidimaging/gui/windows/image_load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/image_load_dialog/test/presenter_test.py
@@ -11,6 +11,9 @@ from mantidimaging.gui.windows.image_load_dialog.presenter import LoadPresenter,
 
 
 class ImageLoadDialogPresenterTest(unittest.TestCase):
+    def _files_equal(self, file1, file2):
+        self.assertEqual(Path(file1).absolute(), Path(file2).absolute())
+
     def setUp(self):
         self.fields = {name: mock.Mock() for name in FILE_TYPES}
         self.v = mock.MagicMock(fields=self.fields)
@@ -24,17 +27,17 @@ class ImageLoadDialogPresenterTest(unittest.TestCase):
 
         self.v.select_file.assert_called_once_with("Sample")
 
-    @mock.patch("mantidimaging.gui.windows.image_load_dialog.presenter.find_log", return_value=3)
+    @mock.patch("mantidimaging.gui.windows.image_load_dialog.presenter.find_log_for_image", return_value=3)
     @mock.patch("mantidimaging.gui.windows.image_load_dialog.presenter.find_180deg_proj", return_value=2)
     @mock.patch("mantidimaging.gui.windows.image_load_dialog.presenter.find_images", return_value=1)
     @mock.patch("mantidimaging.gui.windows.image_load_dialog.presenter.load_log")
     @mock.patch("mantidimaging.gui.windows.image_load_dialog.presenter.read_in_file_information",
-                return_value=FileInformation([], (0, 0, 0), True))
+                return_value=FileInformation(["a"], (0, 0, 0), True))
     @mock.patch(
         "mantidimaging.gui.windows.image_load_dialog.presenter.get_file_extension", )
     @mock.patch("mantidimaging.gui.windows.image_load_dialog.presenter.get_prefix")
     def test_do_update_sample(self, get_prefix, get_file_extension, read_in_file_information, mock_load_log,
-                              find_images, find_180deg_proj, find_log):
+                              find_images, find_180deg_proj, find_log_for_image):
         selected_file = "SelectedFile"
         sample_file_name = "SampleFileName"
         path_text = "PathText"
@@ -63,7 +66,7 @@ class ImageLoadDialogPresenterTest(unittest.TestCase):
         for name in ["Flat Before", "Flat After", "Dark Before", "Dark After"]:
             self.fields[name].set_images.assert_called_once_with(1)
         self.assertEqual(2, self.fields["180 degree"].path)
-        find_log.assert_any_call(Path(dirname), dirname, logger)
+        find_log_for_image.assert_any_call(Path("a"))
         find_images.assert_any_call(Path(dirname),
                                     'Flat',
                                     suffix='Before',
@@ -284,7 +287,7 @@ class ImageLoadDialogPresenterTest(unittest.TestCase):
 
         lp = self.p.get_parameters()
 
-        self.assertEqual(lp.sample.log_file, path_text)
+        self._files_equal(lp.sample.log_file, path_text)
         self.assertEqual(lp.sample.input_path, sample_input_path)
         self.assertEqual(lp.sample.format, image_format)
         self.assertEqual(lp.sample.prefix, "/path")
@@ -292,11 +295,11 @@ class ImageLoadDialogPresenterTest(unittest.TestCase):
         self.assertEqual(lp.name, sample_file_name)
         self.assertEqual(lp.pixel_size, pixel_size)
         self.assertEqual(lp.flat_before.prefix, "/path")
-        self.assertEqual(lp.flat_before.log_file, flat_log_file_name)
+        self._files_equal(lp.flat_before.log_file, flat_log_file_name)
         self.assertEqual(lp.flat_before.format, image_format)
         self.assertEqual(lp.flat_before.input_path, flat_directory)
         self.assertEqual(lp.flat_after.prefix, "/path")
-        self.assertEqual(lp.flat_after.log_file, flat_log_file_name)
+        self._files_equal(lp.flat_after.log_file, flat_log_file_name)
         self.assertEqual(lp.flat_after.format, image_format)
         self.assertEqual(lp.flat_after.input_path, flat_directory)
         self.assertEqual(lp.dark_before.input_path, dark_directory)

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -2,6 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 import uuid
 from logging import getLogger
+from pathlib import Path
 from typing import Dict, Optional, List, Union, NoReturn, TYPE_CHECKING
 
 from mantidimaging.core.data import ImageStack
@@ -145,7 +146,7 @@ class MainWindowModel(object):
     def raise_error_when_parent_strict_dataset_not_found(self, images_id: uuid.UUID) -> NoReturn:
         raise RuntimeError(f"Failed to find strict dataset containing ImageStack with ID {images_id}")
 
-    def add_log_to_sample(self, images_id: uuid.UUID, log_file: str):
+    def add_log_to_sample(self, images_id: uuid.UUID, log_file: Path):
         images = self.get_images_by_uuid(images_id)
         if images is None:
             raise RuntimeError

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -4,6 +4,7 @@ import traceback
 import uuid
 from enum import Enum, auto
 from logging import getLogger, Logger
+from pathlib import Path
 from typing import TYPE_CHECKING, Union, Optional, Dict, List, Any, NamedTuple, Iterable
 
 import numpy as np
@@ -111,7 +112,7 @@ class MainWindowPresenter(BasePresenter):
                 return stack_id.id
         return None
 
-    def add_log_to_sample(self, stack_id: uuid.UUID, log_file: str) -> None:
+    def add_log_to_sample(self, stack_id: uuid.UUID, log_file: Path) -> None:
         self.model.add_log_to_sample(stack_id, log_file)
 
     def _do_rename_stack(self, current_name: str, new_name: str) -> None:

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -4,6 +4,7 @@
 import os
 import uuid
 from logging import getLogger
+from pathlib import Path
 from typing import Optional, List, Union, TYPE_CHECKING
 from uuid import UUID
 
@@ -266,7 +267,7 @@ class MainWindowView(BaseMainWindowView):
         if selected_file == "":
             return
 
-        self.presenter.add_log_to_sample(stack_id=stack_to_add_log_to, log_file=selected_file)
+        self.presenter.add_log_to_sample(stack_id=stack_to_add_log_to, log_file=Path(selected_file))
 
         QMessageBox.information(self, "Load complete", f"{selected_file} was loaded as a log into "
                                 f"{stack_to_add_log_to}.")


### PR DESCRIPTION
### Issue
Progresses #1219

### Description

This improves some of the tests around file finding and loading by using pyfakefs. I have made the tests a bit more rigorous by having reducing mocking and having them act on the fake filesystem. This exposed some issues around how paths are handled on windows (auto finding log files probably never worked). Switching some path handling to use pathlib required a cascade of small changes through a lot of files.

### Testing & Acceptance Criteria 

Failures are expected on the docker tests as the docker images wont have pyfakefs in yet. Other tests should pass.

From the Load Dataset dialog, select the flower dataset sample. Check that the log files get correctly detected:
![image](https://user-images.githubusercontent.com/74248560/203070803-6536368f-cdc9-4fd8-bae2-e24d605a1a08.png)
When loading check that there are no
'Could not find a log file for' messages in the terminal.


### Documentation

Not needed yet
