### PR TITLE
Hide float64 option when loading images

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -51,6 +51,7 @@ Fixes
 - #1721 : For SPDHG show projections per subset
 - #1720 : Update memory requirements for SPDHG
 - #1742 : Restore native dialogs on Linux
+- #1761 : Hide float64 loading
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/ui/image_load_dialog.ui
+++ b/mantidimaging/gui/ui/image_load_dialog.ui
@@ -230,7 +230,7 @@
       </spacer>
      </item>
      <item row="1" column="1">
-      <widget class="QLabel" name="label_5">
+      <widget class="QLabel" name="label_pixel_bit_depth">
        <property name="text">
         <string>Pixel Bit Depth:</string>
        </property>

--- a/mantidimaging/gui/windows/image_load_dialog/view.py
+++ b/mantidimaging/gui/windows/image_load_dialog/view.py
@@ -59,6 +59,9 @@ class ImageLoadDialog(BaseDialogView):
         self.pixelSize.setValue(DEFAULT_PIXEL_SIZE)
         self.pixel_bit_depth.setCurrentText(DEFAULT_PIXEL_DEPTH)
 
+        self.pixel_bit_depth.hide()
+        self.label_pixel_bit_depth.hide()
+
     def create_file_input(self, position: int, file_info: FILE_TYPES) -> Field:
         section: QTreeWidgetItem = self.tree.topLevelItem(position)
 

--- a/mantidimaging/gui/windows/nexus_load_dialog/view.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/view.py
@@ -79,6 +79,9 @@ class NexusLoadDialog(BaseDialogView):
         self.allPushButton.clicked.connect(self._set_all_step)
         self.n_proj = 0
 
+        self.pixelBitDepthLabel.hide()
+        self.pixelDepthComboBox.hide()
+
     def choose_nexus_file(self):
         """
         Select a NeXus file and attempt to load it. If a file is chosen, clear the information/widgets from the


### PR DESCRIPTION
### Issue

Closes #1761

### Description

Some parts of Mantid Imaging don't handle float64. There is not much benefit to the extra precision, only a large memory code. So hide the option, and probably remove it completely in the future.

### Acceptance Criteria 

Load Dataset and Load Nexus should no longer show the bit depth option.

### Documentation
release notes
