### PR TITLE
Use FilenameGroup for Load images

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -46,3 +46,4 @@ Developer Changes
 - #1670 : `tostring()` Deprecation Warning
 - #1673 : Update license year across the repository from 2022 to 2023
 - #1678 : Allow multiple datasets to be opened at once in the GUI when using the CLI `--path` flag
+- #1695 : Use FilenameGroup for Load Images

--- a/mantidimaging/core/io/loader/__init__.py
+++ b/mantidimaging/core/io/loader/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import annotations
 
 from .loader import (  # noqa: F401
-    load, load_stack, load_p, load_log, read_in_file_information, supported_formats, load_stack_from_group)
+    load, load_p, load_log, read_in_file_information, supported_formats, load_stack_from_group)

--- a/mantidimaging/core/io/loader/__init__.py
+++ b/mantidimaging/core/io/loader/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import annotations
 
 from .loader import (  # noqa: F401
-    load, load_stack, load_p, load_log, read_in_file_information, supported_formats)
+    load, load_stack, load_p, load_log, read_in_file_information, supported_formats, load_stack_from_group)

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -104,14 +104,6 @@ def load_p(parameters: ImageParameters, dtype: 'npt.DTypeLike', progress: Progre
                 progress=progress)
 
 
-def load_stack(file_path: str, progress: Optional[Progress] = None) -> ImageStack:
-    image_format = get_file_extension(file_path)
-    prefix = get_prefix(file_path)
-    file_names = get_file_names(path=os.path.dirname(file_path), img_format=image_format, prefix=prefix)
-
-    return load(file_names=file_names, progress=progress)
-
-
 def load_stack_from_group(group: FilenameGroup, progress: Optional[Progress] = None) -> ImageStack:
     return load(file_names=[str(p) for p in group.all_files()], progress=progress)
 

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     import numpy.typing as npt
     from mantidimaging.core.data import ImageStack
     from mantidimaging.core.utility.progress_reporting import Progress
+    from mantidimaging.core.io.filenames import FilenameGroup
 
 LOG = getLogger(__name__)
 
@@ -109,6 +110,10 @@ def load_stack(file_path: str, progress: Optional[Progress] = None) -> ImageStac
     file_names = get_file_names(path=os.path.dirname(file_path), img_format=image_format, prefix=prefix)
 
     return load(file_names=file_names, progress=progress)
+
+
+def load_stack_from_group(group: FilenameGroup, progress: Optional[Progress] = None) -> ImageStack:
+    return load(file_names=[str(p) for p in group.all_files()], progress=progress)
 
 
 def load(input_path: Optional[str] = None,

--- a/mantidimaging/core/io/loader/test/loader_test.py
+++ b/mantidimaging/core/io/loader/test/loader_test.py
@@ -5,7 +5,6 @@ from unittest import mock
 from pathlib import Path
 
 from mantidimaging.core.io import loader
-from mantidimaging.core.io.loader import load_stack
 from mantidimaging.core.io.loader.loader import create_loading_parameters_for_file_path, DEFAULT_PIXEL_DEPTH, \
     DEFAULT_PIXEL_SIZE, DEFAULT_IS_SINOGRAM
 from pyfakefs.fake_filesystem_unittest import TestCase
@@ -24,20 +23,6 @@ class LoaderTest(TestCase):
 
     def test_raise_on_invalid_format(self):
         self.assertRaises(NotImplementedError, loader.load, "/some/path", file_names=["/somefile"], in_format='txt')
-
-    @mock.patch("mantidimaging.core.io.loader.loader.load")
-    def test_load_stack_finds_files(self, load_mock: mock.Mock):
-        progress = mock.Mock()
-        file_paths_tomo = [f"/a/tomo_{x:04d}.tiff" for x in range(5)]
-        file_paths_other = [f"/a/flat_{x:04d}.tiff" for x in range(5)] + ["/a/tomo.log"]
-        for filename in file_paths_tomo + file_paths_other:
-            self.fs.create_file(filename)
-
-        load_stack(file_paths_tomo[0], progress)
-
-        load_mock.assert_called_once()
-        found_files = load_mock.call_args.kwargs['file_names']
-        self._file_list_count_equal(file_paths_tomo, found_files)
 
     @mock.patch("mantidimaging.core.io.loader.loader.load_log")
     @mock.patch("mantidimaging.core.io.loader.loader.read_in_file_information")

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -9,6 +9,7 @@ from typing import Dict, Optional, List, Union, NoReturn, TYPE_CHECKING
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
 from mantidimaging.core.io import loader, saver
+from mantidimaging.core.io.filenames import FilenameGroup
 from mantidimaging.core.utility.data_containers import LoadingParameters, ProjectionAngles
 
 if TYPE_CHECKING:
@@ -68,14 +69,12 @@ class MainWindowModel(object):
         return ds
 
     def load_images_into_mixed_dataset(self, file_path: str, progress: 'Progress') -> MixedDataset:
-        images = self.load_image_stack(file_path, progress)
+        group = FilenameGroup.from_file(Path(file_path))
+        group.find_all_files()
+        images = loader.load_stack_from_group(group, progress)
         sd = MixedDataset([images], images.name)
         self.datasets[sd.id] = sd
         return sd
-
-    @staticmethod
-    def load_image_stack(file_path: str, progress: 'Progress') -> ImageStack:
-        return loader.load_stack(file_path, progress)
 
     def do_images_saving(self, images_id, output_dir, name_prefix, image_format, overwrite, pixel_depth, progress):
         images = self.get_images_by_uuid(images_id)

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -249,13 +249,16 @@ class MainWindowModelTest(unittest.TestCase):
         get_images_mock.return_value.set_projection_angles.assert_called_once_with(proj_angles)
 
     @mock.patch("mantidimaging.gui.windows.main.model.loader")
-    def test_load_stack(self, loader: mock.MagicMock):
+    @mock.patch("mantidimaging.gui.windows.main.model.FilenameGroup")
+    def test_load_stack(self, fng_mock: mock.MagicMock, loader: mock.MagicMock):
         file_path = "file_path"
         progress = mock.Mock()
+        group = mock.Mock()
+        fng_mock.from_file.return_value = group
 
         self.model.load_images_into_mixed_dataset(file_path, progress)
 
-        loader.load_stack.assert_called_once_with(file_path, progress)
+        loader.load_stack_from_group.assert_called_once_with(group, progress)
 
     def test_no_image_with_matching_id(self):
         self.assertIsNone(self.model.get_images_by_uuid(uuid.uuid4()))


### PR DESCRIPTION
### Issue
Progress on #1219

### Description

This moves the "Load Images" option over to using FilenameGroups

This replaces `loader.load_stack`. The logic in FilenameGroups is well tested elsewhere.

### Testing & Acceptance Criteria 

Test that an image stack be loaded with File -> Load Images

### Documentation

release notes
