### PR TITLE
1463: Use recon name for `entry/SAMPLE/name` when saving recons in NeXus files

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -14,6 +14,7 @@ New Features and improvements
 - #1626 : Move stacks between datasets
 - #1622 : Add, Remove and Rename ROIs in spectrum viewer
 - #1464 : NeXus Recon: Add entry/reconstruction/date information
+- #1463 : NeXus Recon: Add entry/SAMPLE/name information
 
 Fixes
 -----

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -36,7 +36,6 @@ class ImageStack:
         :param metadata: Properties to copy when creating a new stack from an existing one
         :param sinograms: Set data ordering, if false: [t,y,x] if true: [y,t,x]
         :param name: A name for the stack
-
         """
 
         if isinstance(data, pu.SharedArray):

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -270,7 +270,7 @@ def _save_recon_to_nexus(nexus_file: h5py.File, recon: ImageStack):
 
     sample = recon_entry.create_group("SAMPLE")
     _set_nx_class(sample, "NXsample")
-    sample.create_dataset("name", data=np.string_("sample description"))
+    sample.create_dataset("name", data=np.string_(recon.name))
 
     reconstruction = recon_entry.create_group("reconstruction")
     _set_nx_class(reconstruction, "NXprocess")

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -355,7 +355,7 @@ class IOTest(FileOutputtingTestCase):
                              "neutron")
 
             self.assertEqual(_decode_nexus_class(nexus_file[recon_name]["SAMPLE"]), "NXsample")
-            self.assertEqual(_nexus_dataset_to_string(nexus_file[recon_name]["SAMPLE"]["name"]), "sample description")
+            self.assertEqual(_nexus_dataset_to_string(nexus_file[recon_name]["SAMPLE"]["name"]), recon_name)
 
             self.assertEqual(_nexus_dataset_to_string(nexus_file[recon_name]["reconstruction"]["program"]),
                              "Mantid Imaging")


### PR DESCRIPTION
### Issue

Closes #1463

### Description

Uses the recon name for the `entry/SAMPLE/name` field when saving NeXus files.

### Testing 

Modified an existing test.

### Acceptance Criteria 

Check that the tests pass. Check that the information is present in the NeXus file.

### Documentation

Updated release notes.
