### PR TITLE
Use FileNameGroups for load dataset

### DIFF
--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -32,7 +32,7 @@ class FilenamePattern:
             self.re_pattern = re.compile("^" + re.escape(prefix) + re.escape(suffix) + "$")
         else:
             # Note: allow extra leading digits, for data sets that go 001 ... 998, 999, 1000, 1001
-            self.re_pattern = re.compile("^" + re.escape(prefix) + "([1-9]?[0-9]{" + str(digit_count) + "})" +
+            self.re_pattern = re.compile("^" + re.escape(prefix) + "([1-9]*[0-9]{" + str(digit_count) + "})" +
                                          re.escape(suffix) + "$")
 
         self.re_pattern_metadata = re.compile("^" + re.escape(prefix.rstrip("_ ")) + ".json$")
@@ -52,7 +52,6 @@ class FilenamePattern:
         prefix = result.group(1)
         digits = result.group(2)
         ext = result.group(3)
-
         return FilenamePattern(prefix, len(digits), ext)
 
     def generate(self, index: int) -> str:

--- a/mantidimaging/core/io/loader/__init__.py
+++ b/mantidimaging/core/io/loader/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import annotations
 
 from .loader import (  # noqa: F401
-    load, load_p, load_log, read_in_file_information, supported_formats, load_stack_from_group)
+    load, load_log, read_in_file_information, supported_formats, load_stack_from_group)

--- a/mantidimaging/core/io/loader/__init__.py
+++ b/mantidimaging/core/io/loader/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import annotations
 
 from .loader import (  # noqa: F401
-    load, load_log, read_in_file_information, supported_formats, load_stack_from_group)
+    load, load_log, read_in_file_information, supported_formats, load_stack_from_group, load_stack_from_image_params)

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -31,7 +31,7 @@ DEFAULT_PIXEL_DEPTH = "float32"
 
 
 @dataclass
-class NewImageParameters:
+class ImageParameters:
     file_group: FilenameGroup
     log_file: Optional[Path] = None
     indices: Optional[Indices] = None
@@ -39,7 +39,7 @@ class NewImageParameters:
 
 @dataclass
 class NewLoadingParameters:
-    image_stacks: dict[FILE_TYPES, NewImageParameters] = field(default_factory=dict)
+    image_stacks: dict[FILE_TYPES, ImageParameters] = field(default_factory=dict)
 
     pixel_size: int = DEFAULT_PIXEL_SIZE
     name: str = ""
@@ -116,7 +116,7 @@ def load_stack_from_group(group: FilenameGroup, progress: Optional[Progress] = N
     return load(file_names=file_names, progress=progress)
 
 
-def load_stack_from_image_params(image_params: NewImageParameters,
+def load_stack_from_image_params(image_params: ImageParameters,
                                  progress: Optional[Progress] = None,
                                  dtype: npt.DTypeLike = np.float32):
     file_names = [str(p) for p in image_params.file_group.all_files()]
@@ -182,7 +182,7 @@ def create_loading_parameters_for_file_path(file_path: Path) -> Optional[NewLoad
     sample_fg = FilenameGroup.from_file(sample_file)
     sample_fg.find_all_files()
     sample_fg.find_log_file()
-    loading_parameters.image_stacks[FILE_TYPES.SAMPLE] = NewImageParameters(sample_fg, sample_fg.log_path)
+    loading_parameters.image_stacks[FILE_TYPES.SAMPLE] = ImageParameters(sample_fg, sample_fg.log_path)
 
     for file_type in [ft for ft in FILE_TYPES if ft.mode in ["images", "180"]]:
         fg = sample_fg.find_related(file_type)
@@ -192,6 +192,6 @@ def create_loading_parameters_for_file_path(file_path: Path) -> Optional[NewLoad
         fg.find_all_files()
         if file_type.tname == "Flat":
             fg.find_log_file()
-        loading_parameters.image_stacks[file_type] = NewImageParameters(fg, fg.log_path)
+        loading_parameters.image_stacks[file_type] = ImageParameters(fg, fg.log_path)
 
     return loading_parameters

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -119,8 +119,10 @@ def load_p(parameters: ImageParameters, dtype: 'npt.DTypeLike', progress: Progre
                 progress=progress)
 
 
-def load_stack_from_group(group: FilenameGroup, progress: Optional[Progress] = None) -> ImageStack:
-    return load(file_names=[str(p) for p in group.all_files()], progress=progress)
+def load_stack_from_group(group: FilenameGroup,
+                          progress: Optional[Progress] = None,
+                          dtype: npt.DTypeLike = np.float32) -> ImageStack:
+    return load(file_names=[str(p) for p in group.all_files()], progress=progress, dtype=dtype)
 
 
 def load(input_path: Optional[str] = None,

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -38,7 +38,7 @@ class ImageParameters:
 
 
 @dataclass
-class NewLoadingParameters:
+class LoadingParameters:
     image_stacks: dict[FILE_TYPES, ImageParameters] = field(default_factory=dict)
 
     pixel_size: int = DEFAULT_PIXEL_SIZE
@@ -171,12 +171,12 @@ def load(input_path: Optional[str] = None,
     return image_stack
 
 
-def create_loading_parameters_for_file_path(file_path: Path) -> Optional[NewLoadingParameters]:
+def create_loading_parameters_for_file_path(file_path: Path) -> Optional[LoadingParameters]:
     sample_file = find_first_file_that_is_possibly_a_sample(str(file_path))
     if sample_file is None:
         return None
 
-    loading_parameters = NewLoadingParameters()
+    loading_parameters = LoadingParameters()
     loading_parameters.name = os.path.basename(sample_file)
 
     sample_fg = FilenameGroup.from_file(sample_file)

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -14,7 +14,7 @@ from tifffile import tifffile
 from mantidimaging.core.io.loader import img_loader
 from mantidimaging.core.io.utility import (DEFAULT_IO_FILE_FORMAT, get_file_names,
                                            find_first_file_that_is_possibly_a_sample)
-from mantidimaging.core.utility.data_containers import ImageParameters, Indices, FILE_TYPES
+from mantidimaging.core.utility.data_containers import Indices, FILE_TYPES
 from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
 from mantidimaging.core.io.filenames import FilenameGroup
 
@@ -108,15 +108,6 @@ def read_in_file_information(input_path: str,
 def load_log(log_file: Path) -> IMATLogFile:
     with open(log_file, 'r') as f:
         return IMATLogFile(f.readlines(), log_file)
-
-
-def load_p(parameters: ImageParameters, dtype: 'npt.DTypeLike', progress: Progress) -> ImageStack:
-    return load(input_path=parameters.input_path,
-                in_prefix=parameters.prefix,
-                in_format=parameters.format,
-                indices=parameters.indices,
-                dtype=dtype,
-                progress=progress)
 
 
 def load_stack_from_group(group: FilenameGroup,

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -32,6 +32,9 @@ DEFAULT_PIXEL_DEPTH = "float32"
 
 @dataclass
 class ImageParameters:
+    """
+    Dataclass to hold info about an image stack that is to be loaded. Used with LoadingParameters
+    """
     file_group: FilenameGroup
     log_file: Optional[Path] = None
     indices: Optional[Indices] = None
@@ -39,6 +42,10 @@ class ImageParameters:
 
 @dataclass
 class LoadingParameters:
+    """
+    Dataclass to hold info about a dataset that is about to be loaded. Used to transfer information from ImageLoadDialog
+    to the loading code.
+    """
     image_stacks: dict[FILE_TYPES, ImageParameters] = field(default_factory=dict)
 
     pixel_size: int = DEFAULT_PIXEL_SIZE

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from logging import getLogger
 from pathlib import Path
 from typing import Tuple, List, Optional, Union, TYPE_CHECKING, Callable
@@ -36,8 +36,9 @@ class NewImageParameters:
     log_file: Optional[Path] = None
 
 
+@dataclass
 class NewLoadingParameters:
-    image_stacks: dict[FILE_TYPES, NewImageParameters] = {}
+    image_stacks: dict[FILE_TYPES, NewImageParameters] = field(default_factory=dict)
 
     pixel_size: int = DEFAULT_PIXEL_SIZE
     name: str = ""

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -40,7 +40,7 @@ class NewLoadingParameters:
     image_stacks: dict[FILE_TYPES, NewImageParameters] = {}
 
     pixel_size: int = DEFAULT_PIXEL_SIZE
-    name: str
+    name: str = ""
     dtype: str = DEFAULT_PIXEL_DEPTH
     sinograms: bool = DEFAULT_IS_SINOGRAM
 

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -34,6 +34,7 @@ DEFAULT_PIXEL_DEPTH = "float32"
 class NewImageParameters:
     file_group: FilenameGroup
     log_file: Optional[Path] = None
+    indices: Optional[Indices] = None
 
 
 @dataclass
@@ -110,10 +111,16 @@ def load_log(log_file: Path) -> IMATLogFile:
         return IMATLogFile(f.readlines(), log_file)
 
 
-def load_stack_from_group(group: FilenameGroup,
-                          progress: Optional[Progress] = None,
-                          dtype: npt.DTypeLike = np.float32) -> ImageStack:
-    return load(file_names=[str(p) for p in group.all_files()], progress=progress, dtype=dtype)
+def load_stack_from_group(group: FilenameGroup, progress: Optional[Progress] = None) -> ImageStack:
+    file_names = [str(p) for p in group.all_files()]
+    return load(file_names=file_names, progress=progress)
+
+
+def load_stack_from_image_params(image_params: NewImageParameters,
+                                 progress: Optional[Progress] = None,
+                                 dtype: npt.DTypeLike = np.float32):
+    file_names = [str(p) for p in image_params.file_group.all_files()]
+    return load(file_names=file_names, progress=progress, dtype=dtype, indices=image_params.indices)
 
 
 def load(input_path: Optional[str] = None,

--- a/mantidimaging/core/io/test/filenames_test.py
+++ b/mantidimaging/core/io/test/filenames_test.py
@@ -57,6 +57,13 @@ class FilenamePatternTest(unittest.TestCase):
         self.assertTrue(p1.match("img_1000.tif"))
         self.assertFalse(p1.match("img_0000.tif"))
 
+    def test_pattern_match_different_digits_no_zeros(self):
+        # Allow cases where index has grown above padding
+        p1 = FilenamePattern.from_name("img_1.tif")
+        self.assertTrue(p1.match("img_10.tif"))
+        self.assertTrue(p1.match("img_1234.tif"))
+        self.assertFalse(p1.match("img_0000.tif"))
+
     def test_pattern_get_index(self):
         p1 = FilenamePattern.from_name("IMAT_Flower_Tomo_000007.tif")
         self.assertEqual(p1.get_index("IMAT_Flower_Tomo_000023.tif"), 23)

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -176,3 +176,10 @@ class FILE_TYPES(Enum):
     @property
     def fname(self) -> str:
         return (self.tname + " " + self.suffix).strip()
+
+
+log_for_file_type = {
+    FILE_TYPES.SAMPLE: FILE_TYPES.SAMPLE_LOG,
+    FILE_TYPES.FLAT_BEFORE: FILE_TYPES.FLAT_BEFORE_LOG,
+    FILE_TYPES.FLAT_AFTER: FILE_TYPES.FLAT_AFTER_LOG,
+}

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass
 from typing import List, Optional, NamedTuple, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from pathlib import Path
     import numpy
 
 
@@ -126,35 +125,6 @@ class ReconstructionParameters:
 
 
 Indices = NamedTuple("Indices", [("start", int), ("end", int), ("step", int)])
-
-
-@dataclass
-class ImageParameters:
-    input_path: str
-    format: str
-    prefix: str
-    indices: Optional[Indices] = None
-    log_file: Optional[Path] = None
-
-
-class LoadingParameters:
-    sample: ImageParameters
-    flat_before: Optional[ImageParameters] = None
-    flat_after: Optional[ImageParameters] = None
-    dark_before: Optional[ImageParameters] = None
-    dark_after: Optional[ImageParameters] = None
-    proj_180deg: Optional[ImageParameters] = None
-
-    pixel_size: int
-    name: str
-    dtype: str
-    sinograms: bool
-
-    def set(self, name: str, img_params: ImageParameters):
-        short_name = name.lower().replace(" ", "_")
-        if name == "180 degree":
-            short_name = "proj_180deg"
-        self.__setattr__(short_name, img_params)
 
 
 class FILE_TYPES(Enum):

--- a/mantidimaging/gui/windows/image_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/image_load_dialog/presenter.py
@@ -122,6 +122,9 @@ class LoadPresenter:
         field.set_images(images)
 
     def get_parameters(self) -> LoadingParameters:
+        """
+        Gather information from the dialog into a LoadingParameters
+        """
         loading_param = LoadingParameters()
         for file_type in FILE_TYPES:
             field = self.view.fields[file_type.fname]

--- a/mantidimaging/gui/windows/image_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/image_load_dialog/presenter.py
@@ -136,6 +136,9 @@ class LoadPresenter:
                 if log_field.use.isChecked():
                     image_param.log_file = Path(log_field.path_text())
 
+            if file_type == FILE_TYPES.SAMPLE:
+                image_param.indices = field.indices
+
             loading_param.image_stacks[file_type] = image_param
 
         loading_param.name = self.view.fields[FILE_TYPES.SAMPLE.fname].file()

--- a/mantidimaging/gui/windows/image_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/image_load_dialog/presenter.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Optional
 from mantidimaging.core.io.filenames import FilenameGroup
 from mantidimaging.core.io.loader import load_log
 from mantidimaging.core.io.loader.loader import read_in_file_information, FileInformation, NewLoadingParameters, \
-    NewImageParameters
+    ImageParameters
 from mantidimaging.core.io.utility import (get_file_extension, get_prefix, find_images, find_log_for_image,
                                            find_180deg_proj)
 from mantidimaging.core.utility.data_containers import FILE_TYPES, log_for_file_type
@@ -129,7 +129,7 @@ class LoadPresenter:
                 continue
             file_group = FilenameGroup.from_file(Path(field.path_text()))
             file_group.find_all_files()
-            image_param = NewImageParameters(file_group)
+            image_param = ImageParameters(file_group)
 
             if file_type in log_for_file_type:
                 log_field = self.view.fields[log_for_file_type[file_type].fname]

--- a/mantidimaging/gui/windows/image_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/image_load_dialog/presenter.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Optional
 
 from mantidimaging.core.io.filenames import FilenameGroup
 from mantidimaging.core.io.loader import load_log
-from mantidimaging.core.io.loader.loader import read_in_file_information, FileInformation, NewLoadingParameters, \
+from mantidimaging.core.io.loader.loader import read_in_file_information, FileInformation, LoadingParameters, \
     ImageParameters
 from mantidimaging.core.io.utility import (get_file_extension, get_prefix, find_images, find_log_for_image,
                                            find_180deg_proj)
@@ -121,8 +121,8 @@ class LoadPresenter:
             images = find_images(selected_dir, base_name, "", image_format=self.image_format)
         field.set_images(images)
 
-    def get_parameters(self) -> NewLoadingParameters:
-        loading_param = NewLoadingParameters()
+    def get_parameters(self) -> LoadingParameters:
+        loading_param = LoadingParameters()
         for file_type in FILE_TYPES:
             field = self.view.fields[file_type.fname]
             if not field.use.isChecked() or field.path_text() == "":

--- a/mantidimaging/gui/windows/image_load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/image_load_dialog/test/presenter_test.py
@@ -233,77 +233,68 @@ class ImageLoadDialogPresenterTest(unittest.TestCase):
         mock_load_log.assert_not_called()
         mock_log.raise_if_angle_missing.assert_not_called()
 
-    @mock.patch("mantidimaging.gui.windows.image_load_dialog.presenter.get_prefix", return_value="/path")
-    def test_get_parameters(self, get_prefix):
-        path_text = "/path/text"
-        sample_input_path = "/sample/input/path"
-        image_format = ".tif"
-        sample_indices = [1, 1]
-        sample_file_name = "/path/sample_file_name"
+    @mock.patch("mantidimaging.gui.windows.image_load_dialog.presenter.FilenameGroup.find_all_files")
+    def test_get_parameters(self, _):
+        sample_path = "/sample/tomo/tomo_0001.tiff"
+        sample_file = "tomo_0001.tiff"
+        sample_log_path = "/sample/tomo.log"
+
+        self.fields["Sample"].path_text.return_value = sample_path
+        self.fields["Sample"].file.return_value = sample_file
+        self.fields["Sample"].use.isChecked.return_value = True
+        self.fields["Sample Log"].path_text.return_value = sample_log_path
+
+        # sample_indices = [1, 1] #TODO
+
+        flat_before_path = "/sample/flat_before/flat_before_0001.tiff"
+        flat_before_log = "/sample/flat_before.log"
+        flat_after_path = "/sample/flat_after/flat_after_0001.tiff"
+        flat_after_log = "/sample/flat_after.log"
+        dark_before_path = "/sample/dark_before/dark_before_0001.tiff"
+        dark_after_path = "/sample/dark_after/dark_after_0001.tiff"
+        proj_180_path = "/sample/180deg/180deg.tiff"
+        self.fields["Flat Before"].use.isChecked.return_value = True
+        self.fields["Flat Before"].path_text.return_value = flat_before_path
+        self.fields["Flat Before Log"].path_text.return_value = flat_before_log
+        self.fields["Flat After"].use.isChecked.return_value = True
+        self.fields["Flat After"].path_text.return_value = flat_after_path
+        self.fields["Flat After Log"].path_text.return_value = flat_after_log
+        self.fields["Dark Before"].path_text.return_value = dark_before_path
+        self.fields["Dark After"].path_text.return_value = dark_after_path
+        self.fields["180 degree"].path_text.return_value = proj_180_path
+
         pixel_size = 24
-        flat_file_name = "/path/flat_file_name"
-        flat_log_file_name = "/path/flat/log/file_name"
-        flat_directory = "/path/directory"
-        dark_directory = "/path/dark/directory"
-        proj180deg_directory = "/path/proj180/directory"
-        proj180deg_file = "/path/proj180/directory/file"
         dtype = "float32"
         sinograms = True
-        sample_path_text = "/path/of/sample"
-        dark_before_path_text = "/path/of/dark"
-        self.fields["Sample Log"].path_text.return_value = path_text
-        self.fields["Sample Log"].use.isChecked.return_value = True
-        self.v.sample.directory.return_value = sample_input_path
-        self.p.image_format = image_format
-        self.v.sample.indices = sample_indices
-        self.v.sample.file.return_value = sample_file_name
         self.v.pixelSize.value.return_value = pixel_size
-        self.fields["Flat Before"].use.isChecked.return_value = True
-        self.fields["Flat Before"].path_text.return_value = flat_file_name
-        self.fields["Flat Before Log"].path_text.return_value = flat_log_file_name
-        self.fields["Flat Before"].directory.return_value = flat_directory
-        self.fields["Flat After"].use.isChecked.return_value = True
-        self.fields["Flat After"].path_text.return_value = flat_file_name
-        self.fields["Flat After Log"].path_text.return_value = flat_log_file_name
-        self.fields["Flat After"].directory.return_value = flat_directory
-        self.fields["Dark Before"].directory.return_value = dark_directory
-        self.fields["Dark After"].directory.return_value = dark_directory
         self.v.pixel_bit_depth.currentText.return_value = dtype
         self.v.images_are_sinograms.isChecked.return_value = sinograms
-        self.fields["180 degree"].path_text.return_value = proj180deg_file
-        self.fields["180 degree"].directory.return_value = proj180deg_directory
-        self.v.sample.path_text.return_value = sample_path_text
-        self.fields["Dark Before"].path_text.return_value = dark_before_path_text
 
         lp = self.p.get_parameters()
 
-        self._files_equal(lp.sample.log_file, path_text)
-        self.assertEqual(lp.sample.input_path, sample_input_path)
-        self.assertEqual(lp.sample.format, image_format)
-        self.assertEqual(lp.sample.prefix, "/path")
-        self.assertEqual(lp.sample.indices, sample_indices)
-        self.assertEqual(lp.name, sample_file_name)
-        self.assertEqual(lp.pixel_size, pixel_size)
-        self.assertEqual(lp.flat_before.prefix, "/path")
-        self._files_equal(lp.flat_before.log_file, flat_log_file_name)
-        self.assertEqual(lp.flat_before.format, image_format)
-        self.assertEqual(lp.flat_before.input_path, flat_directory)
-        self.assertEqual(lp.flat_after.prefix, "/path")
-        self._files_equal(lp.flat_after.log_file, flat_log_file_name)
-        self.assertEqual(lp.flat_after.format, image_format)
-        self.assertEqual(lp.flat_after.input_path, flat_directory)
-        self.assertEqual(lp.dark_before.input_path, dark_directory)
-        self.assertEqual(lp.dark_before.prefix, "/path")
-        self.assertEqual(lp.dark_before.format, image_format)
-        self.assertEqual(lp.dark_after.input_path, dark_directory)
-        self.assertEqual(lp.dark_after.prefix, "/path")
-        self.assertEqual(lp.dark_after.format, image_format)
-        self.assertEqual(lp.proj_180deg.input_path, proj180deg_directory)
-        self.assertEqual(lp.proj_180deg.prefix, "/path/proj180/directory/file")
-        self.assertEqual(lp.proj_180deg.format, image_format)
+        lp_sample = lp.image_stacks[FILE_TYPES.SAMPLE]
+        lp_flat_before = lp.image_stacks[FILE_TYPES.FLAT_BEFORE]
+        lp_flat_after = lp.image_stacks[FILE_TYPES.FLAT_AFTER]
+        lp_dark_before = lp.image_stacks[FILE_TYPES.DARK_BEFORE]
+        lp_dark_after = lp.image_stacks[FILE_TYPES.DARK_AFTER]
+        lp_proj_180deg = lp.image_stacks[FILE_TYPES.PROJ_180]
+
+        self._files_equal(next(lp_sample.file_group.all_files()), sample_path)
+        self._files_equal(lp_sample.log_file, sample_log_path)
+
+        self._files_equal(next(lp_flat_before.file_group.all_files()), flat_before_path)
+        self._files_equal(next(lp_flat_after.file_group.all_files()), flat_after_path)
+        self._files_equal(next(lp_dark_before.file_group.all_files()), dark_before_path)
+        self._files_equal(next(lp_dark_after.file_group.all_files()), dark_after_path)
+        self._files_equal(next(lp_proj_180deg.file_group.all_files()), proj_180_path)
+
+        self._files_equal(lp_flat_before.log_file, flat_before_log)
+        self._files_equal(lp_flat_after.log_file, flat_after_log)
+        self.assertIsNone(lp_dark_before.log_file)
+        self.assertIsNone(lp_dark_after.log_file)
+        self.assertIsNone(lp_proj_180deg.log_file)
+
+        self.assertEqual(lp.name, sample_file)
         self.assertEqual(lp.dtype, dtype)
         self.assertEqual(lp.sinograms, sinograms)
         self.assertEqual(lp.pixel_size, pixel_size)
-        self.assertTrue(mock.call(sample_path_text) in get_prefix.call_args_list)
-        self.assertTrue(mock.call(flat_file_name) in get_prefix.call_args_list)
-        self.assertTrue(mock.call(dark_before_path_text) in get_prefix.call_args_list)

--- a/mantidimaging/gui/windows/image_load_dialog/view.py
+++ b/mantidimaging/gui/windows/image_load_dialog/view.py
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import QComboBox, QCheckBox, QTreeWidget, QTreeWidgetItem, 
     QHeaderView, QSpinBox, QFileDialog, QDialogButtonBox, QWidget
 
 from mantidimaging.core.io.loader.loader import DEFAULT_PIXEL_SIZE, DEFAULT_IS_SINOGRAM, DEFAULT_PIXEL_DEPTH, \
-    NewLoadingParameters
+    LoadingParameters
 from mantidimaging.core.utility.data_containers import FILE_TYPES
 from mantidimaging.gui.windows.image_load_dialog.field import Field
 from .presenter import LoadPresenter
@@ -106,7 +106,7 @@ class ImageLoadDialog(BaseDialogView):
         # FIXME direct attribute access
         self.sample.set_step(self.presenter.last_file_info.shape[0] // 10)
 
-    def get_parameters(self) -> NewLoadingParameters:
+    def get_parameters(self) -> LoadingParameters:
         return self.presenter.get_parameters()
 
     def show_error(self, msg, traceback):

--- a/mantidimaging/gui/windows/image_load_dialog/view.py
+++ b/mantidimaging/gui/windows/image_load_dialog/view.py
@@ -7,8 +7,9 @@ from typing import Optional, Dict
 from PyQt5.QtWidgets import QComboBox, QCheckBox, QTreeWidget, QTreeWidgetItem, QPushButton, QSizePolicy, \
     QHeaderView, QSpinBox, QFileDialog, QDialogButtonBox, QWidget
 
-from mantidimaging.core.io.loader.loader import DEFAULT_PIXEL_SIZE, DEFAULT_IS_SINOGRAM, DEFAULT_PIXEL_DEPTH
-from mantidimaging.core.utility.data_containers import LoadingParameters, FILE_TYPES
+from mantidimaging.core.io.loader.loader import DEFAULT_PIXEL_SIZE, DEFAULT_IS_SINOGRAM, DEFAULT_PIXEL_DEPTH, \
+    NewLoadingParameters
+from mantidimaging.core.utility.data_containers import FILE_TYPES
 from mantidimaging.gui.windows.image_load_dialog.field import Field
 from .presenter import LoadPresenter
 from ...mvp_base import BaseDialogView
@@ -105,7 +106,7 @@ class ImageLoadDialog(BaseDialogView):
         # FIXME direct attribute access
         self.sample.set_step(self.presenter.last_file_info.shape[0] // 10)
 
-    def get_parameters(self) -> LoadingParameters:
+    def get_parameters(self) -> NewLoadingParameters:
         return self.presenter.get_parameters()
 
     def show_error(self, msg, traceback):

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -10,7 +10,7 @@ from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
 from mantidimaging.core.io import loader, saver
 from mantidimaging.core.io.filenames import FilenameGroup
-from mantidimaging.core.io.loader.loader import NewLoadingParameters
+from mantidimaging.core.io.loader.loader import LoadingParameters
 from mantidimaging.core.utility.data_containers import ProjectionAngles, FILE_TYPES
 
 if TYPE_CHECKING:
@@ -35,7 +35,7 @@ class MainWindowModel(object):
                     return image
         return None
 
-    def new_do_load_dataset(self, parameters: NewLoadingParameters, progress: Progress) -> StrictDataset:
+    def new_do_load_dataset(self, parameters: LoadingParameters, progress: Progress) -> StrictDataset:
         def load(im_param):
             return loader.load_stack_from_image_params(im_param, progress, dtype=parameters.dtype)
 

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -35,7 +35,7 @@ class MainWindowModel(object):
                     return image
         return None
 
-    def new_do_load_dataset(self, parameters: LoadingParameters, progress: Progress) -> StrictDataset:
+    def do_load_dataset(self, parameters: LoadingParameters, progress: Progress) -> StrictDataset:
         def load(im_param):
             return loader.load_stack_from_image_params(im_param, progress, dtype=parameters.dtype)
 

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -37,7 +37,7 @@ class MainWindowModel(object):
 
     def new_do_load_dataset(self, parameters: NewLoadingParameters, progress: Progress) -> StrictDataset:
         def load(fg):
-            return loader.load_stack_from_group(fg, progress)
+            return loader.load_stack_from_group(fg, progress, dtype=parameters.dtype)
 
         sample = load(parameters.image_stacks[FILE_TYPES.SAMPLE].file_group)
         ds = StrictDataset(sample)

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -11,7 +11,7 @@ from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
 from mantidimaging.core.io import loader, saver
 from mantidimaging.core.io.filenames import FilenameGroup
 from mantidimaging.core.io.loader.loader import NewLoadingParameters
-from mantidimaging.core.utility.data_containers import LoadingParameters, ProjectionAngles, FILE_TYPES
+from mantidimaging.core.utility.data_containers import ProjectionAngles, FILE_TYPES
 
 if TYPE_CHECKING:
     from mantidimaging.core.utility.progress_reporting import Progress
@@ -60,40 +60,6 @@ class MainWindowModel(object):
                     image_stack.log_file = loader.load_log(log_file)
 
                 ds.set_stack(file_type, image_stack)
-
-        self.datasets[ds.id] = ds
-        return ds
-
-    def do_load_dataset(self, parameters: LoadingParameters, progress) -> StrictDataset:
-        sample = loader.load_p(parameters.sample, parameters.dtype, progress)
-        ds = StrictDataset(sample)
-
-        sample._is_sinograms = parameters.sinograms
-        sample.pixel_size = parameters.pixel_size
-
-        if parameters.sample.log_file:
-            ds.sample.log_file = loader.load_log(parameters.sample.log_file)
-
-        if parameters.flat_before:
-            flat_before = loader.load_p(parameters.flat_before, parameters.dtype, progress)
-            ds.flat_before = flat_before
-            if parameters.flat_before.log_file:
-                flat_before.log_file = loader.load_log(parameters.flat_before.log_file)
-        if parameters.flat_after:
-            flat_after = loader.load_p(parameters.flat_after, parameters.dtype, progress)
-            ds.flat_after = flat_after
-            if parameters.flat_after.log_file:
-                flat_after.log_file = loader.load_log(parameters.flat_after.log_file)
-
-        if parameters.dark_before:
-            dark_before = loader.load_p(parameters.dark_before, parameters.dtype, progress)
-            ds.dark_before = dark_before
-        if parameters.dark_after:
-            dark_after = loader.load_p(parameters.dark_after, parameters.dtype, progress)
-            ds.dark_after = dark_after
-
-        if parameters.proj_180deg:
-            sample.proj180deg = loader.load_p(parameters.proj_180deg, parameters.dtype, progress)
 
         self.datasets[ds.id] = ds
         return ds

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -36,10 +36,10 @@ class MainWindowModel(object):
         return None
 
     def new_do_load_dataset(self, parameters: NewLoadingParameters, progress: Progress) -> StrictDataset:
-        def load(fg):
-            return loader.load_stack_from_group(fg, progress, dtype=parameters.dtype)
+        def load(im_param):
+            return loader.load_stack_from_image_params(im_param, progress, dtype=parameters.dtype)
 
-        sample = load(parameters.image_stacks[FILE_TYPES.SAMPLE].file_group)
+        sample = load(parameters.image_stacks[FILE_TYPES.SAMPLE])
         ds = StrictDataset(sample)
         sample._is_sinograms = parameters.sinograms
         sample.pixel_size = parameters.pixel_size
@@ -55,7 +55,7 @@ class MainWindowModel(object):
                 FILE_TYPES.PROJ_180,
         ]:
             if im_param := parameters.image_stacks.get(file_type):
-                image_stack = load(im_param.file_group)
+                image_stack = load(im_param)
                 if log_file := im_param.log_file:
                     image_stack.log_file = loader.load_log(log_file)
 

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -132,7 +132,8 @@ class MainWindowPresenter(BasePresenter):
         assert self.view.image_load_dialog is not None
         par = self.view.image_load_dialog.get_parameters()
 
-        start_async_task_view(self.view, self.model.do_load_dataset, self._on_dataset_load_done, {'parameters': par})
+        start_async_task_view(self.view, self.model.new_do_load_dataset, self._on_dataset_load_done,
+                              {'parameters': par})
 
     def load_nexus_file(self) -> None:
         assert self.view.nexus_load_dialog is not None

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -132,8 +132,7 @@ class MainWindowPresenter(BasePresenter):
         assert self.view.image_load_dialog is not None
         par = self.view.image_load_dialog.get_parameters()
 
-        start_async_task_view(self.view, self.model.new_do_load_dataset, self._on_dataset_load_done,
-                              {'parameters': par})
+        start_async_task_view(self.view, self.model.do_load_dataset, self._on_dataset_load_done, {'parameters': par})
 
     def load_nexus_file(self) -> None:
         assert self.view.nexus_load_dialog is not None
@@ -488,7 +487,7 @@ class MainWindowPresenter(BasePresenter):
         if loading_params is None:
             return False
 
-        start_async_task_view(self.view, self.model.new_do_load_dataset, self._on_dataset_load_done,
+        start_async_task_view(self.view, self.model.do_load_dataset, self._on_dataset_load_done,
                               {'parameters': loading_params})
         return True
 

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -15,7 +15,7 @@ from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset, _get_stack_data_type
 from mantidimaging.core.io.loader.loader import create_loading_parameters_for_file_path
 from mantidimaging.core.io.utility import find_projection_closest_to_180, THRESHOLD_180
-from mantidimaging.core.utility.data_containers import ProjectionAngles, LoadingParameters
+from mantidimaging.core.utility.data_containers import ProjectionAngles
 from mantidimaging.gui.dialogs.async_task import start_async_task_view
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.windows.stack_visualiser.view import StackVisualiserView
@@ -128,10 +128,9 @@ class MainWindowPresenter(BasePresenter):
             dock.setWindowTitle(new_name)
             self.view.model_changed.emit()
 
-    def load_image_files(self, par: Optional[LoadingParameters] = None) -> None:
-        if par is None:
-            assert self.view.image_load_dialog is not None
-            par = self.view.image_load_dialog.get_parameters()
+    def load_image_files(self) -> None:
+        assert self.view.image_load_dialog is not None
+        par = self.view.image_load_dialog.get_parameters()
 
         start_async_task_view(self.view, self.model.do_load_dataset, self._on_dataset_load_done, {'parameters': par})
 

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -11,7 +11,7 @@ import numpy as np
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
 from mantidimaging.core.data.reconlist import ReconList
-from mantidimaging.core.io.loader.loader import NewLoadingParameters, NewImageParameters
+from mantidimaging.core.io.loader.loader import NewLoadingParameters, ImageParameters
 from mantidimaging.core.utility.data_containers import ProjectionAngles, FILE_TYPES, Indices
 from mantidimaging.gui.windows.main import MainWindowModel
 from mantidimaging.gui.windows.main.model import _matching_dataset_attribute
@@ -41,7 +41,7 @@ class MainWindowModelTest(unittest.TestCase):
     @mock.patch('mantidimaging.core.io.loader.load_stack_from_image_params')
     def test_do_load_stack_sample_only(self, load_mock: mock.Mock, load_log_mock: mock.Mock):
         lp = NewLoadingParameters()
-        sample_mock = NewImageParameters(mock.Mock())
+        sample_mock = ImageParameters(mock.Mock())
         lp.image_stacks[FILE_TYPES.SAMPLE] = sample_mock
         lp.dtype = "dtype_test"
         lp.sinograms = True
@@ -58,7 +58,7 @@ class MainWindowModelTest(unittest.TestCase):
     def test_do_load_stack_sample_and_sample_log(self, load_mock: mock.Mock, load_log_mock: mock.Mock):
         lp = NewLoadingParameters()
         log_file_mock = mock.Mock()
-        sample_mock = NewImageParameters(mock.Mock(), log_file_mock)
+        sample_mock = ImageParameters(mock.Mock(), log_file_mock)
         lp.image_stacks[FILE_TYPES.SAMPLE] = sample_mock
         lp.dtype = "dtype_test"
         lp.sinograms = False
@@ -77,7 +77,7 @@ class MainWindowModelTest(unittest.TestCase):
         all_files = ["filename"] * 10
         mock_filename_group = mock.Mock()
         mock_filename_group.all_files.return_value = all_files
-        sample_mock = NewImageParameters(mock_filename_group)
+        sample_mock = ImageParameters(mock_filename_group)
         indices = Indices(0, 100, 2)
         sample_mock.indices = indices
         lp.image_stacks[FILE_TYPES.SAMPLE] = sample_mock
@@ -98,17 +98,17 @@ class MainWindowModelTest(unittest.TestCase):
                                            load_log_mock: mock.Mock):
         lp = NewLoadingParameters()
         log_file_mock = mock.Mock()
-        sample_mock = NewImageParameters(mock.Mock(), log_file_mock)
+        sample_mock = ImageParameters(mock.Mock(), log_file_mock)
         lp.image_stacks[FILE_TYPES.SAMPLE] = sample_mock
         lp.dtype = "dtype_test"
         lp.sinograms = False
         lp.pixel_size = 101
 
         flat_before_log_mock = mock.Mock()
-        flat_before_mock = NewImageParameters(mock.Mock(), flat_before_log_mock)
+        flat_before_mock = ImageParameters(mock.Mock(), flat_before_log_mock)
         lp.image_stacks[FILE_TYPES.FLAT_BEFORE] = flat_before_mock
         flat_after_log_mock = mock.Mock()
-        flat_after_mock = NewImageParameters(mock.Mock(), flat_after_log_mock)
+        flat_after_mock = ImageParameters(mock.Mock(), flat_after_log_mock)
         lp.image_stacks[FILE_TYPES.FLAT_AFTER] = flat_after_mock
         progress_mock = mock.Mock()
 
@@ -145,18 +145,18 @@ class MainWindowModelTest(unittest.TestCase):
                                                       load_log_mock: mock.Mock):
         lp = NewLoadingParameters()
         log_file_mock = mock.Mock()
-        sample_mock = NewImageParameters(mock.Mock(), log_file_mock)
+        sample_mock = ImageParameters(mock.Mock(), log_file_mock)
         lp.image_stacks[FILE_TYPES.SAMPLE] = sample_mock
         lp.dtype = "dtype_test"
         lp.sinograms = False
         lp.pixel_size = 101
 
-        dark_before_mock = NewImageParameters(mock.Mock())
+        dark_before_mock = ImageParameters(mock.Mock())
         lp.image_stacks[FILE_TYPES.DARK_BEFORE] = dark_before_mock
-        dark_after_mock = NewImageParameters(mock.Mock())
+        dark_after_mock = ImageParameters(mock.Mock())
         lp.image_stacks[FILE_TYPES.DARK_AFTER] = dark_after_mock
 
-        proj_180deg_mock = NewImageParameters(mock.Mock())
+        proj_180deg_mock = ImageParameters(mock.Mock())
         lp.image_stacks[FILE_TYPES.PROJ_180] = proj_180deg_mock
 
         progress_mock = mock.Mock()

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -11,7 +11,7 @@ import numpy as np
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
 from mantidimaging.core.data.reconlist import ReconList
-from mantidimaging.core.io.loader.loader import NewLoadingParameters, ImageParameters
+from mantidimaging.core.io.loader.loader import LoadingParameters, ImageParameters
 from mantidimaging.core.utility.data_containers import ProjectionAngles, FILE_TYPES, Indices
 from mantidimaging.gui.windows.main import MainWindowModel
 from mantidimaging.gui.windows.main.model import _matching_dataset_attribute
@@ -40,7 +40,7 @@ class MainWindowModelTest(unittest.TestCase):
     @mock.patch('mantidimaging.core.io.loader.load_log')
     @mock.patch('mantidimaging.core.io.loader.load_stack_from_image_params')
     def test_do_load_stack_sample_only(self, load_mock: mock.Mock, load_log_mock: mock.Mock):
-        lp = NewLoadingParameters()
+        lp = LoadingParameters()
         sample_mock = ImageParameters(mock.Mock())
         lp.image_stacks[FILE_TYPES.SAMPLE] = sample_mock
         lp.dtype = "dtype_test"
@@ -56,7 +56,7 @@ class MainWindowModelTest(unittest.TestCase):
     @mock.patch('mantidimaging.core.io.loader.load_log')
     @mock.patch('mantidimaging.core.io.loader.load_stack_from_image_params')
     def test_do_load_stack_sample_and_sample_log(self, load_mock: mock.Mock, load_log_mock: mock.Mock):
-        lp = NewLoadingParameters()
+        lp = LoadingParameters()
         log_file_mock = mock.Mock()
         sample_mock = ImageParameters(mock.Mock(), log_file_mock)
         lp.image_stacks[FILE_TYPES.SAMPLE] = sample_mock
@@ -73,7 +73,7 @@ class MainWindowModelTest(unittest.TestCase):
     @mock.patch('mantidimaging.core.io.loader.load_log')
     @mock.patch('mantidimaging.core.io.loader.loader.load')
     def test_do_load_stack_sample_indicies(self, load_mock: mock.Mock, load_log_mock: mock.Mock):
-        lp = NewLoadingParameters()
+        lp = LoadingParameters()
         all_files = ["filename"] * 10
         mock_filename_group = mock.Mock()
         mock_filename_group.all_files.return_value = all_files
@@ -96,7 +96,7 @@ class MainWindowModelTest(unittest.TestCase):
     @mock.patch('mantidimaging.gui.windows.main.model.StrictDataset')
     def test_do_load_stack_sample_and_flat(self, dataset_mock: mock.Mock, load_mock: mock.Mock,
                                            load_log_mock: mock.Mock):
-        lp = NewLoadingParameters()
+        lp = LoadingParameters()
         log_file_mock = mock.Mock()
         sample_mock = ImageParameters(mock.Mock(), log_file_mock)
         lp.image_stacks[FILE_TYPES.SAMPLE] = sample_mock
@@ -143,7 +143,7 @@ class MainWindowModelTest(unittest.TestCase):
     @mock.patch('mantidimaging.gui.windows.main.model.StrictDataset')
     def test_do_load_stack_sample_and_dark_and_180deg(self, dataset_mock: mock.Mock, load_mock: mock.Mock,
                                                       load_log_mock: mock.Mock):
-        lp = NewLoadingParameters()
+        lp = LoadingParameters()
         log_file_mock = mock.Mock()
         sample_mock = ImageParameters(mock.Mock(), log_file_mock)
         lp.image_stacks[FILE_TYPES.SAMPLE] = sample_mock

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -38,11 +38,11 @@ class MainWindowModelTest(unittest.TestCase):
         self.assertIs(image_mock, self.model.get_images_by_uuid(uid))
 
     @mock.patch('mantidimaging.core.io.loader.load_log')
-    @mock.patch('mantidimaging.core.io.loader.load_stack_from_group')
+    @mock.patch('mantidimaging.core.io.loader.load_stack_from_image_params')
     def test_do_load_stack_sample_only(self, load_mock: mock.Mock, load_log_mock: mock.Mock):
         lp = NewLoadingParameters()
-        sample_mock = mock.Mock()
-        lp.image_stacks[FILE_TYPES.SAMPLE] = NewImageParameters(sample_mock)
+        sample_mock = NewImageParameters(mock.Mock())
+        lp.image_stacks[FILE_TYPES.SAMPLE] = sample_mock
         lp.dtype = "dtype_test"
         lp.sinograms = True
         lp.pixel_size = 101
@@ -54,12 +54,12 @@ class MainWindowModelTest(unittest.TestCase):
         load_log_mock.assert_not_called()
 
     @mock.patch('mantidimaging.core.io.loader.load_log')
-    @mock.patch('mantidimaging.core.io.loader.load_stack_from_group')
+    @mock.patch('mantidimaging.core.io.loader.load_stack_from_image_params')
     def test_do_load_stack_sample_and_sample_log(self, load_mock: mock.Mock, load_log_mock: mock.Mock):
         lp = NewLoadingParameters()
-        sample_mock = mock.Mock()
         log_file_mock = mock.Mock()
-        lp.image_stacks[FILE_TYPES.SAMPLE] = NewImageParameters(sample_mock, log_file_mock)
+        sample_mock = NewImageParameters(mock.Mock(), log_file_mock)
+        lp.image_stacks[FILE_TYPES.SAMPLE] = sample_mock
         lp.dtype = "dtype_test"
         lp.sinograms = False
         lp.pixel_size = 101
@@ -71,24 +71,24 @@ class MainWindowModelTest(unittest.TestCase):
         load_log_mock.assert_called_once_with(log_file_mock)
 
     @mock.patch('mantidimaging.gui.windows.main.model.loader.load_log')
-    @mock.patch('mantidimaging.gui.windows.main.model.loader.load_stack_from_group')
+    @mock.patch('mantidimaging.gui.windows.main.model.loader.load_stack_from_image_params')
     @mock.patch('mantidimaging.gui.windows.main.model.StrictDataset')
     def test_do_load_stack_sample_and_flat(self, dataset_mock: mock.Mock, load_mock: mock.Mock,
                                            load_log_mock: mock.Mock):
         lp = NewLoadingParameters()
-        sample_mock = mock.Mock()
         log_file_mock = mock.Mock()
-        lp.image_stacks[FILE_TYPES.SAMPLE] = NewImageParameters(sample_mock, log_file_mock)
+        sample_mock = NewImageParameters(mock.Mock(), log_file_mock)
+        lp.image_stacks[FILE_TYPES.SAMPLE] = sample_mock
         lp.dtype = "dtype_test"
         lp.sinograms = False
         lp.pixel_size = 101
 
-        flat_before_mock = mock.Mock()
         flat_before_log_mock = mock.Mock()
-        lp.image_stacks[FILE_TYPES.FLAT_BEFORE] = NewImageParameters(flat_before_mock, flat_before_log_mock)
-        flat_after_mock = mock.Mock()
+        flat_before_mock = NewImageParameters(mock.Mock(), flat_before_log_mock)
+        lp.image_stacks[FILE_TYPES.FLAT_BEFORE] = flat_before_mock
         flat_after_log_mock = mock.Mock()
-        lp.image_stacks[FILE_TYPES.FLAT_AFTER] = NewImageParameters(flat_after_mock, flat_after_log_mock)
+        flat_after_mock = NewImageParameters(mock.Mock(), flat_after_log_mock)
+        lp.image_stacks[FILE_TYPES.FLAT_AFTER] = flat_after_mock
         progress_mock = mock.Mock()
 
         sample_images_mock = mock.Mock()
@@ -118,25 +118,25 @@ class MainWindowModelTest(unittest.TestCase):
         ])
 
     @mock.patch('mantidimaging.gui.windows.main.model.loader.load_log')
-    @mock.patch('mantidimaging.gui.windows.main.model.loader.load_stack_from_group')
+    @mock.patch('mantidimaging.gui.windows.main.model.loader.load_stack_from_image_params')
     @mock.patch('mantidimaging.gui.windows.main.model.StrictDataset')
     def test_do_load_stack_sample_and_dark_and_180deg(self, dataset_mock: mock.Mock, load_mock: mock.Mock,
                                                       load_log_mock: mock.Mock):
         lp = NewLoadingParameters()
-        sample_mock = mock.Mock()
         log_file_mock = mock.Mock()
-        lp.image_stacks[FILE_TYPES.SAMPLE] = NewImageParameters(sample_mock, log_file_mock)
+        sample_mock = NewImageParameters(mock.Mock(), log_file_mock)
+        lp.image_stacks[FILE_TYPES.SAMPLE] = sample_mock
         lp.dtype = "dtype_test"
         lp.sinograms = False
         lp.pixel_size = 101
 
-        dark_before_mock = mock.Mock()
-        lp.image_stacks[FILE_TYPES.DARK_BEFORE] = NewImageParameters(dark_before_mock)
-        dark_after_mock = mock.Mock()
-        lp.image_stacks[FILE_TYPES.DARK_AFTER] = NewImageParameters(dark_after_mock)
+        dark_before_mock = NewImageParameters(mock.Mock())
+        lp.image_stacks[FILE_TYPES.DARK_BEFORE] = dark_before_mock
+        dark_after_mock = NewImageParameters(mock.Mock())
+        lp.image_stacks[FILE_TYPES.DARK_AFTER] = dark_after_mock
 
-        proj_180deg_mock = mock.Mock()
-        lp.image_stacks[FILE_TYPES.PROJ_180] = NewImageParameters(proj_180deg_mock)
+        proj_180deg_mock = NewImageParameters(mock.Mock())
+        lp.image_stacks[FILE_TYPES.PROJ_180] = proj_180deg_mock
 
         progress_mock = mock.Mock()
 

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -48,7 +48,7 @@ class MainWindowModelTest(unittest.TestCase):
         lp.pixel_size = 101
         progress_mock = mock.Mock()
 
-        self.model.new_do_load_dataset(lp, progress_mock)
+        self.model.do_load_dataset(lp, progress_mock)
 
         load_mock.assert_called_once_with(sample_mock, progress_mock, dtype=lp.dtype)
         load_log_mock.assert_not_called()
@@ -65,7 +65,7 @@ class MainWindowModelTest(unittest.TestCase):
         lp.pixel_size = 101
         progress_mock = mock.Mock()
 
-        self.model.new_do_load_dataset(lp, progress_mock)
+        self.model.do_load_dataset(lp, progress_mock)
 
         load_mock.assert_called_once_with(sample_mock, progress_mock, dtype=lp.dtype)
         load_log_mock.assert_called_once_with(log_file_mock)
@@ -86,7 +86,7 @@ class MainWindowModelTest(unittest.TestCase):
         lp.pixel_size = 101
         progress_mock = mock.Mock()
 
-        self.model.new_do_load_dataset(lp, progress_mock)
+        self.model.do_load_dataset(lp, progress_mock)
 
         load_mock.assert_called_once_with(file_names=all_files, progress=progress_mock, dtype=lp.dtype, indices=indices)
         load_log_mock.assert_not_called()
@@ -119,7 +119,7 @@ class MainWindowModelTest(unittest.TestCase):
 
         ds_mock = dataset_mock.return_value
 
-        self.model.new_do_load_dataset(lp, progress_mock)
+        self.model.do_load_dataset(lp, progress_mock)
 
         load_mock.assert_has_calls([
             mock.call(sample_mock, progress_mock, dtype=lp.dtype),
@@ -169,7 +169,7 @@ class MainWindowModelTest(unittest.TestCase):
 
         ds_mock = dataset_mock.return_value
 
-        self.model.new_do_load_dataset(lp, progress_mock)
+        self.model.do_load_dataset(lp, progress_mock)
 
         load_mock.assert_has_calls([
             mock.call(sample_mock, progress_mock, dtype=lp.dtype),

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -12,7 +12,7 @@ from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
 from mantidimaging.core.data.reconlist import ReconList
 from mantidimaging.core.io.loader.loader import NewLoadingParameters, NewImageParameters
-from mantidimaging.core.utility.data_containers import ProjectionAngles, FILE_TYPES
+from mantidimaging.core.utility.data_containers import ProjectionAngles, FILE_TYPES, Indices
 from mantidimaging.gui.windows.main import MainWindowModel
 from mantidimaging.gui.windows.main.model import _matching_dataset_attribute
 from mantidimaging.test_helpers.unit_test_helper import generate_images
@@ -69,6 +69,27 @@ class MainWindowModelTest(unittest.TestCase):
 
         load_mock.assert_called_once_with(sample_mock, progress_mock, dtype=lp.dtype)
         load_log_mock.assert_called_once_with(log_file_mock)
+
+    @mock.patch('mantidimaging.core.io.loader.load_log')
+    @mock.patch('mantidimaging.core.io.loader.loader.load')
+    def test_do_load_stack_sample_indicies(self, load_mock: mock.Mock, load_log_mock: mock.Mock):
+        lp = NewLoadingParameters()
+        all_files = ["filename"] * 10
+        mock_filename_group = mock.Mock()
+        mock_filename_group.all_files.return_value = all_files
+        sample_mock = NewImageParameters(mock_filename_group)
+        indices = Indices(0, 100, 2)
+        sample_mock.indices = indices
+        lp.image_stacks[FILE_TYPES.SAMPLE] = sample_mock
+        lp.dtype = "dtype_test"
+        lp.sinograms = True
+        lp.pixel_size = 101
+        progress_mock = mock.Mock()
+
+        self.model.new_do_load_dataset(lp, progress_mock)
+
+        load_mock.assert_called_once_with(file_names=all_files, progress=progress_mock, dtype=lp.dtype, indices=indices)
+        load_log_mock.assert_not_called()
 
     @mock.patch('mantidimaging.gui.windows.main.model.loader.load_log')
     @mock.patch('mantidimaging.gui.windows.main.model.loader.load_stack_from_image_params')

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -108,12 +108,11 @@ class MainWindowPresenterTest(unittest.TestCase):
     @mock.patch("mantidimaging.gui.windows.main.presenter.start_async_task_view")
     def test_dataset_stack(self, start_async_mock: mock.Mock):
         parameters_mock = mock.Mock()
-        parameters_mock.sample.input_path.return_value = "123"
         self.view.image_load_dialog.get_parameters.return_value = parameters_mock
 
         self.presenter.load_image_files()
 
-        start_async_mock.assert_called_once_with(self.view, self.presenter.model.do_load_dataset,
+        start_async_mock.assert_called_once_with(self.view, self.presenter.model.new_do_load_dataset,
                                                  self.presenter._on_dataset_load_done, {'parameters': parameters_mock})
 
     @mock.patch("mantidimaging.gui.windows.main.presenter.start_async_task_view")

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -112,7 +112,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         self.presenter.load_image_files()
 
-        start_async_mock.assert_called_once_with(self.view, self.presenter.model.new_do_load_dataset,
+        start_async_mock.assert_called_once_with(self.view, self.presenter.model.do_load_dataset,
                                                  self.presenter._on_dataset_load_done, {'parameters': parameters_mock})
 
     @mock.patch("mantidimaging.gui.windows.main.presenter.start_async_task_view")


### PR DESCRIPTION
### Issue

Nearly there on #1219 

### Description

Move Load Dataset to new code. This covers the loading side, finding files in ImageLoadDialog still uses old methods.

Remove unused code

### Testing & Acceptance Criteria 
Check that you can load  with Load Dataset

### Documentation

Not yet
