### PR TITLE
1622 table of rois

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -11,6 +11,7 @@ New Features and improvements
 - #1625 : Allow adding extra stacks to a dataset
 - #1625 : Load recons to an existing dataset
 - #1625 : Change selection in tree view when switching tabs
+- #1622 : Add, Remove and Rename ROIs in spectrum viewer
 
 Fixes
 -----

--- a/mantidimaging/gui/ui/spectrum_viewer.ui
+++ b/mantidimaging/gui/ui/spectrum_viewer.ui
@@ -206,16 +206,6 @@
                                                             </property>
                                                         </widget>
                                                     </item>
-                                                    <item row="1" column="0">
-                                                        <widget class="QPushButton" name="clearAllBtn">
-                                                            <property name="toolTip">
-                                                                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Removes all rows from the table.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                                                            </property>
-                                                            <property name="text">
-                                                                <string>Clear All</string>
-                                                            </property>
-                                                        </widget>
-                                                    </item>
                                                 </layout>
                                             </item>
                                         </layout>

--- a/mantidimaging/gui/ui/spectrum_viewer.ui
+++ b/mantidimaging/gui/ui/spectrum_viewer.ui
@@ -216,16 +216,6 @@
                                                             </property>
                                                         </widget>
                                                     </item>
-                                                    <item row="1" column="1">
-                                                        <widget class="QPushButton" name="refineroiBtn">
-                                                            <property name="enabled">
-                                                                <bool>false</bool>
-                                                            </property>
-                                                            <property name="text">
-                                                                <string>Refine</string>
-                                                            </property>
-                                                        </widget>
-                                                    </item>
                                                 </layout>
                                             </item>
                                         </layout>

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -170,3 +170,10 @@ class SpectrumViewerWindowModel:
 
         with path.open("w") as outfile:
             csv_output.write(outfile)
+
+    def remove_all_roi(self) -> None:
+        """
+        Remove all ROIs from the model if not 'all' and 'roi'
+        """
+        self._roi_ranges = {key: value for key, value in self._roi_ranges.items() if key in ["all", "roi"]}
+        self._roi_id_counter = 0  # Reset the counter for the next new ROI

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -177,3 +177,16 @@ class SpectrumViewerWindowModel:
         """
         self._roi_ranges = {key: value for key, value in self._roi_ranges.items() if key in ["all", "roi"]}
         self._roi_id_counter = 0  # Reset the counter for the next new ROI
+
+    def remove_roi(self, roi_name) -> None:
+        """
+        Remove the selected ROI from the model
+        """
+
+        if roi_name in self._roi_ranges.keys():
+            if roi_name in ["all", "roi"]:
+                raise RuntimeError("Cannot remove the 'all' or 'roi' ROIs")
+            self._roi_ranges.pop(roi_name)
+        else:
+            raise KeyError(
+                f"Cannot remove ROI {roi_name} as it does not exist. \n Available ROIs: {self._roi_ranges.keys()}")

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -196,7 +196,7 @@ class SpectrumViewerWindowModel:
         if roi_name in self._roi_ranges.keys():
             if roi_name in ["all", "roi"]:
                 raise RuntimeError("Cannot remove the 'all' or 'roi' ROIs")
-            self._roi_ranges.pop(roi_name)
+            del self._roi_ranges[roi_name]
         else:
             raise KeyError(
                 f"Cannot remove ROI {roi_name} as it does not exist. \n Available ROIs: {self._roi_ranges.keys()}")

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -179,13 +179,6 @@ class SpectrumViewerWindowModel:
         with path.open("w") as outfile:
             csv_output.write(outfile)
 
-    def remove_all_roi(self) -> None:
-        """
-        Remove all ROIs from the model if not 'all' and 'roi'
-        """
-        self._roi_ranges = {key: value for key, value in self._roi_ranges.items() if key in ["all", "roi"]}
-        self._roi_id_counter = 0  # Reset the counter for the next new ROI
-
     def remove_roi(self, roi_name) -> None:
         """
         Remove the selected ROI from the model

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -190,3 +190,19 @@ class SpectrumViewerWindowModel:
         else:
             raise KeyError(
                 f"Cannot remove ROI {roi_name} as it does not exist. \n Available ROIs: {self._roi_ranges.keys()}")
+
+    def rename_roi(self, old_name: str, new_name: str) -> None:
+        """
+        Rename the selected ROI from the model
+
+        :param old_name: The current name of the ROI
+        :param new_name: The new name of the ROI
+        :raises KeyError: If the ROI does not exist
+        :raises RuntimeError: If the ROI is 'all' or 'roi'
+        """
+        if old_name in self._roi_ranges.keys():
+            if old_name in ["all", "roi"]:
+                raise RuntimeError("Cannot rename the 'all' or 'roi' ROIs")
+            self._roi_ranges[new_name] = self._roi_ranges.pop(old_name)
+        else:
+            raise KeyError(f"Cannot rename ROI {old_name} Available ROIs:{self._roi_ranges.keys()}")

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -31,6 +31,18 @@ class SpectrumViewerWindowModel:
         self.presenter = presenter
         self._roi_id_counter = 0
         self._roi_ranges = {}
+        self._selected_row = 0
+
+    @property
+    def selected_row(self):
+        return self._selected_row
+
+    @selected_row.setter
+    def selected_row(self, value):
+        self._selected_row = value
+
+    def reset_selected_row(self):
+        self.selected_row = 0
 
     def roi_name_generator(self) -> str:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -21,6 +21,12 @@ class SpecType(Enum):
 
 
 class SpectrumViewerWindowModel:
+    """
+    The model for the spectrum viewer window.
+    This model is responsible for storing the state of the window and providing
+    the presenter with the data it needs to update the view.
+    The model is also responsible for saving ROI data to a csv file.
+    """
     presenter: 'SpectrumViewerWindowPresenter'
     _stack: Optional[ImageStack] = None
     _normalise_stack: Optional[ImageStack] = None
@@ -71,6 +77,8 @@ class SpectrumViewerWindowModel:
     def set_new_roi(self, name: str) -> None:
         """
         Sets a new ROI with the given name
+
+        @param name: The name of the new ROI
         """
         height, width = self.get_image_shape()
         self.set_roi(name, SensibleROI.from_list([0, 0, width, height]))
@@ -85,8 +93,8 @@ class SpectrumViewerWindowModel:
         """
         Get the ROI with the given name from the model
 
-        :param roi_name: The name of the ROI to get
-        :return: The ROI with the given name
+        @param roi_name: The name of the ROI to get
+        @return: The ROI with the given name
         """
         if roi_name not in self._roi_ranges.keys():
             raise KeyError(f"ROI {roi_name} does not exist")
@@ -151,8 +159,8 @@ class SpectrumViewerWindowModel:
         """
         Iterates over all ROIs and saves the spectrum for each one to a CSV file.
 
-        :param path: The path to save the CSV file to.
-        :param normalized: Whether to save the normalized spectrum.
+        @param path: The path to save the CSV file to.
+        @param normalized: Whether to save the normalized spectrum.
         """
         if self._stack is None:
             raise ValueError("No stack selected")
@@ -181,6 +189,8 @@ class SpectrumViewerWindowModel:
     def remove_roi(self, roi_name) -> None:
         """
         Remove the selected ROI from the model
+
+        @param roi_name: The name of the ROI to remove
         """
 
         if roi_name in self._roi_ranges.keys():
@@ -195,10 +205,10 @@ class SpectrumViewerWindowModel:
         """
         Rename the selected ROI from the model
 
-        :param old_name: The current name of the ROI
-        :param new_name: The new name of the ROI
-        :raises KeyError: If the ROI does not exist
-        :raises RuntimeError: If the ROI is 'all' or 'roi'
+        @param old_name: The current name of the ROI
+        @param new_name: The new name of the ROI
+        @raises KeyError: If the ROI does not exist
+        @raises RuntimeError: If the ROI is 'all' or 'roi'
         """
         if old_name in self._roi_ranges.keys():
             if old_name in ["all", "roi"]:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -93,6 +93,12 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.spectrum.add_roi(self.model.get_roi("roi"), "roi")
         self.view.auto_range_image()
 
+    def get_default_table_state(self) -> list:
+        """
+        Get the default state of the table
+        """
+        return ["roi", self.view.spectrum.roi_dict["roi"].colour]
+
     def handle_range_slide_moved(self, tof_range) -> None:
         self.model.tof_range = tof_range
         self.view.set_image(self.model.get_averaged_image(), autoLevels=False)
@@ -146,9 +152,14 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         Add a given ROI to the table
         """
-        # self.view.spectrum.add_roi(self.model.get_roi(roi_name), roi_name)
         row = self.model.selected_row
         roi_colour = self.view.spectrum.roi_dict[roi_name].colour
-        print(
-            f"Presenter row, roi_name and colour to be sent to view add_roi_table_row: {row}, {roi_name}, {roi_colour}")
         self.view.add_roi_table_row(row, roi_name, roi_colour)
+
+    def do_clear_all_rois(self) -> None:
+        """
+        Clear all ROIs from the spectrum viewer
+        """
+
+        self.model.remove_all_roi()
+        self.view.spectrum.remove_all_rois()

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -172,20 +172,14 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         roi_colour = self.view.spectrum.roi_dict[roi_name].colour
         self.view.add_roi_table_row(row, roi_name, roi_colour)
 
-    def do_remove_roi(self, roi_name=None) -> None:
+    def do_remove_roi(self, roi_name: str) -> None:
         """
         Remove a given ROI from the table by ROI name or all ROIs from the table
 
         @param roi_name: Name of the ROI to remove
         """
-
-        if roi_name is None:
-            for roi_item in self.get_roi_names():
-                self.view.spectrum.remove_roi(roi_item)
-            self.model.remove_all_roi()
-        else:
-            self.view.spectrum.remove_roi(roi_name)
-            self.model.remove_roi(roi_name)
+        self.view.spectrum.remove_roi(roi_name)
+        self.model.remove_roi(roi_name)
 
     def rename_roi(self, old_name: str, new_name: str) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -166,19 +166,19 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         roi_colour = self.view.spectrum.roi_dict[roi_name].colour
         self.view.add_roi_table_row(row, roi_name, roi_colour)
 
-    def do_clear_all_rois(self) -> None:
+    def do_remove_roi(self, roi_name=None) -> None:
         """
-        Clear all ROIs from the spectrum viewer
-        """
-
-        self.model.remove_all_roi()
-        self.view.spectrum.remove_all_rois()
-
-    def do_remove_selected_roi(self, roi_name) -> None:
-        """
-        Remove the currently selected ROI from the spectrum viewer
+        Remove a given ROI from the table by ROI name or all ROIs from the table
 
         @param roi_name: Name of the ROI to remove
         """
-        self.model.remove_roi(roi_name)
-        self.view.spectrum.remove_roi(roi_name)
+
+        if roi_name is None:
+            self.model.remove_all_roi()
+
+            for roi_item in self.get_roi_names():
+                self.view.spectrum.remove_roi(roi_item)
+            # self.view.spectrum.remove_all_rois()
+        else:
+            self.model.remove_roi(roi_name)
+            self.view.spectrum.remove_roi(roi_name)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -180,13 +180,12 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
 
         if roi_name is None:
-            self.model.remove_all_roi()
-
             for roi_item in self.get_roi_names():
                 self.view.spectrum.remove_roi(roi_item)
+            self.model.remove_all_roi()
         else:
-            self.model.remove_roi(roi_name)
             self.view.spectrum.remove_roi(roi_name)
+            self.model.remove_roi(roi_name)
 
     def rename_roi(self, old_name: str, new_name: str) -> None:
         """
@@ -195,5 +194,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         @param old_name: Name of the ROI to rename
         @param new_name: New name of the ROI
         """
-        self.model.rename_roi(old_name, new_name)
+
         self.view.spectrum.rename_roi(old_name, new_name)
+        self.model.rename_roi(old_name, new_name)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -140,3 +140,15 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.set_spectrum(self.model.get_spectrum(roi_name, self.spectrum_mode))
         self.view.spectrum.add_roi(self.model.get_roi(roi_name), roi_name)
         self.view.auto_range_image()
+        self.do_add_roi_to_table(roi_name)
+
+    def do_add_roi_to_table(self, roi_name: str) -> None:
+        """
+        Add a given ROI to the table
+        """
+        # self.view.spectrum.add_roi(self.model.get_roi(roi_name), roi_name)
+        row = self.model.selected_row
+        roi_colour = self.view.spectrum.roi_dict[roi_name].colour
+        print(
+            f"Presenter row, roi_name and colour to be sent to view add_roi_table_row: {row}, {roi_name}, {roi_colour}")
+        self.view.add_roi_table_row(row, roi_name, roi_colour)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -137,6 +137,14 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.handle_roi_moved()
         self.view.display_normalise_error()
 
+    def get_roi_names(self) -> list:
+        """
+        Return a list of ROI names
+
+        @return: list of ROI names
+        """
+        return self.model.get_list_of_roi_names()
+
     def do_add_roi(self) -> None:
         """
         Add a new ROI to the spectrum
@@ -150,7 +158,9 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def do_add_roi_to_table(self, roi_name: str) -> None:
         """
-        Add a given ROI to the table
+        Add a given ROI to the table by ROI name
+
+        @param roi_name: Name of the ROI to add
         """
         row = self.model.selected_row
         roi_colour = self.view.spectrum.roi_dict[roi_name].colour
@@ -163,3 +173,12 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
         self.model.remove_all_roi()
         self.view.spectrum.remove_all_rois()
+
+    def do_remove_selected_roi(self, roi_name) -> None:
+        """
+        Remove the currently selected ROI from the spectrum viewer
+
+        @param roi_name: Name of the ROI to remove
+        """
+        self.model.remove_roi(roi_name)
+        self.view.spectrum.remove_roi(roi_name)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -14,6 +14,12 @@ if TYPE_CHECKING:
 
 
 class SpectrumViewerWindowPresenter(BasePresenter):
+    """
+    The presenter for the spectrum viewer window.
+
+    This presenter is responsible for handling user interaction with the view and
+    updating the model and view accordingly to look after the state of the window.
+    """
     view: 'SpectrumViewerWindowView'
     model: SpectrumViewerWindowModel
     spectrum_mode: SpecType = SpecType.SAMPLE
@@ -178,7 +184,16 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
             for roi_item in self.get_roi_names():
                 self.view.spectrum.remove_roi(roi_item)
-            # self.view.spectrum.remove_all_rois()
         else:
             self.model.remove_roi(roi_name)
             self.view.spectrum.remove_roi(roi_name)
+
+    def rename_roi(self, old_name: str, new_name: str) -> None:
+        """
+        Rename a given ROI from the table by ROI name
+
+        @param old_name: Name of the ROI to rename
+        @param new_name: New name of the ROI
+        """
+        self.model.rename_roi(old_name, new_name)
+        self.view.spectrum.rename_roi(old_name, new_name)

--- a/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
@@ -54,6 +54,21 @@ class TableModel(QAbstractTableModel):
             if index.column() == 1:
                 return QBrush(QColor(*self._data[index.row()][index.column()]))
 
+    # edit roi name on double click
+    def setData(self, index, value, role):
+        """
+        Set data in table
+
+        @param index: index of selected row
+        @param value: new value
+        @param role: Qt.EditRole
+        @return: True
+        """
+        if role == Qt.EditRole:
+            self._data[index.row()][index.column()] = value
+            self.dataChanged.emit(index, index)
+            return True
+
     def row_data(self, row: int) -> tuple:
         """
         Return data from selected row
@@ -115,15 +130,33 @@ class TableModel(QAbstractTableModel):
         else:
             print(f"Cannot remove row: {row}")
 
+    def rename_row(self, row: int, new_name: str) -> None:
+        """
+        Rename selected row if new name does not already exist
+        in table and is not default 'roi' ROI or duplicate
+
+        @param row: row number
+        @param new_name: new ROI name
+        @raise ValueError: if new name already exists or is default 'roi' ROI
+        """
+        if row > 0 and row < len(self._data):
+            if new_name in self.roi_names():
+                raise ValueError("ROI name already exists")
+            self._data[row][0] = new_name
+            self.layoutChanged.emit()
+        else:
+            raise ValueError(f"Cannot rename row: {row}")
+
     def flags(self, index):
         """
         Handle selection of table rows to disable selection of ROI colour column
+        if index is equal to roi, item not editable
 
         @param index: index of selected row
         @return: Qt.ItemIsEnabled | Qt.ItemIsSelectable
         """
-        if index.column() == 0:
-            return Qt.ItemIsEnabled | Qt.ItemIsSelectable
+        if index.column() == 0 and index.row() > 0:
+            return Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsEditable
         else:
             return Qt.ItemIsEnabled
 

--- a/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
@@ -1,0 +1,136 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+# Contains ROI table model class which will be used to store ROI information
+# and display it in the spectrum viewer.
+
+# Dependencies
+from PyQt5.QtCore import QAbstractTableModel, Qt
+from PyQt5.QtGui import QColor, QBrush
+
+
+class TableModel(QAbstractTableModel):
+    """
+    A subclass of QAbstractTableModel.
+    Model for table view of ROI names and colours in Spectrum Viewer window to allow
+    user to select which ROIs to plot.
+
+
+    @param data: list of lists of ROI names and colours [str, tuple(int,int,int)]
+    """
+    def __init__(self, data):
+        super(TableModel, self).__init__()
+        self._data = data
+
+    def rowCount(self, *args, **kwargs):
+        """
+        Return number of rows in table
+
+        @return: number of rows in table
+        """
+        return len(self._data)
+
+    def columnCount(self, *args, **kwargs):
+        """
+        Return number of columns in table
+
+        @return: number of columns in table
+        """
+        return len(self._data[0])
+
+    def data(self, index, role):
+        """
+        Set data in table roi name and colour - str and Tuple(int,int,int)
+        and set background colour of colour column
+
+        @param index: index of selected row
+        @param role: Qt.DisplayRole or Qt.BackgroundRole
+        @return: ROI name or colour values and background colour of colour column
+        """
+        if role == Qt.DisplayRole:
+            return self._data[index.row()][index.column()]
+
+        if role == Qt.BackgroundRole:
+            if index.column() == 1:
+                return QBrush(QColor(*self._data[index.row()][index.column()]))
+
+    def row_data(self, row: int) -> tuple:
+        """
+        Return data from selected row
+
+        @param row: row number
+        @return: data from selected rows
+        """
+        return self._data[row]
+
+    def appendNewRow(self, roi_name: str, roi_colour: tuple):
+        """
+        Append new row to table
+
+        @param roi_name: ROI name
+        @param roi_colour: ROI colour
+        """
+        item_list = [roi_name, roi_colour]
+        self._data.append(item_list)
+        self.layoutChanged.emit()
+
+    def sort_points(self):
+        """
+        Sort table by ROI name
+        """
+        self._data.sort(key=lambda x: x[0])
+
+    def headerData(self, section, orientation, role):
+        """
+        Set horizontal colum header names to ROI and Colour
+
+        @param section: column number
+        @param orientation: horizontal
+        @param role: Qt.DisplayRole
+        @return: ROI or Colour
+        """
+        if role == Qt.DisplayRole:
+            if orientation == Qt.Horizontal:
+                if section == 0:
+                    return "ROI"
+                if section == 1:
+                    return "Colour"
+
+    def clear_table(self) -> None:
+        """
+        Clear all data in table except 'roi' (first element in _data list)
+        """
+        self._data = self._data[:1]
+        self.layoutChanged.emit()
+
+    def remove_row(self, row: int) -> None:
+        """
+        Remove selected row from table
+
+        @param row: row number
+        """
+        if row > 0 and row < len(self._data):
+            self._data.pop(row)
+            self.layoutChanged.emit()
+        else:
+            print(f"Cannot remove row: {row}")
+
+    def flags(self, index):
+        """
+        Handle selection of table rows to disable selection of ROI colour column
+
+        @param index: index of selected row
+        @return: Qt.ItemIsEnabled | Qt.ItemIsSelectable
+        """
+        if index.column() == 0:
+            return Qt.ItemIsEnabled | Qt.ItemIsSelectable
+        else:
+            return Qt.ItemIsEnabled
+
+    def roi_names(self) -> list:
+        """
+        Return list of ROI names
+
+        @return: list of ROI names
+        """
+        return [x[0] for x in self._data]

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -182,5 +182,5 @@ class SpectrumWidget(GraphicsLayoutWidget):
         @param new_name: The new name of the ROI.
         @raise KeyError: If the new name is already in use or equal to 'roi' or 'all'.
         """
-        if old_name in self.roi_dict.keys() and new_name not in ["roi", "all"]:
+        if old_name in self.roi_dict.keys() and new_name not in self.roi_dict.keys():
             self.roi_dict[new_name] = self.roi_dict.pop(old_name)

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -154,10 +154,12 @@ class SpectrumWidget(GraphicsLayoutWidget):
         self._set_tof_range_label(tof_range[0], tof_range[1])
         self.range_changed.emit(tof_range)
 
-    def clear_data(self):
-        self.image.clear()
-        self.spectrum.clear()
-        for roi in self.roi_dict:
-            self.image.vb.removeItem(roi)
-
-        self._tof_range_label.setText('')
+    def remove_all_rois(self) -> None:
+        """
+        Remove all ROIs if not 'roi' and 'all' ROIs.
+        """
+        roi_dict_copy = self.roi_dict.copy()
+        for roi_name in roi_dict_copy.keys():
+            if roi_name not in ["roi", "all"]:
+                self.image.vb.removeItem(self.roi_dict[roi_name])
+                del self.roi_dict[roi_name]

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
-import random
 from typing import TYPE_CHECKING, Optional
 
 from PyQt5.QtCore import pyqtSignal
@@ -87,6 +86,7 @@ class SpectrumWidget(GraphicsLayoutWidget):
         self.range_control.sigRegionChanged.connect(self._handle_tof_range_changed)
 
         self.roi_dict = {}
+        self.colour_index = 0
 
     def add_range(self, range_min: int, range_max: int):
         self.range_control.setBounds((range_min, range_max))
@@ -109,7 +109,11 @@ class SpectrumWidget(GraphicsLayoutWidget):
         accessible_colours = [(255, 194, 10), (12, 123, 220), (153, 79, 0), (0, 108, 209), (225, 190, 106),
                               (64, 176, 166), (230, 97, 0), (93, 58, 155), (26, 255, 26), (75, 0, 146), (254, 254, 98),
                               (211, 95, 183), (0, 90, 181), (220, 50, 43), (26, 133, 255), (212, 17, 89)]
-        return random.choice(accessible_colours)
+        if self.colour_index == len(accessible_colours):
+            self.colour_index = 0
+        colour = accessible_colours[self.colour_index]
+        self.colour_index += 1
+        return colour
 
     def add_roi(self, roi: SensibleROI, name: str) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -18,10 +18,10 @@ class SpectrumROI(ROI):
     """
     Spectrum ROI object subclassed from pyqtgraph ROI containing ROI and associated data.
 
-    :param name: Name of the ROI
-    :param sensible_roi: Sensible ROI object containing the ROI data
-    :param args: Arguments to pass to the ROI object
-    :param kwargs: Keyword arguments to pass to the ROI object
+    @param name: Name of the ROI
+    @param sensible_roi: Sensible ROI object containing the ROI data
+    @param args: Arguments to pass to the ROI object
+    @param kwargs: Keyword arguments to pass to the ROI object
     """
     def __init__(self, name: str, sensible_roi: SensibleROI, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -58,6 +58,11 @@ class SpectrumROI(ROI):
 
 
 class SpectrumWidget(GraphicsLayoutWidget):
+    """
+    The widget containing the spectrum plot and the image projection.
+
+    @param parent: The parent widget
+    """
     image: MIMiniImageView
     spectrum: PlotItem
     range_control: LinearRegionItem
@@ -104,7 +109,7 @@ class SpectrumWidget(GraphicsLayoutWidget):
         Generates colours that are easy to see for colour blind people if colour_blind_friendly is True.
         By default colour_blind_friendly is set to False
 
-        :return: A random colour in RGB format. (0-255, 0-255, 0-255)
+        @return: A random colour in RGB format. (0-255, 0-255, 0-255)
         """
         accessible_colours = [(255, 194, 10), (12, 123, 220), (153, 79, 0), (0, 108, 209), (225, 190, 106),
                               (64, 176, 166), (230, 97, 0), (93, 58, 155), (26, 255, 26), (75, 0, 146), (254, 254, 98),
@@ -119,8 +124,8 @@ class SpectrumWidget(GraphicsLayoutWidget):
         """
         Add an ROI to the image view.
 
-        :param roi: The ROI to add.
-        :param name: The name of the ROI.
+        @param roi: The ROI to add.
+        @param name: The name of the ROI.
         """
 
         roi_object = SpectrumROI(name, roi, pos=(0, 0), rotatable=False, scaleSnap=True, translateSnap=True)
@@ -135,8 +140,8 @@ class SpectrumWidget(GraphicsLayoutWidget):
         """
         Get the ROI with the given name. If no name is given, the default ROI is returned.
 
-        :param roi_name: The name of the ROI to return.
-        :return: The ROI with the given name.
+        @param roi_name: The name of the ROI to return.
+        @return: The ROI with the given name.
         """
         if roi_name in self.roi_dict.keys():
             pos = CloseEnoughPoint(self.roi_dict[roi_name].pos())
@@ -162,7 +167,7 @@ class SpectrumWidget(GraphicsLayoutWidget):
         """
         Remove a given ROI by name unless it is 'roi' or 'all'.
 
-        :param roi_name: The name of the ROI to remove.
+        @param roi_name: The name of the ROI to remove.
         """
 
         if roi_name in self.roi_dict.keys() and roi_name not in ["roi", "all"]:

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -168,3 +168,14 @@ class SpectrumWidget(GraphicsLayoutWidget):
         if roi_name in self.roi_dict.keys() and roi_name not in ["roi", "all"]:
             self.image.vb.removeItem(self.roi_dict[roi_name])
             del self.roi_dict[roi_name]
+
+    def rename_roi(self, old_name: str, new_name: str) -> None:
+        """
+        Rename a given ROI by name unless it is 'roi' or 'all'.
+
+        @param old_name: The name of the ROI to rename.
+        @param new_name: The new name of the ROI.
+        @raise KeyError: If the new name is already in use or equal to 'roi' or 'all'.
+        """
+        if old_name in self.roi_dict.keys() and new_name not in ["roi", "all"]:
+            self.roi_dict[new_name] = self.roi_dict.pop(old_name)

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -158,12 +158,13 @@ class SpectrumWidget(GraphicsLayoutWidget):
         self._set_tof_range_label(tof_range[0], tof_range[1])
         self.range_changed.emit(tof_range)
 
-    def remove_all_rois(self) -> None:
+    def remove_roi(self, roi_name: str) -> None:
         """
-        Remove all ROIs if not 'roi' and 'all' ROIs.
+        Remove a given ROI by name unless it is 'roi' or 'all'.
+
+        :param roi_name: The name of the ROI to remove.
         """
-        roi_dict_copy = self.roi_dict.copy()
-        for roi_name in roi_dict_copy.keys():
-            if roi_name not in ["roi", "all"]:
-                self.image.vb.removeItem(self.roi_dict[roi_name])
-                del self.roi_dict[roi_name]
+
+        if roi_name in self.roi_dict.keys() and roi_name not in ["roi", "all"]:
+            self.image.vb.removeItem(self.roi_dict[roi_name])
+            del self.roi_dict[roi_name]

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -244,7 +244,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.model.set_stack(generate_images())
         with self.assertRaises(RuntimeError):
             self.model.remove_roi("all")
-            self.assertEqual(self.model.get_list_of_roi_names(), ["all", "roi"])
+        self.assertEqual(self.model.get_list_of_roi_names(), ["all", "roi"])
 
     def test_WHEN_invalid_roi_removed_THEN_keyerror_raised(self):
         self.model.set_stack(generate_images())

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -232,3 +232,21 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     def test_WHEN_stack_value_set_THEN_can_export_returns_(self, _, image_stack, expected):
         self.model.set_stack(image_stack)
         self.assertEqual(self.model.can_export(), expected)
+
+    def test_WHEN_roi_removed_THEN_roi_name_removed_from_list_of_roi_names(self):
+        self.model.set_stack(generate_images())
+        self.model.set_new_roi("new_roi")
+        self.assertEqual(self.model.get_list_of_roi_names(), ["all", "roi", "new_roi"])
+        self.model.remove_roi("new_roi")
+        self.assertEqual(self.model.get_list_of_roi_names(), ["all", "roi"])
+
+    def test_WHEN_remove_roi_called_with_default_roi_THEN_raise_runtime_error(self):
+        self.model.set_stack(generate_images())
+        with self.assertRaises(RuntimeError):
+            self.model.remove_roi("all")
+            self.assertEqual(self.model.get_list_of_roi_names(), ["all", "roi"])
+
+    def test_WHEN_invalid_roi_removed_THEN_keyerror_raised(self):
+        self.model.set_stack(generate_images())
+        with self.assertRaises(KeyError):
+            self.model.remove_roi("non_existent_roi")

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -212,13 +212,13 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
     def test_WHEN_get_list_of_roi_names_called_THEN_correct_list_returned(self):
         self.model.set_stack(generate_images())
-        self.assertEqual(self.model.get_list_of_roi_names(), ["all", "roi"])
+        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi"])
 
     def test_when_new_roi_set_THEN_roi_name_added_to_list_of_roi_names(self):
         self.model.set_stack(generate_images())
         self.model.set_new_roi("new_roi")
         self.assertTrue(self.model.get_roi("new_roi"))
-        self.assertEqual(self.model.get_list_of_roi_names(), ["all", "roi", "new_roi"])
+        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi", "new_roi"])
 
     def test_WHEN_get_roi_called_with_non_existent_name_THEN_error_raised(self):
         self.model.set_stack(generate_images())
@@ -236,15 +236,15 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     def test_WHEN_roi_removed_THEN_roi_name_removed_from_list_of_roi_names(self):
         self.model.set_stack(generate_images())
         self.model.set_new_roi("new_roi")
-        self.assertEqual(self.model.get_list_of_roi_names(), ["all", "roi", "new_roi"])
+        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi", "new_roi"])
         self.model.remove_roi("new_roi")
-        self.assertEqual(self.model.get_list_of_roi_names(), ["all", "roi"])
+        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi"])
 
     def test_WHEN_remove_roi_called_with_default_roi_THEN_raise_runtime_error(self):
         self.model.set_stack(generate_images())
         with self.assertRaises(RuntimeError):
             self.model.remove_roi("all")
-        self.assertEqual(self.model.get_list_of_roi_names(), ["all", "roi"])
+        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi"])
 
     def test_WHEN_invalid_roi_removed_THEN_keyerror_raised(self):
         self.model.set_stack(generate_images())
@@ -254,9 +254,9 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     def test_WHEN_roi_renamed_THEN_roi_name_changed_in_list_of_roi_names(self):
         self.model.set_stack(generate_images())
         self.model.set_new_roi("new_roi")
-        self.assertEqual(self.model.get_list_of_roi_names(), ["all", "roi", "new_roi"])
+        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi", "new_roi"])
         self.model.rename_roi("new_roi", "imaging_is_the_coolest")
-        self.assertEqual(self.model.get_list_of_roi_names(), ["all", "roi", "imaging_is_the_coolest"])
+        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi", "imaging_is_the_coolest"])
 
     def test_WHEN_invalid_roi_renamed_THEN_keyerror_raised(self):
         self.model.set_stack(generate_images())

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -250,3 +250,24 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.model.set_stack(generate_images())
         with self.assertRaises(KeyError):
             self.model.remove_roi("non_existent_roi")
+
+    def test_WHEN_roi_renamed_THEN_roi_name_changed_in_list_of_roi_names(self):
+        self.model.set_stack(generate_images())
+        self.model.set_new_roi("new_roi")
+        self.assertEqual(self.model.get_list_of_roi_names(), ["all", "roi", "new_roi"])
+        self.model.rename_roi("new_roi", "imaging_is_the_coolest")
+        self.assertEqual(self.model.get_list_of_roi_names(), ["all", "roi", "imaging_is_the_coolest"])
+
+    def test_WHEN_invalid_roi_renamed_THEN_keyerror_raised(self):
+        self.model.set_stack(generate_images())
+        with self.assertRaises(KeyError):
+            self.model.rename_roi("non_existent_roi", "imaging_is_the_coolest")
+
+    @parameterized.expand([
+        ("all"),
+        ("roi"),
+    ])
+    def test_WHEN_default_roi_renamed_THEN_runtime_error_raised(self, roi_name):
+        self.model.set_stack(generate_images())
+        with self.assertRaises(RuntimeError):
+            self.model.rename_roi(roi_name, "imaging_is_the_coolest")

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -108,13 +108,13 @@ class SpectrumViewerWindowView(BaseMainWindowView):
                     existing_roi_name = self.roi_table_model.row_data(roi_item)[0].lower()
                     if existing_roi_name == proposed_roi_name.lower() and roi_item != self.selected_row:
                         QMessageBox.warning(self, "Duplication Warning", "ROI name already exists")
-                        proposed_roi_name = self.current_roi
+                        self.selected_row_data[0] = self.current_roi
                         return
                 self.presenter.rename_roi(self.current_roi, str(self.selected_row_data[0]))
                 return
             QMessageBox.warning(self, "ROI Name Warning",
                                 "ROI name cannot be empty or equal to default names: 'all', 'roi'")
-            proposed_roi_name = self.current_roi
+            self.selected_row_data[0] = self.current_roi
 
         self.roi_table_model.dataChanged.connect(on_data_change)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -102,12 +102,12 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             If the ROI name is empty or already exists in the table that is not the selected row,
             a warning popup will be displayed and the ROI name will be reverted to the previous name
             """
-            proposed_roi_name = self.selected_row_data[0].lower()
+            proposed_roi_name = self.selected_row_data[0]
 
-            if proposed_roi_name not in ["", "all", "roi"]:
+            if proposed_roi_name.lower() not in ["", "all", "roi"]:
                 for roi_item in range(self.roi_table_model.rowCount()):
                     existing_roi_name = self.roi_table_model.row_data(roi_item)[0].lower()
-                    if existing_roi_name == proposed_roi_name and roi_item != self.selected_row:
+                    if existing_roi_name == proposed_roi_name.lower() and roi_item != self.selected_row:
                         QMessageBox.warning(self, "Duplication Warning", "ROI name already exists")
                         proposed_roi_name = self.current_roi
                         return
@@ -115,7 +115,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
                 return
             QMessageBox.warning(self, "ROI Name Warning",
                                 "ROI name cannot be empty or equal to default names: 'all', 'roi'")
-            self.selected_row_data[0] = self.current_roi
+            proposed_roi_name = self.current_roi
 
         self.roi_table_model.dataChanged.connect(on_data_change)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -57,7 +57,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         # ROI action buttons
         self.addBtn.clicked.connect(self.set_new_roi)
-        self.clearAllBtn.clicked.connect(self.clear_all_rois)
         self.removeBtn.clicked.connect(self.remove_roi)
 
         self._configure_dropdown(self.sampleStackSelector)
@@ -217,13 +216,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         circle_label.setStyleSheet(f"background-color: {colour}; border-radius: 5px;")
         self.roi_table_model.appendNewRow(name, colour)
         self.tableView.selectRow(row)
-
-    def clear_all_rois(self) -> None:
-        """
-        Clear all ROIs from the image
-        """
-        self.roi_table_model.clear_table()
-        self.presenter.do_remove_roi()
 
     def remove_roi(self) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -2,14 +2,17 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
+from enum import Enum
 
-from PyQt5.QtGui import QPixmap
-from PyQt5.QtWidgets import QCheckBox, QVBoxLayout, QFileDialog, QPushButton, QLabel
+from PyQt5.QtCore import QAbstractTableModel, Qt
+from PyQt5.QtGui import QPixmap, QColor, QBrush
+from PyQt5.QtWidgets import QCheckBox, QVBoxLayout, QFileDialog, QPushButton, QLabel, QAbstractItemView
 
 from mantidimaging.core.utility import finder
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
 from .presenter import SpectrumViewerWindowPresenter
+from mantidimaging.gui.widgets import RemovableRowTableView
 from .spectrum_widget import SpectrumWidget
 
 if TYPE_CHECKING:
@@ -18,7 +21,95 @@ if TYPE_CHECKING:
     import numpy as np
 
 
+class Column(Enum):
+    name = 0
+    colour = 1
+
+
+class TableModel(QAbstractTableModel):
+    def __init__(self, data):
+        super(TableModel, self).__init__()
+        self._data = data
+        print((f"Data is {self._data}"))
+
+    def rowCount(self, index):
+        return len(self._data)
+
+    def columnCount(self, index):
+        return len(self._data[0])
+
+    def data(self, index, role):
+        """
+        Set data in table roi name and colour - str and Tuple(int,int,int)
+        """
+        if role == Qt.DisplayRole:
+            return self._data[index.row()][index.column()]
+
+        # if role == Qt.ForegroundRole:
+        #     if index.column() == 1:
+        #         return QColor(*self._data[index.row()][index.column()])
+        # change text colour?
+        if role == Qt.BackgroundRole:
+            if index.column() == 1:
+                return QBrush(QColor(*self._data[index.row()][index.column()]))
+                # return QColor(*self._data[index.row()][index.column()])
+
+    def appendNewRow(self, row: int, roi_name: str, roi_colour: tuple):
+        print(f"Appending new row {row} with {roi_name} and {roi_colour}")
+        item_list = [roi_name, roi_colour]
+        self._data.append(item_list)
+
+        self.layoutChanged.emit()
+
+    # def set_point(self, row: int, roi_name: str, roi_colour: tuple):
+    #     """
+    #     Set data str and tuple in table
+    #     """
+    #     item = self._data[row]
+    #     self.dataChanged.emit(self.index(row, 0), self.index(row, 1))
+
+    # def add_point(self, row: int, roi_name: str, roi_colour: tuple):
+    #     """
+    #     Add new row to table
+    #     """
+    #     if row is None:
+    #         self._data.append([roi_name, roi_colour])
+    #     else:
+    #         self._data.insert(row, [roi_name, roi_colour])
+
+    # def insertRows(self, row: int, count: int, roi_name: str, roi_colour: tuple):
+    #     """
+    #     Insert new row of two columns string and tuple
+    #     """
+    #     self.beginInsertRows(QModelIndex(), row, row + count - 1)
+    #     self._data.insert(row, [roi_name, roi_colour])
+    #     self.endInsertRows()
+
+    # self.beginInsertRows(QModelIndex(), row, row + count - 1)
+
+    # for _ in range(count):
+    #     self.add_point(row, roi_name, roi_colour)
+
+    def sort_points(self):
+        """
+        Sort table by ROI name
+        """
+        self._data.sort(key=lambda x: x[0])
+
+    def headerData(self, section, orientation, role):
+        """
+        Set horizontal colum header names to ROI and Colour
+        """
+        if role == Qt.DisplayRole:
+            if orientation == Qt.Horizontal:
+                if section == 0:
+                    return "ROI"
+                if section == 1:
+                    return "Colour"
+
+
 class SpectrumViewerWindowView(BaseMainWindowView):
+    tableView: RemovableRowTableView
     sampleStackSelector: DatasetSelectorWidgetView
     normaliseStackSelector: DatasetSelectorWidgetView
 
@@ -63,10 +154,42 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         self.exportButton.clicked.connect(self.presenter.handle_export_csv)
 
+        # Point table
+        self.tableView.horizontalHeader().setStretchLastSection(True)
+        self.tableView.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.tableView.setSelectionMode(QAbstractItemView.SingleSelection)
+
+        # self.roi_table_model = self.tableView.model()
+
+        # self.roi_table_model.rowsInserted.connect(self.on_table_row_count_change)  # type: ignore
+        # self.roi_table_model.rowsRemoved.connect(self.on_table_row_count_change)  # type: ignore
+        # self.roi_table_model.modelReset.connect(self.on_table_row_count_change)  # type: ignore
+
+        # self.roi_table_model.dataChanged.connect()
+
+        # Update initial UI state
+        # self.on_table_row_count_change()
+
+    def clear_cor_table(self):
+        return self.roi_table_model.removeAllRows()
+
     def cleanup(self):
         self.sampleStackSelector.unsubscribe_from_main_window()
         self.normaliseStackSelector.unsubscribe_from_main_window()
         self.main_window.spectrum_viewer = None
+
+    @property
+    def roi_table_model(self):
+        print("roi_table_model")
+        print(self.tableView)
+        data = [
+            ["roi", (26, 133, 255)],
+        ]
+        if self.tableView.model() is None:
+            mdl = TableModel(data)
+            # mdl = TableModel(self.tableView)
+            self.tableView.setModel(mdl)
+        return self.tableView.model()
 
     @property
     def current_dataset_id(self) -> Optional['UUID']:
@@ -98,6 +221,18 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             return Path(path)
         else:
             return None
+
+    # def on_table_row_count_change(self, _=None, __=None):
+    #     """
+    #     Called when rows have been added or removed from the point table.
+
+    #     Used to conditionally enable UI controls that depend on a certain
+    #     amount of entries in the table.
+    #     """
+    #     # Disable clear buttons when there are no rows in the table
+    #     empty = self.tableView.model().empty
+    #     self.removeBtn.setEnabled(not empty)
+    #     self.clearAllBtn.setEnabled(not empty)
 
     def set_image(self, image_data: Optional['np.ndarray'], autoLevels: bool = True):
         self.spectrum.image.setImage(image_data, autoLevels=autoLevels)
@@ -138,3 +273,16 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         :param enabled: True to enable the button, False to disable it
         """
         self.exportButton.setEnabled(enabled)
+
+    def add_roi_table_row(self, row: int, name: str, colour: str):
+        """
+        Add a new row to the ROI table
+
+        :param row: The row number
+        :param name: The name of the ROI
+        :param colour: The colour of the ROI
+        """
+        circle_label = QLabel()
+        circle_label.setStyleSheet(f"background-color: {colour}; border-radius: 5px;")
+        self.roi_table_model.appendNewRow(row, name, colour)
+        self.tableView.selectRow(row)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -75,6 +75,10 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         self.tableView.setAlternatingRowColors(True)
 
+        self.selected_row_data: list = []
+        self.selected_row: int = 0
+        self.current_roi: str = ""
+
         self.roi_table_model  # Initialise model
 
         def on_row_change(item, _) -> None:

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -101,12 +101,11 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             If the ROI name is empty or already exists in the table that is not the selected row,
             a warning popup will be displayed and the ROI name will be reverted to the previous name
             """
-            proposed_roi_name = self.selected_row_data[0]
 
-            if proposed_roi_name.lower() not in ["", "all", "roi"]:
+            if self.selected_row_data[0].lower() not in ["", "all", "roi"]:
                 for roi_item in range(self.roi_table_model.rowCount()):
                     existing_roi_name = self.roi_table_model.row_data(roi_item)[0].lower()
-                    if existing_roi_name == proposed_roi_name.lower() and roi_item != self.selected_row:
+                    if existing_roi_name == self.selected_row_data[0].lower() and roi_item != self.selected_row:
                         QMessageBox.warning(self, "Duplication Warning", "ROI name already exists")
                         self.selected_row_data[0] = self.current_roi
                         return

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -76,7 +76,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.tableView.setAlternatingRowColors(True)
 
         self.roi_table_model  # Initialise model
-        self.selected_row, self.selected_row_data, self.current_roi = None, None, None
 
         def on_row_change(item, _) -> None:
             """
@@ -102,6 +101,8 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             If the ROI name is empty or already exists in the table that is not the selected row,
             a warning popup will be displayed and the ROI name will be reverted to the previous name
             """
+            print(f"selected row: {self.selected_row_data}")
+            print(f"The data type of selected row: {type(self.selected_row_data)}")
             proposed_roi_name = self.selected_row_data[0]
 
             if proposed_roi_name.lower() not in ["", "all", "roi"]:
@@ -111,7 +112,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
                         QMessageBox.warning(self, "Duplication Warning", "ROI name already exists")
                         proposed_roi_name = self.current_roi
                         return
-                self.presenter.rename_roi(self.current_roi, self.selected_row_data[0])
+                self.presenter.rename_roi(self.current_roi, str(self.selected_row_data[0]))
                 return
             QMessageBox.warning(self, "ROI Name Warning",
                                 "ROI name cannot be empty or equal to default names: 'all', 'roi'")


### PR DESCRIPTION
### Issue

Closes #1622 

### Description

This PR Adds the following functionality to the ROI table within spectrum viewer window to improve user workflow using multiple ROIs:
* Populate table with visible ROIs
* Allow user to add new ROIs
* Allow user to rename ROIs (double click on name)
* Allow user to clear selected ROI
* Default ROIs cannot be modified
* ROIs cannot have duplicate names or be empty e.g. ""
* The most recently added ROIs ToF data is plotted (future PR will allow for plotting of multiple ROI ToF simultaneously)

### Testing 
- [ ] Run Unit tests and ensure they pass
- [ ] Ensure code is cleanly implemented and readable
- [ ] All action buttons within table perform as expected

### Acceptance Criteria 
- [ ] Unit test pass (`mantidimaging/gui/windows/spectrum_viewer/test/model_test.py` and `mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py`)
- [ ] New ROIs can be added and are populated in table using "Add" button
- [ ] ROIs can be renamed
- [ ] Selected ROI can excluding default ROI can be cleared using "Remove"
- [ ] Renamed ROIs are updated throughout application and displayed when exporting data to .csv

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*
