### PR TITLE
Separate arch packages

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -126,8 +126,8 @@ jobs:
       # Label as 'windows-build-test' for testing purposes.
       # To re-enable, use the if rule from the conda workflow and change label to 'unstable' after testing
       - name: publish package
-        if: false
+        if: github.event_name == 'release' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release')))
         uses: ./.github/actions/publish-package
         with:
-          label: windows-build-test
+          label: unstable
           token: ${{ secrets.ANACONDA_API_TOKEN }}

--- a/conda/bld.bat
+++ b/conda/bld.bat
@@ -1,0 +1,3 @@
+python conda\make_versions.py
+python -m pip install --ignore-installed .
+del mantidimaging\versions.py

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -39,7 +39,6 @@ requirements:
     - qt-gtk-platformtheme # [linux]
 
 build:
-  noarch: python
   number: 1
   entry_points:
     - mantidimaging = mantidimaging.main:main

--- a/docs/release_notes/2.5.rst
+++ b/docs/release_notes/2.5.rst
@@ -111,3 +111,4 @@ Developer Changes
 - #1726, #1728 : Use FilenameGroup for Load Dataset
 - #1754 : Migrate Centos7 and Ubuntu18 Docker images from DockerHub to GitHub Container Registry
 - #1757 : CLI log level only on to mantidimaging
+- #1788 : Switch to separate Windows and Linux conda packages


### PR DESCRIPTION
### Issue

Closes #1788

### Description
Make package arch specific to allow different dependencies.
Enable windows package build on merge to main
Add `bld.bat` to do the package build part on windows.

### Testing 
I have tested building packages. These built and uploaded to conda.


Check that
`mamba env create -f https://raw.githubusercontent.com/mantidproject/mantidimaging/main/environment.yml`
installs successfully.

### Documentation

Release notes
