### PR TITLE
1630 numexpr version update

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - scipy=1.7.*
     - scikit-image=0.19.*
     - numpy=1.20.*
+    - numexpr=2.8.*
     - algotom=1.0.*
     - tomopy=1.12.*
     - cudatoolkit=10.2*

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -50,3 +50,4 @@ Developer Changes
 - #1695 : Use FilenameGroup for Load Images
 - #1693 : Increase test coverage for spectrum widget
 - #1703 : Optimize Re-Drawing of ROIs within the Spectrum Viewer
+- #1630 : Update numexpr to 2.8 to resolve dependency deprecation warning


### PR DESCRIPTION
### Issue

Closes #1630 

### Description

Add pinned version of numexpr to `conda/meta.yml` to 2.8.* after spending time exploring into whether the default version of numexpr installed through tomopy was caused by a bug with mamba, tomopy or another dependency (see #1630 comments) 

### Testing 

Reinstall conda environments and verify numexpr 2.8.* has been installed.

### Acceptance Criteria 

Try reinstalling conda environments on both Windows and Linux ensuring that numexpr is pinned to 2.8.* and that operations within mantidimaging which rely on numexpr through tomopy operate as expected such as a reconstruction or core operations.

### Documentation

* `docs/release_notes/next.rst`
