### PR TITLE
1643: Deprecations in GitHub Actions

### DIFF
--- a/.github/workflows/citation_file.yaml
+++ b/.github/workflows/citation_file.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Validate CITATION.cff
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
 
       - name: Install cffconvert
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,7 +40,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -51,7 +51,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -65,4 +65,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.3.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%V")"
+          echo "date=$(/bin/date -u "+%Y%V")" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Cache Mambaforge and Pip packages

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -50,7 +50,7 @@ jobs:
             ${{runner.os}}-condaenv-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml')}}
 
       - name: Setup Mambaforge
-        uses: conda-incubator/setup-miniconda@v2.1.1
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-version: latest
           miniforge-variant: Mambaforge

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash
 
       - name: Cache Mambaforge and Pip packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.5
         env:
           CACHE_NUMBER: 0
         with:
@@ -40,7 +40,7 @@ jobs:
             ${{runner.os}}-condapkg-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml')}}
 
       - name: Cache Mambaforge environment
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.5
         id: cache-mambaforge-environment
         env:
           CACHE_NUMBER: 0

--- a/.github/workflows/cos7_testing.yml
+++ b/.github/workflows/cos7_testing.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.3.0
 
     - name: Pre-load docker image
       run: docker pull mantidproject/mantidimaging:centos7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
             ${{runner.os}}-condaenv-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml')}}
 
       - name: Setup Mambaforge
-        uses: conda-incubator/setup-miniconda@v2.1.1
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-version: latest
           miniforge-variant: Mambaforge

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
         shell: bash
 
       - name: Cache Mambaforge and Pip packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.5
         env:
           CACHE_NUMBER: 0
         with:
@@ -39,7 +39,7 @@ jobs:
             ${{runner.os}}-condapkg-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml')}}
 
       - name: Cache Mambaforge environment
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.5
         id: cache-mambaforge-environment
         env:
           CACHE_NUMBER: 0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%V")"
+          echo "date=$(/bin/date -u "+%Y%V")" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Cache Mambaforge and Pip packages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/license_check.yaml
+++ b/.github/workflows/license_check.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/u18_testing.yml
+++ b/.github/workflows/u18_testing.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.3.0
 
     - name: Pre-load docker image
       run: docker pull mantidproject/mantidimaging:latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash
 
       - name: Cache Mambaforge and Pip packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.5
         env:
           CACHE_NUMBER: 0
         with:
@@ -49,7 +49,7 @@ jobs:
           use-mamba: true
 
       - name: Cache Mambaforge environment
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.5
         id: cache-mambaforge-environment
         env:
           CACHE_NUMBER: 0

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,7 +40,7 @@ jobs:
             ${{runner.os}}-condapkg-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml')}}
 
       - name: Setup Mambaforge
-        uses: conda-incubator/setup-miniconda@v2.1.1
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-version: latest
           miniforge-variant: Mambaforge

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%V")"
+          echo "date=$(/bin/date -u "+%Y%V")" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Cache Mambaforge and Pip packages

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -52,4 +52,4 @@ Developer Changes
 - #1703 : Optimize Re-Drawing of ROIs within the Spectrum Viewer
 - #1630 : Update numexpr to 2.8 to resolve dependency deprecation warning
 - #1641 : More robust logging and error handling in automated testing
-
+- #1643 : Deprecations in GitHub actions


### PR DESCRIPTION
### Issue

Closes #1643 

### Description

Updates actions to remove deprecation warnings.

### Acceptance Criteria 

Check that the log is free of deprecation warnings related to `set-output` and `save-state`.

### Documentation

Updated release notes.
