### PR TITLE
Force numexpr from conda-forge channel

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -54,6 +54,7 @@ Fixes
 - #1720 : Update memory requirements for SPDHG
 - #1742 : Restore native dialogs on Linux
 - #1761 : Hide float64 loading
+- #1774 : Force numexpr from conda-forge channel
 
 Developer Changes
 -----------------

--- a/environment.yml
+++ b/environment.yml
@@ -10,3 +10,4 @@ channels:
 # Dependencies that can be installed with conda should be in conda/meta.yaml
 dependencies:
   - mantidimaging
+  - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774


### PR DESCRIPTION
Otherwise can possibly get from intel channel which has issues finding libimf.so

### Issue
Closes #1774

### Description

Add a channel specifier to `numexpr` in the `environment.yml`.  It would have been nice to have been able to do this in `meta.yaml`, but that is not transferred to the package metadata.

Once this has merged check IDAaaS works again.

### Testing & Acceptance Criteria 

Try creating a nightly environment with
`mamba env create -f ~/git/mantidimaging/environment.yml`
and check the version with
`mamba list numexpr`
With the fix it should be from conda-forge

### Documentation

release_notes
