### PR TITLE
Update CIL memory calc for SPDHG

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -49,6 +49,7 @@ Fixes
 - #1748 : Stop BHC promoting data arrays to float64
 - #1747 : Fix API links in docs
 - #1721 : For SPDHG show projections per subset
+- #1720 : Update memory requirements for SPDHG
 
 Developer Changes
 -----------------

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -245,7 +245,10 @@ class CILRecon(BaseRecon):
         projection_size = full_size_KB(images.data.shape, images.dtype)
         recon_volume_shape = pixel_num_h, pixel_num_h, pixel_num_v
         recon_volume_size = full_size_KB(recon_volume_shape, images.dtype)
-        estimated_mem_required = 5 * projection_size + 13 * recon_volume_size
+        if recon_params.stochastic:
+            estimated_mem_required = 3 * projection_size + 14 * recon_volume_size
+        else:
+            estimated_mem_required = 5 * projection_size + 13 * recon_volume_size
         free_mem = system_free_memory().kb()
 
         if (estimated_mem_required > free_mem):

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -262,12 +262,11 @@ class CILRecon(BaseRecon):
 
         with cil_mutex:
             t0 = time.perf_counter()
-            LOG.info(
-                f"Starting 3D PDHG-TV reconstruction: input shape {images.data.shape}"
-                f"output shape {recon_volume_shape}\n"
-                f"Num iter {recon_params.num_iter}, alpha {recon_params.alpha}, "
-                f"Non-negative {recon_params.non_negative},",
-                f"Stochastic {recon_params.stochastic}, subsets {num_subsets}")
+            LOG.info(f"Starting 3D PDHG-TV reconstruction: input shape {images.data.shape}"
+                     f"output shape {recon_volume_shape}\n"
+                     f"Num iter {recon_params.num_iter}, alpha {recon_params.alpha}, "
+                     f"Non-negative {recon_params.non_negative},"
+                     f"Stochastic {recon_params.stochastic}, subsets {num_subsets}")
             progress.update(steps=1, msg='CIL: Setting up reconstruction', force_continue=False)
             angles = images.projection_angles(recon_params.max_projection_angle).value
 


### PR DESCRIPTION
### Issue

Closes #1720 

### Description

The memory requirement for SPDHG is different from PDHG. When runing SPDHG use 3 and 14 as the coefficients.

Also fix a change to the log message in the previous SPDHG PR.

### Acceptance Criteria 

Try a reconstruction with CIL on an uncropped dataset. When pressing "Reconstruct Volume" and message should be given saying that there is not enough memory to continue.

### Documentation

Release notes
