### PR TITLE
1680 multi spectrum line plots

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -22,6 +22,7 @@ New Features and improvements
 - #1465 : NeXus Recon: Add entry/reconstruction/parameters information
 - #1666 : PyInstaller single file
 - #1665 : PyInstaller exe icon
+- #1680 : Multiple Spectrum Line Plots in Spectrum Viewer
 
 Fixes
 -----

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -104,7 +104,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         if "roi" not in self.view.spectrum.roi_dict:
             self.view.spectrum.add_roi(self.model.get_roi("roi"), "roi")
             self.view.set_spectrum("roi", self.model.get_spectrum("roi", self.spectrum_mode))
-            # self.view.spectrum.add_roi(self.model.get_roi("roi"), "roi")
         self.view.auto_range_image()
         self.view.spectrum.reset_roi_size(self.model.get_image_shape())
 

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -33,6 +33,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view = view
         self.main_window = main_window
         self.model = SpectrumViewerWindowModel(self)
+        self._roi_name = "roi"
 
     def handle_sample_change(self, uuid: Optional['UUID']) -> None:
         if uuid == self.current_stack_uuid:
@@ -99,11 +100,11 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         additional ROIs will be removed leaving only the default ROI.
         """
         self.view.set_image(self.model.get_averaged_image())
-        self.view.set_spectrum("roi", self.model.get_spectrum("roi", self.spectrum_mode))
+        self.view.set_spectrum(self._roi_name, self.model.get_spectrum(self._roi_name, self.spectrum_mode))
         self.view.spectrum.add_range(*self.model.tof_range)
-        if "roi" not in self.view.spectrum.roi_dict:
-            self.view.spectrum.add_roi(self.model.get_roi("roi"), "roi")
-            self.view.set_spectrum("roi", self.model.get_spectrum("roi", self.spectrum_mode))
+        if self._roi_name not in self.view.spectrum.roi_dict:
+            self.view.spectrum.add_roi(self.model.get_roi(self._roi_name), self._roi_name)
+            self.view.set_spectrum(self._roi_name, self.model.get_spectrum(self._roi_name, self.spectrum_mode))
         self.view.auto_range_image()
         self.view.spectrum.reset_roi_size(self.model.get_image_shape())
 
@@ -111,7 +112,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         Get the default state of the table
         """
-        return ["roi", self.view.spectrum.roi_dict["roi"].colour]
+        return [self._roi_name, self.view.spectrum.roi_dict[self._roi_name].colour]
 
     def handle_range_slide_moved(self, tof_range) -> None:
         self.model.tof_range = tof_range

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -99,11 +99,12 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         additional ROIs will be removed leaving only the default ROI.
         """
         self.view.set_image(self.model.get_averaged_image())
-        self.view.set_spectrum(self.model.get_spectrum("roi", self.spectrum_mode))
+        self.view.set_spectrum("roi", self.model.get_spectrum("roi", self.spectrum_mode))
         self.view.spectrum.add_range(*self.model.tof_range)
         if "roi" not in self.view.spectrum.roi_dict:
-            self.view.set_spectrum(self.model.get_spectrum("roi", self.spectrum_mode))
             self.view.spectrum.add_roi(self.model.get_roi("roi"), "roi")
+            self.view.set_spectrum("roi", self.model.get_spectrum("roi", self.spectrum_mode))
+            # self.view.spectrum.add_roi(self.model.get_roi("roi"), "roi")
         self.view.auto_range_image()
         self.view.spectrum.reset_roi_size(self.model.get_image_shape())
 
@@ -125,7 +126,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         for name in roi_names:
             roi = self.view.spectrum.get_roi(name)
             self.model.set_roi(name, roi)
-            self.view.set_spectrum(self.model.get_spectrum(name, self.spectrum_mode))
+            self.view.set_spectrum(name, self.model.get_spectrum(name, self.spectrum_mode))
 
     def handle_export_button_enabled(self) -> None:
         """
@@ -165,7 +166,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         roi_name = self.model.roi_name_generator()
         self.model.set_new_roi(roi_name)
-        self.view.set_spectrum(self.model.get_spectrum(roi_name, self.spectrum_mode))
+        self.view.set_spectrum(roi_name, self.model.get_spectrum(roi_name, self.spectrum_mode))
         self.view.spectrum.add_roi(self.model.get_roi(roi_name), roi_name)
         self.view.auto_range_image()
         self.do_add_roi_to_table(roi_name)

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -178,7 +178,8 @@ class SpectrumWidget(GraphicsLayoutWidget):
 
     def rename_roi(self, old_name: str, new_name: str) -> None:
         """
-        Rename a given ROI by name unless it is 'roi' or 'all'.
+        Rename a given ROI and corresponding spectrum by name
+        unless it is called 'roi' or 'all'
 
         @param old_name: The name of the ROI to rename.
         @param new_name: The new name of the ROI.
@@ -186,6 +187,7 @@ class SpectrumWidget(GraphicsLayoutWidget):
         """
         if old_name in self.roi_dict.keys() and new_name not in self.roi_dict.keys():
             self.roi_dict[new_name] = self.roi_dict.pop(old_name)
+            self.spectrum_data_dict[new_name] = self.spectrum_data_dict.pop(old_name)
 
     def reset_roi_size(self, image_shape) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-import numpy as np
-
 from PyQt5.QtCore import pyqtSignal
 from pyqtgraph import ROI, GraphicsLayoutWidget, LinearRegionItem, PlotItem
 
@@ -14,6 +12,7 @@ from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
 
 if TYPE_CHECKING:
+    import numpy as np
     from .view import SpectrumViewerWindowView
 
 

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
+import numpy as np
+
 from PyQt5.QtCore import pyqtSignal
 from pyqtgraph import ROI, GraphicsLayoutWidget, LinearRegionItem, PlotItem
 
@@ -82,6 +84,7 @@ class SpectrumWidget(GraphicsLayoutWidget):
         self.nextRow()
         self.spectrum = self.addPlot()
 
+        self.spectrum_data_dict: dict[str, Optional['np.ndarray']] = {}
         self.nextRow()
         self._tof_range_label = self.addLabel()
 
@@ -91,7 +94,7 @@ class SpectrumWidget(GraphicsLayoutWidget):
         self.range_control = LinearRegionItem()
         self.range_control.sigRegionChanged.connect(self._handle_tof_range_changed)
 
-        self.roi_dict = {}
+        self.roi_dict: dict[Optional[str], ROI] = {}
         self.colour_index = 0
 
     def add_range(self, range_min: int, range_max: int):

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -117,6 +117,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
         self.presenter.show_new_sample()
         self.view.spectrum.add_range.assert_called_once_with(0, 9)
+        self.view.set_spectrum.assert_called()
 
     def test_roi_exists_WHEN_show_new_sample_called_THEN_add_roi_not_called(self):
         image_stack = generate_images([10, 11, 12])

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -47,7 +47,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.imageLayout.addWidget(self.spectrum)
 
         self.spectrum.range_changed.connect(self.presenter.handle_range_slide_moved)
-        #  Where roi signal is omitted from spectrum_widget.py to be updated on change
         self.spectrum.roi_changed.connect(self.presenter.handle_roi_moved)
 
         self._current_dataset_id = None

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -47,7 +47,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.imageLayout.addWidget(self.spectrum)
 
         self.spectrum.range_changed.connect(self.presenter.handle_range_slide_moved)
-        # Where roi signal is omitted from spectrum_widget.py to be updated on change
+        #  Where roi signal is omitted from spectrum_widget.py to be updated on change
         self.spectrum.roi_changed.connect(self.presenter.handle_roi_moved)
 
         self._current_dataset_id = None
@@ -168,12 +168,18 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     def set_image(self, image_data: Optional['np.ndarray'], autoLevels: bool = True):
         self.spectrum.image.setImage(image_data, autoLevels=autoLevels)
 
-    def set_spectrum(self, spectrum_data: 'np.ndarray'):
+    def set_spectrum(self, name: str, spectrum_data: 'np.ndarray'):
+        self.spectrum.spectrum_data_dict[name] = spectrum_data
         self.spectrum.spectrum.clearPlots()
-        self.spectrum.spectrum.plot(spectrum_data)
+
+        for key, value in self.spectrum.spectrum_data_dict.items():
+            # roi_dict may not be populated with yet on method call
+            if key in self.spectrum.roi_dict:
+                self.spectrum.spectrum.plot(value, name=key, pen=self.spectrum.roi_dict[key].colour)
 
     def clear(self) -> None:
         self.spectrum.clear_data()
+        self.spectrum.spectrum_data_dict = {}
 
     def auto_range_image(self):
         self.spectrum.image.vb.autoRange()
@@ -226,9 +232,14 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             self.roi_table_model.remove_row(self.selected_row)
             self.presenter.do_remove_roi(self.selected_row_data[0])
             self.removeBtn.setEnabled(False)
+            self.spectrum.spectrum_data_dict.pop(self.selected_row_data[0])
+            self.spectrum.spectrum.removeItem(self.selected_row_data[0])
+            self.presenter.handle_roi_moved()  # Update plot View
 
     def clear_all_rois(self) -> None:
         """
         Clear all ROIs from the table view
         """
         self.roi_table_model.clear_table()
+        self.spectrum.spectrum_data_dict = {}
+        self.spectrum.spectrum.clearPlots()


### PR DESCRIPTION
### Issue

Closes #1680 

### Description

* Allow Spectrum to store multiple spectrum line plot data to display all ROI added to the spectrum line plot.
* `set_spectrum` now iterates through spectrum data and plots it. 

![image](https://user-images.githubusercontent.com/32413847/217036278-6a3fc017-e818-42ef-9bcc-bd1c6f5d3eea.png)


### Testing 

Minor change to `test_show_sample` in `presenter_test.py`  to test set_spectrum called on show new sample called.

### Acceptance Criteria 

* ROI spectrum data displayed in line plot for each visible ROI added to a sample in the spectrum viewer.
* Each spectrum line plot is the same colour as its corresponding ROI.
* ROI name changes are applied to spectrum data (If not applied to spectrum data, you should see issues when removing a renamed ROI)
* When an ROI is removed, so is the corresponding line plot.
* When the sample is swapped, the spectrum line plots stay in sync with the state of ROIs.

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*

* `docs/release_notes/next.rst`: New Features and improvements
