### PR TITLE
1697: For NXtomoproc store data in float32

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -24,6 +24,7 @@ New Features and improvements
 - #1665 : PyInstaller exe icon
 - #1680 : Multiple Spectrum Line Plots in Spectrum Viewer
 - #1691 : Remove "Beta" from spectrum viewer
+- #1697 : For NXtomoproc store data in float32
 
 Fixes
 -----

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -292,7 +292,7 @@ def _save_recon_to_nexus(nexus_file: h5py.File, recon: ImageStack, sample_path: 
     data = recon_entry.create_group("data")
     _set_nx_class(data, "NXdata")
 
-    data.create_dataset("data", shape=recon.data.shape, dtype="float16")
+    data.create_dataset("data", shape=recon.data.shape, dtype="float32")
     data["data"][:] = recon.data
 
     x_arr, y_arr, z_arr = _create_pixel_size_arrays(recon)


### PR DESCRIPTION
### Issue

Closes #1697 

### Description

Saves recon NeXus data as float32.

### Testing 

No tests added.

### Acceptance Criteria 

Check a NeXus file generated by Imaging.

### Documentation

Updated release notes.
