### PR TITLE
PEP440 versions

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -2,7 +2,7 @@
 
   {% set version_tag = environ.get('GIT_DESCRIBE_TAG', '0.0.0') %}
   {% set version_number = environ.get('GIT_DESCRIBE_NUMBER', '0') | string %}
-  {% set version_number = '_' + version_number if version_number != '0' else '' %}
+  {% set version_number = '.post' + version_number if version_number != '0' else '' %}
 
   {% set version = version_tag + version_number %}
 

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -28,3 +28,4 @@ Developer Changes
 - #1472 : Investigate issues reported by flake8-bugbear
 - #1607 : Add flake8-bugbear to environment, github actions and precommit
 - #1613 : Refactor Operations window ROI selector to be in its own class
+- #1652 : PEP440 compliant versions for alpha builds

--- a/mantidimaging/core/utility/test/version_check_test.py
+++ b/mantidimaging/core/utility/test/version_check_test.py
@@ -54,6 +54,7 @@ class TestCheckVersion(unittest.TestCase):
         ["1.1.0a_18", "1.1.0_18", False],
         ["1.1.0a_18", "1.1.0rc_18", False],
         ["1.1.0rc_18", "1.1.0a_19", True],
+        ["1.1.0a1_18", "1.1.0a1_19", False],
     ])
     def test_version_is_uptodate(self, local, remote, is_uptodate):
         local_parsed = _parse_version(local)

--- a/mantidimaging/core/utility/test/version_check_test.py
+++ b/mantidimaging/core/utility/test/version_check_test.py
@@ -19,10 +19,12 @@ class TestCheckVersion(unittest.TestCase):
                 self.versions._conda_installed_label = "main"
                 self.versions._conda_available_version = "1.0.0_1"
 
-    def test_parse_version(self):
-        parsed = _parse_version("9.9.9_1234")
+    @parameterized.expand([["9.9.9_1234"], ["9.9.9.post1234"]])
+    def test_parse_version(self, version_string):
+        parsed = _parse_version(version_string)
 
-        self.assertEqual(parsed.release, (9, 9, 9, 1234))
+        self.assertEqual(parsed.release, (9, 9, 9))
+        self.assertEqual(parsed.post, 1234)
 
     def test_parse_version_no_commits(self):
         parsed = _parse_version("9.9.9")
@@ -36,10 +38,11 @@ class TestCheckVersion(unittest.TestCase):
         self.assertEqual(parsed.pre, ("rc", 0))
 
     def test_parse_version_release_candidate_with_commits(self):
-        parsed = _parse_version("9.9.9rc_2")
+        parsed = _parse_version("9.9.9rc.post2")
 
         self.assertEqual(parsed.release, (9, 9, 9))
-        self.assertEqual(parsed.pre, ("rc", 2))
+        self.assertEqual(parsed.pre, ("rc", 0))
+        self.assertEqual(parsed.post, 2)
 
     @parameterized.expand([
         ["8.9.9_1234", "9.9.9_1234", False],
@@ -55,6 +58,7 @@ class TestCheckVersion(unittest.TestCase):
         ["1.1.0a_18", "1.1.0rc_18", False],
         ["1.1.0rc_18", "1.1.0a_19", True],
         ["1.1.0a1_18", "1.1.0a1_19", False],
+        ["1.1.0a1_18", "1.1.0a1.post19", False],
     ])
     def test_version_is_uptodate(self, local, remote, is_uptodate):
         local_parsed = _parse_version(local)

--- a/mantidimaging/core/utility/version_check.py
+++ b/mantidimaging/core/utility/version_check.py
@@ -143,7 +143,7 @@ def _parse_version(package_version_string: Optional[str]) -> version.Version:
     if package_version_string is None:
         raise ValueError
 
-    normalised_version_string = package_version_string.replace("_", ".")
+    normalised_version_string = package_version_string.replace("_", ".post")
     return version.parse(normalised_version_string)
 
 


### PR DESCRIPTION
### Issue
Closes #1652

### Description

Use `.post` instead of `_` for commit count since tag

Also add a test case that would have caught the problem.

### Testing 

Once merged check that IDAaaS unstable build launches

### Acceptance Criteria 



### Documentation

