### PR TITLE
1464: Recon datetime in NeXus file

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -13,6 +13,7 @@ New Features and improvements
 - #1625 : Change selection in tree view when switching tabs
 - #1626 : Move stacks between datasets
 - #1622 : Add, Remove and Rename ROIs in spectrum viewer
+- #1464 : NeXus Recon: Add entry/reconstruction/date information
 
 Fixes
 -----

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -127,14 +127,11 @@ class ImageStack:
                 return o
 
         self.metadata[const.OPERATION_HISTORY].append({
-            const.TIMESTAMP:
-            datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-            const.OPERATION_NAME:
-            func_name,
+            const.TIMESTAMP: datetime.datetime.now().isoformat(),
+            const.OPERATION_NAME: func_name,
             const.OPERATION_KEYWORD_ARGS: {k: prepare(v)
                                            for k, v in kwargs.items() if accepted_type(v)},
-            const.OPERATION_DISPLAY_NAME:
-            display_name
+            const.OPERATION_DISPLAY_NAME: display_name
         })
 
     def copy(self, flip_axes=False) -> 'ImageStack':

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -7,6 +7,7 @@ from typing import List, Union, Optional, Dict, Callable
 
 import h5py
 import numpy as np
+from mantidimaging.core.operation_history.const import TIMESTAMP
 from skimage import io as skio
 import astropy.io.fits as fits
 
@@ -276,7 +277,10 @@ def _save_recon_to_nexus(nexus_file: h5py.File, recon: ImageStack):
 
     reconstruction.create_dataset("program", data=np.string_("Mantid Imaging"))
     reconstruction.create_dataset("version", data=np.string_(CheckVersion().get_version()))
-    reconstruction.create_dataset("date", data=np.string_("T".join(str(datetime.datetime.now()).split())))
+    recon_timestamp = recon.metadata.get(TIMESTAMP)
+    if recon_timestamp is None:
+        recon_timestamp = datetime.datetime.now().isoformat()
+    reconstruction.create_dataset("date", data=np.string_(recon_timestamp))
     reconstruction.create_group("parameters")
 
     data = recon_entry.create_group("data")


### PR DESCRIPTION
### Issue

Closes #1464

### Description

Records the reconstruction time to the NeXus file.

### Testing 

Added a test to check that time of saving is used if a time isn't stored in the recon ImageStack, and that the true recon time is used if it is available.

### Acceptance Criteria 

Check that the tests pass. Check that the information is present in a NeXus file.

### Documentation

Changed release notes.
