### PR TITLE
1514 cil approx norm

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -13,10 +13,12 @@ New Features and improvements
 - #1625 : Change selection in tree view when switching tabs
 - #1626 : Move stacks between datasets
 - #1622 : Add, Remove and Rename ROIs in spectrum viewer
+
 - #1464 : NeXus Recon: Add entry/reconstruction/date information
 - #1463 : NeXus Recon: Add entry/SAMPLE/name information
 - #1468 : NeXus Recon: Load recons
 - #1467 : NeXus Recon: Add other entry/data information
+- #1512 : Speedups for CIL setup
 
 Fixes
 -----
@@ -30,5 +32,8 @@ Developer Changes
 - #1472 : Investigate issues reported by flake8-bugbear
 - #1607 : Add flake8-bugbear to environment, github actions and precommit
 - #1613 : Refactor Operations window ROI selector to be in its own class
+<<<<<<< HEAD
 - #1652 : PEP440 compliant versions for alpha builds
 - #1595 : Store version number in package
+=======
+>>>>>>> 78126f8ba (Update release notes)

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -3,6 +3,7 @@
 
 import time
 from logging import getLogger
+from math import sqrt
 from threading import Lock
 from typing import List, Optional
 
@@ -37,6 +38,12 @@ class CILRecon(BaseRecon):
         # Define Gradient Operator and BlockOperator
         alpha = recon_params.alpha
         Grad = GradientOperator(image_geometry)
+
+        if image_geometry.voxel_num_z == 0:
+            Grad.set_norm(sqrt(8))
+        else:
+            Grad.set_norm(sqrt(12))
+
         K = BlockOperator(alpha * Grad, A2d)
 
         # Define BlockFunction F using the MixedL21Norm() and the L2NormSquared()

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
+import time
 from logging import getLogger
 from threading import Lock
 from typing import List, Optional
@@ -79,6 +80,7 @@ class CILRecon(BaseRecon):
             LOG.warning("CIL recon already in progress")
 
         with cil_mutex:
+            t0 = time.perf_counter()
             sino = BaseRecon.prepare_sinogram(sino, recon_params)
             pixel_num_h = sino.shape[1]
             pixel_size = 1.
@@ -113,6 +115,8 @@ class CILRecon(BaseRecon):
             finally:
                 if progress:
                     progress.mark_complete()
+            t1 = time.perf_counter()
+            LOG.info(f"single_sino time: {t1-t0}s for shape {sino.shape}")
             return pdhg.solution.as_array()
 
     @staticmethod
@@ -158,6 +162,7 @@ class CILRecon(BaseRecon):
             LOG.warning("CIL recon already in progress")
 
         with cil_mutex:
+            t0 = time.perf_counter()
             LOG.info(f"Starting 3D PDHG-TV reconstruction: input shape {images.data.shape}"
                      f"output shape {recon_volume_shape}\n"
                      f"Num iter {recon_params.num_iter}, alpha {recon_params.alpha}, "
@@ -201,6 +206,8 @@ class CILRecon(BaseRecon):
                     pdhg.next()
                 volume = pdhg.solution.as_array()
                 LOG.info('Reconstructed 3D volume with shape: {0}'.format(volume.shape))
+            t1 = time.perf_counter()
+            LOG.info(f"full reconstruction time: {t1-t0}s for shape {images.data.shape}")
             return ImageStack(volume)
 
 

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import time
-from logging import getLogger
+from logging import getLogger, DEBUG
 from math import sqrt
 from threading import Lock
 from typing import List, Optional
@@ -34,6 +34,17 @@ class CILRecon(BaseRecon):
                                  recon_params: ReconstructionParameters):
         # Forward operator
         A2d = ProjectionOperator(image_geometry, acquisition_data.geometry, 'gpu')
+
+        # This is slow to calculate, this approximation is good to with in 5%
+        # When running in debug mode, check the approximation and raise an error if it is bad
+        approx_a2d_norm = sqrt(image_geometry.voxel_num_x * acquisition_data.geometry.num_projections)
+        if LOG.isEnabledFor(DEBUG):
+            num_a2d_norm = A2d.norm()
+            diff = abs(approx_a2d_norm - num_a2d_norm) / max(approx_a2d_norm, num_a2d_norm)
+            LOG.debug(f"ProjectionOperator approx norm: {diff=} {approx_a2d_norm=} {num_a2d_norm=}")
+            if diff > 0.05:
+                raise RuntimeError(f"Bad ProjectionOperator norm: {diff=} {approx_a2d_norm=} {num_a2d_norm=}\n")
+        A2d.set_norm(approx_a2d_norm)
 
         # Define Gradient Operator and BlockOperator
         alpha = recon_params.alpha

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -35,6 +35,8 @@ class CILRecon(BaseRecon):
         # Forward operator
         A2d = ProjectionOperator(image_geometry, acquisition_data.geometry, 'gpu')
 
+        assert all(s == 1.0 for s in image_geometry.spacing), "Norm approximations assume voxel size == 1"
+
         # This is slow to calculate, this approximation is good to with in 5%
         # When running in debug mode, check the approximation and raise an error if it is bad
         approx_a2d_norm = sqrt(image_geometry.voxel_num_x * acquisition_data.geometry.num_projections)

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -39,7 +39,7 @@ class CILRecon(BaseRecon):
         # When running in debug mode, check the approximation and raise an error if it is bad
         approx_a2d_norm = sqrt(image_geometry.voxel_num_x * acquisition_data.geometry.num_projections)
         if LOG.isEnabledFor(DEBUG):
-            num_a2d_norm = A2d.norm()
+            num_a2d_norm = A2d.PowerMethod(A2d, max_iteration=100)
             diff = abs(approx_a2d_norm - num_a2d_norm) / max(approx_a2d_norm, num_a2d_norm)
             LOG.debug(f"ProjectionOperator approx norm: {diff=} {approx_a2d_norm=} {num_a2d_norm=}")
             if diff > 0.05:


### PR DESCRIPTION
### Issue

Closes #1514 

### Description

Avoid calculations of operator norms in CIL.

For Grad use sqrt(8) or sqrt(12) which is the analytic solution, and so more accurate than the value found by the numeric method currently in CIL.

For ProjectionOperator, use sqrt(sinogram size) which seems to always be within a few percent of the value found by numeric method. Add a check that runs if mantid imaging is in debug mode.

This saves about 0.5 s for 2d and 110s for 3d for shape (1143, 512, 512). So mostly useful when adjusting parameters with a small number of iterations set.

### Testing & Acceptance Criteria 

Try doing a reconstruction with CIL PDHG. Check that previews, reconstruct slice and reconstruct volume work.

Try again with --log-level DEBUG and check there are no error windows.

### Documentation

release notes
