### PR TITLE
Package with PyInstaller

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -31,3 +31,4 @@ dependencies:
   - pytest-xdist==2.5.*
   - coverage==6.4.*
   - pyfakefs==5.0.*
+  - pyinstaller==5.6.*

--- a/mantidimaging/__main__.py
+++ b/mantidimaging/__main__.py
@@ -3,6 +3,11 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 if __name__ == '__main__':
-    from mantidimaging import main
+    from multiprocessing import freeze_support
+    # freeze_support adds support for multiprocessing when the application has been frozen to produce a Windows
+    # executable. It is only required for Windows and will have no effect when invoked on any other OS.
+    # It will also have no effect when the script is run normally by the Python interpreter.
+    freeze_support()
 
+    from mantidimaging import main
     main.main()

--- a/mantidimaging/core/operations/loader.py
+++ b/mantidimaging/core/operations/loader.py
@@ -10,19 +10,20 @@ from importlib.abc import Loader
 from mantidimaging.core.operations.base_filter import BaseFilter
 
 MODULES_OPERATIONS = {}
-for finder, module_name, _ in pkgutil.walk_packages([os.path.dirname(__file__)]):
-    if getattr(sys, 'frozen', False):
-        # If we're running a PyInstaller executable then we will get back a FrozenImporter object instead of a
-        # FileFinder. FrozenImporter implements load_module directly, but needs to use the full import name for
-        # the module to load it from the PYZ archive.
-        assert hasattr(finder, 'load_module')
-        MODULES_OPERATIONS[f'mantidimaging.core.operations.{module_name}'] = finder
-    else:
-        assert isinstance(finder, FileFinder)
-        spec = finder.find_spec(module_name)
-        assert isinstance(spec, ModuleSpec)
-        assert isinstance(spec.loader, Loader)
-        MODULES_OPERATIONS[module_name] = spec.loader
+if not MODULES_OPERATIONS:
+    for finder, module_name, _ in pkgutil.walk_packages([os.path.dirname(__file__)]):
+        if getattr(sys, 'frozen', False):
+            # If we're running a PyInstaller executable then we will get back a FrozenImporter object instead of a
+            # FileFinder. FrozenImporter implements load_module directly, but needs to use the full import name for
+            # the module to load it from the PYZ archive.
+            assert hasattr(finder, 'load_module')
+            MODULES_OPERATIONS[f'mantidimaging.core.operations.{module_name}'] = finder
+        else:
+            assert isinstance(finder, FileFinder)
+            spec = finder.find_spec(module_name)
+            assert isinstance(spec, ModuleSpec)
+            assert isinstance(spec.loader, Loader)
+            MODULES_OPERATIONS[module_name] = spec.loader
 
 
 class OperationModule(Protocol):

--- a/mantidimaging/core/operations/loader.py
+++ b/mantidimaging/core/operations/loader.py
@@ -39,12 +39,11 @@ def load_filter_packages(ignored_packages=None) -> List[BaseFilter]:
     :param ignored_packages: List of ignore rules
     """
 
-    filters = {name: MODULES_OPERATIONS[name].load_module(name) for name in MODULES_OPERATIONS.keys()}
-    filters = {name: filters[name] for name in filters.keys() if hasattr(filters[name], 'FILTER_CLASS')}
-    operation_modules = {name: cast(OperationModule, f) for name, f in filters.items()}
-    if not ignored_packages:
-        return [f.FILTER_CLASS for f in operation_modules.values()]
-    return [
-        operation_modules[name].FILTER_CLASS for name in operation_modules.keys()
-        if not any([ignore in name for ignore in ignored_packages])
-    ]
+    operation_modules = []
+    for name in MODULES_OPERATIONS.keys():
+        if not ignored_packages or not any([ignore in name for ignore in ignored_packages]):
+            module = MODULES_OPERATIONS[name].load_module(name)
+            if hasattr(module, 'FILTER_CLASS'):
+                operation_module = cast(OperationModule, module)
+                operation_modules.append(operation_module.FILTER_CLASS)
+    return operation_modules

--- a/mantidimaging/core/operations/loader.py
+++ b/mantidimaging/core/operations/loader.py
@@ -3,13 +3,16 @@
 import os
 import pkgutil
 import sys
-from typing import List, Protocol, cast
+from typing import List, Protocol, cast, Union, TYPE_CHECKING
 from importlib.machinery import FileFinder, ModuleSpec
 from importlib.abc import Loader
 
+if TYPE_CHECKING:
+    from PyInstaller.loader.pyimod02_importers import FrozenImporter
+
 from mantidimaging.core.operations.base_filter import BaseFilter
 
-MODULES_OPERATIONS = {}
+MODULES_OPERATIONS: dict[str, Union['FrozenImporter', Loader]] = {}
 if not MODULES_OPERATIONS:
     for finder, module_name, _ in pkgutil.walk_packages([os.path.dirname(__file__)]):
         if getattr(sys, 'frozen', False):

--- a/packaging/PackageWithPyInstaller.py
+++ b/packaging/PackageWithPyInstaller.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+# Package the application using PyInstaller
+#
+import os
+import pkgutil
+import sys
+from pathlib import Path
+from PyInstaller.utils.hooks import conda_support
+import PyInstaller.__main__
+
+
+def create_run_options():
+    run_options = ['../mantidimaging/__main__.py', '--name=mantidimaging']
+
+    add_hidden_imports(run_options)
+    add_missing_submodules(run_options)
+    add_data_files(run_options)
+    add_conda_dynamic_libs(run_options)
+    add_optional_arguments(run_options)
+
+    return run_options
+
+
+def add_hidden_imports(run_options):
+    imports = [
+        'astra.utils', 'tomopy', 'cupy_backends.cuda.api._runtime_enum', 'cupy_backends.cuda.api._driver_enum',
+        'cupy_backends.cuda.stream', 'fastrlock', 'fastrlock.rlock'
+    ]
+
+    # Operations modules must be added as hidden imports because most are imported programmatically in MantidImaging
+    path_to_operations = Path(__file__).parent.parent.joinpath('mantidimaging/core/operations')
+    for _, ops_module, _ in pkgutil.walk_packages([path_to_operations]):
+        imports.append(f'mantidimaging.core.operations.{ops_module}')
+
+    run_options.extend([f'--hidden-import={name}' for name in imports])
+
+
+def add_missing_submodules(run_options):
+    imports = ['cupy']
+    run_options.extend([f'--collect-submodules={name}' for name in imports])
+
+
+def add_data_files(run_options):
+    # Each tuple in the list should give the location of the data files to copy and the destination to copy them to in
+    # the package
+    data_files = [('../mantidimaging/gui/ui/*.ui', 'mantidimaging/gui/ui/'),
+                  ('../mantidimaging/gui/ui/images/*', 'mantidimaging/gui/ui/images/'),
+                  ('../mantidimaging/gui/windows/wizard/*.yml', 'mantidimaging/gui/windows/wizard/')]
+
+    run_options.extend([f'--add-data={src}{os.pathsep}{dest}' for src, dest in data_files])
+
+
+def add_conda_dynamic_libs(run_options):
+    distributions = ['tomopy', 'cil']
+
+    for dist_name in distributions:
+        binaries = conda_support.collect_dynamic_libs(dist_name)
+        run_options.extend([f'--add-binary={src}{os.pathsep}{dest}' for src, dest in binaries])
+
+
+def add_optional_arguments(run_options):
+    optional_args = ['--noconfirm', '--clean']
+    run_options.extend(optional_args)
+
+
+if __name__ == "__main__":
+    # PyInstaller imports modules recursively. The structure of our module imports results in the nesting being so deep
+    # that it hits Python's stack-limit. PyInstaller suggests increasing the recursion limit to work around this.
+    # The default limit is 1000, meaning a recursion error would occur at around 115 nested imports.
+    # A limit of 5000 means the error should occur at about 660 nested imports.
+    sys.setrecursionlimit(sys.getrecursionlimit() * 5)
+
+    PyInstaller.__main__.run(create_run_options())

--- a/packaging/PackageWithPyInstaller.py
+++ b/packaging/PackageWithPyInstaller.py
@@ -12,7 +12,7 @@ import PyInstaller.__main__
 
 
 def create_run_options():
-    run_options = ['../mantidimaging/__main__.py', '--name=mantidimaging']
+    run_options = ['../mantidimaging/__main__.py', '--name=MantidImaging']
 
     add_hidden_imports(run_options)
     add_missing_submodules(run_options)

--- a/packaging/hooks/hook-cil.py
+++ b/packaging/hooks/hook-cil.py
@@ -1,0 +1,9 @@
+# Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+from PyInstaller.compat import is_pure_conda
+
+if is_pure_conda:
+    from PyInstaller.utils.hooks import conda_support
+
+    binaries = conda_support.collect_dynamic_libs('cil')


### PR DESCRIPTION
### Issue

Refs #1462 

### Description

Adds PyInstaller to the mantidimaging-dev conda environment and adds a script to package the application as a folder.

This PR includes a couple of small code changes that are required to be able to import the operations modules and to ensure multiprocessing works in the frozen application on Windows.

The changes in this PR are just a first step to get the packaging working. See details under Testing below of what is expected to work and what may not. I will also add a to-do list to the referenced issue with the tasks that I think are still outstanding or need consideration.

### Testing 

The packaged application appears to be fully functional (I've checked the main functionality, i.e. running some operations and reconstructions, but a completely comprehensive check is still needed). It runs outside a conda environment on my Windows machine, but still requires a conda/mamba installation to start-up because of the way we do our version check. More testing is required on a clean install for both Windows and Linux to see if there is anything still missing, particularly relating to CUDA. For more notes about the testing I've done so far see https://github.com/mantidproject/mantidimaging/issues/1462#issuecomment-1354747880.

I expect the packaging script to work on both Windows and Linux, but I don't have access to a Linux machine to be able to test.

### Acceptance Criteria 

1) Recreate your `mantidimaging-dev` environment by running the setup script as normal.
2) Run the packaging script - in a terminal, navigate to `mantidimaging/packaging` and run `python PackageWithPyInstaller.py`.
3) This should output a `build` and `dist` folder and a file called `mantidimaging.spec`. Inside the `dist` folder should be a `MantidImaging` directory. This is the folder containing the packaged output.
4) Within the `MantidImaging` directory should be a `MantidImaging.exe` file. Double click on this file to start up the application. It will take some time to start-up, but should eventually run as normal. Tip for debugging, if there are any problems with the start-up then the `.exe` file can be run from a terminal to still be able to read any error messages once the application has exited.

### Documentation

No need to add to release notes. Not yet at a stage where supporting documentation can be added for packaging and installation.
