### PR TITLE
Remove grad norm calculation

### DIFF
--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -57,11 +57,6 @@ class CILRecon(BaseRecon):
         alpha = recon_params.alpha
         Grad = GradientOperator(image_geometry)
 
-        if image_geometry.voxel_num_z == 0:
-            Grad.set_norm(sqrt(8))
-        else:
-            Grad.set_norm(sqrt(12))
-
         if recon_params.stochastic:
             # now, A2d is a BlockOperator as acquisition_data is a BlockDataContainer
             fs = []


### PR DESCRIPTION
### Issue

Closes #1724

### Description
Remove no longer needed grad norm calculation

### Acceptance Criteria 

Check we are no longer using set_norm for the Grad operator.

Manually check that reconstruction with CIL still works.

### Documentation

Not needed.
