### PR TITLE
Timeout fixes

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -104,7 +104,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov --run-system-tests --durations=10
-        timeout-minutes: 30
+        timeout-minutes: 15
 
       - name: Set display resolution for screenshot tests
         run: |

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -38,6 +38,11 @@ class GuiSystemBase(unittest.TestCase):
         QTest.qWait(SHORT_DELAY)
 
     def tearDown(self) -> None:
+        """
+        Closes the main window
+        Will report any leaked images
+        Expects all other windows to be closed, otherwise will raise a RuntimeError
+        """
         QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("Yes"))
         self.main_window.close()
         QTest.qWait(SHORT_DELAY)
@@ -67,7 +72,10 @@ class GuiSystemBase(unittest.TestCase):
 
     @classmethod
     def _click_InputDialog(cls, set_int: Optional[int] = None):
-        """Needs to be queued with QTimer.singleShot before triggering the message box"""
+        """
+        Needs to be queued with QTimer.singleShot before triggering the message box
+        Will raise a RuntimeError if a QInputDialog is not found
+        """
         for widget in cls.app.topLevelWidgets():
             if isinstance(widget, QInputDialog) and widget.isVisible():
                 if set_int:

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -74,6 +74,8 @@ class GuiSystemBase(unittest.TestCase):
                     widget.setIntValue(set_int)
                 QTest.qWait(SHORT_DELAY)
                 widget.accept()
+                return
+        raise RuntimeError("_click_InputDialog did not find QInputDialog")
 
     def _close_welcome(self):
         self.main_window.welcome_window.view.close()

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -48,6 +48,10 @@ class GuiSystemBase(unittest.TestCase):
             leak_tracker.pretty_print(debug_init=False, debug_owners=False, trace_depth=5)
             leak_tracker.clear()
 
+        for widget in self.app.topLevelWidgets():
+            if widget.isVisible():
+                RuntimeError(f"\n\nWindow still open {widget=}")
+
     @classmethod
     def _click_messageBox(cls, button_text: str):
         """Needs to be queued with QTimer.singleShot before triggering the message box"""

--- a/mantidimaging/gui/test/gui_system_operations_test.py
+++ b/mantidimaging/gui/test/gui_system_operations_test.py
@@ -57,6 +57,9 @@ class TestGuiSystemOperations(GuiSystemBase):
         self.op_window = self.main_window.filters
 
     def tearDown(self) -> None:
+        if self.main_window.filters:
+            self.main_window.filters.close()
+        QTest.qWait(SHOW_DELAY)
         self._close_image_stacks()
         super().tearDown()
         self.assertFalse(self.main_window.isVisible())
@@ -107,9 +110,6 @@ class TestGuiSystemOperations(GuiSystemBase):
         QTest.qWait(SHORT_DELAY)
         wait_until(lambda: self.op_window.presenter.filter_is_running is False, max_retry=600)
 
-        self.main_window.filters.close()
-        QTest.qWait(SHOW_DELAY)
-
     @parameterized.expand(product(OP_LIST[:3], ["new", "original"]))
     def test_run_operation_stack_safe(self, op_info, keep_stack):
         op_name, params = op_info
@@ -150,8 +150,6 @@ class TestGuiSystemOperations(GuiSystemBase):
 
             QTest.qWait(SHORT_DELAY)
             wait_until(lambda: self.op_window.presenter.filter_is_running is False)
-            self.main_window.filters.close()
-            QTest.qWait(SHOW_DELAY)
 
     @mock.patch("mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter.do_update_previews")
     def test_selecting_auto_update_triggers_preview(self, mock_do_update_previews):
@@ -187,9 +185,6 @@ class TestGuiSystemOperations(GuiSystemBase):
         QTest.qWait(SHORT_DELAY)
         wait_until(lambda: self.op_window.presenter.filter_is_running is False, max_retry=600)
 
-        self.main_window.filters.close()
-        QTest.qWait(SHOW_DELAY)
-
     @parameterized.expand([(OP_LIST[3][0], "Select ROI", "ROI"), (OP_LIST[13][0], "Select Air Region", "Air Region")])
     def test_opening_roi_selector_window_toggles_controls_correctly(self, op_name, button_name, field_name):
         QTest.qWait(SHOW_DELAY)
@@ -211,6 +206,3 @@ class TestGuiSystemOperations(GuiSystemBase):
         self._close_window(ROISelectorView)
         self.assertTrue(roi_button.isEnabled())
         self.assertTrue(roi_field.isEnabled())
-
-        self.main_window.filters.close()
-        QTest.qWait(SHOW_DELAY)

--- a/mantidimaging/gui/test/gui_system_reconstruction_test.py
+++ b/mantidimaging/gui/test/gui_system_reconstruction_test.py
@@ -54,6 +54,10 @@ class TestGuiSystemReconstruction(GuiSystemBase):
 
     @classmethod
     def _click_cor_inspect(cls):
+        """
+        Needs to be queued with QTimer.singleShot before triggering the message box
+        Will raise a RuntimeError if a CORInspectionDialogView is not found
+        """
         cls._wait_for_widget_visible(CORInspectionDialogView)
         for widget in cls.app.topLevelWidgets():
             if isinstance(widget, CORInspectionDialogView):

--- a/mantidimaging/gui/test/gui_system_reconstruction_test.py
+++ b/mantidimaging/gui/test/gui_system_reconstruction_test.py
@@ -71,6 +71,7 @@ class TestGuiSystemReconstruction(GuiSystemBase):
             QTimer.singleShot(SHORT_DELAY, lambda: self._click_cor_inspect())
             QTest.mouseClick(self.recon_window.refineCorBtn, Qt.MouseButton.LeftButton)
             QTest.qWait(SHORT_DELAY * 2)
+            wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
 
         QTest.qWait(SHOW_DELAY)
 

--- a/mantidimaging/gui/test/gui_system_reconstruction_test.py
+++ b/mantidimaging/gui/test/gui_system_reconstruction_test.py
@@ -59,6 +59,8 @@ class TestGuiSystemReconstruction(GuiSystemBase):
             if isinstance(widget, CORInspectionDialogView):
                 QTest.qWait(SHORT_DELAY)
                 QTest.mouseClick(widget.finishButton, Qt.MouseButton.LeftButton)
+                return
+        raise RuntimeError("_click_InputDialog did not find CORInspectionDialogView")
 
     def test_refine(self):
         QTimer.singleShot(SHORT_DELAY, lambda: self._click_InputDialog(set_int=4))

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -307,6 +307,7 @@ class ReconstructWindowPresenter(BasePresenter):
                                          self.view.recon_params(), False)
 
         res = dialog.exec()
+        dialog.deleteLater()
         LOG.debug('COR refine dialog result: {}'.format(res))
         if res == CORInspectionDialogView.Accepted:
             new_cor = dialog.optimal_rotation_centre


### PR DESCRIPTION
### Issue

Some changes to try to isolate #1641 . 

Turns some possible hangs into exceptions. May not fix all the timeouts, by might mean that we get a backtrace that helps with debugging.

### Description

Make sure that all windows are closed during tearDown(). Prevents things being left open which could effect other tests. Fix a couple of operations tests that did not close the operations window.

For `_click_messageBox()` and `_click_cor_inspect()` raise a runtime error if they are called, but don't find a dialog to work on. This would catch the case were they are called before the dialog is open, which would then cause a hang when the dialog did open.

Reduce timeout to 15mins, because successful runs have recently been below 12 mins.

### Testing 

I can't trigger the hang locally. The hope is that this would improve the error messages on github actions.

### Documentation

Not needed
