### PR TITLE
Golden angle loading part 2

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -30,6 +30,7 @@ New Features and improvements
 - #1664 : PyInstaller version at build time
 - #1632 : Add Stochastic PDHG
 - #1696 : Export ROI positional data following Pascal VOC format in separate `.csv` when exporting spectrum data in spectrum view.
+- #1225 : Loading of Golden Ratio datasets
 
 Fixes
 -----

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -297,10 +297,10 @@ class ImageStack:
         Return only the projection angles that are from a log file or have been manually loaded.
         :return: Real projection angles if they were found, None otherwise.
         """
-        if self._log_file is not None:
-            return self._log_file.projection_angles()
         if self._projection_angles is not None:
             return self._projection_angles
+        if self._log_file is not None:
+            return self._log_file.projection_angles()
         return None
 
     def projection_angles(self, max_angle: float = 360.0) -> ProjectionAngles:

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -44,9 +44,6 @@ class MainWindowModel(object):
         sample._is_sinograms = parameters.sinograms
         sample.pixel_size = parameters.pixel_size
 
-        if log_file := parameters.image_stacks[FILE_TYPES.SAMPLE].log_file:
-            ds.sample.log_file = loader.load_log(log_file)
-
         for file_type in [
                 FILE_TYPES.FLAT_BEFORE,
                 FILE_TYPES.FLAT_AFTER,
@@ -56,9 +53,6 @@ class MainWindowModel(object):
         ]:
             if im_param := parameters.image_stacks.get(file_type):
                 image_stack = load(im_param)
-                if log_file := im_param.log_file:
-                    image_stack.log_file = loader.load_log(log_file)
-
                 ds.set_stack(file_type, image_stack)
 
         self.datasets[ds.id] = ds

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -53,12 +53,12 @@ class MainWindowModelTest(unittest.TestCase):
         load_mock.assert_called_once_with(sample_mock, progress_mock, dtype=lp.dtype)
         load_log_mock.assert_not_called()
 
-    @mock.patch('mantidimaging.core.io.loader.load_log')
-    @mock.patch('mantidimaging.core.io.loader.load_stack_from_image_params')
-    def test_do_load_stack_sample_and_sample_log(self, load_mock: mock.Mock, load_log_mock: mock.Mock):
+    @mock.patch('mantidimaging.core.io.loader.loader.load')
+    def test_do_load_stack_sample_and_sample_log(self, load_mock: mock.Mock):
         lp = LoadingParameters()
         log_file_mock = mock.Mock()
-        sample_mock = ImageParameters(mock.Mock(), log_file_mock)
+        mock_filename_group = mock.Mock()
+        sample_mock = ImageParameters(mock_filename_group, log_file_mock)
         lp.image_stacks[FILE_TYPES.SAMPLE] = sample_mock
         lp.dtype = "dtype_test"
         lp.sinograms = False
@@ -67,12 +67,14 @@ class MainWindowModelTest(unittest.TestCase):
 
         self.model.do_load_dataset(lp, progress_mock)
 
-        load_mock.assert_called_once_with(sample_mock, progress_mock, dtype=lp.dtype)
-        load_log_mock.assert_called_once_with(log_file_mock)
+        load_mock.assert_called_once_with(filename_group=mock_filename_group,
+                                          progress=progress_mock,
+                                          dtype=lp.dtype,
+                                          indices=None,
+                                          log_file=log_file_mock)
 
-    @mock.patch('mantidimaging.core.io.loader.load_log')
     @mock.patch('mantidimaging.core.io.loader.loader.load')
-    def test_do_load_stack_sample_indicies(self, load_mock: mock.Mock, load_log_mock: mock.Mock):
+    def test_do_load_stack_sample_indicies(self, load_mock: mock.Mock):
         lp = LoadingParameters()
         mock_filename_group = mock.Mock()
         sample_mock = ImageParameters(mock_filename_group)
@@ -89,14 +91,12 @@ class MainWindowModelTest(unittest.TestCase):
         load_mock.assert_called_once_with(filename_group=mock_filename_group,
                                           progress=progress_mock,
                                           dtype=lp.dtype,
-                                          indices=indices)
-        load_log_mock.assert_not_called()
+                                          indices=indices,
+                                          log_file=None)
 
-    @mock.patch('mantidimaging.gui.windows.main.model.loader.load_log')
     @mock.patch('mantidimaging.gui.windows.main.model.loader.load_stack_from_image_params')
     @mock.patch('mantidimaging.gui.windows.main.model.StrictDataset')
-    def test_do_load_stack_sample_and_flat(self, dataset_mock: mock.Mock, load_mock: mock.Mock,
-                                           load_log_mock: mock.Mock):
+    def test_do_load_stack_sample_and_flat(self, dataset_mock: mock.Mock, load_mock: mock.Mock):
         lp = LoadingParameters()
         log_file_mock = mock.Mock()
         sample_mock = ImageParameters(mock.Mock(), log_file_mock)
@@ -127,10 +127,6 @@ class MainWindowModelTest(unittest.TestCase):
             mock.call(flat_before_mock, progress_mock, dtype=lp.dtype),
             mock.call(flat_after_mock, progress_mock, dtype=lp.dtype)
         ])
-        load_log_mock.assert_has_calls(
-            [mock.call(log_file_mock),
-             mock.call(flat_before_log_mock),
-             mock.call(flat_after_log_mock)])
 
         dataset_mock.assert_called_with(sample_images_mock)
 
@@ -139,11 +135,9 @@ class MainWindowModelTest(unittest.TestCase):
             mock.call(FILE_TYPES.FLAT_AFTER, flata_images_mock),
         ])
 
-    @mock.patch('mantidimaging.gui.windows.main.model.loader.load_log')
     @mock.patch('mantidimaging.gui.windows.main.model.loader.load_stack_from_image_params')
     @mock.patch('mantidimaging.gui.windows.main.model.StrictDataset')
-    def test_do_load_stack_sample_and_dark_and_180deg(self, dataset_mock: mock.Mock, load_mock: mock.Mock,
-                                                      load_log_mock: mock.Mock):
+    def test_do_load_stack_sample_and_dark_and_180deg(self, dataset_mock: mock.Mock, load_mock: mock.Mock):
         lp = LoadingParameters()
         log_file_mock = mock.Mock()
         sample_mock = ImageParameters(mock.Mock(), log_file_mock)
@@ -177,10 +171,6 @@ class MainWindowModelTest(unittest.TestCase):
             mock.call(dark_before_mock, progress_mock, dtype=lp.dtype),
             mock.call(dark_after_mock, progress_mock, dtype=lp.dtype),
             mock.call(proj_180deg_mock, progress_mock, dtype=lp.dtype),
-        ])
-
-        load_log_mock.assert_has_calls([
-            mock.call(log_file_mock),
         ])
 
         dataset_mock.assert_called_with(sample_images_mock)


### PR DESCRIPTION
### Issue

Closes #1225

~Needs to wait for #1738 to be merged~

### Description
This completes Golden Angle loading. Angles are read from the log file and use to order the images at load time.

### Testing 
`test_load_with_golden_angles()` check that file names are correctly reordered

### Acceptance Criteria 

It should be possible to load the CMOS_LegoScan_GR_PH40 dataset (in the Example Data directory).
If the log file is selected then the angles should correctly display in the main window.
Scrolling through the images in the main window should give them in rotation order.
Note that you need to used the IMAT00021870_CMOS_LegoScan_GR_PH40GRtomo_log_trim.csv log, because the original has some extra lines at the top which upset the parser.

### Documentation
Release notes updated
