### PR TITLE
Only apply user specified log level to mantidimaging

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -71,3 +71,4 @@ Developer Changes
 - #1643 : Deprecations in GitHub actions
 - #1726, #1728 : Use FilenameGroup for Load Dataset
 - #1754 : Migrate Centos7 and Ubuntu18 Docker images from DockerHub to GitHub Container Registry
+- #1757 : CLI log level only on to mantidimaging

--- a/mantidimaging/helper.py
+++ b/mantidimaging/helper.py
@@ -35,11 +35,8 @@ def initialise_logging(default_level=logging.DEBUG):
     console_handler.setFormatter(_log_formatter)
     root_logger.addHandler(console_handler)
 
-    # Default log level
-    root_logger.setLevel(default_level)
-
-    # Don't ever print all the debug logging from Qt
-    logging.getLogger('PyQt5').setLevel(logging.INFO)
+    # Default log level for mantidimaging only
+    logging.getLogger('mantidimaging').setLevel(default_level)
 
 
 def check_data_stack(data, expected_dims=3, expected_class=ImageStack):


### PR DESCRIPTION
### Issue

Closes #1757 

### Description

Only apply user specified log level to mantidimaging

### Acceptance Criteria 

See #1757 . With patch there should not be DEBUG messages from 3rd party libraries.

### Documentation
Release notes
