### PR TITLE
1698: Store processed (but not reconstructed) data in a different place in the nexus file

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -43,6 +43,7 @@ Fixes
 - #1712 : Fix redrawing of all ROIs and spectrum line plots of toggle and change of normalized stacks within spectrum viewer
 - #1219 : Fix image_180deg.tiff being included in sample stack
 - #1730 : Allow any characters in filenames
+- #1698 : Store processed (but not reconstructed) data in a different place in the nexus file
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -23,17 +23,14 @@ if TYPE_CHECKING:
     from ..data.imagestack import ImageStack
     from ..utility.data_containers import Indices
 
-try:
-    from mantidimaging.versions import package_version  # type: ignore
-except ImportError:
-    package_version = '0.0.0.dev1'
-
 LOG = getLogger(__name__)
 
 DEFAULT_ZFILL_LENGTH = 6
 DEFAULT_NAME_PREFIX = 'image'
 DEFAULT_NAME_POSTFIX = ''
 INT16_SIZE = 65536
+
+package_version = CheckVersion().get_version()
 
 
 def write_fits(data: np.ndarray, filename: str, overwrite: bool = False, description: Optional[str] = ""):
@@ -293,7 +290,7 @@ def _save_recon_to_nexus(nexus_file: h5py.File, recon: ImageStack, sample_path: 
     _set_nx_class(reconstruction, "NXprocess")
 
     reconstruction.create_dataset("program", data=np.string_("Mantid Imaging"))
-    reconstruction.create_dataset("version", data=np.string_(CheckVersion().get_version()))
+    reconstruction.create_dataset("version", data=np.string_(package_version))
     recon_timestamp = recon.metadata.get(TIMESTAMP)
     if recon_timestamp is None:
         recon_timestamp = datetime.datetime.now().isoformat()

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -245,7 +245,7 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
         _save_recon_to_nexus(nexus_file, recon, dataset.sample.filenames[0])
 
 
-def _save_processed_data_to_nexus(nexus_file: h5py.File, dataset: StrictDataset, rotation_angle: h5py.Group,
+def _save_processed_data_to_nexus(nexus_file: h5py.File, dataset: StrictDataset, rotation_angle: h5py.Dataset,
                                   image_key: h5py.Dataset):
     data = nexus_file.create_group("processed-data")
     data["rotation_angle"] = rotation_angle

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -223,8 +223,6 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
     _set_nx_class(detector, "NXdetector")
     detector.create_dataset("image_key", data=dataset.image_keys)
 
-    _save_processed_data_to_nexus(nexus_file, dataset)
-
     # sample field
     sample_group = tomo_entry.create_group("sample")
     _set_nx_class(sample_group, "NXsample")
@@ -233,6 +231,8 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
     # rotation angle
     rotation_angle = sample_group.create_dataset("rotation_angle", data=np.concatenate(dataset.nexus_rotation_angles))
     rotation_angle.attrs["units"] = "rad"
+
+    _save_processed_data_to_nexus(nexus_file, dataset, rotation_angle, detector["image_key"])
 
     # data field
     data = tomo_entry.create_group("data")
@@ -245,8 +245,11 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
         _save_recon_to_nexus(nexus_file, recon, dataset.sample.filenames[0])
 
 
-def _save_processed_data_to_nexus(nexus_file: h5py.File, dataset: StrictDataset):
+def _save_processed_data_to_nexus(nexus_file: h5py.File, dataset: StrictDataset, rotation_angle: h5py.Group,
+                                  image_key: h5py.Dataset):
     data = nexus_file.create_group("processed-data")
+    data["rotation_angle"] = rotation_angle
+    data["image_key"] = image_key
     _set_nx_class(data, "NXdata")
     combined_data_shape = (sum([len(arr) for arr in dataset.nexus_arrays]), ) + dataset.nexus_arrays[0].shape[1:]
     data.create_dataset("data", shape=combined_data_shape, dtype="float32")

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -224,9 +224,9 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
     # instrument/detector field
     detector = instrument_group.create_group("detector")
     _set_nx_class(detector, "NXdetector")
-
-    # instrument data
     detector.create_dataset("image_key", data=dataset.image_keys)
+
+    _save_processed_data_to_nexus(nexus_file, dataset)
 
     # sample field
     sample_group = tomo_entry.create_group("sample")
@@ -251,7 +251,7 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
 def _save_processed_data_to_nexus(nexus_file: h5py.File, dataset: StrictDataset):
     data = nexus_file.create_group("processed-data")
     combined_data_shape = (sum([len(arr) for arr in dataset.nexus_arrays]), ) + dataset.nexus_arrays[0].shape[1:]
-    data.create_dataset("data", shape=combined_data_shape, dtype="uint16")
+    data.create_dataset("data", shape=combined_data_shape, dtype="float32")
     index = 0
     for arr in dataset.nexus_arrays:
         data["data"][index:index + arr.shape[0]] = arr

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -247,6 +247,7 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
 
 def _save_processed_data_to_nexus(nexus_file: h5py.File, dataset: StrictDataset):
     data = nexus_file.create_group("processed-data")
+    _set_nx_class(data, "NXdata")
     combined_data_shape = (sum([len(arr) for arr in dataset.nexus_arrays]), ) + dataset.nexus_arrays[0].shape[1:]
     data.create_dataset("data", shape=combined_data_shape, dtype="float32")
     index = 0

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -255,6 +255,7 @@ def _save_processed_data_to_nexus(nexus_file: h5py.File, dataset: StrictDataset)
         index += arr.shape[0]
 
     process = data.create_group("process")
+    _set_nx_class(process, "NXprocess")
     process.create_dataset("program", data=np.string_("Mantid Imaging"))
     process.create_dataset("date", data=np.string_(datetime.datetime.now().isoformat()))
     process.create_dataset("version", data=np.string_(package_version))

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -280,10 +280,10 @@ class IOTest(FileOutputtingTestCase):
 
             # test instrument field
             npt.assert_array_equal(
-                np.array(tomo_entry["instrument"]["detector"]["data"]),
+                np.array(nexus_file["processed-data"]["data"]),
                 np.concatenate(
                     [sd.dark_before.data, sd.flat_before.data, sd.sample.data, sd.flat_after.data,
-                     sd.dark_after.data]).astype("uint16"))
+                     sd.dark_after.data]).astype("float32"))
             npt.assert_array_equal(
                 np.array(tomo_entry["instrument"]["detector"]["image_key"]),
                 [2 for _ in range(sd.dark_before.data.shape[0])] + [1 for _ in range(sd.flat_before.data.shape[0])] +

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -338,6 +338,7 @@ class IOTest(FileOutputtingTestCase):
         with h5py.File("path", "w", driver="core", backing_store=False) as nexus_file:
             _save_processed_data_to_nexus(nexus_file, ds)
             assert "process" in nexus_file["processed-data"]
+            self.assertEqual(_decode_nexus_class(nexus_file[process_path]), "NXprocess")
             self.assertEqual(_nexus_dataset_to_string(nexus_file[process_path]["program"]), "Mantid Imaging")
             self.assertEqual(_nexus_dataset_to_string(nexus_file[process_path]["version"]), CheckVersion.get_version())
             self.assertIn(str(datetime.date.today()), _nexus_dataset_to_string(nexus_file[process_path]["date"]))

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -340,7 +340,8 @@ class IOTest(FileOutputtingTestCase):
             assert "process" in nexus_file["processed-data"]
             self.assertEqual(_decode_nexus_class(nexus_file[process_path]), "NXprocess")
             self.assertEqual(_nexus_dataset_to_string(nexus_file[process_path]["program"]), "Mantid Imaging")
-            self.assertEqual(_nexus_dataset_to_string(nexus_file[process_path]["version"]), CheckVersion.get_version())
+            self.assertEqual(_nexus_dataset_to_string(nexus_file[process_path]["version"]),
+                             CheckVersion().get_version())
             self.assertIn(str(datetime.date.today()), _nexus_dataset_to_string(nexus_file[process_path]["date"]))
 
     @mock.patch("mantidimaging.core.io.saver._save_recon_to_nexus")

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -227,8 +227,7 @@ class IOTest(FileOutputtingTestCase):
 
             # test instrument/detector fields
             self.assertEqual(_decode_nexus_class(tomo_entry["instrument"]["detector"]), "NXdetector")
-            npt.assert_array_equal(np.array(tomo_entry["instrument"]["detector"]["data"]),
-                                   sd.sample.data.astype("uint16"))
+            npt.assert_array_equal(np.array(nexus_file["processed-data"]["data"]), sd.sample.data.astype("float32"))
             npt.assert_array_equal(np.array(tomo_entry["instrument"]["detector"]["image_key"]),
                                    [0 for _ in range(sd.sample.data.shape[0])])
 
@@ -239,7 +238,6 @@ class IOTest(FileOutputtingTestCase):
                                    sd.sample.projection_angles().value)
 
             # test links
-            self.assertEqual(tomo_entry["data"]["data"], tomo_entry["instrument"]["detector"]["data"])
             self.assertEqual(tomo_entry["data"]["rotation_angle"], tomo_entry["sample"]["rotation_angle"])
             self.assertEqual(tomo_entry["data"]["image_key"], tomo_entry["instrument"]["detector"]["image_key"])
 

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -338,6 +338,7 @@ class IOTest(FileOutputtingTestCase):
         with h5py.File("path", "w", driver="core", backing_store=False) as nexus_file:
             _save_processed_data_to_nexus(nexus_file, ds)
             assert "process" in nexus_file["processed-data"]
+            self.assertEqual(_decode_nexus_class(nexus_file["processed-data"]), "NXdata")
             self.assertEqual(_decode_nexus_class(nexus_file[process_path]), "NXprocess")
             self.assertEqual(_nexus_dataset_to_string(nexus_file[process_path]["program"]), "Mantid Imaging")
             self.assertEqual(_nexus_dataset_to_string(nexus_file[process_path]["version"]),

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -338,7 +338,9 @@ class IOTest(FileOutputtingTestCase):
         ds = StrictDataset(th.generate_images())
         process_path = "processed-data/process"
         with h5py.File("path", "w", driver="core", backing_store=False) as nexus_file:
-            _save_processed_data_to_nexus(nexus_file, ds)
+            rotation_angle = nexus_file.create_dataset("rotation_angle", dtype="float")
+            image_key = nexus_file.create_dataset("image_key", dtype="int")
+            _save_processed_data_to_nexus(nexus_file, ds, rotation_angle, image_key)
             assert "process" in nexus_file["processed-data"]
             self.assertEqual(_decode_nexus_class(nexus_file["processed-data"]), "NXdata")
             self.assertEqual(_decode_nexus_class(nexus_file[process_path]), "NXprocess")

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -263,8 +263,7 @@ class IOTest(FileOutputtingTestCase):
             # test rotation angle links
             self.assertEqual(tomo_entry["data"]["rotation_angle"], rotation_angle_entry)
 
-    @staticmethod
-    def test_nexus_complex_dataset_save():
+    def test_nexus_complex_dataset_save(self):
         image_stacks = []
         for _ in range(5):
             image_stack = th.generate_images()
@@ -278,12 +277,12 @@ class IOTest(FileOutputtingTestCase):
             saver._nexus_save(nexus_file, sd, "sample-name")
             tomo_entry = nexus_file["entry1"]["tomo_entry"]
 
-            # test instrument field
             npt.assert_array_equal(
                 np.array(nexus_file["processed-data"]["data"]),
                 np.concatenate(
                     [sd.dark_before.data, sd.flat_before.data, sd.sample.data, sd.flat_after.data,
                      sd.dark_after.data]).astype("float32"))
+            # test instrument field
             npt.assert_array_equal(
                 np.array(tomo_entry["instrument"]["detector"]["image_key"]),
                 [2 for _ in range(sd.dark_before.data.shape[0])] + [1 for _ in range(sd.flat_before.data.shape[0])] +
@@ -293,6 +292,9 @@ class IOTest(FileOutputtingTestCase):
             # test instrument/sample fields
             npt.assert_array_equal(np.array(tomo_entry["sample"]["rotation_angle"]),
                                    np.concatenate([images.projection_angles().value for images in image_stacks]))
+            self.assertEqual(nexus_file["processed-data"]["rotation_angle"], tomo_entry["sample"]["rotation_angle"])
+            self.assertEqual(nexus_file["processed-data"]["image_key"],
+                             tomo_entry["instrument"]["detector"]["image_key"])
 
     @mock.patch("mantidimaging.core.io.saver.h5py.File")
     @mock.patch("mantidimaging.core.io.saver._nexus_save")


### PR DESCRIPTION
### Issue

Closes #1689 

### Description

Creates a separate group for processed NeXus data.

### Testing 

Added test for the NXprocess information and updated existing tests.

### Acceptance Criteria 

Check that processed data is no longer in the NXTomoproc group.

### Documentation

Updated release notes.
