### PR TITLE
1661: Use `tifffile` for writing and reading tiff files

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -16,6 +16,7 @@ New Features and improvements
 - #1464 : NeXus Recon: Add entry/reconstruction/date information
 - #1463 : NeXus Recon: Add entry/SAMPLE/name information
 - #1468 : NeXus Recon: Load recons
+- #1661 : Use `tifffile` for writing and reading tiff files
 
 Fixes
 -----

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import Tuple, List, Optional, Union, TYPE_CHECKING, Callable
 
 import numpy as np
-from skimage import io as skio
 import astropy.io.fits as fits
+from tifffile import tifffile
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -45,7 +45,7 @@ def _fitsread(filename: str) -> np.ndarray:
 
 
 def _imread(filename: str) -> np.ndarray:
-    return skio.imread(filename)
+    return tifffile.imread(filename)
 
 
 def supported_formats() -> List[str]:

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -7,9 +7,9 @@ from typing import List, Union, Optional, Dict, Callable
 
 import h5py
 import numpy as np
+from tifffile import tifffile
 
 from mantidimaging.core.operation_history.const import TIMESTAMP
-from skimage import io as skio
 import astropy.io.fits as fits
 
 from .utility import DEFAULT_IO_FILE_FORMAT
@@ -35,7 +35,7 @@ def write_fits(data: np.ndarray, filename: str, overwrite: bool = False, descrip
 
 
 def write_img(data: np.ndarray, filename: str, overwrite: bool = False, description: Optional[str] = ""):
-    skio.imsave(filename, data, description=description, metadata=None, software="Mantid Imaging")
+    tifffile.imwrite(filename, data, description=description, metadata=None, software="Mantid Imaging")
 
 
 def write_nxs(data: np.ndarray, filename: str, projection_angles: Optional[np.ndarray] = None, overwrite: bool = False):

--- a/mantidimaging/gui/widgets/indicator_icon/view.py
+++ b/mantidimaging/gui/widgets/indicator_icon/view.py
@@ -3,10 +3,11 @@
 
 from typing import List, Optional, Tuple, Callable
 
+import numpy as np
+from PIL import Image
 from pyqtgraph import ViewBox
 from PyQt5.QtWidgets import QGraphicsPixmapItem, QGraphicsSimpleTextItem, QMenu, QAction
 from PyQt5.QtGui import QPixmap, QImage, QColor
-from skimage import io as skio
 
 
 class IndicatorIconView(QGraphicsPixmapItem):
@@ -49,7 +50,8 @@ class IndicatorIconView(QGraphicsPixmapItem):
 
     def set_icon(self, icon_path: str, color: Optional[List[int]] = None):
         if color is not None:
-            image_data = skio.imread(icon_path, plugin="imageio")
+            im = Image.open(icon_path)
+            image_data = np.asarray(im)
             # Set the RGB part to the red channel multiplied by the requested color
             red_channel = image_data[:, :, 0] / 255
             image_data[:, :, 0] = red_channel * color[0]

--- a/mantidimaging/gui/widgets/indicator_icon/view.py
+++ b/mantidimaging/gui/widgets/indicator_icon/view.py
@@ -51,7 +51,7 @@ class IndicatorIconView(QGraphicsPixmapItem):
     def set_icon(self, icon_path: str, color: Optional[List[int]] = None):
         if color is not None:
             im = Image.open(icon_path)
-            image_data = np.asarray(im)
+            image_data = np.array(im)
             # Set the RGB part to the red channel multiplied by the requested color
             red_channel = image_data[:, :, 0] / 255
             image_data[:, :, 0] = red_channel * color[0]


### PR DESCRIPTION
### Issue

Closes #1661 

### Description

Uses `tifffile` for reading/writing tiff files rather than `skio`

### Testing 

Didn't add new tests.

### Acceptance Criteria 

Check that the tests pass. Check that reading and writing tiffs works.

### Documentation

Updated release notes.
