### PR TITLE
1703 optimise roi re drawing

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -49,3 +49,4 @@ Developer Changes
 - #1678 : Allow multiple datasets to be opened at once in the GUI when using the CLI `--path` flag
 - #1695 : Use FilenameGroup for Load Images
 - #1693 : Increase test coverage for spectrum widget
+- #1703 : Optimize Re-Drawing of ROIs within the Spectrum Viewer

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -122,11 +122,11 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         Handle changes to any ROI position and size.
         """
-        roi_names = self.model.get_list_of_roi_names()
-        for name in roi_names:
+        for name in self.model.get_list_of_roi_names():
             roi = self.view.spectrum.get_roi(name)
-            self.model.set_roi(name, roi)
-            self.view.set_spectrum(name, self.model.get_spectrum(name, self.spectrum_mode))
+            if roi != self.model.get_roi(name):
+                self.model.set_roi(name, roi)
+                self.view.set_spectrum(name, self.model.get_spectrum(name, self.spectrum_mode))
 
     def handle_export_button_enabled(self) -> None:
         """
@@ -207,4 +207,5 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             self.model.remove_all_roi()
         else:
             self.view.spectrum.remove_roi(roi_name)
+            self.view.set_spectrum(roi_name, self.model.get_spectrum(roi_name, self.spectrum_mode))
             self.model.remove_roi(roi_name)


### PR DESCRIPTION
### Issue

Closes #1703

### Description

Create a function to optimise re-drawing of ROIs to sample image by only returning the name of a given ROI which has changed since last being drawn over sample image to be used by handle_roi_moved()`

### Acceptance Criteria 

Testing with the Flower dataset, there is a noticeable difference in how quickly ROIs can be moved around the sample image compared to main branch.

### Documentation

* docs/release_notes/next.rst
