### PR TITLE
1465: `raw_file` field in NXtomoproc

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -19,6 +19,7 @@ New Features and improvements
 - #1467 : NeXus Recon: Add other entry/data information
 - #1661 : Use `tifffile` for writing and reading tiff files
 - #1512 : Speedups for CIL setup
+- #1465 : NeXus Recon: Add entry/reconstruction/parameters information
 
 Fixes
 -----

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -246,10 +246,10 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
     data["image_key"] = detector["image_key"]
 
     for recon in dataset.recons:
-        _save_recon_to_nexus(nexus_file, recon)
+        _save_recon_to_nexus(nexus_file, recon, dataset.sample.filenames[0])
 
 
-def _save_recon_to_nexus(nexus_file: h5py.File, recon: ImageStack):
+def _save_recon_to_nexus(nexus_file: h5py.File, recon: ImageStack, sample_path: str):
     """
     Saves a recon to a NeXus file.
     :param nexus_file: The NeXus file.
@@ -284,7 +284,9 @@ def _save_recon_to_nexus(nexus_file: h5py.File, recon: ImageStack):
     if recon_timestamp is None:
         recon_timestamp = datetime.datetime.now().isoformat()
     reconstruction.create_dataset("date", data=np.string_(recon_timestamp))
-    reconstruction.create_group("parameters")
+
+    parameters = reconstruction.create_group("parameters")
+    parameters.create_dataset("raw_file", data=np.string_(sample_path))
 
     data = recon_entry.create_group("data")
     _set_nx_class(data, "NXdata")

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -246,6 +246,7 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
     data["image_key"] = detector["image_key"]
 
     for recon in dataset.recons:
+        assert dataset.sample.filenames is not None
         _save_recon_to_nexus(nexus_file, recon, dataset.sample.filenames[0])
 
 

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -32,6 +32,12 @@ def _nexus_dataset_to_string(nexus_dataset) -> str:
     return np.array(nexus_dataset).tobytes().decode("utf-8")
 
 
+def _create_sample_with_filename() -> ImageStack:
+    sample = th.generate_images()
+    sample.filenames = [f"image{str(i)}.tiff" for i in range(sample.data.shape[0])]
+    return sample
+
+
 def test_rescale_negative_recon_data():
 
     recon = th.generate_images()
@@ -47,6 +53,8 @@ class IOTest(FileOutputtingTestCase):
 
         # force silent outputs
         initialise_logging()
+
+        self.sample_path = "sample/file/path.tiff"
 
     def assert_files_exist(self, base_name, file_format, stack=True, num_images=1, indices=None):
 
@@ -303,7 +311,7 @@ class IOTest(FileOutputtingTestCase):
 
     @mock.patch("mantidimaging.core.io.saver._save_recon_to_nexus")
     def test_save_recons_if_present(self, recon_save_mock: mock.Mock):
-        sample = th.generate_images()
+        sample = _create_sample_with_filename()
         sample._projection_angles = sample.projection_angles()
 
         sd = StrictDataset(sample)
@@ -329,7 +337,7 @@ class IOTest(FileOutputtingTestCase):
 
     def test_save_recon_to_nexus(self):
 
-        sample = th.generate_images()
+        sample = _create_sample_with_filename()
         sample._projection_angles = sample.projection_angles()
 
         sd = StrictDataset(sample)
@@ -368,7 +376,7 @@ class IOTest(FileOutputtingTestCase):
             npt.assert_allclose(np.array(nexus_file[recon_name]["data"]["data"]), recon.data, rtol=1e-3)
 
     def test_use_recon_date_from_image_stack(self):
-        sample = th.generate_images()
+        sample = _create_sample_with_filename()
         sample._projection_angles = sample.projection_angles()
 
         sd = StrictDataset(sample)
@@ -384,14 +392,13 @@ class IOTest(FileOutputtingTestCase):
             self.assertIn(str(datetime.date.fromisoformat(gemini)),
                           _nexus_dataset_to_string(nexus_file[recon_name]["reconstruction"]["date"]))
 
-    @staticmethod
-    def test_save_recon_xyz_data():
+    def test_save_recon_xyz_data(self):
         recon = th.generate_images()
         recon.name = recon_name = "Recon"
         recon.pixel_size = pixel_size = 3
 
         with h5py.File("path", "w", driver="core", backing_store=False) as nexus_file:
-            _save_recon_to_nexus(nexus_file, recon)
+            _save_recon_to_nexus(nexus_file, recon, self.sample_path)
             npt.assert_array_equal(np.array(nexus_file[recon_name]["data"]["x"]),
                                    np.array([pixel_size * i for i in range(recon.data.shape[0])]))
             npt.assert_array_equal(np.array(nexus_file[recon_name]["data"]["y"]),

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -406,6 +406,16 @@ class IOTest(FileOutputtingTestCase):
             npt.assert_array_equal(np.array(nexus_file[recon_name]["data"]["z"]),
                                    np.array([pixel_size * i for i in range(recon.data.shape[2])]))
 
+    def test_raw_file_field(self):
+        recon = th.generate_images()
+        recon.name = recon_name = "Recon"
+
+        with h5py.File("path", "w", driver="core", backing_store=False) as nexus_file:
+            _save_recon_to_nexus(nexus_file, recon, self.sample_path)
+            self.assertEqual(
+                _nexus_dataset_to_string(nexus_file[recon_name]["reconstruction"]["parameters"]["raw_file"]),
+                self.sample_path)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Issue

Closes #1465

### Description

Writes to the `raw_file` field in NXtomoproc.

### Testing 

Added a test to check that the expected information is in the field.

### Acceptance Criteria 

Check that the tests pass. Check that the information is the NeXus file output when doing a recon.

### Documentation

Updated release notes.
