### PR TITLE
New loading params

### DIFF
--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.reconlist import ReconList
+from mantidimaging.core.utility.data_containers import FILE_TYPES
 
 
 def _delete_stack_error_message(images_id: uuid.UUID) -> str:
@@ -196,6 +197,15 @@ class StrictDataset(BaseDataset):
                     self.recons.remove(recon)
         else:
             raise KeyError(_delete_stack_error_message(images_id))
+
+    def set_stack(self, file_type: FILE_TYPES, image_stack: ImageStack):
+        attr_name = file_type.fname.lower().replace(" ", "_")
+        if file_type == FILE_TYPES.PROJ_180:
+            attr_name = "proj180deg"
+        if hasattr(self, attr_name):
+            setattr(self, attr_name, image_stack)
+        else:
+            raise AttributeError(f"StrictDataset does not have an attribute for {attr_name}")
 
 
 def _get_stack_data_type(stack_id: uuid.UUID, dataset: Union[MixedDataset, StrictDataset]) -> str:

--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -7,6 +7,8 @@ import re
 from typing import List, Iterator, Optional, Union
 from logging import getLogger
 
+from mantidimaging.core.utility.data_containers import FILE_TYPES
+
 LOG = getLogger(__name__)
 
 
@@ -119,3 +121,20 @@ class FilenameGroup:
             # choose shortest match
             shortest = min(log_paths, key=lambda p: len(p.name))
             self.log_path = self.directory / shortest
+
+    def find_related(self, file_type: FILE_TYPES) -> Optional[FilenameGroup]:
+        sample_first_name = next(self.all_files()).name
+
+        test_names = [file_type.fname.replace(" ", "_")]
+        if file_type.suffix == "Before":
+            test_names.append(file_type.tname)
+        test_names.extend([s.lower() for s in test_names])
+        if self.directory.name in ["Tomo", "tomo"]:
+            for test_name in test_names:
+                new_dir = self.directory.parent / test_name
+                if new_dir.exists():
+                    new_path = new_dir / sample_first_name.replace("Tomo", test_name).replace("tomo", test_name)
+                    if new_path.exists():
+                        return self.from_file(new_path)
+
+        return None

--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -88,6 +88,9 @@ class FilenameGroup:
         path = Path(path)
         if path.is_dir():
             raise ValueError(f"path is a directory: {path}")
+        if 'WindowsPath' in type(path).__name__:
+            # for a windows like path, resolve actual case
+            path = path.resolve()
         directory = path.parent
         name = path.name
         pattern = FilenamePattern.from_name(name)

--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -123,6 +123,9 @@ class FilenameGroup:
             self.log_path = self.directory / shortest
 
     def find_related(self, file_type: FILE_TYPES) -> Optional[FilenameGroup]:
+        if file_type == FILE_TYPES.PROJ_180:
+            return self._find_related_180_proj()
+
         sample_first_name = next(self.all_files()).name
 
         test_names = [file_type.fname.replace(" ", "_")]
@@ -134,6 +137,25 @@ class FilenameGroup:
                 new_dir = self.directory.parent / test_name
                 if new_dir.exists():
                     new_path = new_dir / sample_first_name.replace("Tomo", test_name).replace("tomo", test_name)
+                    if new_path.exists():
+                        return self.from_file(new_path)
+
+        return None
+
+    def _find_related_180_proj(self) -> Optional[FilenameGroup]:
+        sample_first_name = next(self.all_files()).name
+
+        test_name = "180deg"
+        if self.directory.name in ["Tomo", "tomo"]:
+            new_dir = self.directory.parent / test_name
+            if new_dir.exists():
+                for trim_numbers in [True, False]:
+                    if trim_numbers:
+                        new_name = re.sub(r'_([0-9]+)', "", sample_first_name)
+                    else:
+                        new_name = sample_first_name
+                    new_name = new_name.replace("Tomo", test_name).replace("tomo", test_name)
+                    new_path = new_dir / new_name
                     if new_path.exists():
                         return self.from_file(new_path)
 

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -170,7 +170,7 @@ def load(input_path: Optional[str] = None,
     return image_stack
 
 
-def new_create_loading_parameters_for_file_path(file_path: Path) -> Optional[NewLoadingParameters]:
+def create_loading_parameters_for_file_path(file_path: Path) -> Optional[NewLoadingParameters]:
     sample_file = find_first_file_that_is_possibly_a_sample(str(file_path))
     if sample_file is None:
         return None

--- a/mantidimaging/core/io/loader/test/loader_test.py
+++ b/mantidimaging/core/io/loader/test/loader_test.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
-from unittest import mock
 from pathlib import Path
 
 from mantidimaging.core.io import loader
@@ -28,9 +27,7 @@ class LoaderTest(TestCase):
     def test_raise_on_invalid_format(self):
         self.assertRaises(NotImplementedError, loader.load, "/some/path", file_names=["/somefile"], in_format='txt')
 
-    @mock.patch("mantidimaging.core.io.loader.loader.load_log")
-    @mock.patch("mantidimaging.core.io.loader.loader.read_in_file_information")
-    def test_create_loading_parameters_for_file_path_new(self, _load_log, _read_in_file_information):
+    def test_create_loading_parameters_for_file_path(self):
         output_directory = Path("/b")
         for filename in ["Tomo_log.txt", "Flat_After_log.txt", "Flat_Before_log.txt"]:
             self.fs.create_file(output_directory / filename)

--- a/mantidimaging/core/io/loader/test/loader_test.py
+++ b/mantidimaging/core/io/loader/test/loader_test.py
@@ -6,24 +6,12 @@ from pathlib import Path
 from mantidimaging.core.io import loader
 from mantidimaging.core.io.loader.loader import DEFAULT_PIXEL_DEPTH, \
     DEFAULT_PIXEL_SIZE, DEFAULT_IS_SINOGRAM, create_loading_parameters_for_file_path
-from pyfakefs.fake_filesystem_unittest import TestCase
 
 from mantidimaging.core.utility.data_containers import FILE_TYPES
+from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
 
 
-class LoaderTest(TestCase):
-    def setUp(self) -> None:
-        self.setUpPyfakefs()
-
-    def _files_equal(self, file1, file2):
-        self.assertIsNotNone(file1)
-        self.assertIsNotNone(file2)
-        self.assertEqual(Path(file1).absolute(), Path(file2).absolute())
-
-    def _file_list_count_equal(self, list1, list2):
-        """Check that 2 lists of paths refer to the same files. Order independent"""
-        self.assertCountEqual((Path(s).absolute() for s in list1), (Path(s).absolute() for s in list2))
-
+class LoaderTest(FakeFSTestCase):
     def test_raise_on_invalid_format(self):
         self.assertRaises(NotImplementedError, loader.load, "/some/path", file_names=["/somefile"], in_format='txt')
 
@@ -46,28 +34,28 @@ class LoaderTest(TestCase):
         self.assertEqual(DEFAULT_IS_SINOGRAM, lp.sinograms)
 
         sample = lp.image_stacks[FILE_TYPES.SAMPLE]
-        self.assertIn(Path("/b/Tomo/Tomo_0000.tif"), sample.file_group.all_files())
+        self._file_in_sequence(Path("/b/Tomo/Tomo_0000.tif"), sample.file_group.all_files())
         self.assertEqual(5, len(list(sample.file_group.all_files())))
         self._files_equal("/b/Tomo_log.txt", sample.log_file)
 
         sample = lp.image_stacks[FILE_TYPES.FLAT_BEFORE]
-        self.assertIn(Path("/b/Flat_Before/Flat_Before_0000.tif"), sample.file_group.all_files())
+        self._file_in_sequence(Path("/b/Flat_Before/Flat_Before_0000.tif"), sample.file_group.all_files())
         self.assertEqual(5, len(list(sample.file_group.all_files())))
         self._files_equal("/b/Flat_Before_log.txt", sample.log_file)
 
         sample = lp.image_stacks[FILE_TYPES.FLAT_AFTER]
-        self.assertIn(Path("/b/Flat_After/Flat_After_0000.tif"), sample.file_group.all_files())
+        self._file_in_sequence(Path("/b/Flat_After/Flat_After_0000.tif"), sample.file_group.all_files())
         self.assertEqual(5, len(list(sample.file_group.all_files())))
         self._files_equal("/b/Flat_After_log.txt", sample.log_file)
 
         sample = lp.image_stacks[FILE_TYPES.DARK_BEFORE]
-        self.assertIn(Path("/b/Dark_Before/Dark_Before_0000.tif"), sample.file_group.all_files())
+        self._file_in_sequence(Path("/b/Dark_Before/Dark_Before_0000.tif"), sample.file_group.all_files())
         self.assertEqual(5, len(list(sample.file_group.all_files())))
 
         sample = lp.image_stacks[FILE_TYPES.DARK_AFTER]
-        self.assertIn(Path("/b/Dark_After/Dark_After_0000.tif"), sample.file_group.all_files())
+        self._file_in_sequence(Path("/b/Dark_After/Dark_After_0000.tif"), sample.file_group.all_files())
         self.assertEqual(5, len(list(sample.file_group.all_files())))
 
         sample = lp.image_stacks[FILE_TYPES.PROJ_180]
-        self.assertIn(Path("/b/180deg/180deg_0000.tif"), sample.file_group.all_files())
+        self._file_in_sequence(Path("/b/180deg/180deg_0000.tif"), sample.file_group.all_files())
         self.assertEqual(1, len(list(sample.file_group.all_files())))

--- a/mantidimaging/core/io/loader/test/loader_test.py
+++ b/mantidimaging/core/io/loader/test/loader_test.py
@@ -5,7 +5,7 @@ from unittest import mock
 from pathlib import Path
 
 from mantidimaging.core.io import loader
-from mantidimaging.core.io.loader.loader import create_loading_parameters_for_file_path, DEFAULT_PIXEL_DEPTH, \
+from mantidimaging.core.io.loader.loader import DEFAULT_PIXEL_DEPTH, \
     DEFAULT_PIXEL_SIZE, DEFAULT_IS_SINOGRAM, new_create_loading_parameters_for_file_path
 from pyfakefs.fake_filesystem_unittest import TestCase
 
@@ -74,71 +74,3 @@ class LoaderTest(TestCase):
         sample = lp.image_stacks[FILE_TYPES.PROJ_180]
         self.assertIn(Path("/b/180deg/180deg_0000.tif"), sample.file_group.all_files())
         self.assertEqual(1, len(list(sample.file_group.all_files())))
-
-    @mock.patch("mantidimaging.core.io.loader.loader.load_log")
-    @mock.patch("mantidimaging.core.io.loader.loader.read_in_file_information")
-    def test_create_loading_parameters_for_file_path(self, _load_log, _read_in_file_information):
-        output_directory = Path("/b")
-        for filename in ["Tomo_log.txt", "Flat_After_log.txt", "Flat_Before_log.txt"]:
-            self.fs.create_file(output_directory / filename)
-
-        for stack_type in ["Flat_Before", "Flat_After", "Dark_Before", "Dark_After", "Tomo"]:
-            for image_number in range(0, 5):
-                filename = Path(output_directory / stack_type / f"{stack_type}_{image_number:04d}.tif")
-                self.fs.create_file(filename)
-
-        self.fs.create_file(output_directory / "180deg" / "180deg_000.tif")
-
-        image_format = "tif"
-
-        lp = create_loading_parameters_for_file_path(output_directory)
-
-        self.assertEqual(DEFAULT_PIXEL_DEPTH, lp.dtype)
-        self.assertEqual(DEFAULT_PIXEL_SIZE, lp.pixel_size)
-        self.assertEqual(DEFAULT_IS_SINOGRAM, lp.sinograms)
-
-        # Sample checking
-        sample = lp.sample
-        self.assertEqual(image_format, sample.format)
-        self.assertEqual(None, sample.indices)
-        self._files_equal("/b/Tomo", sample.input_path)
-        self._files_equal("/b/Tomo_log.txt", sample.log_file)
-        self._files_equal("/b/Tomo/Tomo", sample.prefix)
-
-        # Flat before checking
-        flat_before = lp.flat_before
-        self.assertEqual(image_format, flat_before.format)
-        self.assertEqual(None, flat_before.indices)
-        self._files_equal("/b/Flat_Before_log.txt", flat_before.log_file)
-        self._files_equal("/b/Flat_Before", flat_before.input_path)
-        self._files_equal("/b/Flat_Before/Flat_Before", flat_before.prefix)
-
-        # Flat after checking
-        flat_after = lp.flat_after
-        self.assertEqual(image_format, flat_after.format)
-        self.assertEqual(None, flat_after.indices)
-        self._files_equal("/b/Flat_After_log.txt", flat_after.log_file)
-        self._files_equal("/b/Flat_After", flat_after.input_path)
-        self._files_equal("/b/Flat_After/Flat_After", flat_after.prefix)
-
-        # Dark before checking
-        dark_before = lp.dark_before
-        self.assertEqual(image_format, dark_before.format)
-        self.assertEqual(None, dark_before.indices)
-        self._files_equal("/b/Dark_Before", dark_before.input_path)
-        self._files_equal("/b/Dark_Before/Dark_Before", dark_before.prefix)
-
-        # Dark after checking
-        dark_after = lp.dark_after
-        self.assertEqual(image_format, dark_after.format)
-        self.assertEqual(None, dark_after.indices)
-        self._files_equal("/b/Dark_After", dark_after.input_path)
-        self._files_equal("/b/Dark_After/Dark_After", dark_after.prefix)
-
-        # 180 degree checking
-        proj180 = lp.proj_180deg
-        self.assertEqual(image_format, proj180.format)
-        self.assertEqual(None, proj180.indices)
-        self._files_equal("/b/180deg/180deg_000.tif", proj180.input_path)
-        self.assertEqual(None, proj180.log_file)
-        self._files_equal("/b/180deg/180deg", proj180.prefix)

--- a/mantidimaging/core/io/loader/test/loader_test.py
+++ b/mantidimaging/core/io/loader/test/loader_test.py
@@ -6,8 +6,10 @@ from pathlib import Path
 
 from mantidimaging.core.io import loader
 from mantidimaging.core.io.loader.loader import create_loading_parameters_for_file_path, DEFAULT_PIXEL_DEPTH, \
-    DEFAULT_PIXEL_SIZE, DEFAULT_IS_SINOGRAM
+    DEFAULT_PIXEL_SIZE, DEFAULT_IS_SINOGRAM, new_create_loading_parameters_for_file_path
 from pyfakefs.fake_filesystem_unittest import TestCase
+
+from mantidimaging.core.utility.data_containers import FILE_TYPES
 
 
 class LoaderTest(TestCase):
@@ -15,6 +17,8 @@ class LoaderTest(TestCase):
         self.setUpPyfakefs()
 
     def _files_equal(self, file1, file2):
+        self.assertIsNotNone(file1)
+        self.assertIsNotNone(file2)
         self.assertEqual(Path(file1).absolute(), Path(file2).absolute())
 
     def _file_list_count_equal(self, list1, list2):
@@ -23,6 +27,53 @@ class LoaderTest(TestCase):
 
     def test_raise_on_invalid_format(self):
         self.assertRaises(NotImplementedError, loader.load, "/some/path", file_names=["/somefile"], in_format='txt')
+
+    @mock.patch("mantidimaging.core.io.loader.loader.load_log")
+    @mock.patch("mantidimaging.core.io.loader.loader.read_in_file_information")
+    def test_create_loading_parameters_for_file_path_new(self, _load_log, _read_in_file_information):
+        output_directory = Path("/b")
+        for filename in ["Tomo_log.txt", "Flat_After_log.txt", "Flat_Before_log.txt"]:
+            self.fs.create_file(output_directory / filename)
+
+        for stack_type in ["Flat_Before", "Flat_After", "Dark_Before", "Dark_After", "Tomo"]:
+            for image_number in range(0, 5):
+                filename = Path(output_directory / stack_type / f"{stack_type}_{image_number:04d}.tif")
+                self.fs.create_file(filename)
+
+        self.fs.create_file(output_directory / "180deg" / "180deg_0000.tif")
+
+        lp = new_create_loading_parameters_for_file_path(output_directory)
+
+        self.assertEqual(DEFAULT_PIXEL_DEPTH, lp.dtype)
+        self.assertEqual(DEFAULT_PIXEL_SIZE, lp.pixel_size)
+        self.assertEqual(DEFAULT_IS_SINOGRAM, lp.sinograms)
+
+        sample = lp.image_stacks[FILE_TYPES.SAMPLE]
+        self.assertIn(Path("/b/Tomo/Tomo_0000.tif"), sample.file_group.all_files())
+        self.assertEqual(5, len(list(sample.file_group.all_files())))
+        self._files_equal("/b/Tomo_log.txt", sample.log_file)
+
+        sample = lp.image_stacks[FILE_TYPES.FLAT_BEFORE]
+        self.assertIn(Path("/b/Flat_Before/Flat_Before_0000.tif"), sample.file_group.all_files())
+        self.assertEqual(5, len(list(sample.file_group.all_files())))
+        self._files_equal("/b/Flat_Before_log.txt", sample.log_file)
+
+        sample = lp.image_stacks[FILE_TYPES.FLAT_AFTER]
+        self.assertIn(Path("/b/Flat_After/Flat_After_0000.tif"), sample.file_group.all_files())
+        self.assertEqual(5, len(list(sample.file_group.all_files())))
+        self._files_equal("/b/Flat_After_log.txt", sample.log_file)
+
+        sample = lp.image_stacks[FILE_TYPES.DARK_BEFORE]
+        self.assertIn(Path("/b/Dark_Before/Dark_Before_0000.tif"), sample.file_group.all_files())
+        self.assertEqual(5, len(list(sample.file_group.all_files())))
+
+        sample = lp.image_stacks[FILE_TYPES.DARK_AFTER]
+        self.assertIn(Path("/b/Dark_After/Dark_After_0000.tif"), sample.file_group.all_files())
+        self.assertEqual(5, len(list(sample.file_group.all_files())))
+
+        sample = lp.image_stacks[FILE_TYPES.PROJ_180]
+        self.assertIn(Path("/b/180deg/180deg_0000.tif"), sample.file_group.all_files())
+        self.assertEqual(1, len(list(sample.file_group.all_files())))
 
     @mock.patch("mantidimaging.core.io.loader.loader.load_log")
     @mock.patch("mantidimaging.core.io.loader.loader.read_in_file_information")

--- a/mantidimaging/core/io/loader/test/loader_test.py
+++ b/mantidimaging/core/io/loader/test/loader_test.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from mantidimaging.core.io import loader
 from mantidimaging.core.io.loader.loader import DEFAULT_PIXEL_DEPTH, \
-    DEFAULT_PIXEL_SIZE, DEFAULT_IS_SINOGRAM, new_create_loading_parameters_for_file_path
+    DEFAULT_PIXEL_SIZE, DEFAULT_IS_SINOGRAM, create_loading_parameters_for_file_path
 from pyfakefs.fake_filesystem_unittest import TestCase
 
 from mantidimaging.core.utility.data_containers import FILE_TYPES
@@ -39,7 +39,7 @@ class LoaderTest(TestCase):
 
         self.fs.create_file(output_directory / "180deg" / "180deg_0000.tif")
 
-        lp = new_create_loading_parameters_for_file_path(output_directory)
+        lp = create_loading_parameters_for_file_path(output_directory)
 
         self.assertEqual(DEFAULT_PIXEL_DEPTH, lp.dtype)
         self.assertEqual(DEFAULT_PIXEL_SIZE, lp.pixel_size)

--- a/mantidimaging/core/io/test/filenames_test.py
+++ b/mantidimaging/core/io/test/filenames_test.py
@@ -6,8 +6,8 @@ from pathlib import Path
 import unittest
 
 from parameterized import parameterized
-from pyfakefs.fake_filesystem_unittest import TestCase
 
+from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
 from ..filenames import FilenameGroup, FilenamePattern
 from ...utility.data_containers import FILE_TYPES
 
@@ -78,33 +78,30 @@ class FilenamePatternTest(unittest.TestCase):
         self.assertTrue(p2.match_metadata("foo.json"))
 
 
-class FilenameGroupTest(TestCase):
-    def setUp(self) -> None:
-        self.setUpPyfakefs()
-
+class FilenameGroupTest(FakeFSTestCase):
     def test_filenamepattern_from_file_unindexed(self):
         p1 = Path("foo", "bar", "baz.tiff")
         f1 = FilenameGroup.from_file(p1)
-        self.assertEqual(f1.directory, Path("foo", "bar"))
+        self._files_equal(f1.directory, Path("foo", "bar"))
 
         all_files = list(f1.all_files())
-        self.assertEqual(all_files, [p1])
+        self._file_list_count_equal(all_files, [p1])
 
     def test_filenamepattern_from_file_indexed(self):
         p1 = Path("foo", "IMAT_Flower_Tomo_000007.tif")
         f1 = FilenameGroup.from_file(p1)
 
         all_files = list(f1.all_files())
-        self.assertEqual(all_files, [p1])
+        self._file_list_count_equal(all_files, [p1])
 
     def test_all_files(self):
         pattern = FilenamePattern.from_name("IMAT_Flower_Tomo_000007.tif")
         f1 = FilenameGroup(Path("foo"), pattern, [0, 1, 2])
 
         all_files = list(f1.all_files())
-        self.assertEqual(all_files[0], Path("foo", "IMAT_Flower_Tomo_000000.tif"))
-        self.assertEqual(all_files[1], Path("foo", "IMAT_Flower_Tomo_000001.tif"))
-        self.assertEqual(all_files[2], Path("foo", "IMAT_Flower_Tomo_000002.tif"))
+        self._files_equal(all_files[0], Path("foo", "IMAT_Flower_Tomo_000000.tif"))
+        self._files_equal(all_files[1], Path("foo", "IMAT_Flower_Tomo_000001.tif"))
+        self._files_equal(all_files[2], Path("foo", "IMAT_Flower_Tomo_000002.tif"))
 
     def test_find_all_files(self):
         file_list = [Path(f"IMAT_Flower_Tomo_{i:06d}.tif") for i in range(10)]
@@ -135,7 +132,7 @@ class FilenameGroupTest(TestCase):
         fg = FilenameGroup.from_file("IMAT_Flower_Tomo_000000.tif")
         fg.find_all_files()
 
-        self.assertEqual(fg.metadata_path, Path("IMAT_Flower_Tomo.json"))
+        self._files_equal(fg.metadata_path, Path("IMAT_Flower_Tomo.json"))
 
     def test_find_log(self):
         log = Path("/foo", "tomo.txt")
@@ -147,7 +144,7 @@ class FilenameGroupTest(TestCase):
         fg = FilenameGroup.from_file(sample)
         fg.find_log_file()
 
-        self.assertEqual(fg.log_path, log)
+        self._files_equal(fg.log_path, log)
 
     def test_find_log_best(self):
         log = Path("/foo", "Dark_log.txt")
@@ -161,7 +158,7 @@ class FilenameGroupTest(TestCase):
         fg = FilenameGroup.from_file(sample)
         fg.find_log_file()
 
-        self.assertEqual(fg.log_path, log)
+        self._files_equal(fg.log_path, log)
 
     @parameterized.expand([
         ("/a/Tomo/foo_Tomo_%06d.tif", "/a/Flat_Before/foo_Flat_Before_%06d.tif"),
@@ -176,10 +173,10 @@ class FilenameGroupTest(TestCase):
 
         fg = FilenameGroup.from_file(tomo_list[0])
         flat_before_fg = fg.find_related(FILE_TYPES.FLAT_BEFORE)
+
         self.assertIsNotNone(flat_before_fg)
         flat_before_fg.find_all_files()
-
-        self.assertCountEqual(flat_before_list, list(flat_before_fg.all_files()))
+        self._file_list_count_equal(flat_before_list, flat_before_fg.all_files())
 
     @parameterized.expand([
         ("/a/180deg/foo_180deg.tif"),
@@ -196,4 +193,4 @@ class FilenameGroupTest(TestCase):
         self.assertIsNotNone(proj_180_fg)
         proj_180_fg.find_all_files()
 
-        self.assertCountEqual(proj_180_list, list(proj_180_fg.all_files()))
+        self._file_list_count_equal(proj_180_list, list(proj_180_fg.all_files()))

--- a/mantidimaging/core/io/test/filenames_test.py
+++ b/mantidimaging/core/io/test/filenames_test.py
@@ -180,3 +180,20 @@ class FilenameGroupTest(TestCase):
         flat_before_fg.find_all_files()
 
         self.assertCountEqual(flat_before_list, list(flat_before_fg.all_files()))
+
+    @parameterized.expand([
+        ("/a/180deg/foo_180deg.tif"),
+        ("/a/180deg/foo_180deg_000000.tif"),
+    ])
+    def test_find_related_proj_180(self, proj_name):
+        tomo_list = [Path("/a/Tomo/foo_Tomo_%06d.tif" % i) for i in range(10)]
+        proj_180_list = [Path(proj_name)]
+        for file_name in tomo_list + proj_180_list:
+            self.fs.create_file(file_name)
+
+        fg = FilenameGroup.from_file(tomo_list[0])
+        proj_180_fg = fg.find_related(FILE_TYPES.PROJ_180)
+        self.assertIsNotNone(proj_180_fg)
+        proj_180_fg.find_all_files()
+
+        self.assertCountEqual(proj_180_list, list(proj_180_fg.all_files()))

--- a/mantidimaging/core/io/test/utility_test.py
+++ b/mantidimaging/core/io/test/utility_test.py
@@ -5,17 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 
 from mantidimaging.core.io import utility
-from pyfakefs.fake_filesystem_unittest import TestCase
+
+from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
 
 
-class UtilityTest(TestCase):
-    def setUp(self) -> None:
-        self.setUpPyfakefs()
-
-    def _file_list_count_equal(self, list1, list2):
-        """Check that 2 lists of paths refer to the same files. Order independent"""
-        self.assertCountEqual((Path(s).absolute() for s in list1), (Path(s).absolute() for s in list2))
-
+class UtilityTest(FakeFSTestCase):
     def test_get_candidate_file_extensions(self):
         self.assertEqual(['tif', 'tiff'], utility.get_candidate_file_extensions('tif'))
 
@@ -39,4 +33,4 @@ class UtilityTest(TestCase):
 
         log_found = utility.find_log_for_image(image_name)
 
-        self.assertEqual(log_name, log_found)
+        self._files_equal(log_name, log_found)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -13,7 +13,7 @@ from PyQt5.QtWidgets import QTabBar, QApplication, QTreeWidgetItem
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset, _get_stack_data_type
-from mantidimaging.core.io.loader.loader import create_loading_parameters_for_file_path
+from mantidimaging.core.io.loader.loader import new_create_loading_parameters_for_file_path
 from mantidimaging.core.io.utility import find_projection_closest_to_180, THRESHOLD_180
 from mantidimaging.core.utility.data_containers import ProjectionAngles, LoadingParameters
 from mantidimaging.gui.dialogs.async_task import start_async_task_view
@@ -484,11 +484,12 @@ class MainWindowPresenter(BasePresenter):
         self.model.add_projection_angles_to_sample(stack_id, proj_angles)
 
     def load_stacks_from_folder(self, file_path: str) -> bool:
-        loading_params = create_loading_parameters_for_file_path(file_path)
+        loading_params = new_create_loading_parameters_for_file_path(Path(file_path))
         if loading_params is None:
             return False
 
-        self.load_image_files(loading_params)
+        start_async_task_view(self.view, self.model.new_do_load_dataset, self._on_dataset_load_done,
+                              {'parameters': loading_params})
         return True
 
     def wizard_action_load(self) -> None:

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -13,7 +13,7 @@ from PyQt5.QtWidgets import QTabBar, QApplication, QTreeWidgetItem
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset, _get_stack_data_type
-from mantidimaging.core.io.loader.loader import new_create_loading_parameters_for_file_path
+from mantidimaging.core.io.loader.loader import create_loading_parameters_for_file_path
 from mantidimaging.core.io.utility import find_projection_closest_to_180, THRESHOLD_180
 from mantidimaging.core.utility.data_containers import ProjectionAngles, LoadingParameters
 from mantidimaging.gui.dialogs.async_task import start_async_task_view
@@ -484,7 +484,7 @@ class MainWindowPresenter(BasePresenter):
         self.model.add_projection_angles_to_sample(stack_id, proj_angles)
 
     def load_stacks_from_folder(self, file_path: str) -> bool:
-        loading_params = new_create_loading_parameters_for_file_path(Path(file_path))
+        loading_params = create_loading_parameters_for_file_path(Path(file_path))
         if loading_params is None:
             return False
 

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import sys
 from functools import partial
+from pathlib import Path
 from typing import Optional
 
 from unittest import mock
@@ -12,6 +13,7 @@ import numpy as np
 import numpy.random
 import numpy.testing as npt
 from io import StringIO
+import pyfakefs.fake_filesystem_unittest
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.parallel import utility as pu
@@ -155,3 +157,21 @@ def assert_called_once_with(mock: mock.Mock, *args):
             assert actual.keywords == expected.keywords
         else:
             assert actual == expected, f"Expected {expected}, got {actual}"
+
+
+class FakeFSTestCase(pyfakefs.fake_filesystem_unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.setUpPyfakefs()
+
+    def _files_equal(self, file1, file2) -> None:
+        self.assertIsNotNone(file1)
+        self.assertIsNotNone(file2)
+        self.assertEqual(Path(file1).absolute(), Path(file2).absolute())
+
+    def _file_list_count_equal(self, list1, list2) -> None:
+        """Check that 2 lists of paths refer to the same files. Order independent"""
+        self.assertCountEqual((Path(s).absolute() for s in list1), (Path(s).absolute() for s in list2))
+
+    def _file_in_sequence(self, file1, list1) -> None:
+        self.assertIn(Path(file1).absolute(), (Path(s).absolute() for s in list1))


### PR DESCRIPTION
### Issue
More towards #1219

### Description

Aiming to have all the file finding and filename pattern matching in `FilenameGroup` and `FilenamePattern`

`FilenameGroup.find_related()` for finding the related image stacks (e.g. flats and darks).

`NewLoadingParameters` that uses `FilenameGroup` (will replace `LoadingParameters` in next PR)

Rewrite `create_loading_parameters_for_file_path` and `new_do_load_dataset` using new logic.
 
### Testing & Acceptance Criteria 

Check loading files with command line arg.

### Documentation
Not needed
