### PR TITLE
ProjectionOperator norm for SPDHG case

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -18,7 +18,7 @@ New Features and improvements
 - #1468 : NeXus Recon: Load recons
 - #1467 : NeXus Recon: Add other entry/data information
 - #1661 : Use `tifffile` for writing and reading tiff files
-- #1512 : Speedups for CIL setup
+- #1512, #1725 : Speedups for CIL setup
 - #1465 : NeXus Recon: Add entry/reconstruction/parameters information
 - #1666 : PyInstaller single file
 - #1665 : PyInstaller exe icon


### PR DESCRIPTION
### Issue

Closes #1725 

### Description

Follow on from #1647 for spdhg. In the case we must iterate over the operator and data blocks.

### Testing 

No tests added. Better testing of recon is a bigger issue

### Acceptance Criteria 

Run mantid imaging with
`python -m mantidimaging --log-level DEBUG`

Test a reconstruction with CIL with stochastic on and off.

Look for `DEBUG: ProjectionOperator approx norm` messages

### Documentation

Release notes
