### PR TITLE
1666: PyInstaller single file

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -19,6 +19,7 @@ New Features and improvements
 - #1467 : NeXus Recon: Add other entry/data information
 - #1661 : Use `tifffile` for writing and reading tiff files
 - #1512 : Speedups for CIL setup
+- #1666 : PyInstaller single file
 
 Fixes
 -----

--- a/packaging/PackageWithPyInstaller.py
+++ b/packaging/PackageWithPyInstaller.py
@@ -13,7 +13,7 @@ import PyInstaller.__main__
 
 
 def create_run_options():
-    run_options = ['../mantidimaging/__main__.py', '--name=MantidImaging', '--additional-hooks-dir=hooks']
+    run_options = ['../mantidimaging/__main__.py', '--name=MantidImaging', '--additional-hooks-dir=hooks', '--onefile']
 
     add_hidden_imports(run_options)
     add_missing_submodules(run_options)


### PR DESCRIPTION
### Issue

Closes #1666

### Description

Makes PyInstaller run in single file mode.

### Testing 

Ran the PyInstaller script on Linux and Windows. Used the program for recon/filters.

### Acceptance Criteria 

Check that a single file is created and that Imaging runs.

### Documentation

Updated release notes.
