### PR TITLE
Fix preview button in load dialog

### DIFF
--- a/mantidimaging/gui/windows/image_load_dialog/field.py
+++ b/mantidimaging/gui/windows/image_load_dialog/field.py
@@ -169,9 +169,12 @@ class Field:
         # Enforce the maximum step (ensure a minimum of 1)
         self._increment.setMaximum(max(number_of_images, 1))
 
-    def set_step(self, value: int) -> None:
+    def set_preview(self, preview_mode: bool) -> None:
         if self._increment_spinbox is not None:
-            self._increment_spinbox.setValue(value)
+            if preview_mode:
+                self._increment_spinbox.setValue(self._stop.maximum() // 10)
+            else:
+                self._increment_spinbox.setValue(1)
 
     def _update_expected_mem_usage(self, shape: Tuple[int, int]) -> Tuple[int, float]:
         num_images = size_calculator.number_of_images_from_indices(self._start.value(), self._stop.value(),

--- a/mantidimaging/gui/windows/image_load_dialog/view.py
+++ b/mantidimaging/gui/windows/image_load_dialog/view.py
@@ -100,11 +100,10 @@ class ImageLoadDialog(BaseDialogView):
             return None
 
     def _set_all_step(self) -> None:
-        self.sample.set_step(1)
+        self.sample.set_preview(False)
 
     def _set_preview_step(self) -> None:
-        # FIXME direct attribute access
-        self.sample.set_step(self.presenter.last_file_info.shape[0] // 10)
+        self.sample.set_preview(True)
 
     def get_parameters(self) -> LoadingParameters:
         return self.presenter.get_parameters()

--- a/mantidimaging/gui/windows/image_load_dialog/view.py
+++ b/mantidimaging/gui/windows/image_load_dialog/view.py
@@ -79,7 +79,7 @@ class ImageLoadDialog(BaseDialogView):
         return field
 
     @staticmethod
-    def select_file(caption: str, image_file=True) -> Optional[str]:
+    def select_file(caption: str, image_file: bool = True) -> Optional[str]:
         """
         :param caption: Title of the file browser window that will be opened
         :param image_file: Whether or not the file being looked for is an image
@@ -99,19 +99,16 @@ class ImageLoadDialog(BaseDialogView):
         else:
             return None
 
-    def _set_all_step(self):
+    def _set_all_step(self) -> None:
         self.sample.set_step(1)
 
-    def _set_preview_step(self):
+    def _set_preview_step(self) -> None:
         # FIXME direct attribute access
         self.sample.set_step(self.presenter.last_file_info.shape[0] // 10)
 
     def get_parameters(self) -> LoadingParameters:
         return self.presenter.get_parameters()
 
-    def show_error(self, msg, traceback):
-        self.parent_view.presenter.show_error(msg, traceback)
-
-    def enable_preview_all_buttons(self):
+    def enable_preview_all_buttons(self) -> None:
         self.step_preview.setEnabled(True)
         self.step_all.setEnabled(True)


### PR DESCRIPTION
### Issue

CLoses #1740

### Description

Add some type annotations that should have caught the original issue.

Re-jig how the increment is adjusted.

### Testing 
Better type annotations

### Acceptance Criteria 

File -> Load Dataset and select a sample.
Clicking 'Preview' should adjust the increment such that approx 10 projections will be loaded.
Clicking 'All' will set the increment back to 1
If loaded after pressing preview, only 10 (or 11) projections should be loaded.

### Documentation
Not needed
