### PR TITLE
StackChoicePresenter cleanups

### DIFF
--- a/mantidimaging/gui/test/gui_system_operations_test.py
+++ b/mantidimaging/gui/test/gui_system_operations_test.py
@@ -132,7 +132,7 @@ class TestGuiSystemOperations(GuiSystemBase):
 
         def mock_wait_for_stack_choice(self, new_stack: ImageStack, stack_uuid: UUID):
             print("mock_wait_for_stack_choice")
-            stack_choice = StackChoicePresenter(self.original_images_stack, new_stack, self, stack_uuid)
+            stack_choice = StackChoicePresenter(self.original_images_stack[stack_uuid], new_stack, self)
             stack_choice.show()
             QTest.qWait(SHOW_DELAY)
             if keep_stack == "new":

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -7,7 +7,7 @@ from functools import partial
 from itertools import groupby
 from logging import getLogger
 from time import sleep
-from typing import List, TYPE_CHECKING, Optional, Tuple, Union
+from typing import List, TYPE_CHECKING, Optional, Tuple
 from uuid import UUID
 
 import numpy as np
@@ -102,7 +102,7 @@ class FiltersWindowPresenter(BasePresenter):
         self.model = FiltersWindowModel(self)
         self._main_window = main_window
 
-        self.original_images_stack: Union[List[Tuple[ImageStack, UUID]]] = []
+        self.original_images_stack: dict[UUID, ImageStack] = {}
         self.applying_to_all = False
         self.filter_is_running = False
 
@@ -222,7 +222,7 @@ class FiltersWindowPresenter(BasePresenter):
 
         if self.view.safeApply.isChecked():
             with operation_in_progress("Safe Apply: Copying Data", "-------------------------------------", self.view):
-                self.original_images_stack = self.stack.copy()
+                self.original_images_stack = {self.stack.id: self.stack.copy()}
 
         # if is a 180degree stack and a user says no, cancel apply filter.
         if self.is_a_proj180deg(self.stack) and not self.view.ask_confirmation(APPLY_TO_180_MSG):
@@ -239,16 +239,17 @@ class FiltersWindowPresenter(BasePresenter):
         stacks = self.main_window.get_all_stacks()
         if self.view.safeApply.isChecked():
             with operation_in_progress("Safe Apply: Copying Data", "-------------------------------------", self.view):
-                self.original_images_stack = []
+                self.original_images_stack = {}
                 for stack in stacks:
-                    self.original_images_stack.append((stack.copy(), stack.id))
+                    self.original_images_stack[stack.id] = stack.copy()
 
         if len(stacks) > 0:
             self.applying_to_all = True
         self._do_apply_filter(stacks)
 
     def _wait_for_stack_choice(self, new_stack: ImageStack, stack_uuid: UUID):
-        stack_choice = StackChoicePresenter(self.original_images_stack, new_stack, self, stack_uuid)
+        stack_choice = StackChoicePresenter(self.original_images_stack[stack_uuid], new_stack, self, stack_uuid)
+        del self.original_images_stack[stack_uuid]
         if self.model.show_negative_overlay():
             stack_choice.enable_nonpositive_check()
         stack_choice.show()

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -248,7 +248,7 @@ class FiltersWindowPresenter(BasePresenter):
         self._do_apply_filter(stacks)
 
     def _wait_for_stack_choice(self, new_stack: ImageStack, stack_uuid: UUID):
-        stack_choice = StackChoicePresenter(self.original_images_stack[stack_uuid], new_stack, self, stack_uuid)
+        stack_choice = StackChoicePresenter(self.original_images_stack[stack_uuid], new_stack, self)
         del self.original_images_stack[stack_uuid]
         if self.model.show_negative_overlay():
             stack_choice.enable_nonpositive_check()

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -326,11 +326,13 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.presenter._do_apply_filter = mock.MagicMock()  # type: ignore
         task = mock.MagicMock()
         task.error = None
+        self.presenter.original_images_stack = {stack.id: mock.Mock() for stack in self.mock_stacks}
 
         self.presenter._post_filter(self.mock_stacks, task)
 
         self.assertEqual(2, stack_choice_presenter.call_count)
         self.assertEqual(2, stack_choice_presenter.return_value.show.call_count)
+        self.assertDictEqual(self.presenter.original_images_stack, {})
 
     @mock.patch('mantidimaging.gui.windows.operations.presenter.StackChoicePresenter')
     def test_unchecked_safe_apply_does_not_start_stack_choice_presenter(self, stack_choice_presenter):
@@ -347,15 +349,16 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     @mock.patch("mantidimaging.gui.windows.operations.presenter.operation_in_progress")
     def test_original_stack_assigned_when_safe_apply_checked(self, _):
         stack = mock.MagicMock()
+        stack.id = "123"
         self.presenter.stack = stack
-        stack_data = "THIS IS USEFUL STACK DATA"
-        stack.copy.return_value = stack_data
+        stack_copy = "THIS IS USEFUL STACK DATA"
+        stack.copy.return_value = stack_copy
         self.presenter._do_apply_filter = mock.MagicMock()
 
         self.presenter.do_apply_filter()
 
         stack.copy.assert_called_once()
-        self.assertEqual(stack_data, self.presenter.original_images_stack)
+        self.assertDictEqual({stack.id: stack_copy}, self.presenter.original_images_stack)
 
     def test_set_filter_by_name(self):
         NAME = "ROI Normalisation"

--- a/mantidimaging/gui/windows/stack_choice/presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/presenter.py
@@ -2,8 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import traceback
-from typing import TYPE_CHECKING, Optional
-from uuid import UUID
+from typing import TYPE_CHECKING
 
 from mantidimaging.core.data.imagestack import ImageStack
 from mantidimaging.gui.windows.stack_choice.presenter_base import StackChoicePresenterMixin
@@ -15,14 +14,13 @@ if TYPE_CHECKING:
 
 class StackChoicePresenter(StackChoicePresenterMixin):
     def __init__(self, original_stack: ImageStack, new_stack: ImageStack,
-                 operations_presenter: 'FiltersWindowPresenter', stack_uuid: Optional[UUID]):
+                 operations_presenter: 'FiltersWindowPresenter'):
 
         self.operations_presenter = operations_presenter
         self.original_stack = original_stack
 
         self.view = StackChoiceView(self.original_stack, new_stack, self, parent=operations_presenter.view)
         self.new_stack = new_stack
-        self.stack_uuid = stack_uuid
         self.done = False
         self.use_new_data = False
 

--- a/mantidimaging/gui/windows/stack_choice/presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/presenter.py
@@ -21,23 +21,17 @@ def _get_stack_from_uuid(original_stack, stack_uuid):
 
 
 class StackChoicePresenter(StackChoicePresenterMixin):
-    def __init__(self,
-                 original_stack: Union[List[Tuple[ImageStack, UUID]], ImageStack],
-                 new_stack: ImageStack,
-                 operations_presenter: 'FiltersWindowPresenter',
-                 stack_uuid: Optional[UUID],
-                 view: Optional[StackChoiceView] = None):
+    def __init__(self, original_stack: Union[List[Tuple[ImageStack, UUID]], ImageStack], new_stack: ImageStack,
+                 operations_presenter: 'FiltersWindowPresenter', stack_uuid: Optional[UUID]):
         self.operations_presenter = operations_presenter
 
-        if view is None:
-            # Check if multiple stacks to choose from
-            if isinstance(original_stack, list):
-                self.original_stack = _get_stack_from_uuid(original_stack, stack_uuid)
-            else:
-                self.original_stack = original_stack
-            view = StackChoiceView(self.original_stack, new_stack, self, parent=operations_presenter.view)
+        # Check if multiple stacks to choose from
+        if isinstance(original_stack, list):
+            self.original_stack = _get_stack_from_uuid(original_stack, stack_uuid)
+        else:
+            self.original_stack = original_stack
 
-        self.view = view
+        self.view = StackChoiceView(self.original_stack, new_stack, self, parent=operations_presenter.view)
         self.new_stack = new_stack
         self.stack_uuid = stack_uuid
         self.done = False

--- a/mantidimaging/gui/windows/stack_choice/tests/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/presenter_test.py
@@ -23,15 +23,14 @@ class StackChoicePresenterTest(unittest.TestCase):
         self.uuid = uuid4()
         self.p = StackChoicePresenter(original_stack=self.original_stack,
                                       new_stack=self.new_stack,
-                                      operations_presenter=self.op_p,
-                                      stack_uuid=self.uuid)
+                                      operations_presenter=self.op_p)
         self.v = self.p.view
 
     @mock.patch("mantidimaging.gui.windows.stack_choice.presenter.StackChoiceView")
     def test_presenter_doesnt_raise_lists_for_original_stack(self, _):
         single_stack_uuid = uuid4()
         original_stack = [(th.generate_images(), single_stack_uuid), (th.generate_images(), uuid4())]
-        StackChoicePresenter(original_stack, mock.MagicMock(), mock.MagicMock(), single_stack_uuid)
+        StackChoicePresenter(original_stack, mock.MagicMock(), mock.MagicMock())
 
     def test_show_calls_show_in_the_view(self):
         self.p.show()

--- a/mantidimaging/gui/windows/stack_choice/tests/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/presenter_test.py
@@ -15,28 +15,29 @@ from mantidimaging.core.data.imagestack import ImageStack
 
 
 class StackChoicePresenterTest(unittest.TestCase):
-    def setUp(self):
+    @mock.patch("mantidimaging.gui.windows.stack_choice.presenter.StackChoiceView")
+    def setUp(self, _):
         self.original_stack = th.generate_images()
         self.new_stack = th.generate_images()
-        self.v = mock.MagicMock()
         self.op_p = mock.MagicMock()
         self.uuid = uuid4()
         self.p = StackChoicePresenter(original_stack=self.original_stack,
                                       new_stack=self.new_stack,
                                       operations_presenter=self.op_p,
-                                      stack_uuid=self.uuid,
-                                      view=self.v)
+                                      stack_uuid=self.uuid)
+        self.v = self.p.view
 
-    def test_presenter_doesnt_raise_lists_for_original_stack(self):
+    @mock.patch("mantidimaging.gui.windows.stack_choice.presenter.StackChoiceView")
+    def test_presenter_doesnt_raise_lists_for_original_stack(self, _):
         single_stack_uuid = uuid4()
         original_stack = [(th.generate_images(), single_stack_uuid), (th.generate_images(), uuid4())]
-        StackChoicePresenter(original_stack, mock.MagicMock(), mock.MagicMock(), single_stack_uuid, mock.MagicMock())
+        StackChoicePresenter(original_stack, mock.MagicMock(), mock.MagicMock(), single_stack_uuid)
 
     @mock.patch("mantidimaging.gui.windows.stack_choice.presenter.StackChoiceView")
     def test_presenter_throws_if_uuid_is_not_in_stack(self, _):
         original_stack = [(th.generate_images(), uuid4()), (th.generate_images(), uuid4())]
         with self.assertRaises(RuntimeError):
-            StackChoicePresenter(original_stack, mock.MagicMock(), mock.MagicMock(), uuid4(), None)
+            StackChoicePresenter(original_stack, mock.MagicMock(), mock.MagicMock(), uuid4())
 
     def test_show_calls_show_in_the_view(self):
         self.p.show()

--- a/mantidimaging/gui/windows/stack_choice/tests/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/presenter_test.py
@@ -33,12 +33,6 @@ class StackChoicePresenterTest(unittest.TestCase):
         original_stack = [(th.generate_images(), single_stack_uuid), (th.generate_images(), uuid4())]
         StackChoicePresenter(original_stack, mock.MagicMock(), mock.MagicMock(), single_stack_uuid)
 
-    @mock.patch("mantidimaging.gui.windows.stack_choice.presenter.StackChoiceView")
-    def test_presenter_throws_if_uuid_is_not_in_stack(self, _):
-        original_stack = [(th.generate_images(), uuid4()), (th.generate_images(), uuid4())]
-        with self.assertRaises(RuntimeError):
-            StackChoicePresenter(original_stack, mock.MagicMock(), mock.MagicMock(), uuid4())
-
     def test_show_calls_show_in_the_view(self):
         self.p.show()
 
@@ -66,20 +60,7 @@ class StackChoicePresenterTest(unittest.TestCase):
 
         self.p.do_clean_up_original_data.assert_called_once()
 
-    def test_clean_up_original_images_stack(self):
-        self.op_p.original_images_stack = [(1, self.uuid), (2, uuid4())]
-
-        self.p._clean_up_original_images_stack()
-
-        self.assertEqual(1, len(self.op_p.original_images_stack))
-        self.assertEqual(2, self.op_p.original_images_stack[0][0])
-
-        self.p._clean_up_original_images_stack()
-
-        self.assertEqual(None, self.op_p.original_images_stack)
-
     def test_do_reapply_original_data(self):
-        self.p._clean_up_original_images_stack = mock.MagicMock()
         self.p.close_view = mock.MagicMock()
         img1 = ImageStack(np.zeros((3, 3, 3)) + 1)
         img1.metadata = {"name": 1}
@@ -92,18 +73,15 @@ class StackChoicePresenterTest(unittest.TestCase):
 
         self.assertEqual(self.p.new_stack.data[0, 0, 0], 1)
         self.assertEqual(self.p.new_stack.metadata["name"], 1)
-        self.p._clean_up_original_images_stack.assert_called_once()
         self.assertTrue(self.v.choice_made)
         self.p.close_view.assert_called_once()
 
     def test_do_clean_up_original_data(self):
         self.p.original_stack = mock.MagicMock()
-        self.p._clean_up_original_images_stack = mock.MagicMock()
         self.p.close_view = mock.MagicMock()
 
         self.p.do_clean_up_original_data()
 
-        self.p._clean_up_original_images_stack.assert_called_once()
         self.assertTrue(self.v.choice_made)
         self.p.close_view.assert_called_once()
 


### PR DESCRIPTION
### Issue

Related to #1558 

### Description

I can't reproduce the issue in #1558, but there were some opportunities for cleanups around the code in question. This should make any future debugging easier.

### Testing 

Apply an operation to a single stack with safe apply enabled

Apply an operation to all stacks with safe apply enabled

### Acceptance Criteria 

Everything should still work

### Documentation

Not needed
