### PR TITLE
1712 Redraw All ROIs on Normalised Stack Change

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -36,6 +36,7 @@ Fixes
 - #1669 : Fix table or ROIs falling out of synchronisation with ROIs visible in the image when changing between samples
 - #1659 : PyInstaller missing cupy files
 - #1657 : PyInstaller: order of operations in menu is not sorted
+- #1712 : Fix redrawing of all ROIs and spectrum line plots of toggle and change of normalized stacks within spectrum viewer
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -77,7 +77,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             return
         self.model.set_normalise_stack(self.main_window.get_stack(normalise_uuid))
         self.view.set_normalise_error(self.model.normalise_issue())
-        self.handle_roi_moved()
+        self.redraw_all_rois()
 
     def auto_find_flat_stack(self, new_dataset_id):
         if self.view.current_dataset_id != new_dataset_id:
@@ -128,6 +128,14 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                 self.model.set_roi(name, roi)
                 self.view.set_spectrum(name, self.model.get_spectrum(name, self.spectrum_mode))
 
+    def redraw_all_rois(self) -> None:
+        """
+        Redraw all ROIs and spectrum plots
+        """
+        for name in self.model.get_list_of_roi_names():
+            self.model.set_roi(name, self.view.spectrum.get_roi(name))
+            self.view.set_spectrum(name, self.model.get_spectrum(name, self.spectrum_mode))
+
     def handle_export_button_enabled(self) -> None:
         """
         Enable the export button if the current stack is not None
@@ -149,7 +157,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             self.spectrum_mode = SpecType.SAMPLE_NORMED
         else:
             self.spectrum_mode = SpecType.SAMPLE
-        self.handle_roi_moved()
+        self.redraw_all_rois()
         self.view.display_normalise_error()
 
     def get_roi_names(self) -> list:


### PR DESCRIPTION
### Issue

Closes #1712 

### Description

Create a method to re-draw all ROIs as previous method to handle ROI change was optimised to only redraw ROIs if they changed in size or position.
New method to redraw all ROIs called when a normalised stack toggled on or off or changed to update ROIs and spectrum line plots.

### Acceptance Criteria 
- [ ] Load 4 podwers dataset
- [ ] Open Spectrum viewer
- [ ] Add rois and resize
- [ ] Toggle normalise to open beam checkbox and normalised stacks checking that ROIs and Spectrum lines plots update on change.


### Documentation

- `docs/release_notes/next.rst` - under "Fixes" subheader
