### PR TITLE
1669 Sync Rois and Reset Default ROI State on Sample Change

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -26,6 +26,7 @@ Fixes
 - #1330 : Initial ROI box is sometimes much larger than image for relevant filters
 - #1602 : Prevent multiple ROI selector windows opening from Operations window
 - #1610 : Apply bug fix to disable Spectrum Viewer export button when no data is loaded
+- #1669 : Fix table or ROIs falling out of synchronisation with ROIs visible in the image when changing between samples
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-from __future__ import annotations
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
@@ -79,7 +78,7 @@ class SpectrumViewerWindowModel:
         if stack is None:
             return
         self.tof_range = (0, stack.data.shape[0] - 1)
-        width, height = self.get_image_shape()
+        height, width = self.get_image_shape()
         self.set_roi("all", SensibleROI.from_list([0, 0, width, height]))
         # Remove additional ROIs if they exist on sample change and reset
         if len(self._roi_ranges) > 2:

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -79,11 +79,12 @@ class SpectrumViewerWindowModel:
             return
         self.tof_range = (0, stack.data.shape[0] - 1)
         height, width = self.get_image_shape()
-        # Remove additional ROIs if they exist on sample change
+        self.set_roi("all", SensibleROI.from_list([0, 0, width, height]))
+        # Remove additional ROIs if they exist on sample change and reset
         if len(self._roi_ranges) > 2:
             self.presenter.do_remove_roi()
-        self.set_roi("all", SensibleROI.from_list([0, 0, width, height]))
-        self.set_roi("roi", SensibleROI.from_list([0, 0, width, height]))
+        else:
+            self.set_roi("roi", SensibleROI.from_list([0, 0, width, height]))
 
     def set_new_roi(self, name: str) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -78,7 +78,7 @@ class SpectrumViewerWindowModel:
         if stack is None:
             return
         self.tof_range = (0, stack.data.shape[0] - 1)
-        height, width = self.get_image_shape()
+        width, height = self.get_image_shape()
         self.set_roi("all", SensibleROI.from_list([0, 0, width, height]))
         # Remove additional ROIs if they exist on sample change and reset
         if len(self._roi_ranges) > 2:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -73,7 +73,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         if normalise_uuid is None:
             self.model.set_normalise_stack(None)
             return
-
         self.model.set_normalise_stack(self.main_window.get_stack(normalise_uuid))
         self.view.set_normalise_error(self.model.normalise_issue())
         self.handle_roi_moved()
@@ -102,9 +101,10 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.set_spectrum(self.model.get_spectrum("roi", self.spectrum_mode))
         self.view.spectrum.add_range(*self.model.tof_range)
         if "roi" not in self.view.spectrum.roi_dict:
+            self.view.set_spectrum(self.model.get_spectrum("roi", self.spectrum_mode))
             self.view.spectrum.add_roi(self.model.get_roi("roi"), "roi")
         self.view.auto_range_image()
-        self.view.spectrum.reset_roi_size()
+        self.view.spectrum.reset_roi_size(self.model.get_image_shape())
 
     def get_default_table_state(self) -> list:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -183,10 +183,12 @@ class SpectrumWidget(GraphicsLayoutWidget):
         if old_name in self.roi_dict.keys() and new_name not in self.roi_dict.keys():
             self.roi_dict[new_name] = self.roi_dict.pop(old_name)
 
-    def reset_roi_size(self) -> None:
+    def reset_roi_size(self, image_shape) -> None:
         """
         Reset the size of the ROI to the maximum size of the image.
         """
-        self.roi_dict["roi"].setSize(self.max_roi_size)
-        self.roi_dict["roi"].setPos((0, 0))
+        self.roi_dict["roi"].setSize(list(image_shape))
+        self.roi_dict["roi"].setPos([0, 0])
+        self.roi_dict["roi"].maxBounds = self.roi_dict["roi"].parentBounds()
+        self.image.vb.addItem(self.roi_dict["roi"])
         self.roi_dict["roi"].sigRegionChanged.connect(self.roi_changed.emit)

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -190,7 +190,8 @@ class SpectrumWidget(GraphicsLayoutWidget):
 
         @param image_shape: The shape of the image.
         """
-        self.roi_dict["roi"].setSize(list(image_shape))
+        height, width = image_shape
+        self.roi_dict["roi"].setSize([width, height])
         self.roi_dict["roi"].setPos([0, 0])
         self.roi_dict["roi"].maxBounds = self.roi_dict["roi"].parentBounds()
         self.image.vb.addItem(self.roi_dict["roi"])

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -186,6 +186,8 @@ class SpectrumWidget(GraphicsLayoutWidget):
     def reset_roi_size(self, image_shape) -> None:
         """
         Reset the size of the ROI to the maximum size of the image.
+
+        @param image_shape: The shape of the image.
         """
         self.roi_dict["roi"].setSize(list(image_shape))
         self.roi_dict["roi"].setPos([0, 0])

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -111,9 +111,8 @@ class SpectrumWidget(GraphicsLayoutWidget):
 
         @return: A random colour in RGB format. (0-255, 0-255, 0-255)
         """
-        accessible_colours = [(255, 194, 10), (12, 123, 220), (153, 79, 0), (0, 108, 209), (225, 190, 106),
-                              (64, 176, 166), (230, 97, 0), (93, 58, 155), (26, 255, 26), (75, 0, 146), (254, 254, 98),
-                              (211, 95, 183), (0, 90, 181), (220, 50, 43), (26, 133, 255), (212, 17, 89)]
+        accessible_colours = [(255, 194, 10), (12, 123, 220), (153, 79, 0), (64, 176, 166), (230, 97, 0), (93, 58, 155),
+                              (26, 255, 26), (254, 254, 98), (211, 95, 183), (220, 50, 43)]
         if self.colour_index == len(accessible_colours):
             self.colour_index = 0
         colour = accessible_colours[self.colour_index]
@@ -127,7 +126,6 @@ class SpectrumWidget(GraphicsLayoutWidget):
         @param roi: The ROI to add.
         @param name: The name of the ROI.
         """
-
         roi_object = SpectrumROI(name, roi, pos=(0, 0), rotatable=False, scaleSnap=True, translateSnap=True)
         roi_object.colour = self.random_colour_generator()
 
@@ -184,3 +182,11 @@ class SpectrumWidget(GraphicsLayoutWidget):
         """
         if old_name in self.roi_dict.keys() and new_name not in self.roi_dict.keys():
             self.roi_dict[new_name] = self.roi_dict.pop(old_name)
+
+    def reset_roi_size(self) -> None:
+        """
+        Reset the size of the ROI to the maximum size of the image.
+        """
+        self.roi_dict["roi"].setSize(self.max_roi_size)
+        self.roi_dict["roi"].setPos((0, 0))
+        self.roi_dict["roi"].sigRegionChanged.connect(self.roi_changed.emit)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -143,6 +143,22 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         npt.assert_array_equal(self.model.get_roi("all").right, 12)
         npt.assert_array_equal(self.model.get_roi("all").bottom, 11)
 
+    def test_if_set_stack_called_with_additional_rois_present_THEN_do_remove_roi_called(self):
+        self.model.set_stack(generate_images())
+        self.model.set_new_roi("new_roi")
+        self.model.set_new_roi("new_roi_2")
+
+        self.assertListEqual(self.model.get_list_of_roi_names(), ['all', 'roi', 'new_roi', 'new_roi_2'])
+        self.model.set_stack(generate_images())
+        self.presenter.do_remove_roi.assert_called_once()
+
+    def test_if_set_stack_called_with_no_additional_rois_present_THEN_do_remove_roi_not_called(self):
+        self.model.set_stack(generate_images())
+
+        self.assertListEqual(self.model.get_list_of_roi_names(), ['all', 'roi'])
+        self.model.set_stack(generate_images())
+        self.presenter.do_remove_roi.assert_not_called()
+
     def test_get_spectrum_roi(self):
         stack = ImageStack(np.ones([10, 11, 12]))
         spectrum = np.arange(0, 10)
@@ -250,6 +266,14 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.model.set_stack(generate_images())
         with self.assertRaises(KeyError):
             self.model.remove_roi("non_existent_roi")
+
+    def test_WHEN_remove_all_rois_called_THEN_all_but_default_rois_removed(self):
+        self.model.set_stack(generate_images())
+        self.model.set_new_roi("new_roi")
+        self.model.set_new_roi("new_roi_2")
+        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi", "new_roi", "new_roi_2"])
+        self.model.remove_all_roi()
+        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi"])
 
     def test_WHEN_roi_renamed_THEN_roi_name_changed_in_list_of_roi_names(self):
         self.model.set_stack(generate_images())

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -110,11 +110,19 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view.try_to_select_relevant_normalise_stack.assert_not_called()
 
     def test_show_sample(self):
+        self.view.spectrum.roi_dict = {}
         image_stack = generate_images([10, 11, 12])
         self.presenter.model.set_stack(image_stack)
 
         self.presenter.show_new_sample()
         self.view.spectrum.add_range.assert_called_once_with(0, 9)
+
+    def test_roi_exists_WHEN_show_new_sample_called_THEN_add_roi_not_called(self):
+        image_stack = generate_images([10, 11, 12])
+        self.presenter.model.set_stack(image_stack)
+        self.view.spectrum.roi_dict = {"roi": mock.Mock()}
+        self.presenter.show_new_sample()
+        self.view.spectrum.add_roi.assert_not_called()
 
     def test_gui_changes_tof_range(self):
         image_stack = generate_images([30, 11, 12])
@@ -186,4 +194,15 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.model.set_stack(generate_images())
         with self.assertRaises(RuntimeError):
             self.presenter.rename_roi("roi", name)
+        self.assertEqual(["all", "roi"], self.presenter.model.get_list_of_roi_names())
+
+    def test_WHEN_do_remove_roi_called_with_no_arguments_THEN_all_rois_removed(self):
+        self.presenter.model.set_stack(generate_images())
+        with mock.patch(
+                "mantidimaging.gui.windows.spectrum_viewer.presenter.SpectrumViewerWindowPresenter.do_add_roi_to_table"
+        ):
+            self.presenter.do_add_roi()
+            self.presenter.do_add_roi()
+        self.assertEqual(["all", "roi", "roi_1", "roi_2"], self.presenter.model.get_list_of_roi_names())
+        self.presenter.do_remove_roi()
         self.assertEqual(["all", "roi"], self.presenter.model.get_list_of_roi_names())

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -221,8 +221,13 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         """
         Clear the selected ROI in the table view
         """
-
         if self.selected_row_data:
             self.roi_table_model.remove_row(self.selected_row)
             self.presenter.do_remove_roi(self.selected_row_data[0])
             self.removeBtn.setEnabled(False)
+
+    def clear_all_rois(self) -> None:
+        """
+        Clear all ROIs from the table view
+        """
+        self.roi_table_model.clear_table()


### PR DESCRIPTION
### Issue

Closes #1669 

### Description

* Ensure table of ROIs stay in synchronisation  with ROIs visible within image when swapping between different samples
* When Swapping between samples, additional ROIs added to the previous sample are cleared.
* Default ROIs _"all"_ and _"roi"_ are reset to reflect size of new sample to compensate for changes in sample size. 

#### Where
- `mantidimaging/gui/windows/spectrum_viewer/model.py`
- `mantidimaging/gui/windows/spectrum_viewer/presenter.py`
- `mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py`
- `mantidimaging/gui/windows/spectrum_viewer/view.py`
- `mantidimaging/gui/windows/spectrum_viewer/test/model_test.py`
- `mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py`
- `docs/release_notes/next.rst`

### Testing 
Updated existing tests and created additional tests to test sample changes are handled correctly and removal of multiple ROIs on sample change.
* `mantidimaging/gui/windows/spectrum_viewer/test/model_test.py`
* `mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py`

### Acceptance Criteria 

- [ ] Additional tests are sufficiently testing newly created methods
- [ ] Additional ROIs are cleared on swapping between samples in the spectrum viewer
- [ ] When adding additional ROIs and then changing sample and adding additional ROIs again, the table of ROIs updates accordingly to reflect the number of visible ROIs within the spectrum viewer image
- [ ] Default ROIs are rest on swapping between samples of different sizes
- [ ] ROIs can be moved after swapping to a larger or smaller sample

### Documentation

- [ ] `docs/release_notes/next.rst` has been updated
