### PR TITLE
1225 golden angle loading

### DIFF
--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -75,7 +75,40 @@ class FilenamePattern:
 
 
 class FilenamePatternGolden(FilenamePattern):
-    pass
+    PATTERN_p = r'^(.+?)'
+    PATTERN_a = r'_([0-9\.]+)_'
+    PATTERN_d = r'([0-9]+)'
+    PATTERN_s = r'(\.[a-zA-Z]+)$'
+    PATTERN = re.compile(PATTERN_p + PATTERN_a + PATTERN_d + PATTERN_s)
+
+    def __init__(self, prefix: str, digit_count: int, suffix: str):
+        self.prefix = prefix
+        self.digit_count = digit_count
+        self.suffix = suffix
+        print(f"FilenamePatternGolden {prefix=} {digit_count=} {suffix=}")
+
+        self.re_pattern = re.compile("^" + re.escape(prefix) + self.PATTERN_a + "([1-9]*[0-9]{" + str(digit_count) +
+                                     "})" + re.escape(suffix) + "$")
+
+        self.re_pattern_metadata = re.compile("^" + re.escape(prefix.rstrip("_ ")) + ".json$")
+        self.template = prefix + "{:0" + str(digit_count) + "d}" + suffix
+
+    @classmethod
+    def from_name(cls, filename: str) -> FilenamePattern:
+        result = cls.PATTERN.search(filename)
+        if result is None:
+            raise ValueError(f"Could not match FilenamePatternGolden from: '{filename}'")
+
+        prefix = result.group(1)
+        digits = result.group(3)
+        ext = result.group(4)
+        return cls(prefix, len(digits), ext)
+
+    def get_index(self, filename: str) -> int:
+        result = self.re_pattern.match(filename)
+        if result is None:
+            raise ValueError(f"Filename ({filename}) does not match pattern: {self.re_pattern}")
+        return int(result.group(2))
 
 
 class FilenameGroup:

--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -85,13 +85,12 @@ class FilenamePatternGolden(FilenamePattern):
         self.prefix = prefix
         self.digit_count = digit_count
         self.suffix = suffix
-        print(f"FilenamePatternGolden {prefix=} {digit_count=} {suffix=}")
+        self.name_store: dict[int, str] = {}
 
         self.re_pattern = re.compile("^" + re.escape(prefix) + self.PATTERN_a + "([1-9]*[0-9]{" + str(digit_count) +
                                      "})" + re.escape(suffix) + "$")
 
         self.re_pattern_metadata = re.compile("^" + re.escape(prefix.rstrip("_ ")) + ".json$")
-        self.template = prefix + "{:0" + str(digit_count) + "d}" + suffix
 
     @classmethod
     def from_name(cls, filename: str) -> FilenamePattern:
@@ -108,7 +107,12 @@ class FilenamePatternGolden(FilenamePattern):
         result = self.re_pattern.match(filename)
         if result is None:
             raise ValueError(f"Filename ({filename}) does not match pattern: {self.re_pattern}")
-        return int(result.group(2))
+        index = int(result.group(2))
+        self.name_store[index] = filename
+        return index
+
+    def generate(self, index: int) -> str:
+        return self.name_store[index]
 
 
 class FilenameGroup:

--- a/mantidimaging/core/io/test/filenames_test.py
+++ b/mantidimaging/core/io/test/filenames_test.py
@@ -221,3 +221,16 @@ class GoldenFilenameGroupTest(FakeFSTestCase):
 
         self.assertTrue(isinstance(group.pattern, FilenamePatternGolden))
         self.assertEqual([1], group.all_indexes)
+
+    def test_all_files(self):
+        angles = [0.0, 111.2461, 42.4922, 153.7384, 16.2306]
+        basename = "IMAT00021870_CMOS_LegoScan_GR_PH40_GRtomo_{}_{:03d}.tif"
+        filenames = [basename.format(a, n) for n, a in enumerate(angles)]
+
+        for filename in filenames:
+            self.fs.create_file(filename)
+
+        group = FilenameGroup.from_file(filenames[0])
+        group.find_all_files()
+
+        self._file_list_count_equal(filenames, group.all_files())

--- a/mantidimaging/core/io/test/filenames_test.py
+++ b/mantidimaging/core/io/test/filenames_test.py
@@ -8,7 +8,7 @@ import unittest
 from parameterized import parameterized
 
 from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
-from ..filenames import FilenameGroup, FilenamePattern
+from ..filenames import FilenameGroup, FilenamePattern, FilenamePatternGolden
 from ...utility.data_containers import FILE_TYPES
 
 
@@ -212,3 +212,11 @@ class FilenameGroupTest(FakeFSTestCase):
         proj_180_fg.find_all_files()
 
         self._file_list_count_equal(proj_180_list, list(proj_180_fg.all_files()))
+
+
+class GoldenFilenameGroupTest(FakeFSTestCase):
+    def test_golden_pattern(self):
+        filename = "IMAT00021870_CMOS_LegoScan_GR_PH40_GRtomo_0.0_001.tif"
+        group = FilenameGroup.from_file(filename)
+
+        self.assertTrue(isinstance(group.pattern, FilenamePatternGolden))

--- a/mantidimaging/core/io/test/filenames_test.py
+++ b/mantidimaging/core/io/test/filenames_test.py
@@ -220,3 +220,4 @@ class GoldenFilenameGroupTest(FakeFSTestCase):
         group = FilenameGroup.from_file(filename)
 
         self.assertTrue(isinstance(group.pattern, FilenamePatternGolden))
+        self.assertEqual([1], group.all_indexes)

--- a/mantidimaging/gui/mvp_base/presenter.py
+++ b/mantidimaging/gui/mvp_base/presenter.py
@@ -19,10 +19,10 @@ class BasePresenter(object):
         raise NotImplementedError("Presenter must implement the notify() method")
 
     def show_error(self, error, traceback):
+        getLogger(__name__).exception(f'Presenter error: {error}\n{traceback}')
         if hasattr(self.view, 'show_error_dialog'):
             # If the view knows how to handle an error message
             self.view.show_error_dialog(str(error))
-        getLogger(__name__).exception(f'Presenter error: {error}\n{traceback}')
 
     def show_information(self, info):
         self.view.show_info_dialog(info)

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -134,15 +134,15 @@ class MIImageView(ImageView, BadDataOverlay, AutoColorMenu):
     def viewbox(self) -> ViewBox:
         return self.view
 
-    def setImage(self, *args, **kwargs):
-        dimensions_changed = self.image_data is None or self.image_data.shape != args[0].shape
-        if args[0].ndim == 3:
+    def setImage(self, image: np.ndarray, *args, **kwargs):
+        dimensions_changed = self.image_data is None or self.image_data.shape != image.shape
+        if image.ndim == 3:
             # For a 3 dimensional image, we need to specify which axes we are providing and their indices in the
             # array's shape attribute
             # If we don't do this then it is interpreted incorrectly for very small images by ImageView.setImage
             # Note that, for our purposes, the t axis corresponds to angle data
             kwargs['axes'] = kwargs.get('axes', {'t': 0, 'x': 2, 'y': 1, 'c': None})
-        ImageView.setImage(self, *args, **kwargs)
+        ImageView.setImage(self, image, *args, **kwargs)
         self.check_for_bad_data()
         if dimensions_changed:
             self.set_roi(self.default_roi())

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -91,10 +91,10 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
         self.clear_overlays()
         self.details.setText("")
 
-    def setImage(self, *args, **kwargs):
-        self.im.setImage(*args, **kwargs)
+    def setImage(self, image: np.ndarray, *args, **kwargs):
+        self.im.setImage(image, *args, **kwargs)
         self.check_for_bad_data()
-        self.set_auto_color_enabled(self.im.image is not None)
+        self.set_auto_color_enabled(image is not None)
 
     @staticmethod
     def set_siblings(sibling_views: List["MIMiniImageView"], axis=False, hist=False):

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -73,8 +73,10 @@ class StackVisualiserPresenter(BasePresenter):
         self.view = None
 
     def refresh_image(self):
-        self.view.image = self.summed_image if self.image_mode is SVImageMode.SUMMED \
-            else self.images.data
+        if self.image_mode is SVImageMode.SUMMED:
+            self.view.image = self.summed_image
+        else:
+            self.view.set_image(self.images)
 
     def get_parameter_value(self, parameter: SVParameters):
         """

--- a/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
@@ -34,7 +34,7 @@ class StackVisualiserPresenterTest(unittest.TestCase):
     def test_notify_refresh_image_normal_image_mode(self):
         self.presenter.image_mode = SVImageMode.NORMAL
         self.presenter.notify(SVNotification.REFRESH_IMAGE)
-        self.assertIs(self.view.image, self.presenter.images.data, "Image should have been set as sample images")
+        self.view.set_image.assert_called_with(self.presenter.images)
 
     def test_notify_refresh_image_averaged_image_mode(self):
         self.presenter.image_mode = SVImageMode.SUMMED

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -21,6 +21,7 @@ from ...utility.qt_helpers import populate_menu
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401   # pragma: no cover
+    import numpy as np
 
 
 class StackVisualiserView(QDockWidget):
@@ -73,7 +74,7 @@ class StackVisualiserView(QDockWidget):
                           ("NaN Removal", lambda: self._main_window.presenter.show_operation("NaN Removal"))]
         self.image_view.enable_nan_check(actions=nan_check_menu)
         self.addAction(self.actionCloseStack)
-        self.image_view.setImage(self.presenter.images.data)
+        self.set_image(self.presenter.images)
         self.image_view.roi_changed_callback = self.roi_changed_callback
         self.layout.addWidget(self.image_view)
 
@@ -97,8 +98,12 @@ class StackVisualiserView(QDockWidget):
         return self.image_view.imageItem
 
     @image.setter
-    def image(self, to_display):
+    def image(self, to_display: np.ndarray):
         self.image_view.setImage(to_display)
+
+    def set_image(self, image_stack: ImageStack):
+        self.image = image_stack.data
+        self.image_view.angles = image_stack.real_projection_angles()
 
     @property
     def main_window(self) -> 'MainWindowView':


### PR DESCRIPTION
### Issue
Work towards #1225 

### Description

Some work towards golden angle loading:
Allow the filename patterns to pick up GR name scheme
Show angle in the main window values text. Generally useful, but makes debugging easier
Fix issue where the log fields were being put into loading_param.image_stacks. The log should only be added to the associated image_stacks.

### Testing 

Some changes for the above.

### Acceptance Criteria 

It should be possible to load the CMOS_LegoScan_GR_PH40 dataset (in the Example Data directory).
Not that the stack is loaded in projection order, so scrolling though the data will not be smooth.
If the log file is selected then the angles should correctly display in the main window.
Note that you need to used the IMAT00021870_CMOS_LegoScan_GR_PH40GRtomo_log_trim.csv log, because the orignal has some extra lines at the top which upset the parser.

### Documentation

I'll save for the next PR
