### PR TITLE
1659: pyinstall missing cuda files

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -26,6 +26,7 @@ Fixes
 - #1330 : Initial ROI box is sometimes much larger than image for relevant filters
 - #1602 : Prevent multiple ROI selector windows opening from Operations window
 - #1610 : Apply bug fix to disable Spectrum Viewer export button when no data is loaded
+- #1659 : PyInsaller missing cupy files
 
 Developer Changes
 -----------------

--- a/packaging/PackageWithPyInstaller.py
+++ b/packaging/PackageWithPyInstaller.py
@@ -7,7 +7,7 @@ import os
 import pkgutil
 import sys
 from pathlib import Path
-from PyInstaller.utils.hooks import conda_support
+from PyInstaller.utils.hooks import conda_support, collect_data_files
 import PyInstaller.__main__
 
 
@@ -52,8 +52,10 @@ def add_data_files(run_options):
     # the package
     data_files = [('../mantidimaging/gui/ui/*.ui', 'mantidimaging/gui/ui/'),
                   ('../mantidimaging/gui/ui/images/*', 'mantidimaging/gui/ui/images/'),
+                  ('../mantidimaging/core/gpu/*.cu', 'mantidimaging/core/gpu/'),
                   ('../mantidimaging/gui/windows/wizard/*.yml', 'mantidimaging/gui/windows/wizard/')]
 
+    data_files += collect_data_files("cupy")
     run_options.extend([f'--add-data={src}{os.pathsep}{dest}' for src, dest in data_files])
 
 


### PR DESCRIPTION
### Issue

Closes #1659

### Description

Makes PyInstall pick up the needed cuda files.

### Acceptance Criteria 

Check that the GPU Median filter works with the pyinstalled Mantid Imaging.

### Documentation

Updated release notes.
