### PR TITLE
Use Enum for FILE_TYPES

### DIFF
--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -153,3 +153,22 @@ class LoadingParameters:
         if name == "180 degree":
             short_name = "proj_180deg"
         self.__setattr__(short_name, img_params)
+
+
+class TypeInfo(NamedTuple):
+    name: str
+    suffix: str
+    mode: str
+
+
+FILE_TYPES: dict[str, TypeInfo] = {
+    "Sample": TypeInfo("Sample", "", "sample"),
+    "Flat Before": TypeInfo("Flat", "Before", "images"),
+    "Flat After": TypeInfo("Flat", "After", "images"),
+    "Dark Before": TypeInfo("Dark", "Before", "images"),
+    "Dark After": TypeInfo("Dark", "After", "images"),
+    "180 degree": TypeInfo("180 degree", "", "180"),
+    "Sample Log": TypeInfo("Sample Log", "", "log"),
+    "Flat Before Log": TypeInfo("Flat Before Log", "", "log"),
+    "Flat After Log": TypeInfo("Flat After Log", "", "log"),
+}

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
+
+from enum import Enum
 """
 Containers for data. They don't do much apart from storing the data,
 and optionally provide helpful operations.
@@ -155,20 +157,22 @@ class LoadingParameters:
         self.__setattr__(short_name, img_params)
 
 
-class TypeInfo(NamedTuple):
-    name: str
-    suffix: str
-    mode: str
+class FILE_TYPES(Enum):
+    SAMPLE = ("Sample", "", "sample")
+    FLAT_BEFORE = ("Flat", "Before", "images")
+    FLAT_AFTER = ("Flat", "After", "images")
+    DARK_BEFORE = ("Dark", "Before", "images")
+    DARK_AFTER = ("Dark", "After", "images")
+    PROJ_180 = ("180 degree", "", "180")
+    SAMPLE_LOG = ("Sample Log", "", "log")
+    FLAT_BEFORE_LOG = ("Flat Before Log", "", "log")
+    FLAT_AFTER_LOG = ("Flat After Log", "", "log")
 
+    def __init__(self, tname: str, suffix: str, mode: str) -> None:
+        self.tname = tname
+        self.suffix = suffix
+        self.mode = mode
 
-FILE_TYPES: dict[str, TypeInfo] = {
-    "Sample": TypeInfo("Sample", "", "sample"),
-    "Flat Before": TypeInfo("Flat", "Before", "images"),
-    "Flat After": TypeInfo("Flat", "After", "images"),
-    "Dark Before": TypeInfo("Dark", "Before", "images"),
-    "Dark After": TypeInfo("Dark", "After", "images"),
-    "180 degree": TypeInfo("180 degree", "", "180"),
-    "Sample Log": TypeInfo("Sample Log", "", "log"),
-    "Flat Before Log": TypeInfo("Flat Before Log", "", "log"),
-    "Flat After Log": TypeInfo("Flat After Log", "", "log"),
-}
+    @property
+    def fname(self) -> str:
+        return (self.tname + " " + self.suffix).strip()

--- a/mantidimaging/gui/windows/image_load_dialog/field.py
+++ b/mantidimaging/gui/windows/image_load_dialog/field.py
@@ -5,15 +5,12 @@ from pathlib import Path
 
 import numpy as np
 import os
-from typing import Optional, List, Union, Tuple, TYPE_CHECKING
+from typing import Optional, List, Union, Tuple
 
 from PyQt5.QtWidgets import QTreeWidgetItem, QWidget, QSpinBox, QTreeWidget, QHBoxLayout, QLabel, QCheckBox, QPushButton
 
 from mantidimaging.core.utility import size_calculator
-from mantidimaging.core.utility.data_containers import Indices
-
-if TYPE_CHECKING:
-    from .presenter import TypeInfo
+from mantidimaging.core.utility.data_containers import Indices, TypeInfo
 
 
 class Field:
@@ -28,7 +25,7 @@ class Field:
     _path: Optional[QTreeWidgetItem]
 
     def __init__(self, tree: QTreeWidget, widget: QTreeWidgetItem, use: QCheckBox, select_button: QPushButton,
-                 file_info: 'TypeInfo'):
+                 file_info: TypeInfo):
         self._tree = tree
         self._widget = widget
         self._use = use

--- a/mantidimaging/gui/windows/image_load_dialog/field.py
+++ b/mantidimaging/gui/windows/image_load_dialog/field.py
@@ -10,7 +10,7 @@ from typing import Optional, List, Union, Tuple
 from PyQt5.QtWidgets import QTreeWidgetItem, QWidget, QSpinBox, QTreeWidget, QHBoxLayout, QLabel, QCheckBox, QPushButton
 
 from mantidimaging.core.utility import size_calculator
-from mantidimaging.core.utility.data_containers import Indices, TypeInfo
+from mantidimaging.core.utility.data_containers import Indices, FILE_TYPES
 
 
 class Field:
@@ -25,7 +25,7 @@ class Field:
     _path: Optional[QTreeWidgetItem]
 
     def __init__(self, tree: QTreeWidget, widget: QTreeWidgetItem, use: QCheckBox, select_button: QPushButton,
-                 file_info: TypeInfo):
+                 file_info: FILE_TYPES):
         self._tree = tree
         self._widget = widget
         self._use = use

--- a/mantidimaging/gui/windows/image_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/image_load_dialog/presenter.py
@@ -6,38 +6,19 @@ import os
 import traceback
 from logging import getLogger
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, NamedTuple, Dict
+from typing import TYPE_CHECKING, Optional
 
 from mantidimaging.core.io.loader import load_log
 from mantidimaging.core.io.loader.loader import read_in_file_information, FileInformation
 from mantidimaging.core.io.utility import (get_file_extension, get_prefix, find_images, find_log_for_image,
                                            find_180deg_proj)
-from mantidimaging.core.utility.data_containers import LoadingParameters, ImageParameters
+from mantidimaging.core.utility.data_containers import LoadingParameters, ImageParameters, FILE_TYPES
 from mantidimaging.gui.windows.image_load_dialog.field import Field
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.image_load_dialog import ImageLoadDialog  # pragma: no cover
 
 logger = getLogger(__name__)
-
-
-class TypeInfo(NamedTuple):
-    name: str
-    suffix: str
-    mode: str
-
-
-FILE_TYPES: Dict[str, TypeInfo] = {
-    "Sample": TypeInfo("Sample", "", "sample"),
-    "Flat Before": TypeInfo("Flat", "Before", "images"),
-    "Flat After": TypeInfo("Flat", "After", "images"),
-    "Dark Before": TypeInfo("Dark", "Before", "images"),
-    "Dark After": TypeInfo("Dark", "After", "images"),
-    "180 degree": TypeInfo("180 degree", "", "180"),
-    "Sample Log": TypeInfo("Sample Log", "", "log"),
-    "Flat Before Log": TypeInfo("Flat Before Log", "", "log"),
-    "Flat After Log": TypeInfo("Flat After Log", "", "log"),
-}
 
 
 class LoadPresenter:

--- a/mantidimaging/gui/windows/image_load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/image_load_dialog/test/presenter_test.py
@@ -9,7 +9,8 @@ from unittest import mock
 from mantidimaging.core.io.loader.loader import FileInformation
 from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
 from mantidimaging.gui.windows.image_load_dialog.field import Field
-from mantidimaging.gui.windows.image_load_dialog.presenter import LoadPresenter, FILE_TYPES, TypeInfo
+from mantidimaging.gui.windows.image_load_dialog.presenter import LoadPresenter
+from mantidimaging.core.utility.data_containers import FILE_TYPES, TypeInfo
 
 
 class ImageLoadDialogPresenterTest(unittest.TestCase):

--- a/mantidimaging/gui/windows/image_load_dialog/view.py
+++ b/mantidimaging/gui/windows/image_load_dialog/view.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from typing import Optional, Dict
 
 from PyQt5.QtWidgets import QComboBox, QCheckBox, QTreeWidget, QTreeWidgetItem, QPushButton, QSizePolicy, \
-    QHeaderView, QSpinBox, QFileDialog, QDialogButtonBox
+    QHeaderView, QSpinBox, QFileDialog, QDialogButtonBox, QWidget
 
 from mantidimaging.core.io.loader.loader import DEFAULT_PIXEL_SIZE, DEFAULT_IS_SINOGRAM, DEFAULT_PIXEL_DEPTH
-from mantidimaging.core.utility.data_containers import LoadingParameters, FILE_TYPES, TypeInfo
+from mantidimaging.core.utility.data_containers import LoadingParameters, FILE_TYPES
 from mantidimaging.gui.windows.image_load_dialog.field import Field
 from .presenter import LoadPresenter
 from ...mvp_base import BaseDialogView
@@ -26,7 +26,7 @@ class ImageLoadDialog(BaseDialogView):
 
     fields: Dict[str, Field]
 
-    def __init__(self, parent):
+    def __init__(self, parent: QWidget) -> None:
         super().__init__(parent, 'gui/ui/image_load_dialog.ui')
 
         self.parent_view = parent
@@ -38,8 +38,8 @@ class ImageLoadDialog(BaseDialogView):
         self.tree.header().setStretchLastSection(False)
         self.tree.setTabKeyNavigation(True)
 
-        for n, file_info in enumerate(FILE_TYPES.items()):
-            self.fields[file_info[0]] = self.create_file_input(n, file_info[1])
+        for n, file_info in enumerate(FILE_TYPES):
+            self.fields[file_info.fname] = self.create_file_input(n, file_info)
 
         self.sample = self.fields["Sample"]
 
@@ -58,7 +58,7 @@ class ImageLoadDialog(BaseDialogView):
         self.pixelSize.setValue(DEFAULT_PIXEL_SIZE)
         self.pixel_bit_depth.setCurrentText(DEFAULT_PIXEL_DEPTH)
 
-    def create_file_input(self, position: int, file_info: TypeInfo) -> Field:
+    def create_file_input(self, position: int, file_info: FILE_TYPES) -> Field:
         section: QTreeWidgetItem = self.tree.topLevelItem(position)
 
         use = QCheckBox(self)

--- a/mantidimaging/gui/windows/image_load_dialog/view.py
+++ b/mantidimaging/gui/windows/image_load_dialog/view.py
@@ -8,9 +8,9 @@ from PyQt5.QtWidgets import QComboBox, QCheckBox, QTreeWidget, QTreeWidgetItem, 
     QHeaderView, QSpinBox, QFileDialog, QDialogButtonBox
 
 from mantidimaging.core.io.loader.loader import DEFAULT_PIXEL_SIZE, DEFAULT_IS_SINOGRAM, DEFAULT_PIXEL_DEPTH
-from mantidimaging.core.utility.data_containers import LoadingParameters
+from mantidimaging.core.utility.data_containers import LoadingParameters, FILE_TYPES, TypeInfo
 from mantidimaging.gui.windows.image_load_dialog.field import Field
-from .presenter import LoadPresenter, FILE_TYPES, TypeInfo
+from .presenter import LoadPresenter
 from ...mvp_base import BaseDialogView
 
 


### PR DESCRIPTION
### Issue
Cleanup for #1219

### Description

Move FILE_TYPES and change to an Enum to make it safer.

### Testing & Acceptance Criteria 
Tests should pass.
Test File->Load Dataset

### Documentation

not needed
