### PR TITLE
1657: PyInstaller operations menu order

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -26,7 +26,8 @@ Fixes
 - #1330 : Initial ROI box is sometimes much larger than image for relevant filters
 - #1602 : Prevent multiple ROI selector windows opening from Operations window
 - #1610 : Apply bug fix to disable Spectrum Viewer export button when no data is loaded
-- #1659 : PyInsaller missing cupy files
+- #1659 : PyInstaller missing cupy files
+- #1657 : PyInstaller: order of operations in menu is not sorted
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -31,6 +31,13 @@ class FiltersWindowModel(object):
         self.presenter = presenter
         # Update the local filter registry
         self.filters = load_filter_packages(ignored_packages=['mantidimaging.core.operations.wip'])
+
+        # Sort by name for PyInstaller
+        def _name(ops):
+            return ops.filter_name
+
+        self.filters.sort(key=lambda ops: _name(ops))
+
         self._format_filters()
 
         self.preview_image_idx = 0

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -36,7 +36,7 @@ class FiltersWindowModel(object):
         def _name(ops):
             return ops.filter_name.lower()
 
-        self.filters.sort(key=lambda ops: _name(ops))
+        self.filters.sort(key=_name)
 
         self._format_filters()
 

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -34,7 +34,7 @@ class FiltersWindowModel(object):
 
         # Sort by name for PyInstaller
         def _name(ops):
-            return ops.filter_name
+            return ops.filter_name.lower()
 
         self.filters.sort(key=lambda ops: _name(ops))
 

--- a/mantidimaging/gui/windows/operations/test/model_test.py
+++ b/mantidimaging/gui/windows/operations/test/model_test.py
@@ -2,11 +2,13 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+import random
 import unittest
 from functools import partial
 
 from unittest import mock
 import numpy as np
+from mantidimaging.core.operations.loader import load_filter_packages
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operation_history import const
@@ -172,8 +174,15 @@ class FiltersWindowModelTest(unittest.TestCase):
         self.assertEqual(1, self.model._find_filter_index_from_filter_name("2"))
 
     def test_filter_names(self):
-        self.model.presenter.divider = "-----------------"
-        filter_names = self.model.filter_names
+
+        filters = load_filter_packages(ignored_packages=['mantidimaging.core.operations.wip'])
+        random.shuffle(filters)
+
+        with mock.patch("mantidimaging.gui.windows.operations.model.load_filter_packages") as load_filter_packages_mock:
+            load_filter_packages_mock.return_value = filters
+            model = FiltersWindowModel(mock.MagicMock)
+            model.presenter.divider = "-----------------"
+            filter_names = model.filter_names
 
         self.assertEqual([
             'Crop Coordinates', 'Flat-fielding', 'Remove Outliers', 'ROI Normalisation', "-----------------",


### PR DESCRIPTION
### Issue

Closes #1657

### Description

Uses a sort in the `FilterWindowsModel` to undo the changes in the PyInstaller operations menu order.

### Testing 

Modified an existing test so that the filters collected from `load_filter_packages` are randomised but the menu order remains the same.

### Acceptance Criteria 

Check that the tests pass. Check that PyInstalled Imaging now has the right operations menu order.

### Documentation

Updated release notes.
