### PR TITLE
Force numexpr from conda-forge channel for dev

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -9,6 +9,7 @@ channels:
   - intel
 dependencies:
   - mantidimaging
+  - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774
   - pip
   - pip:
       - coveralls==3.3.*


### PR DESCRIPTION


### Issue
Closes #1787 

### Description

Should have been included in #1775 . We were not seeing problems with the dev environment at the time, but now its clear that this is needed for dev too.

### Acceptance Criteria 

`python3 ./setup.py create_dev_env` should succeed.