### PR TITLE
1739: Load processed nexus data

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -31,6 +31,7 @@ New Features and improvements
 - #1632 : Add Stochastic PDHG
 - #1696 : Export ROI positional data following Pascal VOC format in separate `.csv` when exporting spectrum data in spectrum view.
 - #1225 : Loading of Golden Ratio datasets
+- #1739 : Load processed NeXus data
 
 Fixes
 -----

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -208,12 +208,12 @@ class StrictDataset(BaseDataset):
             raise AttributeError(f"StrictDataset does not have an attribute for {attr_name}")
 
     @property
-    def processed(self) -> bool:
+    def is_processed(self) -> bool:
         """
-        :return: True if the any of the data has been processed, False otherwise.
+        :return: True if any of the data has been processed, False otherwise.
         """
         for image in self.all:
-            if image.processed:
+            if image.is_processed:
                 return True
         return False
 

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -207,6 +207,16 @@ class StrictDataset(BaseDataset):
         else:
             raise AttributeError(f"StrictDataset does not have an attribute for {attr_name}")
 
+    @property
+    def processed(self) -> bool:
+        """
+        :return: True if the any of the data has been processed, False otherwise.
+        """
+        for image in self.all:
+            if image.processed:
+                return True
+        return False
+
 
 def _get_stack_data_type(stack_id: uuid.UUID, dataset: Union[MixedDataset, StrictDataset]) -> str:
     """

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -141,9 +141,7 @@ class ImageStack:
         """
         :return: True if any of the data has been processed, False otherwise.
         """
-        if const.OPERATION_HISTORY not in self.metadata:
-            return 0
-        return len(self.metadata[const.OPERATION_HISTORY]) > 0
+        return const.OPERATION_HISTORY in self.metadata
 
     def copy(self, flip_axes=False) -> 'ImageStack':
         shape = (self.data.shape[1], self.data.shape[0], self.data.shape[2]) if flip_axes else self.data.shape

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -136,6 +136,15 @@ class ImageStack:
             const.OPERATION_DISPLAY_NAME: display_name
         })
 
+    @property
+    def processed(self) -> bool:
+        """
+        :return: True if any of the data has been processed, False otherwise.
+        """
+        if const.OPERATION_HISTORY not in self.metadata:
+            return 0
+        return len(self.metadata[const.OPERATION_HISTORY]) > 0
+
     def copy(self, flip_axes=False) -> 'ImageStack':
         shape = (self.data.shape[1], self.data.shape[0], self.data.shape[2]) if flip_axes else self.data.shape
         data_copy = pu.create_array(shape, self.data.dtype)

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -137,7 +137,7 @@ class ImageStack:
         })
 
     @property
-    def processed(self) -> bool:
+    def is_processed(self) -> bool:
         """
         :return: True if any of the data has been processed, False otherwise.
         """

--- a/mantidimaging/core/data/test/image_stack_test.py
+++ b/mantidimaging/core/data/test/image_stack_test.py
@@ -287,3 +287,12 @@ class ImageStackTest(unittest.TestCase):
 
         image = ImageStack(raw_pixels.copy(), name="tomo", sinograms=True)
         np.testing.assert_array_equal(raw_pixels[[0], :, :].swapaxes(0, 1), image.sino_as_image_stack(0).data)
+
+    def test_processed_is_true(self):
+        images = generate_images()
+        images.record_operation("", "")
+        self.assertTrue(images.is_processed)
+
+    def test_processed_is_false(self):
+        images = generate_images()
+        self.assertFalse(images.is_processed)

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -13,7 +13,7 @@ from tifffile import tifffile
 from mantidimaging.core.operation_history.const import TIMESTAMP
 import astropy.io.fits as fits
 
-from .utility import DEFAULT_IO_FILE_FORMAT
+from .utility import DEFAULT_IO_FILE_FORMAT, NEXUS_PROCESSED_DATA_PATH
 from ..operations.rescale import RescaleFilter
 from ..utility.progress_reporting import Progress
 from ..utility.version_check import CheckVersion
@@ -247,7 +247,7 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
 
 def _save_processed_data_to_nexus(nexus_file: h5py.File, dataset: StrictDataset, rotation_angle: h5py.Dataset,
                                   image_key: h5py.Dataset):
-    data = nexus_file.create_group("processed-data")
+    data = nexus_file.create_group(NEXUS_PROCESSED_DATA_PATH)
     data["rotation_angle"] = rotation_angle
     data["image_key"] = image_key
     _set_nx_class(data, "NXdata")

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -232,7 +232,7 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
     rotation_angle = sample_group.create_dataset("rotation_angle", data=np.concatenate(dataset.nexus_rotation_angles))
     rotation_angle.attrs["units"] = "rad"
 
-    if dataset.processed:
+    if dataset.is_processed:
         _save_processed_data_to_nexus(nexus_file, dataset, rotation_angle, detector["image_key"])
     else:
         _save_image_stacks_to_nexus(dataset, detector)

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -247,7 +247,8 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
 
 def _save_processed_data_to_nexus(nexus_file: h5py.File, dataset: StrictDataset, rotation_angle: h5py.Dataset,
                                   image_key: h5py.Dataset):
-    data = nexus_file.create_group("processed-data")
+    processed_data = nexus_file.create_group("processed-data")
+    data = processed_data.create_group(dataset.name)
     data["rotation_angle"] = rotation_angle
     data["image_key"] = image_key
     _set_nx_class(data, "NXdata")

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -247,8 +247,7 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
 
 def _save_processed_data_to_nexus(nexus_file: h5py.File, dataset: StrictDataset, rotation_angle: h5py.Dataset,
                                   image_key: h5py.Dataset):
-    processed_data = nexus_file.create_group("processed-data")
-    data = processed_data.create_group(dataset.name)
+    data = nexus_file.create_group("processed-data")
     data["rotation_angle"] = rotation_angle
     data["image_key"] = image_key
     _set_nx_class(data, "NXdata")

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -232,7 +232,10 @@ def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str)
     rotation_angle = sample_group.create_dataset("rotation_angle", data=np.concatenate(dataset.nexus_rotation_angles))
     rotation_angle.attrs["units"] = "rad"
 
-    _save_processed_data_to_nexus(nexus_file, dataset, rotation_angle, detector["image_key"])
+    if dataset.processed:
+        _save_processed_data_to_nexus(nexus_file, dataset, rotation_angle, detector["image_key"])
+    else:
+        _save_image_stacks_to_nexus(dataset, detector)
 
     # data field
     data = tomo_entry.create_group("data")
@@ -251,18 +254,22 @@ def _save_processed_data_to_nexus(nexus_file: h5py.File, dataset: StrictDataset,
     data["rotation_angle"] = rotation_angle
     data["image_key"] = image_key
     _set_nx_class(data, "NXdata")
-    combined_data_shape = (sum([len(arr) for arr in dataset.nexus_arrays]), ) + dataset.nexus_arrays[0].shape[1:]
-    data.create_dataset("data", shape=combined_data_shape, dtype="float32")
-    index = 0
-    for arr in dataset.nexus_arrays:
-        data["data"][index:index + arr.shape[0]] = arr
-        index += arr.shape[0]
+    _save_image_stacks_to_nexus(dataset, data)
 
     process = data.create_group("process")
     _set_nx_class(process, "NXprocess")
     process.create_dataset("program", data=np.string_("Mantid Imaging"))
     process.create_dataset("date", data=np.string_(datetime.datetime.now().isoformat()))
     process.create_dataset("version", data=np.string_(package_version))
+
+
+def _save_image_stacks_to_nexus(dataset: StrictDataset, data_group: h5py.Group):
+    combined_data_shape = (sum([len(arr) for arr in dataset.nexus_arrays]), ) + dataset.nexus_arrays[0].shape[1:]
+    data_group.create_dataset("data", shape=combined_data_shape, dtype="float32")
+    index = 0
+    for arr in dataset.nexus_arrays:
+        data_group["data"][index:index + arr.shape[0]] = arr
+        index += arr.shape[0]
 
 
 def _save_recon_to_nexus(nexus_file: h5py.File, recon: ImageStack, sample_path: str):

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -12,6 +12,7 @@ import numpy as np
 import numpy.testing as npt
 
 from mantidimaging.core.io.filenames import FilenameGroup
+from mantidimaging.core.io.utility import NEXUS_PROCESSED_DATA_PATH
 from mantidimaging.core.operation_history.const import TIMESTAMP
 
 import mantidimaging.test_helpers.unit_test_helper as th
@@ -227,7 +228,8 @@ class IOTest(FileOutputtingTestCase):
 
             # test instrument/detector fields
             self.assertEqual(_decode_nexus_class(tomo_entry["instrument"]["detector"]), "NXdetector")
-            npt.assert_array_equal(np.array(nexus_file["processed-data"]["data"]), sd.sample.data.astype("float32"))
+            npt.assert_array_equal(np.array(nexus_file[NEXUS_PROCESSED_DATA_PATH]["data"]),
+                                   sd.sample.data.astype("float32"))
             npt.assert_array_equal(np.array(tomo_entry["instrument"]["detector"]["image_key"]),
                                    [0 for _ in range(sd.sample.data.shape[0])])
 
@@ -278,7 +280,7 @@ class IOTest(FileOutputtingTestCase):
             tomo_entry = nexus_file["entry1"]["tomo_entry"]
 
             npt.assert_array_equal(
-                np.array(nexus_file["processed-data"]["data"]),
+                np.array(nexus_file[NEXUS_PROCESSED_DATA_PATH]["data"]),
                 np.concatenate(
                     [sd.dark_before.data, sd.flat_before.data, sd.sample.data, sd.flat_after.data,
                      sd.dark_after.data]).astype("float32"))
@@ -292,8 +294,9 @@ class IOTest(FileOutputtingTestCase):
             # test instrument/sample fields
             npt.assert_array_equal(np.array(tomo_entry["sample"]["rotation_angle"]),
                                    np.concatenate([images.projection_angles().value for images in image_stacks]))
-            self.assertEqual(nexus_file["processed-data"]["rotation_angle"], tomo_entry["sample"]["rotation_angle"])
-            self.assertEqual(nexus_file["processed-data"]["image_key"],
+            self.assertEqual(nexus_file[NEXUS_PROCESSED_DATA_PATH]["rotation_angle"],
+                             tomo_entry["sample"]["rotation_angle"])
+            self.assertEqual(nexus_file[NEXUS_PROCESSED_DATA_PATH]["image_key"],
                              tomo_entry["instrument"]["detector"]["image_key"])
 
     @mock.patch("mantidimaging.core.io.saver.h5py.File")
@@ -341,8 +344,8 @@ class IOTest(FileOutputtingTestCase):
             rotation_angle = nexus_file.create_dataset("rotation_angle", dtype="float")
             image_key = nexus_file.create_dataset("image_key", dtype="int")
             _save_processed_data_to_nexus(nexus_file, ds, rotation_angle, image_key)
-            assert "process" in nexus_file["processed-data"]
-            self.assertEqual(_decode_nexus_class(nexus_file["processed-data"]), "NXdata")
+            assert "process" in nexus_file[NEXUS_PROCESSED_DATA_PATH]
+            self.assertEqual(_decode_nexus_class(nexus_file[NEXUS_PROCESSED_DATA_PATH]), "NXdata")
             self.assertEqual(_decode_nexus_class(nexus_file[process_path]), "NXprocess")
             self.assertEqual(_nexus_dataset_to_string(nexus_file[process_path]["program"]), "Mantid Imaging")
             self.assertEqual(_nexus_dataset_to_string(nexus_file[process_path]["version"]),

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -208,6 +208,8 @@ class IOTest(FileOutputtingTestCase):
         sample._projection_angles = sample.projection_angles()
 
         sd = StrictDataset(sample)
+        sd.sample.record_operation("", "")
+
         path = "nexus/file/path"
         sample_name = "sample-name"
 
@@ -274,6 +276,7 @@ class IOTest(FileOutputtingTestCase):
             image_stack._projection_angles = image_stack.projection_angles()
 
         sd = StrictDataset(*image_stacks)
+        sd.sample.record_operation("", "")
 
         with h5py.File("nexus/file/path", "w", driver="core", backing_store=False) as nexus_file:
             saver._nexus_save(nexus_file, sd, "sample-name")

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -272,14 +272,13 @@ class IOTest(FileOutputtingTestCase):
             image_stack._projection_angles = image_stack.projection_angles()
 
         sd = StrictDataset(*image_stacks)
-        sd.name = "strict-dataset"
 
         with h5py.File("nexus/file/path", "w", driver="core", backing_store=False) as nexus_file:
             saver._nexus_save(nexus_file, sd, "sample-name")
             tomo_entry = nexus_file["entry1"]["tomo_entry"]
 
             npt.assert_array_equal(
-                np.array(nexus_file["processed-data"][sd.name]["data"]),
+                np.array(nexus_file["processed-data"]["data"]),
                 np.concatenate(
                     [sd.dark_before.data, sd.flat_before.data, sd.sample.data, sd.flat_after.data,
                      sd.dark_after.data]).astype("float32"))
@@ -293,9 +292,8 @@ class IOTest(FileOutputtingTestCase):
             # test instrument/sample fields
             npt.assert_array_equal(np.array(tomo_entry["sample"]["rotation_angle"]),
                                    np.concatenate([images.projection_angles().value for images in image_stacks]))
-            self.assertEqual(nexus_file["processed-data"][sd.name]["rotation_angle"],
-                             tomo_entry["sample"]["rotation_angle"])
-            self.assertEqual(nexus_file["processed-data"][sd.name]["image_key"],
+            self.assertEqual(nexus_file["processed-data"]["rotation_angle"], tomo_entry["sample"]["rotation_angle"])
+            self.assertEqual(nexus_file["processed-data"]["image_key"],
                              tomo_entry["instrument"]["detector"]["image_key"])
 
     @mock.patch("mantidimaging.core.io.saver.h5py.File")

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -321,12 +321,6 @@ class IOTest(FileOutputtingTestCase):
                 np.concatenate(
                     [sd.dark_before.data, sd.flat_before.data, sd.sample.data, sd.flat_after.data,
                      sd.dark_after.data]).astype("float32"))
-            # test instrument field
-            npt.assert_array_equal(
-                np.array(tomo_entry["instrument"]["detector"]["image_key"]),
-                [2 for _ in range(sd.dark_before.data.shape[0])] + [1 for _ in range(sd.flat_before.data.shape[0])] +
-                [0 for _ in range(sd.sample.data.shape[0])] + [1 for _ in range(sd.flat_after.data.shape[0])] +
-                [2 for _ in range(sd.dark_after.data.shape[0])])
 
     @mock.patch("mantidimaging.core.io.saver.h5py.File")
     @mock.patch("mantidimaging.core.io.saver._nexus_save")

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -272,13 +272,14 @@ class IOTest(FileOutputtingTestCase):
             image_stack._projection_angles = image_stack.projection_angles()
 
         sd = StrictDataset(*image_stacks)
+        sd.name = "strict-dataset"
 
         with h5py.File("nexus/file/path", "w", driver="core", backing_store=False) as nexus_file:
             saver._nexus_save(nexus_file, sd, "sample-name")
             tomo_entry = nexus_file["entry1"]["tomo_entry"]
 
             npt.assert_array_equal(
-                np.array(nexus_file["processed-data"]["data"]),
+                np.array(nexus_file["processed-data"][sd.name]["data"]),
                 np.concatenate(
                     [sd.dark_before.data, sd.flat_before.data, sd.sample.data, sd.flat_after.data,
                      sd.dark_after.data]).astype("float32"))
@@ -292,8 +293,9 @@ class IOTest(FileOutputtingTestCase):
             # test instrument/sample fields
             npt.assert_array_equal(np.array(tomo_entry["sample"]["rotation_angle"]),
                                    np.concatenate([images.projection_angles().value for images in image_stacks]))
-            self.assertEqual(nexus_file["processed-data"]["rotation_angle"], tomo_entry["sample"]["rotation_angle"])
-            self.assertEqual(nexus_file["processed-data"]["image_key"],
+            self.assertEqual(nexus_file["processed-data"][sd.name]["rotation_angle"],
+                             tomo_entry["sample"]["rotation_angle"])
+            self.assertEqual(nexus_file["processed-data"][sd.name]["image_key"],
                              tomo_entry["instrument"]["detector"]["image_key"])
 
     @mock.patch("mantidimaging.core.io.saver.h5py.File")

--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -11,6 +11,7 @@ from typing import Optional, Tuple
 log = getLogger(__name__)
 
 DEFAULT_IO_FILE_FORMAT = 'tif'
+NEXUS_PROCESSED_DATA_PATH = "processed-data"
 
 THRESHOLD_180 = np.radians(1)
 

--- a/mantidimaging/gui/windows/main/test/strictdataset_test.py
+++ b/mantidimaging/gui/windows/main/test/strictdataset_test.py
@@ -275,3 +275,12 @@ class StrictDatasetTest(unittest.TestCase):
         empty_ds = StrictDataset(generate_images())
         with self.assertRaises(RuntimeError):
             _get_stack_data_type("bad-id", empty_ds)
+
+    def test_processed_is_true(self):
+        ds = StrictDataset(generate_images())
+        ds.sample.record_operation("", "")
+        self.assertTrue(ds.is_processed)
+
+    def test_processed_is_false(self):
+        ds = StrictDataset(generate_images())
+        self.assertFalse(ds.is_processed)

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -13,6 +13,7 @@ from mantidimaging.core.data.reconlist import ReconList
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset
+from mantidimaging.core.io.utility import NEXUS_PROCESSED_DATA_PATH
 from mantidimaging.core.parallel import utility as pu
 from mantidimaging.core.utility.data_containers import ProjectionAngles
 
@@ -184,9 +185,9 @@ class NexusLoadPresenter:
             return dataset
         else:
             assert self.nexus_file is not None
-            if "processed-data" in self.nexus_file:
-                dataset = self.nexus_file["processed-data"]["data"]
-                self.view.set_data_found(position, True, "processed-data", dataset.shape)
+            if NEXUS_PROCESSED_DATA_PATH in self.nexus_file:
+                dataset = self.nexus_file[NEXUS_PROCESSED_DATA_PATH]["data"]
+                self.view.set_data_found(position, True, NEXUS_PROCESSED_DATA_PATH, dataset.shape)
                 return dataset
 
         self._missing_data_error(DATA_PATH)

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -93,6 +93,7 @@ class NexusLoadPresenter:
                 self.data = self._look_for_tomo_data_and_update_view(DATA_PATH, 2)
                 if self.data is None:
                     return
+                    self.data = self._look_for_image_data_and_update_view(DATA_PATH, 2)
 
                 self.image_key_dataset = self._look_for_tomo_data_and_update_view(IMAGE_KEY_PATH, 0)
                 if self.image_key_dataset is None:
@@ -175,6 +176,18 @@ class NexusLoadPresenter:
         else:
             self.view.set_data_found(position, True, self.tomo_path + "/" + field, dataset.shape)
         return dataset
+
+    def _look_for_image_data_and_update_view(self) -> Optional[h5py.Dataset]:
+        position = 2
+        dataset = self._look_for_tomo_data(DATA_PATH)
+        if dataset is not None:
+            self.view.set_data_found(position, True, self.tomo_path + "/" + DATA_PATH, dataset.shape)
+            return dataset
+        else:
+            if "processed-data" in self.nexus_file:
+                dataset = self.nexus_file["processed-data"]["data"]
+                self.view.set_data_found(position, True, "processed-data", dataset.shape)
+                return dataset
 
     def _look_for_nxtomo_entry(self) -> Optional[h5py.Group]:
         """

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -90,10 +90,9 @@ class NexusLoadPresenter:
                 if self.tomo_entry is None:
                     return
 
-                self.data = self._look_for_tomo_data_and_update_view(DATA_PATH, 2)
+                self.data = self._look_for_image_data_and_update_view()
                 if self.data is None:
                     return
-                    self.data = self._look_for_image_data_and_update_view(DATA_PATH, 2)
 
                 self.image_key_dataset = self._look_for_tomo_data_and_update_view(IMAGE_KEY_PATH, 0)
                 if self.image_key_dataset is None:
@@ -188,6 +187,10 @@ class NexusLoadPresenter:
                 dataset = self.nexus_file["processed-data"]["data"]
                 self.view.set_data_found(position, True, "processed-data", dataset.shape)
                 return dataset
+
+        self._missing_data_error(DATA_PATH)
+        self.view.set_data_found(position, False, "", ())
+        self.view.disable_ok_button()
 
     def _look_for_nxtomo_entry(self) -> Optional[h5py.Group]:
         """

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -183,6 +183,7 @@ class NexusLoadPresenter:
             self.view.set_data_found(position, True, self.tomo_path + "/" + DATA_PATH, dataset.shape)
             return dataset
         else:
+            assert self.nexus_file is not None
             if "processed-data" in self.nexus_file:
                 dataset = self.nexus_file["processed-data"]["data"]
                 self.view.set_data_found(position, True, "processed-data", dataset.shape)
@@ -191,6 +192,7 @@ class NexusLoadPresenter:
         self._missing_data_error(DATA_PATH)
         self.view.set_data_found(position, False, "", ())
         self.view.disable_ok_button()
+        return None
 
     def _look_for_nxtomo_entry(self) -> Optional[h5py.Group]:
         """

--- a/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
@@ -377,8 +377,9 @@ class NexusLoaderTest(unittest.TestCase):
 
     def test_look_for_image_data_and_update_view_with_nonprocessed_file(self):
         self.nexus_loader.tomo_entry = self.tomo_entry
+        self.nexus_loader.tomo_path = self.full_tomo_path
         self.assertIsNotNone(self.nexus_loader._look_for_image_data_and_update_view())
-        self.view.set_data_found.assert_called_once_with(2, True, self.tomo_path + "/" + DATA_PATH,
+        self.view.set_data_found.assert_called_once_with(2, True, self.full_tomo_path + "/" + DATA_PATH,
                                                          self.tomo_entry[DATA_PATH].shape)
 
     def test_look_for_image_data_and_update_view_with_processed_file(self):


### PR DESCRIPTION
### Issue

CLoses #1739 

### Description

Loads processed NeXus data.

### Testing 

Added tests for reading as well as saving to the expected place depending on whether or not the data has been processed.

### Acceptance Criteria 

Check that a processed NeXus file can be read back into Imaging.

### Documentation

Updated release notes.
