### PR TITLE
1678 Load Multiple Datasets Using CLI Path Flag into Mantid Imaging

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -39,3 +39,4 @@ Developer Changes
 - #1663 : Postponed Evaluation of Annotations
 - #1670 : `tostring()` Deprecation Warning
 - #1673 : Update license year across the repository from 2022 to 2023
+- #1678 : Allow multiple datasets to be opened at once in the GUI when using the CLI `--path` flag

--- a/mantidimaging/core/utility/command_line_arguments.py
+++ b/mantidimaging/core/utility/command_line_arguments.py
@@ -35,7 +35,7 @@ def _log_and_exit(msg: str):
 
 class CommandLineArguments:
     _instance = None
-    _images_path = ""
+    _images_path = [""]
     _init_operation = ""
     _show_recon = False
 
@@ -46,10 +46,12 @@ class CommandLineArguments:
         if cls._instance is None:
             cls._instance = super().__new__(cls)
             if path:
-                if not os.path.exists(path):
-                    _log_and_exit(f"Path {path} doesn't exist. Exiting.")
-                else:
-                    cls._images_path = path
+                for filepath in path.split(","):
+                    if not os.path.exists(filepath):
+                        _log_and_exit(f"Path {filepath} doesn't exist. Exiting.")
+                    else:
+                        print(f"Loading {filepath}")
+                        cls._images_path.append(filepath)
             if operation:
                 if not cls._images_path:
                     _log_and_exit("No path given for initial operation. Exiting.")

--- a/mantidimaging/core/utility/command_line_arguments.py
+++ b/mantidimaging/core/utility/command_line_arguments.py
@@ -45,13 +45,15 @@ class CommandLineArguments:
         """
         if cls._instance is None:
             cls._instance = super().__new__(cls)
+            valid_paths: list[str] = []
             if path:
-                for filepath in path.split(","):
+                path_list = path.split(",")
+                for filepath in path_list:
                     if not os.path.exists(filepath):
                         _log_and_exit(f"Path {filepath} doesn't exist. Exiting.")
                     else:
-                        print(f"Loading {filepath}")
-                        cls._images_path.append(filepath)
+                        valid_paths.append(filepath)
+                cls._images_path = valid_paths
             if operation:
                 if not cls._images_path:
                     _log_and_exit("No path given for initial operation. Exiting.")

--- a/mantidimaging/core/utility/command_line_arguments.py
+++ b/mantidimaging/core/utility/command_line_arguments.py
@@ -47,8 +47,7 @@ class CommandLineArguments:
             cls._instance = super().__new__(cls)
             valid_paths: list[str] = []
             if path:
-                path_list = path.split(",")
-                for filepath in path_list:
+                for filepath in path.split(","):
                     if not os.path.exists(filepath):
                         _log_and_exit(f"Path {filepath} doesn't exist. Exiting.")
                     else:

--- a/mantidimaging/core/utility/command_line_arguments.py
+++ b/mantidimaging/core/utility/command_line_arguments.py
@@ -35,7 +35,7 @@ def _log_and_exit(msg: str):
 
 class CommandLineArguments:
     _instance = None
-    _images_path = [""]
+    _images_path: list[str] = []
     _init_operation = ""
     _show_recon = False
 

--- a/mantidimaging/core/utility/command_line_arguments.py
+++ b/mantidimaging/core/utility/command_line_arguments.py
@@ -70,7 +70,7 @@ class CommandLineArguments:
         return cls._instance
 
     @classmethod
-    def path(cls) -> str:
+    def path(cls) -> list:
         """
         Returns the command line images path.
         """

--- a/mantidimaging/core/utility/test/command_line_arguments_test.py
+++ b/mantidimaging/core/utility/test/command_line_arguments_test.py
@@ -38,7 +38,7 @@ class CommandLineArgumentsTest(unittest.TestCase):
             CommandLineArguments(first_path)
             CommandLineArguments("second/path")
         exists_mock.assert_called_once_with(first_path)
-        self.assertEqual(CommandLineArguments().path(), first_path)
+        self.assertEqual(CommandLineArguments().path(), [first_path])
 
     def test_no_check_if_no_path_is_given(self):
         with mock.patch("mantidimaging.core.utility.command_line_arguments.os.path.exists") as exists_mock:

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -319,7 +319,8 @@ class MainWindowViewTest(unittest.TestCase):
     @mock.patch("mantidimaging.gui.windows.main.view.WelcomeScreenPresenter")
     @mock.patch("mantidimaging.gui.windows.main.view.MainWindowPresenter")
     def test_load_path_from_command_line(self, main_window_presenter, welcome_screen_presenter, command_line_args):
-        command_line_args.return_value.path.return_value = test_path = "./"
+        test_path = "./"
+        command_line_args.return_value.path.return_value = [test_path]
         command_line_args.return_value.recon.return_value = False
         command_line_args.return_value.operation.return_value = ""
         MainWindowView()

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -137,7 +137,8 @@ class MainWindowView(BaseMainWindowView):
 
         args = CommandLineArguments()
         if args.path():
-            self.presenter.load_stacks_from_folder(args.path())
+            for filepath in args.path():
+                self.presenter.load_stacks_from_folder(filepath)
 
         if args.operation():
             self.presenter.show_operation(args.operation())

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -137,7 +137,8 @@ class MainWindowView(BaseMainWindowView):
 
         args = CommandLineArguments()
         if args.path():
-            for filepath in args.path():
+            paths_list: List[str] = list(filter(None, args.path()))
+            for filepath in paths_list:
                 self.presenter.load_stacks_from_folder(filepath)
 
         if args.operation():

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -137,8 +137,7 @@ class MainWindowView(BaseMainWindowView):
 
         args = CommandLineArguments()
         if args.path():
-            paths_list: List[str] = list(filter(None, args.path()))
-            for filepath in paths_list:
+            for filepath in list(args.path()):
                 self.presenter.load_stacks_from_folder(filepath)
 
         if args.operation():

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -30,7 +30,7 @@ def parse_args():
 
     parser.add_argument("--version", action="store_true", help="Print version number and exit.")
 
-    parser.add_argument("--path", type=str, help="Path for the data you wish to load.")
+    parser.add_argument("--path", type=str, help="Comma separated Paths with no spaces for the data you wish to load.")
     parser.add_argument("--operation", type=str, help="The initial operation to run on the dataset.")
     parser.add_argument("--recon",
                         default=False,


### PR DESCRIPTION
### Issue

Closes #1678 

### Description

Refactored how `--path` cli flag operates within `main.py` to allow for multiple datasets to be loaded on starting a client from the command line to speed up developer testing when working with multiple datasets.

**Usage Example:**
```bash
python -m mantidimaging --path /home/4_powders_tof_tiffs/4_powders_tof/,/home/IMAT00010675/Tomo
```

### Testing 

* Try starting the client with multiple datasets using the `--path` flag similar to the example above.

### Acceptance Criteria 

* One or more datasets can be opened using the `--path` cli flag when opening the client using the cli

### Documentation
* Developer changes updates in upcoming release notes
