### PR TITLE
Allow spaces and non-ascii chars in filenames

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -41,6 +41,7 @@ Fixes
 - #1657 : PyInstaller: order of operations in menu is not sorted
 - #1712 : Fix redrawing of all ROIs and spectrum line plots of toggle and change of normalized stacks within spectrum viewer
 - #1219 : Fix image_180deg.tiff being included in sample stack
+- #1730 : Allow any characters in filenames
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -18,7 +18,7 @@ class FilenamePattern:
 
     Handles patterns like "aaaa_####.bbb" where # are digits
     """
-    PATTERN_p = r'^([a-zA-Z0-9_]+?)'
+    PATTERN_p = r'^(.+?)'
     PATTERN_d = r'([0-9]+)'
     PATTERN_s = r'(\.[a-zA-Z_]+)$'
     PATTERN = re.compile(PATTERN_p + PATTERN_d + PATTERN_s)

--- a/mantidimaging/core/io/test/filenames_test.py
+++ b/mantidimaging/core/io/test/filenames_test.py
@@ -22,6 +22,10 @@ class FilenamePatternTest(unittest.TestCase):
         ("IMAT00006388_PSI_cylinder_Sample_000.tif", "IMAT00006388_PSI_cylinder_Sample_", 3, ".tif"),
         ("IMAT_Flower_Dark_Before_000000.tif", "IMAT_Flower_Dark_Before_", 6, ".tif"),
         ("IMAT_Flower_Dark_Before.json", "IMAT_Flower_Dark_Before", 0, ".json"),
+        ("IMAT00024129_double_capillary_working_image_60C_wet gas_current holding_new_000.tif",
+         "IMAT00024129_double_capillary_working_image_60C_wet gas_current holding_new_", 3, ".tif"),
+        ("τομογραφία_01.tiff", "τομογραφία_", 2, ".tiff"),
+        ("𓊨𓏏𓆇𓁐_0001.txt", "𓊨𓏏𓆇𓁐_", 4, ".txt"),
     ])
     def test_pattern_from_name(self, filename, prefix, count, suffix):
         p1 = FilenamePattern.from_name(filename)

--- a/mantidimaging/core/io/test/filenames_test.py
+++ b/mantidimaging/core/io/test/filenames_test.py
@@ -26,6 +26,7 @@ class FilenamePatternTest(unittest.TestCase):
          "IMAT00024129_double_capillary_working_image_60C_wet gas_current holding_new_", 3, ".tif"),
         ("τομογραφία_01.tiff", "τομογραφία_", 2, ".tiff"),
         ("𓊨𓏏𓆇𓁐_0001.txt", "𓊨𓏏𓆇𓁐_", 4, ".txt"),
+        ("📷_000.tif", "📷_", 3, ".tif"),
     ])
     def test_pattern_from_name(self, filename, prefix, count, suffix):
         p1 = FilenamePattern.from_name(filename)


### PR DESCRIPTION
### Issue

Closes #1730 

### Description

Accept spaces and any other character in file names.

Add tests for example from  #1730 and some non-ascii examples

### Testing & Acceptance Criteria 

I put a spheres_fun_names.tar.xz in the Example Data folder.
Check that the dataset can  be loaded with the Load Dataset dialog (auto finding flat, dark and 180 will not work but they should be manually selectable.)

### Documentation

Release notes
