### PR TITLE
1468: Load recons from NeXus files

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -14,6 +14,7 @@ New Features and improvements
 - #1626 : Move stacks between datasets
 - #1622 : Add, Remove and Rename ROIs in spectrum viewer
 - #1464 : NeXus Recon: Add entry/reconstruction/date information
+- #1468 : NeXus Recon: Load recons
 
 Fixes
 -----

--- a/docs/user_guide/gui/loading_saving.rst
+++ b/docs/user_guide/gui/loading_saving.rst
@@ -127,6 +127,9 @@ When *Save as NeXus File* is selected the save NeXus dialog appears. Only Datase
 with sample images data can be saved as NeXus files. A sample name and an output
 directory are required before a save can be attempted.
 
+.. note::
+    Recon data is currently saved as float16.
+
 Dataset Tree View
 -----------------
 

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -7,6 +7,7 @@ from typing import List, Union, Optional, Dict, Callable
 
 import h5py
 import numpy as np
+
 from mantidimaging.core.operation_history.const import TIMESTAMP
 from skimage import io as skio
 import astropy.io.fits as fits
@@ -286,8 +287,8 @@ def _save_recon_to_nexus(nexus_file: h5py.File, recon: ImageStack):
     data = recon_entry.create_group("data")
     _set_nx_class(data, "NXdata")
 
-    data.create_dataset("data", shape=recon.data.shape, dtype="uint16")
-    data["data"][:] = _rescale_recon_data(recon.data)
+    data.create_dataset("data", shape=recon.data.shape, dtype="float16")
+    data["data"][:] = recon.data
 
 
 def _set_nx_class(group: h5py.Group, class_name: str):

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -364,7 +364,7 @@ class IOTest(FileOutputtingTestCase):
             self.assertIn(str(datetime.date.today()),
                           _nexus_dataset_to_string(nexus_file[recon_name]["reconstruction"]["date"]))
 
-            assert abs(np.max(np.array(nexus_file[recon_name]["data"]["data"]) - recon.data)) <= 1
+            npt.assert_allclose(np.array(nexus_file[recon_name]["data"]["data"]), recon.data, rtol=1e-3)
 
     def test_use_recon_date_from_image_stack(self):
         sample = th.generate_images()

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -364,10 +364,7 @@ class IOTest(FileOutputtingTestCase):
             self.assertIn(str(datetime.date.today()),
                           _nexus_dataset_to_string(nexus_file[recon_name]["reconstruction"]["date"]))
 
-            assert abs(
-                np.max(
-                    np.array(nexus_file[recon_name]["data"]["data"]) -
-                    _rescale_recon_data(recon.data).astype("uint16"))) <= 1
+            assert abs(np.max(np.array(nexus_file[recon_name]["data"]["data"]) - recon.data)) <= 1
 
     def test_use_recon_date_from_image_stack(self):
         sample = th.generate_images()

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -249,6 +249,8 @@ class MainWindowPresenter(BasePresenter):
             self._create_and_tabify_stack_window(
                 dataset.sample.proj180deg,  # type: ignore
                 sample_stack_vis)
+        for recon in dataset.recons:
+            self._create_and_tabify_stack_window(recon, sample_stack_vis)
 
         self._focus_on_newest_stack_tab()
         return sample_stack_vis
@@ -345,6 +347,8 @@ class MainWindowPresenter(BasePresenter):
                 dataset_tree_item,
                 dataset.sample.proj180deg.id,  # type: ignore
                 "180")
+        for recon in dataset.recons:
+            self.add_recon_item_to_tree_view(dataset.id, recon.id, recon.name)
 
         self.view.add_item_to_tree_view(dataset_tree_item)
 

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -564,8 +564,12 @@ class MainWindowPresenterTest(unittest.TestCase):
         dataset = StrictDataset(*generate_images_with_filenames(5))
         dataset.proj180deg = generate_images((1, 20, 20))
         dataset.proj180deg.filenames = ["filename"]
+        recon = generate_images()
+        recon.name = recon_name = "Recon"
+        dataset.add_recon(recon)
 
         dataset_tree_item_mock = self.view.create_dataset_tree_widget_item.return_value
+        self.presenter.add_recon_item_to_tree_view = mock.Mock()
         self.presenter.create_strict_dataset_tree_view_items(dataset)
 
         s_call = call(dataset_tree_item_mock, dataset.sample.id, "Projections")
@@ -576,6 +580,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         _180_call = call(dataset_tree_item_mock, dataset.proj180deg.id, "180")
 
         self.view.create_child_tree_item.assert_has_calls([s_call, fb_call, fa_call, db_call, da_call, _180_call])
+        self.presenter.add_recon_item_to_tree_view.assert_called_once_with(dataset.id, dataset.recons[0].id, recon_name)
         self.view.add_item_to_tree_view.assert_called_once_with(dataset_tree_item_mock)
 
     def test_add_recon_item_to_tree_view_first_item(self):

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -48,6 +48,11 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.dataset_tree_widget = mock.Mock()
         self.view.get_dataset_tree_view_item = mock.Mock()
 
+        self.dataset.flat_before.filenames = ["filename"] * 10
+        self.dataset.dark_before.filenames = ["filename"] * 10
+        self.dataset.flat_after.filenames = ["filename"] * 10
+        self.dataset.dark_after.filenames = ["filename"] * 10
+
         def stack_id():
             return uuid.uuid4()
 
@@ -165,16 +170,20 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.dataset.proj180deg = generate_images(shape=(1, 20, 20))
         self.dataset.proj180deg.filenames = ["filename"]
 
-        self.dataset.flat_before.filenames = ["filename"] * 10
-        self.dataset.dark_before.filenames = ["filename"] * 10
-        self.dataset.flat_after.filenames = ["filename"] * 10
-        self.dataset.dark_after.filenames = ["filename"] * 10
-
         self.create_stack_mocks(self.dataset)
 
         self.presenter.create_strict_dataset_stack_windows(self.dataset)
 
         self.assertEqual(6, len(self.presenter.stack_visualisers))
+
+    def test_create_recon_windows(self):
+
+        self.dataset.add_recon(generate_images())
+        self.dataset.add_recon(generate_images())
+        self.create_stack_mocks(self.dataset)
+
+        self.presenter.create_strict_dataset_stack_windows(self.dataset)
+        self.assertEqual(7, len(self.presenter.stack_visualisers))
 
     @mock.patch("mantidimaging.gui.windows.main.presenter.MainWindowPresenter.add_child_item_to_tree_view")
     @mock.patch("mantidimaging.gui.windows.main.presenter.MainWindowPresenter.get_stack_visualiser")

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -193,8 +193,7 @@ class NexusLoadPresenter:
 
     def _look_for_recon_entries(self):
         """
-        Tries to find recon entries in the NeXus file.
-        :return:
+        Tries to find recon entries in the NeXus file then stores the data in a list.
         """
         assert self.nexus_file is not None
         for key in self.nexus_file.keys():

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -112,7 +112,6 @@ class NexusLoadPresenter:
                 self.rotation_angles = self.rotation_angles[:]
 
                 self._look_for_recon_entries()
-                print(self.nexus_recons)
 
                 self._get_data_from_image_key()
                 self.title = self._find_data_title()
@@ -192,9 +191,13 @@ class NexusLoadPresenter:
         return None
 
     def _look_for_recon_entries(self):
+        """
+        Tries to find recon entries in the NeXus file.
+        :return:
+        """
         assert self.nexus_file is not None
         for key in self.nexus_file.keys():
-            if "definition" in self.nexus_file[key].keys():
+            if DEFINITION in self.nexus_file[key].keys():
                 if np.array(self.nexus_file[key][DEFINITION]).tostring().decode("utf-8") == NXTOMOPROC:
                     self.nexus_recons.append(self.nexus_file[key])
 

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -4,7 +4,7 @@ import enum
 import traceback
 from enum import auto, Enum
 from logging import getLogger
-from typing import TYPE_CHECKING, Optional, Union, Tuple
+from typing import TYPE_CHECKING, Optional, Union, Tuple, List
 
 import h5py
 import numpy as np
@@ -63,7 +63,7 @@ class NexusLoadPresenter:
         self.image_key_dataset = None
         self.rotation_angles = None
         self.title = ""
-        self.recon_data = []
+        self.recon_data: List[np.array] = []
 
         self.sample_array = None
         self.dark_before_array = None

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -112,6 +112,7 @@ class NexusLoadPresenter:
                 self.rotation_angles = self.rotation_angles[:]
 
                 self._look_for_recon_entries()
+                print(self.nexus_recons)
 
                 self._get_data_from_image_key()
                 self.title = self._find_data_title()
@@ -194,7 +195,7 @@ class NexusLoadPresenter:
         assert self.nexus_file is not None
         for key in self.nexus_file.keys():
             if "definition" in self.nexus_file[key].keys():
-                if np.array(self.nexus_file[key][DEFINITION]).tostring().decone("utf-8") == NXTOMOPROC:
+                if np.array(self.nexus_file[key][DEFINITION]).tostring().decode("utf-8") == NXTOMOPROC:
                     self.nexus_recons.append(self.nexus_file[key])
 
     def _look_for_tomo_data(self, entry_path: str) -> Optional[Union[h5py.Group, h5py.Dataset]]:

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -347,6 +347,10 @@ class NexusLoadPresenter:
         return image_stack
 
     def _create_recon_list(self) -> ReconList:
+        """
+        Uses the array of recon data extracted from the NeXus file to create a ReconList object.
+        :return: The ReconList object containing recons from the NeXus file.
+        """
         recon_list = ReconList()
         for recon_array in self.recon_data:
             recon_list.append(ImageStack(recon_array))

--- a/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
@@ -365,3 +365,9 @@ class NexusLoaderTest(unittest.TestCase):
 
         self.nexus_loader._look_for_recon_entries()
         self.assertEqual(len(self.nexus_loader.recon_data), 1)
+
+    def test_get_dataset_creates_recon_list(self):
+        self.nexus_loader.recon_data = [generate_images(), generate_images()]
+        self.nexus_loader.scan_nexus_file()
+        ds, _ = self.nexus_loader.get_dataset()
+        self.assertEqual(len(ds.recons), 2)

--- a/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import h5py
 import numpy as np
+from mantidimaging.test_helpers.unit_test_helper import generate_images
 
 from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.gui.windows.nexus_load_dialog.presenter import _missing_data_message, TOMO_ENTRY, DATA_PATH, \
@@ -348,3 +349,19 @@ class NexusLoaderTest(unittest.TestCase):
         assert np.array_equal(ds.sample.projection_angles().value, [rotation_angle_data[4], rotation_angle_data[5]])
         self.assertIsNone(ds.dark_after._projection_angles)
         self.assertIsNone(ds.flat_after._projection_angles)
+
+    def test_recon_entry_found_in_file(self):
+        recon = generate_images()
+        recon.name = "Recon"
+
+        recon_entry = self.nexus.create_group(recon.name)
+        recon_entry.attrs["NX_class"] = np.string_("NXentry")
+        recon_entry.create_dataset("title", data=np.string_(recon.name))
+        recon_entry.create_dataset("definition", data=np.string_("NXtomoproc"))
+        data = recon_entry.create_group("data")
+        data.attrs["NX_class"] = np.string_("NXdata")
+        data.create_dataset("data", shape=recon.data.shape, dtype="float16")
+        data["data"][:] = recon.data
+
+        self.nexus_loader._look_for_recon_entries()
+        self.assertEqual(len(self.nexus_loader.recon_data), 1)


### PR DESCRIPTION
### Issue

Closes #1468 

### Description

Reads recon information from NeXus files.

### Testing 

Wrote tests for the reading functions.

### Acceptance Criteria 

Check that the tests pass. Check that a recon can be saved to NeXus and read from NeXus.

### Documentation

Updated release notes. Also added a note in docs about recon being saved as float16.
