### PR TITLE
Drag and drop loading dialog and cleanup

### DIFF
--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -189,7 +189,7 @@ def find_first_file_that_is_possibly_a_sample(file_path: str) -> Optional[str]:
     # Grab all .tif or .tiff files
     possible_files = glob.glob(os.path.join(file_path, "**/*.tif*"), recursive=True)
 
-    for possible_file in possible_files:
+    for possible_file in sorted(possible_files):
         lower_filename = os.path.basename(possible_file).lower()
         if "flat" not in lower_filename and "dark" not in lower_filename and "180" not in lower_filename:
             return possible_file

--- a/mantidimaging/eyes_tests/image_load_dialog_test.py
+++ b/mantidimaging/eyes_tests/image_load_dialog_test.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
-from unittest import mock
 
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest, LOAD_SAMPLE
 
@@ -14,8 +13,6 @@ class ImageLoadDialogTest(BaseEyesTest):
 
     def test_load_dialog_selected_dataset(self):
         self.imaging.actionLoadDataset.trigger()
-        self.imaging.image_load_dialog.select_file = mock.MagicMock(return_value=LOAD_SAMPLE)
-
-        self.imaging.image_load_dialog.presenter.do_update_sample()
+        self.imaging.image_load_dialog.presenter.do_update_sample(LOAD_SAMPLE)
 
         self.check_target(widget=self.imaging.image_load_dialog)

--- a/mantidimaging/gui/test/gui_system_windows_test.py
+++ b/mantidimaging/gui/test/gui_system_windows_test.py
@@ -26,6 +26,22 @@ class TestGuiSystemWindows(GuiSystemBase):
         self._close_welcome()
         self._load_data_set()
 
+        datasets = list(self.main_window.presenter.datasets)
+        self.assertEqual(len(datasets), 1)
+        dataset = datasets[0]
+        self.assertIsNotNone(dataset.sample)
+        self.assertIsNotNone(dataset.flat_before)
+        self.assertIsNotNone(dataset.flat_after)
+        self.assertIsNotNone(dataset.dark_before)
+        self.assertIsNotNone(dataset.proj180deg)
+        self.assertIsNone(dataset.dark_after)
+
+        self.assertTupleEqual(dataset.sample.data.shape, (100, 128, 128))
+        self.assertTupleEqual(dataset.flat_before.data.shape, (20, 128, 128))
+        self.assertTupleEqual(dataset.flat_after.data.shape, (20, 128, 128))
+        self.assertTupleEqual(dataset.dark_before.data.shape, (10, 128, 128))
+        self.assertTupleEqual(dataset.proj180deg.data.shape, (1, 128, 128))
+
     def test_open_operations(self):
         self._close_welcome()
         self._load_data_set()

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -17,6 +17,7 @@ from PyQt5.QtWidgets import QAction, QDialog, QLabel, QMessageBox, QMenu, QFileD
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset
+from mantidimaging.core.io.utility import find_first_file_that_is_possibly_a_sample
 from mantidimaging.core.utility import finder
 from mantidimaging.core.utility.command_line_arguments import CommandLineArguments
 from mantidimaging.core.utility.projection_angle_parser import ProjectionAngleFileParser
@@ -225,6 +226,14 @@ class MainWindowView(BaseMainWindowView):
     def show_image_load_dialog(self):
         self.image_load_dialog = ImageLoadDialog(self)
         self.image_load_dialog.show()
+
+    def show_image_load_dialog_with_path(self, file_path: str) -> bool:
+        sample_file = find_first_file_that_is_possibly_a_sample(file_path)
+        if sample_file is not None:
+            self.image_load_dialog = ImageLoadDialog(self)
+            self.image_load_dialog.presenter.do_update_sample(sample_file)
+            self.image_load_dialog.show()
+        return sample_file is not None
 
     def show_nexus_load_dialog(self):
         self.nexus_load_dialog = NexusLoadDialog(self)
@@ -494,8 +503,7 @@ class MainWindowView(BaseMainWindowView):
             if not os.path.exists(file_path):
                 continue
             if os.path.isdir(file_path):
-                # Load directory as stack
-                sample_loading = self.presenter.load_stacks_from_folder(file_path)
+                sample_loading = self.show_image_load_dialog_with_path(file_path)
                 if not sample_loading:
                     QMessageBox.critical(
                         self, "Load not possible!", "Please provide a directory that has .tif or .tiff files in it, or "

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -228,6 +228,9 @@ class MainWindowView(BaseMainWindowView):
         self.image_load_dialog.show()
 
     def show_image_load_dialog_with_path(self, file_path: str) -> bool:
+        """
+        Open the dataset loading dialog with a given file_path preset as the sample
+        """
         sample_file = find_first_file_that_is_possibly_a_sample(file_path)
         if sample_file is not None:
             self.image_load_dialog = ImageLoadDialog(self)


### PR DESCRIPTION
### Issue
Cleanups for #1219 

### Description

When loading through drag and drop go though the Load Dataset dialog. This is useful as it allows the user to check settings, and avoids using a different code path.

I was hope to remove the need for `create_loading_parameters_for_file_path()` but it is still needed when using `--path` on the CLI. So not as big a cleanup as hoped.

This updates a system test to check that loading a dataset from the dialog actually works.

Moving calls to `select_file()` into `do_update_field` simplifies the `do_update...()` and reduces the amount of mocking needed in tests.

(I recommend view changes a commit at a time).

### Testing & Acceptance Criteria 

Check that a dataset can be loaded by drag and drop

### Documentation

Not needed
