### PR TITLE
Fix API links in docs

### DIFF
--- a/docs/ext/operations_user_doc.py
+++ b/docs/ext/operations_user_doc.py
@@ -77,7 +77,7 @@ class OperationsUserDoc(Directive):
                 rst_lines += get_params(op.filter_func.__doc__)
                 rst_lines.append("")
 
-            rst_lines.append(f":class:`{op.filter_name} API docs<{op.__module__}>`")
+            rst_lines.append(f":class:`{op.filter_name} API docs<mantidimaging.core.operations.{op.__module__}>`")
             rst_lines.append("")
 
         rst = ViewList()

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -46,6 +46,7 @@ Fixes
 - #1730 : Allow any characters in filenames
 - #1698 : Store processed (but not reconstructed) data in a different place in the nexus file
 - #1748 : Stop BHC promoting data arrays to float64
+- #1747 : Fix API links in docs
 
 Developer Changes
 -----------------


### PR DESCRIPTION
### Issue
Closes #1747 

### Description

Add full path to module in link

### Acceptance Criteria 

See issue for building the docs. Confirm that the Operations list page now has links to the API docs.

### Documentation

Release notes
