### PR TITLE
Postponed Evaluation of Annotations

### DIFF
--- a/AddLicensesToFiles.py
+++ b/AddLicensesToFiles.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 # Update license comment block at the top files
 #

--- a/CheckLicensesInFiles.py
+++ b/CheckLicensesInFiles.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 # Checks the license comment block at the top of files
 #

--- a/conda/make_versions.py
+++ b/conda/make_versions.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import os
 import sys
 import subprocess

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import pytest
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import sys
 import os

--- a/docs/ext/operations_user_doc.py
+++ b/docs/ext/operations_user_doc.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import List
 import inspect

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -34,3 +34,4 @@ Developer Changes
 - #1613 : Refactor Operations window ROI selector to be in its own class
 - #1652 : PEP440 compliant versions for alpha builds
 - #1595 : Store version number in package
+- #1663 : Postponed Evaluation of Annotations

--- a/mantidimaging/__init__.py
+++ b/mantidimaging/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 """
 The gui package is not imported here, because it will pull in all of PyQt
 packages, which we do not want when using only the CLI. This is both a speedup

--- a/mantidimaging/__main__.py
+++ b/mantidimaging/__main__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 if __name__ == '__main__':
     from multiprocessing import freeze_support

--- a/mantidimaging/core/__init__.py
+++ b/mantidimaging/core/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from . import operations, io, parallel, utility  # noqa: F401

--- a/mantidimaging/core/data/__init__.py
+++ b/mantidimaging/core/data/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .imagestack import ImageStack  # noqa: F401

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 from typing import Optional, List, Union

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -7,7 +7,7 @@ import json
 import os.path
 import uuid
 from copy import deepcopy
-from typing import List, Optional, Any, Dict, Union, TextIO
+from typing import List, Optional, Any, Dict, Union, TextIO, TYPE_CHECKING
 
 import numpy as np
 
@@ -15,9 +15,11 @@ from mantidimaging.core.data.utility import mark_cropped
 from mantidimaging.core.operation_history import const
 from mantidimaging.core.parallel import utility as pu
 from mantidimaging.core.utility.data_containers import ProjectionAngles, Counts, Indices
-from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.core.utility.leak_tracker import leak_tracker
+
+if TYPE_CHECKING:
+    from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
 
 
 class ImageStack:

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import datetime
 import json

--- a/mantidimaging/core/data/reconlist.py
+++ b/mantidimaging/core/data/reconlist.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import uuid
 from collections import UserList
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING
 
-from mantidimaging.core.data import ImageStack
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
 
 
 class ReconList(UserList):

--- a/mantidimaging/core/data/reconlist.py
+++ b/mantidimaging/core/data/reconlist.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import uuid
 from collections import UserList

--- a/mantidimaging/core/data/test/__init__.py
+++ b/mantidimaging/core/data/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/data/test/fake_logfile.py
+++ b/mantidimaging/core/data/test/fake_logfile.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from pathlib import Path
 
 from mantidimaging.core.utility.imat_log_file_parser import CSVLogParser, IMATLogFile, TextLogParser

--- a/mantidimaging/core/data/test/image_stack_test.py
+++ b/mantidimaging/core/data/test/image_stack_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import io
 from mantidimaging.core.utility.data_containers import ProjectionAngles

--- a/mantidimaging/core/data/test/reconlist_test.py
+++ b/mantidimaging/core/data/test/reconlist_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import unittest
 import uuid
 

--- a/mantidimaging/core/data/utility.py
+++ b/mantidimaging/core/data/utility.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mantidimaging.core.utility.sensible_roi import SensibleROI
-
 if TYPE_CHECKING:
-    from mantidimaging.core.data import ImageStack  # pragma: no cover
+    from mantidimaging.core.data import ImageStack
+    from mantidimaging.core.utility.sensible_roi import SensibleROI
 
 
-def mark_cropped(images: 'ImageStack', roi: SensibleROI):
+def mark_cropped(images: ImageStack, roi: SensibleROI):
     # avoids circular import error
     from mantidimaging.core.operations.crop_coords import CropCoordinatesFilter
     # not ideal.. but it will allow to replicate the result accurately

--- a/mantidimaging/core/data/utility.py
+++ b/mantidimaging/core/data/utility.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import TYPE_CHECKING
 

--- a/mantidimaging/core/gpu/__init__.py
+++ b/mantidimaging/core/gpu/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/gpu/test/__init__.py
+++ b/mantidimaging/core/gpu/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/gpu/test/gpu_test.py
+++ b/mantidimaging/core/gpu/test/gpu_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 

--- a/mantidimaging/core/gpu/test/import_test.py
+++ b/mantidimaging/core/gpu/test/import_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 

--- a/mantidimaging/core/gpu/utility.py
+++ b/mantidimaging/core/gpu/utility.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import os
 import numpy as np

--- a/mantidimaging/core/io/__init__.py
+++ b/mantidimaging/core/io/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from . import (  # noqa: F401
     saver, loader, utility)

--- a/mantidimaging/core/io/csv_output.py
+++ b/mantidimaging/core/io/csv_output.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from typing import IO, Optional
 
 import numpy as np

--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from pathlib import Path
 import re

--- a/mantidimaging/core/io/loader/__init__.py
+++ b/mantidimaging/core/io/loader/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .loader import (  # noqa: F401
     load, load_stack, load_p, load_log, read_in_file_information, supported_formats)

--- a/mantidimaging/core/io/loader/img_loader.py
+++ b/mantidimaging/core/io/loader/img_loader.py
@@ -6,15 +6,14 @@ This module handles the loading of FIT, FITS, TIF, TIFF
 """
 from typing import Tuple, Optional, List, Callable, Union, TYPE_CHECKING
 
-import numpy as np
-
-if TYPE_CHECKING:
-    import numpy.typing as npt
-
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.parallel import utility as pu
 from mantidimaging.core.utility.progress_reporting import Progress
-from ...utility.data_containers import Indices
+
+if TYPE_CHECKING:
+    import numpy as np
+    import numpy.typing as npt
+    from ...utility.data_containers import Indices
 
 
 def execute(load_func: Callable[[str], np.ndarray],

--- a/mantidimaging/core/io/loader/img_loader.py
+++ b/mantidimaging/core/io/loader/img_loader.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 """
 This module handles the loading of FIT, FITS, TIF, TIFF
 """

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import os
 from dataclasses import dataclass
 from logging import getLogger

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -11,17 +11,17 @@ import numpy as np
 import astropy.io.fits as fits
 from tifffile import tifffile
 
-if TYPE_CHECKING:
-    import numpy.typing as npt
-
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.io.loader import img_loader
 from mantidimaging.core.io.utility import (DEFAULT_IO_FILE_FORMAT, get_file_names, get_prefix, get_file_extension,
                                            find_images, find_first_file_that_is_possibly_a_sample, find_log_for_image,
                                            find_180deg_proj)
 from mantidimaging.core.utility.data_containers import ImageParameters, LoadingParameters, Indices
 from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
-from mantidimaging.core.utility.progress_reporting import Progress
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+    from mantidimaging.core.data import ImageStack
+    from mantidimaging.core.utility.progress_reporting import Progress
 
 LOG = getLogger(__name__)
 

--- a/mantidimaging/core/io/loader/test/__init__.py
+++ b/mantidimaging/core/io/loader/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/io/loader/test/loader_test.py
+++ b/mantidimaging/core/io/loader/test/loader_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from unittest import mock
 from pathlib import Path
 

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import datetime
 import os
 from logging import getLogger

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import datetime
 import os
 from logging import getLogger
-from typing import List, Union, Optional, Dict, Callable, Tuple
+from typing import List, Union, Optional, Dict, Callable, Tuple, TYPE_CHECKING
 
 import h5py
 import numpy as np
@@ -14,12 +14,14 @@ from mantidimaging.core.operation_history.const import TIMESTAMP
 import astropy.io.fits as fits
 
 from .utility import DEFAULT_IO_FILE_FORMAT
-from ..data.dataset import StrictDataset
-from ..data.imagestack import ImageStack
 from ..operations.rescale import RescaleFilter
-from ..utility.data_containers import Indices
 from ..utility.progress_reporting import Progress
 from ..utility.version_check import CheckVersion
+
+if TYPE_CHECKING:
+    from ..data.dataset import StrictDataset
+    from ..data.imagestack import ImageStack
+    from ..utility.data_containers import Indices
 
 LOG = getLogger(__name__)
 

--- a/mantidimaging/core/io/test/__init__.py
+++ b/mantidimaging/core/io/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/io/test/filenames_test.py
+++ b/mantidimaging/core/io/test/filenames_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from pathlib import Path
 import unittest

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import datetime
 import os
 import unittest

--- a/mantidimaging/core/io/test/test_csv_output.py
+++ b/mantidimaging/core/io/test/test_csv_output.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import io
 import unittest
 

--- a/mantidimaging/core/io/test/utility_test.py
+++ b/mantidimaging/core/io/test/utility_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from pathlib import Path
 

--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -8,10 +8,12 @@ import os
 import re
 import numpy as np
 from logging import getLogger
-from pathlib import Path
-from typing import List, Optional, Union, Tuple
+from typing import List, Optional, Union, Tuple, TYPE_CHECKING
 
 from mantidimaging.core.io.filenames import FilenameGroup
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 log = getLogger(__name__)
 

--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import glob
 import itertools

--- a/mantidimaging/core/net/__init__.py
+++ b/mantidimaging/core/net/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/net/help_pages.py
+++ b/mantidimaging/core/net/help_pages.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import Optional
 

--- a/mantidimaging/core/net/test/__init__.py
+++ b/mantidimaging/core/net/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/net/test/help_pages_test.py
+++ b/mantidimaging/core/net/test/help_pages_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/core/operation_history/__init__.py
+++ b/mantidimaging/core/operation_history/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operation_history/const.py
+++ b/mantidimaging/core/operation_history/const.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 OPERATION_HISTORY = 'operation_history'
 OPERATION_NAME = 'name'

--- a/mantidimaging/core/operation_history/operations.py
+++ b/mantidimaging/core/operation_history/operations.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 from logging import getLogger

--- a/mantidimaging/core/operation_history/test/__init__.py
+++ b/mantidimaging/core/operation_history/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operation_history/test/operation_history_test.py
+++ b/mantidimaging/core/operation_history/test/operation_history_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 

--- a/mantidimaging/core/operations/__init__.py
+++ b/mantidimaging/core/operations/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/arithmetic/__init__.py
+++ b/mantidimaging/core/operations/arithmetic/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .arithmetic import ArithmeticFilter  # noqa:F401
 

--- a/mantidimaging/core/operations/arithmetic/arithmetic.py
+++ b/mantidimaging/core/operations/arithmetic/arithmetic.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from functools import partial
 from typing import Callable, Dict
 

--- a/mantidimaging/core/operations/arithmetic/arithmetic.py
+++ b/mantidimaging/core/operations/arithmetic/arithmetic.py
@@ -2,17 +2,17 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from functools import partial
-from typing import Callable, Dict
+from typing import Callable, Dict, TYPE_CHECKING
 
-import numpy as np
-from PyQt5.QtWidgets import QFormLayout, QWidget, QDoubleSpinBox
-
-from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.utility.qt_helpers import add_property_to_form, MAX_SPIN_BOX, Type
-
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.parallel import shared as ps
+
+if TYPE_CHECKING:
+    import numpy as np
+    from mantidimaging.gui.mvp_base import BaseMainWindowView
+    from mantidimaging.core.data import ImageStack
+    from PyQt5.QtWidgets import QFormLayout, QWidget, QDoubleSpinBox
 
 
 class ArithmeticFilter(BaseFilter):

--- a/mantidimaging/core/operations/arithmetic/test/__init__.py
+++ b/mantidimaging/core/operations/arithmetic/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/arithmetic/test/arithmetic_test.py
+++ b/mantidimaging/core/operations/arithmetic/test/arithmetic_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import unittest
 
 import numpy.testing as npt

--- a/mantidimaging/core/operations/base_filter.py
+++ b/mantidimaging/core/operations/base_filter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional

--- a/mantidimaging/core/operations/circular_mask/__init__.py
+++ b/mantidimaging/core/operations/circular_mask/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .circular_mask import CircularMaskFilter  # noqa:F401
 

--- a/mantidimaging/core/operations/circular_mask/circular_mask.py
+++ b/mantidimaging/core/operations/circular_mask/circular_mask.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 from functools import partial
+from typing import TYPE_CHECKING
 
 import tomopy
 
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.utility.qt_helpers import Type
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
 
 
 class CircularMaskFilter(BaseFilter):

--- a/mantidimaging/core/operations/circular_mask/circular_mask.py
+++ b/mantidimaging/core/operations/circular_mask/circular_mask.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 

--- a/mantidimaging/core/operations/circular_mask/test/__init__.py
+++ b/mantidimaging/core/operations/circular_mask/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/circular_mask/test/circular_mask_test.py
+++ b/mantidimaging/core/operations/circular_mask/test/circular_mask_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from parameterized import parameterized
 import unittest

--- a/mantidimaging/core/operations/clip_values/__init__.py
+++ b/mantidimaging/core/operations/clip_values/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .clip_values import ClipValuesFilter  # noqa:F401
 

--- a/mantidimaging/core/operations/clip_values/clip_values.py
+++ b/mantidimaging/core/operations/clip_values/clip_values.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from functools import partial
+from typing import TYPE_CHECKING
 
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.utility.progress_reporting import Progress
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
 
 
 class ClipValuesFilter(BaseFilter):

--- a/mantidimaging/core/operations/clip_values/clip_values.py
+++ b/mantidimaging/core/operations/clip_values/clip_values.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 

--- a/mantidimaging/core/operations/clip_values/test/__init__.py
+++ b/mantidimaging/core/operations/clip_values/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/clip_values/test/clip_values_test.py
+++ b/mantidimaging/core/operations/clip_values/test/clip_values_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/core/operations/crop_coords/__init__.py
+++ b/mantidimaging/core/operations/crop_coords/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .crop_coords import CropCoordinatesFilter, execute_single  # noqa:F401
 

--- a/mantidimaging/core/operations/crop_coords/crop_coords.py
+++ b/mantidimaging/core/operations/crop_coords/crop_coords.py
@@ -3,17 +3,18 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Union, Optional, List
-
-from PyQt5.QtWidgets import QLineEdit
+from typing import Union, Optional, List, TYPE_CHECKING
 
 from mantidimaging import helper as h
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
 from mantidimaging.core.parallel import utility as pu
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.utility.qt_helpers import Type
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
+    from PyQt5.QtWidgets import QLineEdit
 
 
 class CropCoordinatesFilter(BaseFilter):

--- a/mantidimaging/core/operations/crop_coords/crop_coords.py
+++ b/mantidimaging/core/operations/crop_coords/crop_coords.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 from typing import Union, Optional, List

--- a/mantidimaging/core/operations/crop_coords/test/__init__.py
+++ b/mantidimaging/core/operations/crop_coords/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
+++ b/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 

--- a/mantidimaging/core/operations/divide/__init__.py
+++ b/mantidimaging/core/operations/divide/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .divide import DivideFilter  # noqa:F401
 

--- a/mantidimaging/core/operations/divide/divide.py
+++ b/mantidimaging/core/operations/divide/divide.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 from typing import Union, Callable, Dict, Any

--- a/mantidimaging/core/operations/divide/divide.py
+++ b/mantidimaging/core/operations/divide/divide.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Union, Callable, Dict, Any
-
-from PyQt5.QtWidgets import QFormLayout, QDoubleSpinBox, QComboBox
+from typing import Union, Callable, Dict, Any, TYPE_CHECKING
 
 from mantidimaging import helper as h
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
-from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.utility.qt_helpers import Type
+
+if TYPE_CHECKING:
+    from PyQt5.QtWidgets import QFormLayout, QDoubleSpinBox, QComboBox
+    from mantidimaging.gui.mvp_base import BasePresenter
+    from mantidimaging.core.data import ImageStack
 
 
 class DivideFilter(BaseFilter):

--- a/mantidimaging/core/operations/divide/test/__init__.py
+++ b/mantidimaging/core/operations/divide/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/divide/test/divide_test.py
+++ b/mantidimaging/core/operations/divide/test/divide_test.py
@@ -6,10 +6,13 @@ from parameterized import parameterized
 import unittest
 from unittest import mock
 import numpy as np
+from typing import TYPE_CHECKING
 
 import mantidimaging.test_helpers.unit_test_helper as th
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.divide import DivideFilter
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
 
 
 class DivideTest(unittest.TestCase):

--- a/mantidimaging/core/operations/divide/test/divide_test.py
+++ b/mantidimaging/core/operations/divide/test/divide_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from parameterized import parameterized
 import unittest

--- a/mantidimaging/core/operations/flat_fielding/__init__.py
+++ b/mantidimaging/core/operations/flat_fielding/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .flat_fielding import FlatFieldFilter  # noqa:F401
 

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -3,18 +3,20 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Any, Dict
+from typing import Any, Dict, TYPE_CHECKING
 from PyQt5.QtWidgets import QComboBox, QCheckBox
 
 import numpy as np
 
 from mantidimaging import helper as h
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
 from mantidimaging.core.parallel import utility as pu, shared as ps
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.utility.qt_helpers import Type
 from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
 
 # The smallest and largest allowed pixel value
 MINIMUM_PIXEL_VALUE = 1e-9

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 from typing import Any, Dict

--- a/mantidimaging/core/operations/flat_fielding/test/__init__.py
+++ b/mantidimaging/core/operations/flat_fielding/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
+++ b/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from parameterized import parameterized
 import unittest
-from typing import Tuple
+from typing import Tuple, TYPE_CHECKING
 from unittest import mock
 
 import numpy as np
@@ -12,8 +12,10 @@ import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.flat_fielding.flat_fielding import enable_correct_fields_only
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.flat_fielding import FlatFieldFilter
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
 
 
 class FlatFieldingTest(unittest.TestCase):

--- a/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
+++ b/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from parameterized import parameterized
 import unittest

--- a/mantidimaging/core/operations/gaussian/__init__.py
+++ b/mantidimaging/core/operations/gaussian/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .gaussian import GaussianFilter, modes  # noqa:F401
 

--- a/mantidimaging/core/operations/gaussian/gaussian.py
+++ b/mantidimaging/core/operations/gaussian/gaussian.py
@@ -4,16 +4,19 @@ from __future__ import annotations
 
 from functools import partial
 from logging import getLogger
+from typing import TYPE_CHECKING
 
 import scipy.ndimage as scipy_ndimage
 
 from mantidimaging import helper as h
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.utility import add_property_to_form
 from mantidimaging.gui.utility.qt_helpers import Type
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
 
 
 class GaussianFilter(BaseFilter):

--- a/mantidimaging/core/operations/gaussian/gaussian.py
+++ b/mantidimaging/core/operations/gaussian/gaussian.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 from logging import getLogger

--- a/mantidimaging/core/operations/gaussian/test/__init__.py
+++ b/mantidimaging/core/operations/gaussian/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/gaussian/test/gaussian_test.py
+++ b/mantidimaging/core/operations/gaussian/test/gaussian_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from parameterized import parameterized
 import unittest

--- a/mantidimaging/core/operations/loader.py
+++ b/mantidimaging/core/operations/loader.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import os
 import pkgutil
 import sys

--- a/mantidimaging/core/operations/loader.py
+++ b/mantidimaging/core/operations/loader.py
@@ -10,8 +10,7 @@ from importlib.abc import Loader
 
 if TYPE_CHECKING:
     from PyInstaller.loader.pyimod02_importers import FrozenImporter
-
-from mantidimaging.core.operations.base_filter import BaseFilter
+    from mantidimaging.core.operations.base_filter import BaseFilter
 
 MODULES_OPERATIONS: dict[str, Union['FrozenImporter', Loader]] = {}
 if not MODULES_OPERATIONS:
@@ -49,6 +48,6 @@ def load_filter_packages(ignored_packages=None) -> List[BaseFilter]:
         if not ignored_packages or not any([ignore in name for ignore in ignored_packages]):
             module = MODULES_OPERATIONS[name].load_module(name)
             if hasattr(module, 'FILTER_CLASS'):
-                operation_module = cast(OperationModule, module)
+                operation_module = cast("OperationModule", module)
                 operation_modules.append(operation_module.FILTER_CLASS)
     return operation_modules

--- a/mantidimaging/core/operations/median_filter/__init__.py
+++ b/mantidimaging/core/operations/median_filter/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .median_filter import MedianFilter, modes  # noqa:F401
 

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -12,7 +12,6 @@ from PyQt5.QtGui import QValidator
 from PyQt5.QtWidgets import QSpinBox, QLabel, QSizePolicy
 
 from mantidimaging import helper as h
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.gpu import utility as gpu
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.parallel import shared as ps
@@ -22,6 +21,7 @@ from mantidimaging.gui.utility.qt_helpers import Type, on_change_and_disable
 
 if TYPE_CHECKING:
     from PyQt5.QtWidgets import QFormLayout  # pragma: no cover
+    from mantidimaging.core.data import ImageStack
 
 KERNEL_SIZE_TOOLTIP = "Size of the median filter kernel"
 

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 from logging import getLogger

--- a/mantidimaging/core/operations/median_filter/test/__init__.py
+++ b/mantidimaging/core/operations/median_filter/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/median_filter/test/median_filter_test.py
+++ b/mantidimaging/core/operations/median_filter/test/median_filter_test.py
@@ -5,15 +5,18 @@ from __future__ import annotations
 from parameterized import parameterized
 import unittest
 from unittest import mock
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
-from mantidimaging.core.data.imagestack import ImageStack
 from mantidimaging.core.gpu import utility as gpu
 from mantidimaging.core.operations.median_filter import MedianFilter
 from mantidimaging.test_helpers.start_qapplication import start_multiprocessing_pool
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data.imagestack import ImageStack
 
 GPU_UTIL_LOC = "mantidimaging.core.gpu.utility.gpu_available"
 

--- a/mantidimaging/core/operations/median_filter/test/median_filter_test.py
+++ b/mantidimaging/core/operations/median_filter/test/median_filter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from parameterized import parameterized
 import unittest

--- a/mantidimaging/core/operations/median_filter/test/median_kernel_test.py
+++ b/mantidimaging/core/operations/median_filter/test/median_kernel_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/core/operations/monitor_normalisation/__init__.py
+++ b/mantidimaging/core/operations/monitor_normalisation/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .monitor_normalisation import MonitorNormalisation  # noqa:F401
 

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from functools import partial
 from typing import Callable, Dict, Any
 

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -2,16 +2,18 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from functools import partial
-from typing import Callable, Dict, Any
+from typing import Callable, Dict, Any, TYPE_CHECKING
 
 import numpy as np
-from PyQt5.QtWidgets import QFormLayout, QWidget
 
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.core.parallel import utility as pu
-from mantidimaging.gui.mvp_base import BaseMainWindowView
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
+    from mantidimaging.gui.mvp_base import BaseMainWindowView
+    from PyQt5.QtWidgets import QFormLayout, QWidget
 
 
 def _divide_by_counts(data=None, counts=None):

--- a/mantidimaging/core/operations/monitor_normalisation/test/__init__.py
+++ b/mantidimaging/core/operations/monitor_normalisation/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/monitor_normalisation/test/monitor_normalisation_test.py
+++ b/mantidimaging/core/operations/monitor_normalisation/test/monitor_normalisation_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from functools import partial
 
 from unittest import mock

--- a/mantidimaging/core/operations/nan_removal/__init__.py
+++ b/mantidimaging/core/operations/nan_removal/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .nan_removal import NaNRemovalFilter  # noqa:F401
 

--- a/mantidimaging/core/operations/nan_removal/nan_removal.py
+++ b/mantidimaging/core/operations/nan_removal/nan_removal.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from collections.abc import Callable
 from functools import partial

--- a/mantidimaging/core/operations/nan_removal/nan_removal.py
+++ b/mantidimaging/core/operations/nan_removal/nan_removal.py
@@ -2,21 +2,23 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from collections.abc import Callable
 from functools import partial
 from logging import getLogger
-from typing import Dict
+from typing import Dict, TYPE_CHECKING
 
 import numpy as np
-from PyQt5.QtWidgets import QFormLayout, QWidget
 import scipy.ndimage as scipy_ndimage
 
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.core.utility.progress_reporting import Progress
-from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.utility.qt_helpers import Type
+
+if TYPE_CHECKING:
+    from PyQt5.QtWidgets import QFormLayout, QWidget
+    from mantidimaging.core.data import ImageStack
+    from mantidimaging.gui.mvp_base import BaseMainWindowView
+    from collections.abc import Callable
 
 
 def enable_correct_fields_only(mode_field, replace_value_field):

--- a/mantidimaging/core/operations/nan_removal/test/__init__.py
+++ b/mantidimaging/core/operations/nan_removal/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/nan_removal/test/nan_removal_test.py
+++ b/mantidimaging/core/operations/nan_removal/test/nan_removal_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 

--- a/mantidimaging/core/operations/outliers/__init__.py
+++ b/mantidimaging/core/operations/outliers/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .outliers import OutliersFilter, modes  # noqa:F401
 

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -3,16 +3,19 @@
 from __future__ import annotations
 
 from functools import partial
+from typing import TYPE_CHECKING
 
 import numpy as np
 import scipy.ndimage as scipy_ndimage
 
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
 from mantidimaging.core.parallel import shared as ps
-from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.utility import add_property_to_form
 from mantidimaging.gui.utility.qt_helpers import Type
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
+    from mantidimaging.core.utility.progress_reporting import Progress
 
 OUTLIERS_DARK = 'dark'
 OUTLIERS_BRIGHT = 'bright'

--- a/mantidimaging/core/operations/outliers/test/__init__.py
+++ b/mantidimaging/core/operations/outliers/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/outliers/test/outliers_test.py
+++ b/mantidimaging/core/operations/outliers/test/outliers_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from parameterized import parameterized
 import unittest

--- a/mantidimaging/core/operations/rebin/__init__.py
+++ b/mantidimaging/core/operations/rebin/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .rebin import RebinFilter, modes  # noqa:F401
 

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -3,16 +3,19 @@
 from __future__ import annotations
 
 from functools import partial
+from typing import TYPE_CHECKING
 
 import skimage.transform
 
 from mantidimaging import helper as h
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.core.parallel import utility as pu
 from mantidimaging.gui.utility import add_property_to_form
 from mantidimaging.gui.utility.qt_helpers import Type
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
 
 
 class RebinFilter(BaseFilter):

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 

--- a/mantidimaging/core/operations/rebin/test/__init__.py
+++ b/mantidimaging/core/operations/rebin/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/rebin/test/rebin_test.py
+++ b/mantidimaging/core/operations/rebin/test/rebin_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from parameterized import parameterized
 import unittest

--- a/mantidimaging/core/operations/remove_all_stripe/__init__.py
+++ b/mantidimaging/core/operations/remove_all_stripe/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .remove_all_stripe import RemoveAllStripesFilter  # noqa:F401
 

--- a/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
+++ b/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 from typing import Dict, Any

--- a/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
+++ b/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
@@ -3,16 +3,18 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Dict, Any
-from mantidimaging.core.data.imagestack import ImageStack
+from typing import Dict, Any, TYPE_CHECKING
 
-from PyQt5.QtWidgets import QSpinBox, QDoubleSpinBox
 from algotom.prep.removal import remove_all_stripe
-from numpy import ndarray
 
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.gui.utility.qt_helpers import Type
+
+if TYPE_CHECKING:
+    from numpy import ndarray
+    from mantidimaging.core.data.imagestack import ImageStack
+    from PyQt5.QtWidgets import QSpinBox, QDoubleSpinBox
 
 
 class RemoveAllStripesFilter(BaseFilter):

--- a/mantidimaging/core/operations/remove_all_stripe/test/__init__.py
+++ b/mantidimaging/core/operations/remove_all_stripe/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/remove_all_stripe/test/remove_all_stripe_test.py
+++ b/mantidimaging/core/operations/remove_all_stripe/test/remove_all_stripe_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/core/operations/remove_dead_stripe/__init__.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .remove_dead_stripe import RemoveDeadStripesFilter  # noqa:F401
 

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 from typing import Dict, Any

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -3,16 +3,18 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Dict, Any
+from typing import Dict, Any, TYPE_CHECKING
 
-from PyQt5.QtWidgets import QDoubleSpinBox, QSpinBox
 from algotom.prep.removal import remove_dead_stripe
-from numpy import ndarray
 
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.gui.utility.qt_helpers import Type
-from mantidimaging.core.data.imagestack import ImageStack
+
+if TYPE_CHECKING:
+    from numpy import ndarray
+    from mantidimaging.core.data.imagestack import ImageStack
+    from PyQt5.QtWidgets import QDoubleSpinBox, QSpinBox
 
 
 class RemoveDeadStripesFilter(BaseFilter):

--- a/mantidimaging/core/operations/remove_dead_stripe/test/__init__.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/remove_dead_stripe/test/remove_dead_stripe_test.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/test/remove_dead_stripe_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/core/operations/remove_large_stripe/__init__.py
+++ b/mantidimaging/core/operations/remove_large_stripe/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .remove_large_stripe import RemoveLargeStripesFilter  # noqa:F401
 

--- a/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
+++ b/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from functools import partial
 from typing import TYPE_CHECKING, Dict, Any
 
-from PyQt5.QtWidgets import QSpinBox, QDoubleSpinBox
 from algotom.prep.removal import remove_large_stripe
 
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
@@ -15,6 +14,7 @@ from mantidimaging.gui.utility.qt_helpers import Type
 if TYPE_CHECKING:
     from mantidimaging.core.data.imagestack import ImageStack
     from numpy import ndarray
+    from PyQt5.QtWidgets import QSpinBox, QDoubleSpinBox
 
 
 class RemoveLargeStripesFilter(BaseFilter):

--- a/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
+++ b/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 from typing import TYPE_CHECKING, Dict, Any

--- a/mantidimaging/core/operations/remove_large_stripe/test/__init__.py
+++ b/mantidimaging/core/operations/remove_large_stripe/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/remove_large_stripe/test/remove_large_stripe_test.py
+++ b/mantidimaging/core/operations/remove_large_stripe/test/remove_large_stripe_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/core/operations/remove_stripe_filtering/__init__.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .remove_stripe_filtering import RemoveStripeFilteringFilter  # noqa:F401
 

--- a/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 from typing import Dict, Any

--- a/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
@@ -3,16 +3,18 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Dict, Any
+from typing import Dict, Any, TYPE_CHECKING
 
-from PyQt5.QtWidgets import QSpinBox
 from algotom.prep.removal import remove_stripe_based_filtering, remove_stripe_based_2d_filtering_sorting
-from numpy import ndarray
 
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.gui.utility.qt_helpers import Type
-from mantidimaging.core.data.imagestack import ImageStack
+
+if TYPE_CHECKING:
+    from numpy import ndarray
+    from mantidimaging.core.data.imagestack import ImageStack
+    from PyQt5.QtWidgets import QSpinBox
 
 
 class RemoveStripeFilteringFilter(BaseFilter):

--- a/mantidimaging/core/operations/remove_stripe_filtering/test/__init__.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/remove_stripe_filtering/test/remove_stripe_filtering_test.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/test/remove_stripe_filtering_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/__init__.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .remove_stripe_sorting_fitting import RemoveStripeSortingFittingFilter  # noqa:F401
 

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 from typing import Dict, Any

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
@@ -3,16 +3,18 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Dict, Any
+from typing import Dict, Any, TYPE_CHECKING
 
-from PyQt5.QtWidgets import QSpinBox
 from algotom.prep.removal import remove_stripe_based_fitting
-from numpy import ndarray
 
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.gui.utility.qt_helpers import Type
-from mantidimaging.core.data.imagestack import ImageStack
+
+if TYPE_CHECKING:
+    from numpy import ndarray
+    from mantidimaging.core.data.imagestack import ImageStack
+    from PyQt5.QtWidgets import QSpinBox
 
 
 class RemoveStripeSortingFittingFilter(BaseFilter):

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/test/__init__.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/test/remove_stripe_sorting_fitting_test.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/test/remove_stripe_sorting_fitting_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/core/operations/rescale/__init__.py
+++ b/mantidimaging/core/operations/rescale/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .rescale import RescaleFilter  # noqa:F401
 

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Any, Dict
+from typing import Any, Dict, TYPE_CHECKING
 
 import numpy as np
-from PyQt5.QtWidgets import QComboBox, QDoubleSpinBox
 
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.gui.utility.qt_helpers import Type
-from mantidimaging.gui.windows.operations import FiltersWindowView
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
+    from mantidimaging.gui.windows.operations import FiltersWindowView
+    from PyQt5.QtWidgets import QComboBox, QDoubleSpinBox
 
 
 class RescaleFilter(BaseFilter):

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 from typing import Any, Dict

--- a/mantidimaging/core/operations/rescale/rescale_test.py
+++ b/mantidimaging/core/operations/rescale/rescale_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import math
 import numpy as np

--- a/mantidimaging/core/operations/ring_removal/__init__.py
+++ b/mantidimaging/core/operations/ring_removal/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .ring_removal import RingRemovalFilter  # noqa:F401
 

--- a/mantidimaging/core/operations/ring_removal/ring_removal.py
+++ b/mantidimaging/core/operations/ring_removal/ring_removal.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 from functools import partial
+from typing import TYPE_CHECKING
 
 from PyQt5.QtWidgets import QComboBox
 
 from mantidimaging import helper as h
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.utility.optional_imports import safe_import
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.utility.qt_helpers import Type
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
 
 
 class RingRemovalFilter(BaseFilter):

--- a/mantidimaging/core/operations/ring_removal/ring_removal.py
+++ b/mantidimaging/core/operations/ring_removal/ring_removal.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 

--- a/mantidimaging/core/operations/ring_removal/test/__init__.py
+++ b/mantidimaging/core/operations/ring_removal/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/ring_removal/test/ring_removal_test.py
+++ b/mantidimaging/core/operations/ring_removal/test/ring_removal_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest.mock import Mock

--- a/mantidimaging/core/operations/roi_normalisation/__init__.py
+++ b/mantidimaging/core/operations/roi_normalisation/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .roi_normalisation import RoiNormalisationFilter  # noqa:F401
 

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 from functools import partial
 from logging import getLogger
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING
 
 import numpy as np
 
 from mantidimaging import helper as h
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.core.parallel import utility as pu
@@ -18,6 +17,9 @@ from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.utility import add_property_to_form
 from mantidimaging.gui.utility.qt_helpers import Type
 from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
 
 
 def modes() -> List[str]:

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 from logging import getLogger

--- a/mantidimaging/core/operations/roi_normalisation/test/__init__.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
@@ -4,15 +4,18 @@ from __future__ import annotations
 
 import unittest
 from unittest import mock
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.testing as npt
 
 import mantidimaging.test_helpers.unit_test_helper as th
-from mantidimaging.core.data.imagestack import ImageStack
 from mantidimaging.core.operations.roi_normalisation import RoiNormalisationFilter
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.test_helpers.start_qapplication import start_multiprocessing_pool
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data.imagestack import ImageStack
 
 
 @start_multiprocessing_pool

--- a/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/core/operations/rotate_stack/__init__.py
+++ b/mantidimaging/core/operations/rotate_stack/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .rotate_stack import RotateFilter  # noqa:F401
 

--- a/mantidimaging/core/operations/rotate_stack/rotate_stack.py
+++ b/mantidimaging/core/operations/rotate_stack/rotate_stack.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 from functools import partial
+from typing import TYPE_CHECKING
 
 from skimage.transform import rotate
 
 from mantidimaging import helper as h
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.utility.qt_helpers import Type
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
 
 
 class RotateFilter(BaseFilter):

--- a/mantidimaging/core/operations/rotate_stack/rotate_stack.py
+++ b/mantidimaging/core/operations/rotate_stack/rotate_stack.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 

--- a/mantidimaging/core/operations/rotate_stack/test/__init__.py
+++ b/mantidimaging/core/operations/rotate_stack/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/rotate_stack/test/rotate_stack_test.py
+++ b/mantidimaging/core/operations/rotate_stack/test/rotate_stack_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/core/operations/test/__init__.py
+++ b/mantidimaging/core/operations/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/test/operations_test.py
+++ b/mantidimaging/core/operations/test/operations_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import Dict, List
 import unittest

--- a/mantidimaging/core/operations/test/operations_test.py
+++ b/mantidimaging/core/operations/test/operations_test.py
@@ -2,16 +2,19 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Dict, List, TYPE_CHECKING
 import unittest
 from unittest import mock
 
 import numpy
 
-from mantidimaging.core.operations.loader import load_filter_packages, BaseFilter
+from mantidimaging.core.operations.loader import load_filter_packages
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.utility.data_containers import Counts
 from mantidimaging.core.gpu import utility as gpu
+
+if TYPE_CHECKING:
+    from mantidimaging.core.operations.base_filter import BaseFilter
 
 GPU_NOT_AVAIL = not gpu.gpu_available()
 

--- a/mantidimaging/core/parallel/__init__.py
+++ b/mantidimaging/core/parallel/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/parallel/manager.py
+++ b/mantidimaging/core/parallel/manager.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from multiprocessing import get_context
 import os
 import uuid

--- a/mantidimaging/core/parallel/shared.py
+++ b/mantidimaging/core/parallel/shared.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 from typing import List, Tuple, Union, Callable, Dict, Any, TYPE_CHECKING

--- a/mantidimaging/core/parallel/test/__init__.py
+++ b/mantidimaging/core/parallel/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/parallel/test/manager_test.py
+++ b/mantidimaging/core/parallel/test/manager_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import unittest
 from unittest.mock import patch
 

--- a/mantidimaging/core/parallel/test/shared_test.py
+++ b/mantidimaging/core/parallel/test/shared_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import unittest
 from unittest import mock
 

--- a/mantidimaging/core/parallel/test/utility_test.py
+++ b/mantidimaging/core/parallel/test/utility_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import numpy as np
 from unittest import mock

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -3,21 +3,21 @@
 from __future__ import annotations
 
 import os
-from functools import partial
 from logging import getLogger
 from multiprocessing import shared_memory
-from multiprocessing.shared_memory import SharedMemory
 from typing import Tuple, TYPE_CHECKING, Optional, Callable
 
 import numpy as np
-
-if TYPE_CHECKING:
-    import numpy.typing as npt
 
 from mantidimaging.core.utility.memory_usage import system_free_memory
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.core.utility.size_calculator import full_size_KB, full_size_bytes
 from mantidimaging.core.parallel import manager as pm
+
+if TYPE_CHECKING:
+    from functools import partial
+    import numpy.typing as npt
+    from multiprocessing.shared_memory import SharedMemory
 
 LOG = getLogger(__name__)
 

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import os
 from functools import partial

--- a/mantidimaging/core/reconstruct/__init__.py
+++ b/mantidimaging/core/reconstruct/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .astra_recon import AstraRecon
 from .tomopy_recon import TomopyRecon

--- a/mantidimaging/core/reconstruct/__init__.py
+++ b/mantidimaging/core/reconstruct/__init__.py
@@ -2,10 +2,14 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from .astra_recon import AstraRecon
 from .tomopy_recon import TomopyRecon
 from .cil_recon import CILRecon
-from .base_recon import BaseRecon
+
+if TYPE_CHECKING:
+    from .base_recon import BaseRecon
 
 
 def get_reconstructor_for(algorithm: str) -> BaseRecon:

--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from contextlib import contextmanager
 from logging import getLogger

--- a/mantidimaging/core/reconstruct/base_recon.py
+++ b/mantidimaging/core/reconstruct/base_recon.py
@@ -2,14 +2,15 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING
 
 import numpy as np
 from numpy.polynomial import Polynomial
 
-from mantidimaging.core.data import ImageStack
-from mantidimaging.core.utility.data_containers import ScalarCoR, ProjectionAngles, ReconstructionParameters
-from mantidimaging.core.utility.progress_reporting import Progress
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
+    from mantidimaging.core.utility.data_containers import ScalarCoR, ProjectionAngles, ReconstructionParameters
+    from mantidimaging.core.utility.progress_reporting import Progress
 
 
 class BaseRecon:

--- a/mantidimaging/core/reconstruct/base_recon.py
+++ b/mantidimaging/core/reconstruct/base_recon.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import List, Optional
 

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -6,7 +6,7 @@ import time
 from logging import getLogger, DEBUG
 from math import sqrt
 from threading import Lock
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING
 
 import numpy as np
 
@@ -18,11 +18,13 @@ from cil.plugins.astra.operators import ProjectionOperator
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.reconstruct.base_recon import BaseRecon
-from mantidimaging.core.utility.data_containers import ProjectionAngles, ReconstructionParameters, ScalarCoR
 from mantidimaging.core.utility.optional_imports import safe_import
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.core.utility.size_calculator import full_size_KB
 from mantidimaging.core.utility.memory_usage import system_free_memory
+
+if TYPE_CHECKING:
+    from mantidimaging.core.utility.data_containers import ProjectionAngles, ReconstructionParameters, ScalarCoR
 
 LOG = getLogger(__name__)
 tomopy = safe_import('tomopy')

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import time
 from logging import getLogger, DEBUG

--- a/mantidimaging/core/reconstruct/tomopy_recon.py
+++ b/mantidimaging/core/reconstruct/tomopy_recon.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from logging import getLogger
 from typing import List, Optional

--- a/mantidimaging/core/reconstruct/tomopy_recon.py
+++ b/mantidimaging/core/reconstruct/tomopy_recon.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 from logging import getLogger
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING
 
 import numpy as np
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.reconstruct.base_recon import BaseRecon
-from mantidimaging.core.utility.data_containers import ProjectionAngles, ReconstructionParameters, ScalarCoR
 from mantidimaging.core.utility.optional_imports import safe_import
 from mantidimaging.core.utility.progress_reporting import Progress
+
+if TYPE_CHECKING:
+    from mantidimaging.core.utility.data_containers import ProjectionAngles, ReconstructionParameters, ScalarCoR
 
 LOG = getLogger(__name__)
 tomopy = safe_import('tomopy')

--- a/mantidimaging/core/rotation/__init__.py
+++ b/mantidimaging/core/rotation/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .data_model import CorTiltDataModel  # noqa: F401

--- a/mantidimaging/core/rotation/data_model.py
+++ b/mantidimaging/core/rotation/data_model.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from logging import getLogger
 from typing import Optional, List, Iterator, NamedTuple

--- a/mantidimaging/core/rotation/polyfit_correlation.py
+++ b/mantidimaging/core/rotation/polyfit_correlation.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from logging import getLogger
 from typing import Tuple

--- a/mantidimaging/core/rotation/polyfit_correlation.py
+++ b/mantidimaging/core/rotation/polyfit_correlation.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 from logging import getLogger
-from typing import Tuple
+from typing import Tuple, TYPE_CHECKING
 
 import numpy as np
 
-from mantidimaging.core.data import ImageStack
 from mantidimaging.core.parallel import utility as pu, shared as ps
 from mantidimaging.core.utility.data_containers import Degrees, ScalarCoR
-from mantidimaging.core.utility.progress_reporting import Progress
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
+    from mantidimaging.core.utility.progress_reporting import Progress
 
 LOG = getLogger(__name__)
 

--- a/mantidimaging/core/rotation/test/__init__.py
+++ b/mantidimaging/core/rotation/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/rotation/test/data_model_test.py
+++ b/mantidimaging/core/rotation/test/data_model_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from unittest import TestCase
 

--- a/mantidimaging/core/rotation/test/polyfit_correlation_test.py
+++ b/mantidimaging/core/rotation/test/polyfit_correlation_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import unittest
 from unittest import mock
 import numpy as np

--- a/mantidimaging/core/utility/__init__.py
+++ b/mantidimaging/core/utility/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from . import (  # noqa: F401
     progress_reporting, cor_interpolate, finder, histogram, memory_usage, projection_angles, size_calculator)

--- a/mantidimaging/core/utility/close_enough_point.py
+++ b/mantidimaging/core/utility/close_enough_point.py
@@ -2,8 +2,10 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from typing import Union
-from collections.abc import Sequence
+from typing import Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class CloseEnoughPoint:

--- a/mantidimaging/core/utility/close_enough_point.py
+++ b/mantidimaging/core/utility/close_enough_point.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import Union
 from collections.abc import Sequence

--- a/mantidimaging/core/utility/command_line_arguments.py
+++ b/mantidimaging/core/utility/command_line_arguments.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from logging import getLogger
 import os
 

--- a/mantidimaging/core/utility/cor_interpolate.py
+++ b/mantidimaging/core/utility/cor_interpolate.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import numpy as np
 

--- a/mantidimaging/core/utility/cuda_check.py
+++ b/mantidimaging/core/utility/cuda_check.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from logging import getLogger
 from typing import Tuple
 

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -10,10 +10,11 @@ and helps the type hints to tell you that you might be passing the wrong value (
 while they're both Float underneath and the value can be used, it just will produce nonsense.
 """
 from dataclasses import dataclass
-from pathlib import Path
-from typing import List, Optional, NamedTuple
+from typing import List, Optional, NamedTuple, TYPE_CHECKING
 
-import numpy
+if TYPE_CHECKING:
+    from pathlib import Path
+    import numpy
 
 
 @dataclass

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 """
 Containers for data. They don't do much apart from storing the data,
 and optionally provide helpful operations.

--- a/mantidimaging/core/utility/execution_timer.py
+++ b/mantidimaging/core/utility/execution_timer.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import time
 

--- a/mantidimaging/core/utility/finder.py
+++ b/mantidimaging/core/utility/finder.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import os
 import mantidimaging

--- a/mantidimaging/core/utility/func_call.py
+++ b/mantidimaging/core/utility/func_call.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import inspect
 

--- a/mantidimaging/core/utility/histogram.py
+++ b/mantidimaging/core/utility/histogram.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import numpy as np
 

--- a/mantidimaging/core/utility/histogram_test.py
+++ b/mantidimaging/core/utility/histogram_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import numpy as np
 

--- a/mantidimaging/core/utility/imat_log_file_parser.py
+++ b/mantidimaging/core/utility/imat_log_file_parser.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import csv
 import re

--- a/mantidimaging/core/utility/imat_log_file_parser.py
+++ b/mantidimaging/core/utility/imat_log_file_parser.py
@@ -6,12 +6,14 @@ import csv
 import re
 from enum import Enum, auto
 from itertools import zip_longest
-from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, TYPE_CHECKING
 
 import numpy
 
 from mantidimaging.core.utility.data_containers import Counts, ProjectionAngles
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _get_projection_number(s: str) -> int:

--- a/mantidimaging/core/utility/leak_tracker.py
+++ b/mantidimaging/core/utility/leak_tracker.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import gc
 import sys
 import traceback

--- a/mantidimaging/core/utility/memory_usage.py
+++ b/mantidimaging/core/utility/memory_usage.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from logging import getLogger
 

--- a/mantidimaging/core/utility/optional_imports.py
+++ b/mantidimaging/core/utility/optional_imports.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 """
 A place for availability checking and import logic for optional dependencies to
 live.

--- a/mantidimaging/core/utility/progress_reporting/__init__.py
+++ b/mantidimaging/core/utility/progress_reporting/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .progress import Progress, ProgressHandler  # noqa: F401
 from .console_progress_bar import ConsoleProgressBar  # noqa: F401

--- a/mantidimaging/core/utility/progress_reporting/console_progress_bar.py
+++ b/mantidimaging/core/utility/progress_reporting/console_progress_bar.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import sys
 

--- a/mantidimaging/core/utility/progress_reporting/progress.py
+++ b/mantidimaging/core/utility/progress_reporting/progress.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import threading
 import time

--- a/mantidimaging/core/utility/progress_reporting/test/__init__.py
+++ b/mantidimaging/core/utility/progress_reporting/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/utility/progress_reporting/test/progress_test.py
+++ b/mantidimaging/core/utility/progress_reporting/test/progress_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 

--- a/mantidimaging/core/utility/projection_angle_parser.py
+++ b/mantidimaging/core/utility/projection_angle_parser.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import numpy as np
 from mantidimaging.core.utility.data_containers import ProjectionAngles

--- a/mantidimaging/core/utility/projection_angles.py
+++ b/mantidimaging/core/utility/projection_angles.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import math
 

--- a/mantidimaging/core/utility/sensible_roi.py
+++ b/mantidimaging/core/utility/sensible_roi.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass

--- a/mantidimaging/core/utility/sensible_roi.py
+++ b/mantidimaging/core/utility/sensible_roi.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Union, List, Iterator
+from typing import Union, List, Iterator, TYPE_CHECKING
 
-from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint
+if TYPE_CHECKING:
+    from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint
 
 
 @dataclass

--- a/mantidimaging/core/utility/size_calculator.py
+++ b/mantidimaging/core/utility/size_calculator.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import math
 import numpy

--- a/mantidimaging/core/utility/test/__init__.py
+++ b/mantidimaging/core/utility/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/utility/test/command_line_arguments_test.py
+++ b/mantidimaging/core/utility/test/command_line_arguments_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import logging
 import unittest
 from unittest import mock

--- a/mantidimaging/core/utility/test/cuda_checker_test.py
+++ b/mantidimaging/core/utility/test/cuda_checker_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import unittest
 from unittest import mock
 from unittest.mock import patch

--- a/mantidimaging/core/utility/test/execution_timer_test.py
+++ b/mantidimaging/core/utility/test/execution_timer_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 import time

--- a/mantidimaging/core/utility/test/imat_log_file_parser_test.py
+++ b/mantidimaging/core/utility/test/imat_log_file_parser_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import numpy as np
 import pytest

--- a/mantidimaging/core/utility/test/leak_tracker_test.py
+++ b/mantidimaging/core/utility/test/leak_tracker_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from io import StringIO

--- a/mantidimaging/core/utility/test/projection_angle_parser_test.py
+++ b/mantidimaging/core/utility/test/projection_angle_parser_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import os
 import tempfile

--- a/mantidimaging/core/utility/test/size_calculator_test.py
+++ b/mantidimaging/core/utility/test/size_calculator_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import numpy as np
 

--- a/mantidimaging/core/utility/test/version_check_test.py
+++ b/mantidimaging/core/utility/test/version_check_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from parameterized import parameterized
 import unittest

--- a/mantidimaging/core/utility/version_check.py
+++ b/mantidimaging/core/utility/version_check.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import json
 import os

--- a/mantidimaging/eyes_tests/__init__.py
+++ b/mantidimaging/eyes_tests/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import os
 import unittest

--- a/mantidimaging/eyes_tests/compare_images_window_test.py
+++ b/mantidimaging/eyes_tests/compare_images_window_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from unittest import mock
 

--- a/mantidimaging/eyes_tests/eyes_manager.py
+++ b/mantidimaging/eyes_tests/eyes_manager.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import inspect
 import os

--- a/mantidimaging/eyes_tests/image_load_dialog_test.py
+++ b/mantidimaging/eyes_tests/image_load_dialog_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from unittest import mock
 
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest, LOAD_SAMPLE

--- a/mantidimaging/eyes_tests/image_save_dialog_test.py
+++ b/mantidimaging/eyes_tests/image_save_dialog_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from unittest import mock
 from uuid import UUID, uuid4
 

--- a/mantidimaging/eyes_tests/main_window_test.py
+++ b/mantidimaging/eyes_tests/main_window_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from unittest import mock
 

--- a/mantidimaging/eyes_tests/nexus_load_dialog_test.py
+++ b/mantidimaging/eyes_tests/nexus_load_dialog_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest, NEXUS_SAMPLE
 

--- a/mantidimaging/eyes_tests/nexus_save_dialog_test.py
+++ b/mantidimaging/eyes_tests/nexus_save_dialog_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import NamedTuple
 from unittest import mock

--- a/mantidimaging/eyes_tests/operations_window_test.py
+++ b/mantidimaging/eyes_tests/operations_window_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from PyQt5.QtWidgets import QApplication, QWidget, QPushButton
 from unittest import mock
 

--- a/mantidimaging/eyes_tests/reconstruct_window_test.py
+++ b/mantidimaging/eyes_tests/reconstruct_window_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import numpy as np
 from PyQt5.QtTest import QTest

--- a/mantidimaging/eyes_tests/welcome_window_test.py
+++ b/mantidimaging/eyes_tests/welcome_window_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from unittest import mock
 
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest

--- a/mantidimaging/gui/__init__.py
+++ b/mantidimaging/gui/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .gui import execute, setup_application  # noqa: F401  # noqa:F821

--- a/mantidimaging/gui/dialogs/__init__.py
+++ b/mantidimaging/gui/dialogs/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/dialogs/async_task/__init__.py
+++ b/mantidimaging/gui/dialogs/async_task/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .model import AsyncTaskDialogModel, TaskWorkerThread  # noqa: F401
 from .view import AsyncTaskDialogView, start_async_task_view  # noqa: F401

--- a/mantidimaging/gui/dialogs/async_task/model.py
+++ b/mantidimaging/gui/dialogs/async_task/model.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from logging import getLogger
 from typing import Callable, Optional, Set

--- a/mantidimaging/gui/dialogs/async_task/presenter.py
+++ b/mantidimaging/gui/dialogs/async_task/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import traceback
 from logging import getLogger

--- a/mantidimaging/gui/dialogs/async_task/task.py
+++ b/mantidimaging/gui/dialogs/async_task/task.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from logging import getLogger
 from typing import Callable, Optional

--- a/mantidimaging/gui/dialogs/async_task/test/__init__.py
+++ b/mantidimaging/gui/dialogs/async_task/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/dialogs/async_task/test/model_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/model_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import time
 import unittest

--- a/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import time
 import unittest

--- a/mantidimaging/gui/dialogs/async_task/test/task_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/task_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 

--- a/mantidimaging/gui/dialogs/async_task/test/view_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/view_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import Any, Callable, Dict, Optional, Set
 

--- a/mantidimaging/gui/dialogs/cor_inspection/__init__.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .model import CORInspectionDialogModel  # noqa: F401
 from .view import CORInspectionDialogView  # noqa: F401

--- a/mantidimaging/gui/dialogs/cor_inspection/model.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/model.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from dataclasses import replace
 from logging import getLogger
 from typing import Union

--- a/mantidimaging/gui/dialogs/cor_inspection/presenter.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import traceback
 from enum import Enum

--- a/mantidimaging/gui/dialogs/cor_inspection/recon_slice_view.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/recon_slice_view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import TYPE_CHECKING
 

--- a/mantidimaging/gui/dialogs/cor_inspection/test/__init__.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/dialogs/cor_inspection/test/model_test.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/test/model_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest.mock import Mock, patch

--- a/mantidimaging/gui/dialogs/cor_inspection/test/presenter_test.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/test/presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/gui/dialogs/cor_inspection/types.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/types.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from enum import Enum
 

--- a/mantidimaging/gui/dialogs/cor_inspection/view.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import List, Union
 

--- a/mantidimaging/gui/dialogs/multiple_stack_select/__init__.py
+++ b/mantidimaging/gui/dialogs/multiple_stack_select/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/dialogs/multiple_stack_select/view.py
+++ b/mantidimaging/gui/dialogs/multiple_stack_select/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import TYPE_CHECKING
 

--- a/mantidimaging/gui/dialogs/op_history_copy/__init__.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .view import OpHistoryCopyDialogView  # noqa:F401
 from .presenter import OpHistoryCopyDialogPresenter  # noqa:F401

--- a/mantidimaging/gui/dialogs/op_history_copy/model.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/model.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import Iterable
 

--- a/mantidimaging/gui/dialogs/op_history_copy/presenter.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import List, TYPE_CHECKING, Iterable, Any, Dict
 

--- a/mantidimaging/gui/dialogs/op_history_copy/test/__init__.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/dialogs/op_history_copy/test/model_test.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/test/model_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest.mock import patch, MagicMock

--- a/mantidimaging/gui/dialogs/op_history_copy/view.py
+++ b/mantidimaging/gui/dialogs/op_history_copy/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import Iterable, Tuple
 

--- a/mantidimaging/gui/gui.py
+++ b/mantidimaging/gui/gui.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import logging
 import os

--- a/mantidimaging/gui/mvp_base/__init__.py
+++ b/mantidimaging/gui/mvp_base/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .view import (BaseDialogView, BaseMainWindowView)  # noqa: F401
 from .presenter import BasePresenter  # noqa: F401  # noqa:F821

--- a/mantidimaging/gui/mvp_base/presenter.py
+++ b/mantidimaging/gui/mvp_base/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from logging import getLogger
 from typing import TYPE_CHECKING, Union

--- a/mantidimaging/gui/mvp_base/test/__init__.py
+++ b/mantidimaging/gui/mvp_base/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/mvp_base/test/presenter_test.py
+++ b/mantidimaging/gui/mvp_base/test/presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 

--- a/mantidimaging/gui/mvp_base/view.py
+++ b/mantidimaging/gui/mvp_base/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from logging import getLogger
 

--- a/mantidimaging/gui/test/__init__.py
+++ b/mantidimaging/gui/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import os
 from pathlib import Path

--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import math
 import os

--- a/mantidimaging/gui/test/gui_system_operations_test.py
+++ b/mantidimaging/gui/test/gui_system_operations_test.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from itertools import product
 from unittest import mock
-from uuid import UUID
+from typing import TYPE_CHECKING
 
 from parameterized import parameterized
 from PyQt5.QtTest import QTest
@@ -18,6 +18,9 @@ from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHOW_DELAY, SH
 from mantidimaging.gui.windows.operations.view import FiltersWindowView
 from mantidimaging.test_helpers.qt_test_helpers import wait_until
 from mantidimaging.test_helpers.start_qapplication import start_multiprocessing_pool
+
+if TYPE_CHECKING:
+    from uuid import UUID
 
 OP_LIST = [
     ("Arithmetic", [["Multiply", "2"]]),

--- a/mantidimaging/gui/test/gui_system_operations_test.py
+++ b/mantidimaging/gui/test/gui_system_operations_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from itertools import product
 from unittest import mock

--- a/mantidimaging/gui/test/gui_system_reconstruction_test.py
+++ b/mantidimaging/gui/test/gui_system_reconstruction_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from unittest import mock
 
 from PyQt5.QtTest import QTest

--- a/mantidimaging/gui/test/gui_system_windows_test.py
+++ b/mantidimaging/gui/test/gui_system_windows_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from PyQt5.QtTest import QTest
 

--- a/mantidimaging/gui/utility/__init__.py
+++ b/mantidimaging/gui/utility/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from mantidimaging.gui.utility.qt_helpers import (  # noqa: F401
     compile_ui, select_directory, add_property_to_form, delete_all_widgets_from_layout, BlockQtSignals)

--- a/mantidimaging/gui/utility/common.py
+++ b/mantidimaging/gui/utility/common.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from contextlib import contextmanager
 

--- a/mantidimaging/gui/utility/qt_helpers.py
+++ b/mantidimaging/gui/utility/qt_helpers.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 """
 Module containing helper functions relating to PyQt.
 """

--- a/mantidimaging/gui/widgets/__init__.py
+++ b/mantidimaging/gui/widgets/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .removable_row_table_view import (  # noqa: F401
     RemovableRowTableView)

--- a/mantidimaging/gui/widgets/auto_colour_menu/__init__.py
+++ b/mantidimaging/gui/widgets/auto_colour_menu/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/widgets/auto_colour_menu/auto_color_menu.py
+++ b/mantidimaging/gui/widgets/auto_colour_menu/auto_color_menu.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from typing import Optional, TYPE_CHECKING, List
 
 from PyQt5.QtWidgets import QAction

--- a/mantidimaging/gui/widgets/bad_data_overlay/__init__.py
+++ b/mantidimaging/gui/widgets/bad_data_overlay/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
+++ b/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from collections import OrderedDict
 from typing import Callable, List, Optional, Tuple

--- a/mantidimaging/gui/widgets/dataset_selector/__init__.py
+++ b/mantidimaging/gui/widgets/dataset_selector/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .view import DatasetSelectorWidgetView  # noqa: F401
 from .presenter import DatasetSelectorWidgetPresenter  # noqa: F401

--- a/mantidimaging/gui/widgets/dataset_selector/presenter.py
+++ b/mantidimaging/gui/widgets/dataset_selector/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import traceback
 from enum import Enum

--- a/mantidimaging/gui/widgets/dataset_selector/test/__init__.py
+++ b/mantidimaging/gui/widgets/dataset_selector/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/widgets/dataset_selector/test/presenter_test.py
+++ b/mantidimaging/gui/widgets/dataset_selector/test/presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/gui/widgets/dataset_selector/test/view_test.py
+++ b/mantidimaging/gui/widgets/dataset_selector/test/view_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/gui/widgets/dataset_selector/view.py
+++ b/mantidimaging/gui/widgets/dataset_selector/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import uuid
 from typing import TYPE_CHECKING, Optional, Union, Tuple, List

--- a/mantidimaging/gui/widgets/dataset_selector_dialog/__init__.py
+++ b/mantidimaging/gui/widgets/dataset_selector_dialog/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/widgets/dataset_selector_dialog/dataset_selector_dialog.py
+++ b/mantidimaging/gui/widgets/dataset_selector_dialog/dataset_selector_dialog.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING, Optional
 

--- a/mantidimaging/gui/widgets/dataset_selector_dialog/test/__init__.py
+++ b/mantidimaging/gui/widgets/dataset_selector_dialog/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/widgets/dataset_selector_dialog/test/dataset_selector_dialog_test.py
+++ b/mantidimaging/gui/widgets/dataset_selector_dialog/test/dataset_selector_dialog_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/gui/widgets/indicator_icon/__init__.py
+++ b/mantidimaging/gui/widgets/indicator_icon/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/widgets/indicator_icon/view.py
+++ b/mantidimaging/gui/widgets/indicator_icon/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import List, Optional, Tuple, Callable
 

--- a/mantidimaging/gui/widgets/line_profile_plot/__init__.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/widgets/line_profile_plot/test/__init__.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/widgets/line_profile_plot/test/view_test.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/test/view_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import unittest
 from unittest import mock
 

--- a/mantidimaging/gui/widgets/line_profile_plot/view.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from typing import TYPE_CHECKING, Union, Optional, Any
 
 from PyQt5.QtCore import QRect

--- a/mantidimaging/gui/widgets/mi_image_view/__init__.py
+++ b/mantidimaging/gui/widgets/mi_image_view/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/widgets/mi_image_view/presenter.py
+++ b/mantidimaging/gui/widgets/mi_image_view/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from logging import getLogger
 from typing import List

--- a/mantidimaging/gui/widgets/mi_image_view/test/__init__.py
+++ b/mantidimaging/gui/widgets/mi_image_view/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/widgets/mi_image_view/test/presenter_test.py
+++ b/mantidimaging/gui/widgets/mi_image_view/test/presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import List
 

--- a/mantidimaging/gui/widgets/mi_image_view/test/view_test.py
+++ b/mantidimaging/gui/widgets/mi_image_view/test/view_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from unittest import mock
 
 import numpy as np

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from time import sleep
 from typing import Callable, Optional, Tuple, TYPE_CHECKING

--- a/mantidimaging/gui/widgets/mi_mini_image_view/__init__.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from itertools import chain, tee
 from typing import List, TYPE_CHECKING, Optional, Union

--- a/mantidimaging/gui/widgets/palette_changer/__init__.py
+++ b/mantidimaging/gui/widgets/palette_changer/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/widgets/palette_changer/presenter.py
+++ b/mantidimaging/gui/widgets/palette_changer/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from typing import List, TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/mantidimaging/gui/widgets/palette_changer/test/presenter_test.py
+++ b/mantidimaging/gui/widgets/palette_changer/test/presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/gui/widgets/palette_changer/view.py
+++ b/mantidimaging/gui/widgets/palette_changer/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from PyQt5.QtWidgets import QSpinBox, QComboBox
 

--- a/mantidimaging/gui/widgets/removable_row_table_view.py
+++ b/mantidimaging/gui/widgets/removable_row_table_view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from PyQt5.QtCore import Qt, QModelIndex
 from PyQt5.QtWidgets import QTableView

--- a/mantidimaging/gui/widgets/roi_selector/__init__.py
+++ b/mantidimaging/gui/widgets/roi_selector/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/widgets/roi_selector/test/__init__.py
+++ b/mantidimaging/gui/widgets/roi_selector/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/widgets/roi_selector/test/view_test.py
+++ b/mantidimaging/gui/widgets/roi_selector/test/view_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/gui/widgets/roi_selector/view.py
+++ b/mantidimaging/gui/widgets/roi_selector/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 import numpy as np

--- a/mantidimaging/gui/widgets/stack_selector/test/__init__.py
+++ b/mantidimaging/gui/widgets/stack_selector/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/__init__.py
+++ b/mantidimaging/gui/windows/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/add_images_to_dataset_dialog/__init__.py
+++ b/mantidimaging/gui/windows/add_images_to_dataset_dialog/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/add_images_to_dataset_dialog/presenter.py
+++ b/mantidimaging/gui/windows/add_images_to_dataset_dialog/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import traceback
 from enum import Enum, auto
 from typing import TYPE_CHECKING

--- a/mantidimaging/gui/windows/add_images_to_dataset_dialog/test/__init__.py
+++ b/mantidimaging/gui/windows/add_images_to_dataset_dialog/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/add_images_to_dataset_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/add_images_to_dataset_dialog/test/presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import unittest
 from unittest import mock
 

--- a/mantidimaging/gui/windows/add_images_to_dataset_dialog/test/view_test.py
+++ b/mantidimaging/gui/windows/add_images_to_dataset_dialog/test/view_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 import uuid

--- a/mantidimaging/gui/windows/add_images_to_dataset_dialog/view.py
+++ b/mantidimaging/gui/windows/add_images_to_dataset_dialog/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import uuid
 
 from PyQt5.QtWidgets import QComboBox, QFileDialog, QDialogButtonBox, QPushButton, QLineEdit, QLabel

--- a/mantidimaging/gui/windows/image_load_dialog/__init__.py
+++ b/mantidimaging/gui/windows/image_load_dialog/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .view import ImageLoadDialog  # noqa: F401

--- a/mantidimaging/gui/windows/image_load_dialog/field.py
+++ b/mantidimaging/gui/windows/image_load_dialog/field.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from pathlib import Path
 
 import numpy as np

--- a/mantidimaging/gui/windows/image_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/image_load_dialog/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import os
 import traceback

--- a/mantidimaging/gui/windows/image_load_dialog/test/__init__.py
+++ b/mantidimaging/gui/windows/image_load_dialog/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/image_load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/image_load_dialog/test/presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from pathlib import Path

--- a/mantidimaging/gui/windows/image_load_dialog/view.py
+++ b/mantidimaging/gui/windows/image_load_dialog/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import Optional, Dict
 

--- a/mantidimaging/gui/windows/main/__init__.py
+++ b/mantidimaging/gui/windows/main/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .model import MainWindowModel  # noqa: F401
 from .view import MainWindowView  # noqa: F401

--- a/mantidimaging/gui/windows/main/image_save_dialog.py
+++ b/mantidimaging/gui/windows/main/image_save_dialog.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import uuid
 from typing import Optional, TYPE_CHECKING
 

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import uuid
 from logging import getLogger
 from pathlib import Path

--- a/mantidimaging/gui/windows/main/nexus_save_dialog.py
+++ b/mantidimaging/gui/windows/main/nexus_save_dialog.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import os
 import uuid
 from typing import Optional, List

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import traceback
 import uuid
 from enum import Enum, auto

--- a/mantidimaging/gui/windows/main/test/Image_save_test.py
+++ b/mantidimaging/gui/windows/main/test/Image_save_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 import uuid

--- a/mantidimaging/gui/windows/main/test/__init__.py
+++ b/mantidimaging/gui/windows/main/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/main/test/mixeddataset_test.py
+++ b/mantidimaging/gui/windows/main/test/mixeddataset_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 import uuid

--- a/mantidimaging/gui/windows/main/test/nexus_save_test.py
+++ b/mantidimaging/gui/windows/main/test/nexus_save_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import unittest
 from unittest import mock
 

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 import uuid

--- a/mantidimaging/gui/windows/main/test/strictdataset_test.py
+++ b/mantidimaging/gui/windows/main/test/strictdataset_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest.mock import DEFAULT, Mock

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import os
 import uuid

--- a/mantidimaging/gui/windows/move_stack_dialog/__init__.py
+++ b/mantidimaging/gui/windows/move_stack_dialog/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/move_stack_dialog/presenter.py
+++ b/mantidimaging/gui/windows/move_stack_dialog/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from enum import Enum, auto
 from typing import TYPE_CHECKING
 

--- a/mantidimaging/gui/windows/move_stack_dialog/test/__init__.py
+++ b/mantidimaging/gui/windows/move_stack_dialog/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/move_stack_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/move_stack_dialog/test/presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import unittest
 from unittest import mock
 

--- a/mantidimaging/gui/windows/move_stack_dialog/test/view_test.py
+++ b/mantidimaging/gui/windows/move_stack_dialog/test/view_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import unittest
 import uuid
 from unittest import mock

--- a/mantidimaging/gui/windows/move_stack_dialog/view.py
+++ b/mantidimaging/gui/windows/move_stack_dialog/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import uuid
 
 from PyQt5.QtWidgets import QLabel, QComboBox

--- a/mantidimaging/gui/windows/nexus_load_dialog/__init__.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import enum
 import traceback
 from enum import auto, Enum

--- a/mantidimaging/gui/windows/nexus_load_dialog/test/__init__.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/gui/windows/nexus_load_dialog/view.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from typing import Tuple
 
 from PyQt5.QtCore import Qt, QEventLoop

--- a/mantidimaging/gui/windows/operations/__init__.py
+++ b/mantidimaging/gui/windows/operations/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .model import FiltersWindowModel  # noqa: F401
 from .presenter import FiltersWindowPresenter  # noqa: F401

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from logging import getLogger
 from typing import TYPE_CHECKING

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from functools import partial
 from typing import Callable, TYPE_CHECKING, List, Any, Dict

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import traceback
 import uuid
 from enum import Enum, auto

--- a/mantidimaging/gui/windows/operations/test/__init__.py
+++ b/mantidimaging/gui/windows/operations/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/operations/test/model_test.py
+++ b/mantidimaging/gui/windows/operations/test/model_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from functools import partial

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import logging
 import unittest
 import numpy as np

--- a/mantidimaging/gui/windows/operations/test/view_test.py
+++ b/mantidimaging/gui/windows/operations/test/view_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import functools
 from typing import TYPE_CHECKING
 

--- a/mantidimaging/gui/windows/recon/__init__.py
+++ b/mantidimaging/gui/windows/recon/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .model import ReconstructWindowModel  # noqa: F401
 from .point_table_model import CorTiltPointQtModel, Column, COLUMN_NAMES  # noqa: F401

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from math import isnan
 from typing import Optional
 

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from logging import getLogger
 from typing import List, Optional, Tuple, Union, TYPE_CHECKING
 

--- a/mantidimaging/gui/windows/recon/point_table_model.py
+++ b/mantidimaging/gui/windows/recon/point_table_model.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from enum import Enum
 from typing import List

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import traceback
 from enum import Enum, auto

--- a/mantidimaging/gui/windows/recon/test/__init__.py
+++ b/mantidimaging/gui/windows/recon/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/recon/test/model_test.py
+++ b/mantidimaging/gui/windows/recon/test/model_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import uuid
 from logging import getLogger
 from typing import TYPE_CHECKING, List, Optional

--- a/mantidimaging/gui/windows/spectrum_viewer/__init__.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from .view import SpectrumViewerWindowView  # noqa: F401
 from .presenter import SpectrumViewerWindowPresenter  # noqa: F401

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from mantidimaging.core.data.dataset import StrictDataset

--- a/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 # Contains ROI table model class which will be used to store ROI information
 # and display it in the spectrum viewer.

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 

--- a/mantidimaging/gui/windows/spectrum_viewer/test/__init__.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import unittest
 from pathlib import Path
 from unittest import mock

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import unittest
 import uuid
 from pathlib import Path

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 

--- a/mantidimaging/gui/windows/stack_choice/__init__.py
+++ b/mantidimaging/gui/windows/stack_choice/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/stack_choice/compare_presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/compare_presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import traceback
 

--- a/mantidimaging/gui/windows/stack_choice/presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import traceback
 from typing import TYPE_CHECKING

--- a/mantidimaging/gui/windows/stack_choice/presenter_base.py
+++ b/mantidimaging/gui/windows/stack_choice/presenter_base.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from mantidimaging.gui.mvp_base.presenter import BasePresenter
 from mantidimaging.gui.windows.stack_choice.view import Notification

--- a/mantidimaging/gui/windows/stack_choice/tests/__init__.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/stack_choice/tests/compare_presenter_test.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/compare_presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/gui/windows/stack_choice/tests/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/gui/windows/stack_choice/tests/view_test.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/view_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import unittest
 from unittest import mock
 from unittest.mock import DEFAULT, Mock, patch

--- a/mantidimaging/gui/windows/stack_choice/view.py
+++ b/mantidimaging/gui/windows/stack_choice/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Optional, Tuple, Union

--- a/mantidimaging/gui/windows/stack_visualiser/__init__.py
+++ b/mantidimaging/gui/windows/stack_visualiser/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from mantidimaging.gui.windows.stack_visualiser.presenter import (  # noqa: F401
     StackVisualiserPresenter, SVNotification, SVParameters, SVImageMode)  # noqa:F821

--- a/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
+++ b/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import json
 

--- a/mantidimaging/gui/windows/stack_visualiser/model.py
+++ b/mantidimaging/gui/windows/stack_visualiser/model.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import numpy as np
 

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import numpy as np
 import traceback

--- a/mantidimaging/gui/windows/stack_visualiser/test/__init__.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import unittest
 from typing import Tuple
 from unittest import mock

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import TYPE_CHECKING
 

--- a/mantidimaging/gui/windows/welcome_screen/__init__.py
+++ b/mantidimaging/gui/windows/welcome_screen/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/welcome_screen/presenter.py
+++ b/mantidimaging/gui/windows/welcome_screen/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from PyQt5.QtCore import QSettings
 from logging import getLogger

--- a/mantidimaging/gui/windows/welcome_screen/tests/__init__.py
+++ b/mantidimaging/gui/windows/welcome_screen/tests/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/welcome_screen/tests/presenter_test.py
+++ b/mantidimaging/gui/windows/welcome_screen/tests/presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/gui/windows/welcome_screen/tests/view_test.py
+++ b/mantidimaging/gui/windows/welcome_screen/tests/view_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/gui/windows/welcome_screen/view.py
+++ b/mantidimaging/gui/windows/welcome_screen/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from mantidimaging.core.utility import finder
 from PyQt5.QtWidgets import QLabel

--- a/mantidimaging/gui/windows/wizard/__init__.py
+++ b/mantidimaging/gui/windows/wizard/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/wizard/model.py
+++ b/mantidimaging/gui/windows/wizard/model.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import Iterable, List, Optional

--- a/mantidimaging/gui/windows/wizard/presenter.py
+++ b/mantidimaging/gui/windows/wizard/presenter.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from logging import getLogger
 from pathlib import Path

--- a/mantidimaging/gui/windows/wizard/test/__init__.py
+++ b/mantidimaging/gui/windows/wizard/test/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/wizard/test/model_test.py
+++ b/mantidimaging/gui/windows/wizard/test/model_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 

--- a/mantidimaging/gui/windows/wizard/test/presenter_test.py
+++ b/mantidimaging/gui/windows/wizard/test/presenter_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/gui/windows/wizard/test/view_test.py
+++ b/mantidimaging/gui/windows/wizard/test/view_test.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import unittest
 from unittest import mock

--- a/mantidimaging/gui/windows/wizard/view.py
+++ b/mantidimaging/gui/windows/wizard/view.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from __future__ import annotations
 from PyQt5.QtWidgets import QLabel, QWidget, QVBoxLayout, QGroupBox, QPushButton, QStyle

--- a/mantidimaging/helper.py
+++ b/mantidimaging/helper.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 """
 Module for commonly used functions across the modules.
 """

--- a/mantidimaging/ipython.py
+++ b/mantidimaging/ipython.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 
 def main():

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import argparse
 import logging

--- a/mantidimaging/test_helpers/__init__.py
+++ b/mantidimaging/test_helpers/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 """
 This package contains testing helpers for unit tests across the application
 """

--- a/mantidimaging/test_helpers/file_outputting_test_case.py
+++ b/mantidimaging/test_helpers/file_outputting_test_case.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import shutil
 import tempfile

--- a/mantidimaging/test_helpers/qt_mocks.py
+++ b/mantidimaging/test_helpers/qt_mocks.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from unittest.mock import Mock
 

--- a/mantidimaging/test_helpers/qt_test_helpers.py
+++ b/mantidimaging/test_helpers/qt_test_helpers.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from typing import Callable
 

--- a/mantidimaging/test_helpers/start_qapplication.py
+++ b/mantidimaging/test_helpers/start_qapplication.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 # Mantid Repository : https://github.com/mantidproject/mantid
 #

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import os
 import sys

--- a/packaging/PackageWithPyInstaller.py
+++ b/packaging/PackageWithPyInstaller.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 # Package the application using PyInstaller
 #

--- a/packaging/hooks/hook-cil.py
+++ b/packaging/hooks/hook-cil.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 from PyInstaller.compat import is_pure_conda
 

--- a/scripts/operations_tests/__init__.py
+++ b/scripts/operations_tests/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/scripts/operations_tests/operations_tests.py
+++ b/scripts/operations_tests/operations_tests.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 import argparse
 import csv
 import json

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Copyright (C) 2022 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import fnmatch
 import os


### PR DESCRIPTION
### Issue

Final part to close #1588

### Description

Use `from __future__ import annotations` to prevent annotations being evaluated at import time. (see https://peps.python.org/pep-0563/ ). 

Also move some imports behind a `if TYPE_CHECKING` check so they don't happen at run time. Used `flake8-type-checking` to find where this can be done.

The benefit of this is small, maybe only 2 or 3% speed up. It might be worth completing the TYPE_CHECKING in the future, but its time consuming to change without a big improvement. 

### Testing & Acceptance Criteria 

Tests should pass

### Documentation

release_notes
