### PR TITLE
Fix duplicate files in FilenameGroup

### DIFF
--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -99,6 +99,7 @@ class FilenameGroup:
             yield self.directory / self.pattern.generate(index)
 
     def find_all_files(self) -> None:
+        self.all_indexes = []
         for filename in self.directory.iterdir():
             if self.pattern.match(filename.name):
                 self.all_indexes.append(self.pattern.get_index(filename.name))

--- a/mantidimaging/core/io/test/filenames_test.py
+++ b/mantidimaging/core/io/test/filenames_test.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 import unittest
 
-import pytest
 from parameterized import parameterized
 from pyfakefs.fake_filesystem_unittest import TestCase
 
@@ -106,7 +105,6 @@ class FilenameGroupTest(TestCase):
         self.assertEqual(all_files[1], Path("foo", "IMAT_Flower_Tomo_000001.tif"))
         self.assertEqual(all_files[2], Path("foo", "IMAT_Flower_Tomo_000002.tif"))
 
-    @pytest.mark.xfail
     def test_find_all_files(self):
         file_list = [Path(f"IMAT_Flower_Tomo_{i:06d}.tif") for i in range(10)]
         for file_name in file_list:
@@ -117,7 +115,6 @@ class FilenameGroupTest(TestCase):
 
         self.assertEqual(fg.all_indexes, list(range(10)))
 
-    @pytest.mark.xfail
     def test_find_all_files_different_digits(self):
         file_list = [Path(f"IMAT_Flower_Tomo_{i:01d}.tif") for i in range(5, 15)]
         for file_name in file_list:


### PR DESCRIPTION
### Issue
Closes #1675 

### Description

Reset index in find_all_files

Also make tests use pyfakefs and call `FilenameGroup.from_file()` so that they see the issue

### Testing 

Tests should pass

### Documentation

Not needed
