### PR TITLE
NeXus DeprecationWarning

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -36,3 +36,4 @@ Developer Changes
 - #1652 : PEP440 compliant versions for alpha builds
 - #1595 : Store version number in package
 - #1663 : Postponed Evaluation of Annotations
+- #1670 : `tostring()` Deprecation Warning

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -29,7 +29,7 @@ def _decode_nexus_class(nexus_data) -> str:
 
 
 def _nexus_dataset_to_string(nexus_dataset) -> str:
-    return np.array(nexus_dataset).tostring().decode("utf-8")
+    return np.array(nexus_dataset).tobytes().decode("utf-8")
 
 
 def test_rescale_negative_recon_data():

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -199,7 +199,7 @@ class NexusLoadPresenter:
         assert self.nexus_file is not None
         for key in self.nexus_file.keys():
             if DEFINITION in self.nexus_file[key].keys():
-                if np.array(self.nexus_file[key][DEFINITION]).tostring().decode("utf-8") == NXTOMOPROC:
+                if np.array(self.nexus_file[key][DEFINITION]).tobytes().decode("utf-8") == NXTOMOPROC:
                     nexus_recon = self.nexus_file[key]
                     self.recon_data.append(np.array(nexus_recon["data"]["data"]))
 


### PR DESCRIPTION
### Issue

Closes #1670

### Description

Gets ride of the DeprecationWarning by using `tobytes()` rather than `tostring()`

### Acceptance Criteria 

Check that the DeprecationWarning no longer appears when running tests.

### Documentation

Updated release notes.