### PR TITLE
1765: NeXus float/int save option

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -33,6 +33,7 @@ New Features and improvements
 - #1225 : Loading of Golden Ratio datasets
 - #1739 : Load processed NeXus data
 - #1762 : NSIS installer for Windows
+- #1765 : NeXus float/int save option
 
 Fixes
 -----

--- a/docs/user_guide/gui/loading_saving.rst
+++ b/docs/user_guide/gui/loading_saving.rst
@@ -125,7 +125,9 @@ Save as a NeXus File
 
 When *Save as NeXus File* is selected the save NeXus dialog appears. Only Datasets
 with sample images data can be saved as NeXus files. A sample name and an output
-directory are required before a save can be attempted.
+directory are required before a save can be attempted. The image data (excluding
+recons) can be saved as either float 32 or int 16. Users should be aware that
+there will be data loss when saving as int.
 
 .. note::
     Recon data is currently saved as float16.

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -272,7 +272,7 @@ def _save_image_stacks_to_nexus(dataset: StrictDataset, data_group: h5py.Group, 
         dtype = "float32"
     else:
         data, _ = _convert_float_to_int(dataset.nexus_arrays)
-        dtype = "int32"
+        dtype = "int16"
 
     data_group.create_dataset("data", shape=combined_data_shape, dtype=dtype)
 

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -291,11 +291,10 @@ def _convert_float_to_int(arrays: List[np.ndarray]) -> Tuple[List[np.ndarray], L
     factors = []
 
     def scale_row(row):
-        return np.round(row * scaling_factor).astype(int)
+        return np.round(row * scaling_factor).astype("int16")
 
     for arr in arrays:
-        max_decimal_places = np.max([len(str(f).split('.')[1]) for f in arr.flatten()])
-        scaling_factor = 10**max_decimal_places
+        scaling_factor = np.iinfo("int16").max / max(abs(arr.min()), abs(arr.max()))
         scaled_arr = np.apply_along_axis(scale_row, axis=1, arr=arr)
         converted.append(scaled_arr)
         factors.append(scaling_factor)

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -285,7 +285,7 @@ def _convert_float_to_int(arrays: List[np.ndarray]) -> Tuple[List[np.ndarray], L
     """
     Scales a float array to convert it to ints.
     :param arrays: The dataset arrays.
-    :return: A list of int arrays.
+    :return: A list of int arrays and a list of scaling factors.
     """
     converted = []
     factors = []

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -294,7 +294,7 @@ def _convert_float_to_int(arrays: List[np.ndarray]) -> Tuple[List[np.ndarray], L
         return np.round(row * scaling_factor).astype(int)
 
     for arr in arrays:
-        max_decimal_places = max_decimal_places = np.max([len(str(f).split('.')[1]) for f in arr.flatten()])
+        max_decimal_places = np.max([len(str(f).split('.')[1]) for f in arr.flatten()])
         scaling_factor = 10**max_decimal_places
         scaled_arr = np.apply_along_axis(scale_row, axis=1, arr=arr)
         converted.append(scaled_arr)

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -174,7 +174,7 @@ def image_save(images: ImageStack,
         return names
 
 
-def nexus_save(dataset: StrictDataset, path: str, sample_name: str):
+def nexus_save(dataset: StrictDataset, path: str, sample_name: str, save_as_float: bool):
     """
     Uses information from a StrictDataset to create a NeXus file.
     :param dataset: The dataset to save as a NeXus file.
@@ -187,7 +187,7 @@ def nexus_save(dataset: StrictDataset, path: str, sample_name: str):
         raise RuntimeError("Unable to save NeXus file. " + str(e))
 
     try:
-        _nexus_save(nexus_file, dataset, sample_name)
+        _nexus_save(nexus_file, dataset, sample_name, save_as_float)
     except OSError as e:
         nexus_file.close()
         os.remove(path)
@@ -196,7 +196,7 @@ def nexus_save(dataset: StrictDataset, path: str, sample_name: str):
     nexus_file.close()
 
 
-def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str):
+def _nexus_save(nexus_file: h5py.File, dataset: StrictDataset, sample_name: str, save_as_float: bool):
     """
     Takes a NeXus file and writes the StrictDataset information to it.
     :param nexus_file: The NeXus file.

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -483,7 +483,7 @@ class IOTest(FileOutputtingTestCase):
         conv, factors = _convert_float_to_int(float_arr)
 
         for i in range(n_arrs):
-            close_arr = np.isclose(conv[i] / factors[i], float_arr[i], rtol=1e-4)
+            close_arr = np.isclose(conv[i] / factors[i], float_arr[i], rtol=1e-5)
             self.assertTrue(np.count_nonzero(close_arr) >= len(close_arr) * 0.75)
 
 

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -57,7 +57,7 @@ def test_convert_float_to_int():
     conv, factors = _convert_float_to_int(float_arr)
 
     for i in range(n_arrs):
-        npt.assert_allclose(conv[i] / factors[i], float_arr[i])
+        npt.assert_allclose(conv[i] / factors[i], float_arr[i], rtol=1e-5)
 
 
 class IOTest(FileOutputtingTestCase):

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -20,7 +20,8 @@ from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.core.io import loader
 from mantidimaging.core.io import saver
-from mantidimaging.core.io.saver import _rescale_recon_data, _save_recon_to_nexus, _save_processed_data_to_nexus
+from mantidimaging.core.io.saver import _rescale_recon_data, _save_recon_to_nexus, _save_processed_data_to_nexus, \
+    _save_image_stacks_to_nexus
 from mantidimaging.core.utility.version_check import CheckVersion
 from mantidimaging.helper import initialise_logging
 from mantidimaging.test_helpers import FileOutputtingTestCase
@@ -468,6 +469,15 @@ class IOTest(FileOutputtingTestCase):
             self.assertEqual(
                 _nexus_dataset_to_string(nexus_file[recon_name]["reconstruction"]["parameters"]["raw_file"]),
                 self.sample_path)
+
+    def test_save_image_stacks_to_nexus_as_int(self):
+
+        ds = StrictDataset(th.generate_images())
+
+        with h5py.File("path", "w", driver="core", backing_store=False) as nexus_file:
+            data = nexus_file.create_group("data")
+            _save_image_stacks_to_nexus(ds, data, False)
+            self.assertEqual(data["data"].dtype, "int32")
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -51,15 +51,6 @@ def test_rescale_negative_recon_data():
     assert int(np.max(_rescale_recon_data(recon.data))) == np.iinfo("uint16").max
 
 
-def test_convert_float_to_int():
-    n_arrs = 3
-    float_arr = [th.gen_img_numpy_rand() for _ in range(3)]
-    conv, factors = _convert_float_to_int(float_arr)
-
-    for i in range(n_arrs):
-        npt.assert_allclose(conv[i] / factors[i], float_arr[i], rtol=1e-5)
-
-
 class IOTest(FileOutputtingTestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -485,6 +476,15 @@ class IOTest(FileOutputtingTestCase):
             data = nexus_file.create_group("data")
             _save_image_stacks_to_nexus(ds, data, False)
             self.assertEqual(data["data"].dtype, "int16")
+
+    def test_convert_float_to_int(self):
+        n_arrs = 3
+        float_arr = [th.gen_img_numpy_rand() for _ in range(3)]
+        conv, factors = _convert_float_to_int(float_arr)
+
+        for i in range(n_arrs):
+            close_arr = np.isclose(conv[i] / factors[i], float_arr[i], rtol=1e-4)
+            self.assertTrue(np.count_nonzero(close_arr) >= len(close_arr) * 0.75)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -484,7 +484,7 @@ class IOTest(FileOutputtingTestCase):
         with h5py.File("path", "w", driver="core", backing_store=False) as nexus_file:
             data = nexus_file.create_group("data")
             _save_image_stacks_to_nexus(ds, data, False)
-            self.assertEqual(data["data"].dtype, "int32")
+            self.assertEqual(data["data"].dtype, "int16")
 
 
 if __name__ == '__main__':

--- a/mantidimaging/gui/ui/nexus_save_dialog.ui
+++ b/mantidimaging/gui/ui/nexus_save_dialog.ui
@@ -48,9 +48,12 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QRadioButton" name="intRadioButton">
+      <widget class="QRadioButton" name="floatRadioButton">
        <property name="text">
-        <string>int</string>
+        <string>float</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -65,9 +68,9 @@
       <widget class="QLineEdit" name="sampleNameLineEdit"/>
      </item>
      <item row="3" column="1">
-      <widget class="QRadioButton" name="floatRadioButton">
+      <widget class="QRadioButton" name="intRadioButton">
        <property name="text">
-        <string>float</string>
+        <string>int</string>
        </property>
       </widget>
      </item>

--- a/mantidimaging/gui/ui/nexus_save_dialog.ui
+++ b/mantidimaging/gui/ui/nexus_save_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>432</width>
-    <height>148</height>
+    <width>444</width>
+    <height>221</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,10 +26,31 @@
        </property>
       </widget>
      </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="sampleNameLabel">
+       <property name="text">
+        <string>Sample Name:</string>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Output Directory:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="formatLabel">
+       <property name="text">
+        <string>Format:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QRadioButton" name="intRadioButton">
+       <property name="text">
+        <string>int</string>
        </property>
       </widget>
      </item>
@@ -40,15 +61,15 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="sampleNameLabel">
-       <property name="text">
-        <string>Sample Name:</string>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="1">
       <widget class="QLineEdit" name="sampleNameLineEdit"/>
+     </item>
+     <item row="3" column="1">
+      <widget class="QRadioButton" name="floatRadioButton">
+       <property name="text">
+        <string>float</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/mantidimaging/gui/ui/nexus_save_dialog.ui
+++ b/mantidimaging/gui/ui/nexus_save_dialog.ui
@@ -50,7 +50,7 @@
      <item row="2" column="1">
       <widget class="QRadioButton" name="floatRadioButton">
        <property name="text">
-        <string>float</string>
+        <string>float 32</string>
        </property>
        <property name="checked">
         <bool>true</bool>
@@ -70,7 +70,7 @@
      <item row="3" column="1">
       <widget class="QRadioButton" name="intRadioButton">
        <property name="text">
-        <string>int</string>
+        <string>int 16</string>
        </property>
       </widget>
      </item>

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -80,9 +80,10 @@ class MainWindowModel(object):
         images.filenames = filenames
         return True
 
-    def do_nexus_saving(self, dataset_id: uuid.UUID, path: str, sample_name: str) -> Optional[bool]:
+    def do_nexus_saving(self, dataset_id: uuid.UUID, path: str, sample_name: str,
+                        save_as_float: bool) -> Optional[bool]:
         if dataset_id in self.datasets and isinstance(self.datasets[dataset_id], StrictDataset):
-            saver.nexus_save(self.datasets[dataset_id], path, sample_name)  # type: ignore
+            saver.nexus_save(self.datasets[dataset_id], path, sample_name, save_as_float)  # type: ignore
             return True
         else:
             raise RuntimeError(f"Failed to get StrictDataset with ID {dataset_id}")

--- a/mantidimaging/gui/windows/main/nexus_save_dialog.py
+++ b/mantidimaging/gui/windows/main/nexus_save_dialog.py
@@ -5,7 +5,7 @@ import os
 import uuid
 from typing import Optional, List
 
-from PyQt5.QtWidgets import QDialogButtonBox, QFileDialog
+from PyQt5.QtWidgets import QDialogButtonBox, QFileDialog, QRadioButton
 
 from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.gui.mvp_base import BaseDialogView
@@ -16,6 +16,8 @@ NXS_EXT = ".nxs"
 class NexusSaveDialog(BaseDialogView):
 
     selected_dataset = Optional[uuid.UUID]
+    floatRadioButton: QRadioButton
+    intRadioButton: QRadioButton
 
     def __init__(self, parent, dataset_list: List[StrictDataset]):
         super().__init__(parent, 'gui/ui/nexus_save_dialog.ui')
@@ -63,3 +65,7 @@ class NexusSaveDialog(BaseDialogView):
         path = self.save_path()
         if os.path.splitext(path)[1] != NXS_EXT:
             self.savePath.setText(path + NXS_EXT)
+
+    @property
+    def save_as_float(self) -> bool:
+        return self.floatRadioButton.isChecked()

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -149,7 +149,8 @@ class MainWindowPresenter(BasePresenter):
                               self._on_save_done, {
                                   'dataset_id': dataset_id,
                                   'path': self.view.nexus_save_dialog.save_path(),
-                                  'sample_name': self.view.nexus_save_dialog.sample_name()
+                                  'sample_name': self.view.nexus_save_dialog.sample_name(),
+                                  'save_as_float': self.view.nexus_save_dialog.save_as_float
                               },
                               busy=True)
 

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -507,14 +507,14 @@ class MainWindowModelTest(unittest.TestCase):
 
     def test_do_nexus_saving_fails_from_no_dataset(self):
         with self.assertRaises(RuntimeError):
-            self.model.do_nexus_saving("bad-dataset-id", "path", "sample-name")
+            self.model.do_nexus_saving("bad-dataset-id", "path", "sample-name", True)
 
     def test_do_nexus_saving_fails_from_wrong_dataset(self):
         md = MixedDataset()
         self.model.add_dataset_to_model(md)
 
         with self.assertRaises(RuntimeError):
-            self.model.do_nexus_saving(md.id, "path", "sample-name")
+            self.model.do_nexus_saving(md.id, "path", "sample-name", True)
 
     @mock.patch("mantidimaging.gui.windows.main.model.saver.nexus_save")
     def test_do_nexus_save_success(self, nexus_save):
@@ -522,9 +522,10 @@ class MainWindowModelTest(unittest.TestCase):
         self.model.add_dataset_to_model(sd)
         path = "path"
         sample_name = "sample-name"
+        save_as_float = True
 
-        self.model.do_nexus_saving(sd.id, path, sample_name)
-        nexus_save.assert_called_once_with(sd, path, sample_name)
+        self.model.do_nexus_saving(sd.id, path, sample_name, save_as_float)
+        nexus_save.assert_called_once_with(sd, path, sample_name, save_as_float)
 
     def test_is_dataset_strict_returns_true(self):
         strict_ds = StrictDataset(generate_images())

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -754,6 +754,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         nexus_save_dialog_mock.save_path.return_value = save_path = "nexus/save/path"
         nexus_save_dialog_mock.sample_name.return_value = sample_name = "sample-name"
         nexus_save_dialog_mock.selected_dataset = dataset_id = "dataset-id"
+        nexus_save_dialog_mock.save_as_float = save_as_float = False
 
         self.presenter.notify(Notification.NEXUS_SAVE)
         start_async_mock.assert_called_once_with(self.presenter.view,
@@ -761,7 +762,8 @@ class MainWindowPresenterTest(unittest.TestCase):
                                                  self.presenter._on_save_done, {
                                                      'dataset_id': dataset_id,
                                                      'path': save_path,
-                                                     'sample_name': sample_name
+                                                     'sample_name': sample_name,
+                                                     'save_as_float': save_as_float
                                                  },
                                                  busy=True)
 


### PR DESCRIPTION
### Issue

Closes #1765

### Description

Adds the option to save NeXus data as float or int.

### Testing 

Added tests for the conversion and some method calls.

### Acceptance Criteria 

Save a NeXus file as int and open it. Check that the data looks the same but has been scaled.

### Documentation

Updated release notes.
