### PR TITLE
1696 export roi cords

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -29,6 +29,7 @@ New Features and improvements
 - #1714 : Improve ROI hover behavior within Spectrum Viewer to be more intuitive.
 - #1664 : PyInstaller version at build time
 - #1632 : Add Stochastic PDHG
+- #1696 : Export ROI positional data following Pascal VOC format in separate `.csv` when exporting spectrum data in spectrum view.
 
 Fixes
 -----

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
+import csv
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
@@ -191,6 +192,33 @@ class SpectrumViewerWindowModel:
 
         with path.open("w") as outfile:
             csv_output.write(outfile)
+            self.save_roi_coords(self.get_roi_coords_filename(path))
+
+    def get_roi_coords_filename(self, path: Path) -> Path:
+        """
+        Get the path to save the ROI coordinates to.
+        @param path: The path to save the CSV file to.
+        @return: The path to save the ROI coordinates to.
+        """
+        return path.with_stem(f"{path.stem}_roi_coords")
+
+    def save_roi_coords(self, path: Path) -> None:
+        """
+        Save the coordinates of the ROIs to a csv file (ROI name, x_min, x_max, y_min, y_max)
+        following Pascal VOC format.
+        @param path: The path to save the CSV file to.
+        """
+        with open(path, encoding='utf-8', mode='w') as f:
+            csv_writer = csv.DictWriter(f, fieldnames=["ROI", "X Min", "X Max", "Y Min", "Y Max"])
+            csv_writer.writeheader()
+            for roi_name, coords in self._roi_ranges.items():
+                csv_writer.writerow({
+                    "ROI": roi_name,
+                    "X Min": coords.left,
+                    "X Max": coords.right,
+                    "Y Min": coords.top,
+                    "Y Max": coords.bottom
+                })
 
     def remove_roi(self, roi_name) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import unittest
-from pathlib import Path
+from pathlib import Path, PurePath
 from unittest import mock
 import io
 
@@ -192,6 +192,17 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.assertIn("0.0,0.0,0.0", mock_stream.getvalue())
         self.assertIn("1.0,2.0,2.0", mock_stream.getvalue())
         self.assertTrue(mock_stream.is_closed)
+
+    def test_WHEN_save_csv_called_THEN_save_roi_coords_called_WITH_correct_args(self):
+        path = Path("test_file.csv")
+        with mock.patch('builtins.open', mock.mock_open()) as mock_open:
+            self.model.save_roi_coords(path)
+        mock_open.assert_called_once_with(path, encoding='utf-8', mode='w')
+
+    def test_WHEN_get_roi_coords_filename_called_THEN_correct_filename_returned(self):
+        path = PurePath("test_file.csv")
+        expected_path = PurePath("test_file_roi_coords.csv")
+        self.assertEqual(expected_path, self.model.get_roi_coords_filename(path))
 
     def test_save_csv_norm_missing_stack(self):
         stack = ImageStack(np.ones([10, 11, 12]))


### PR DESCRIPTION
### Issue

Closes #1696 

### Description

Export ROI positional data following Pascal VOC format when exporting spectrum data within spectrum viewer following the file naming format `<Filename>_roi_coords.csv` which will be exported to the same path as spectrum data.

### Testing 

* Manually test ROI coords have been exported for a given number of ROIs added
* Modify unit test to verify that new method to handle exporting of ROIs is called with correct path name

### Acceptance Criteria 

- [ ] Load Mantid Imaging with test dataset and open spectrum Viewer.
- [ ] Add and resize a few ROIs
- [ ] Export Spectrum Data with the name `test.csv`
- [ ] Verify that two files are exported to the selected location: `test.csv` and `test_roi_coords.csv`

### Documentation

- `docs/release_notes/next.rst` 
