### PR TITLE
1694 roi vis

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -110,9 +110,10 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def get_default_table_state(self) -> list:
         """
-        Get the default state of the table
+        Get the default state of the table for the view:
+        [ROI name:str, colour:float, visibility: bool]
         """
-        return [self.roi_name, self.view.spectrum.roi_dict[self.roi_name].colour]
+        return [self.roi_name, self.view.spectrum.roi_dict[self.roi_name].colour, True]
 
     def handle_range_slide_moved(self, tof_range) -> None:
         self.model.tof_range = tof_range
@@ -128,6 +129,12 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                 self.model.set_roi(name, roi)
                 self.view.set_spectrum(name, self.model.get_spectrum(name, self.spectrum_mode))
 
+    def redraw_spectrum(self, name: str) -> None:
+        """
+        Redraw the spectrum with the given name
+        """
+        self.view.set_spectrum(name, self.model.get_spectrum(name, self.spectrum_mode))
+
     def redraw_all_rois(self) -> None:
         """
         Redraw all ROIs and spectrum plots
@@ -135,6 +142,15 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         for name in self.model.get_list_of_roi_names():
             self.model.set_roi(name, self.view.spectrum.get_roi(name))
             self.view.set_spectrum(name, self.model.get_spectrum(name, self.spectrum_mode))
+
+    def do_set_roi_alpha(self, name: str, alpha: float) -> None:
+        """
+        Set the alpha value of the ROI with the given name
+
+        :param name: The name of the ROI
+        :param alpha: The new alpha value (0-255)
+        """
+        self.view.spectrum.set_roi_alpha(name, alpha)
 
     def handle_export_button_enabled(self) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
@@ -29,7 +29,7 @@ class SpectrumWidgetTest(unittest.TestCase):
 
     def test_WHEN_colour_generator_called_THEN_return_value_of_length_3(self):
         colour = self.spectrum_widget.random_colour_generator()
-        self.assertEqual(len(colour), 3)
+        self.assertEqual(len(colour), 4)
 
     def test_WHEN_colour_generator_called_THEN_valid_rgb_tuple_returned(self):
         colour = self.spectrum_widget.random_colour_generator()
@@ -38,6 +38,61 @@ class SpectrumWidgetTest(unittest.TestCase):
     def test_WHEN_colour_generator_called_THEN_different_colours_returned(self):
         colour_list = [self.spectrum_widget.random_colour_generator() for _ in range(10)]
         self.assertEqual(len(colour_list), len(set(tuple(c) for c in colour_list)))
+
+    def test_WHEN_change_roi_colour_called_THEN_roi_colour_changed(self):
+        spectrum_roi = SpectrumROI("roi",
+                                   self.sensible_roi,
+                                   pos=(0, 0),
+                                   rotatable=False,
+                                   scaleSnap=True,
+                                   translateSnap=True)
+        self.spectrum_widget.roi_dict["roi"] = spectrum_roi
+        self.spectrum_widget.spectrum_data_dict["roi"] = np.array([0, 0, 0, 0])
+        roi_colour = self.spectrum_widget.roi_dict["roi"].pen.color().getRgb()
+        self.spectrum_widget.change_roi_colour("roi", (255, 0, 0, 255))
+        self.assertEqual(self.spectrum_widget.roi_dict["roi"].pen.color().getRgb(), (255, 0, 0, 255))
+        self.assertNotEqual(self.spectrum_widget.roi_dict["roi"].pen.color().getRgb(), roi_colour)
+
+    @parameterized.expand([("Visible", "visible_roi", 1), ("Invisible", "invisible_roi", 0)])
+    def test_WHEN_set_roi_visibility_flags_called_THEN_roi_Visibility_flags_toggled(self, _, name, alpha):
+        spectrum_roi = SpectrumROI(name,
+                                   self.sensible_roi,
+                                   pos=(0, 0),
+                                   rotatable=False,
+                                   scaleSnap=True,
+                                   translateSnap=True)
+        self.spectrum_widget.roi_dict[name] = spectrum_roi
+        self.spectrum_widget.spectrum_data_dict[name] = np.array([0, 0, 0, 0])
+        self.spectrum_widget.set_roi_visibility_flags(name, alpha)
+        self.assertEqual(bool(alpha), self.spectrum_widget.roi_dict[name].isVisible())
+
+    @parameterized.expand([("Visible", "visible_roi", 1), ("Invisible", "invisible_roi", 0)])
+    def test_WHEN_set_roi_alpha_called_THEN_roi_alpha_updated(self, _, name, alpha):
+        spectrum_roi = SpectrumROI(name,
+                                   self.sensible_roi,
+                                   pos=(0, 0),
+                                   rotatable=False,
+                                   scaleSnap=True,
+                                   translateSnap=True)
+        self.spectrum_widget.roi_dict[name] = spectrum_roi
+        self.spectrum_widget.spectrum_data_dict[name] = np.array([0, 0, 0, 0])
+        self.spectrum_widget.set_roi_alpha(name, alpha)
+        self.assertEqual(self.spectrum_widget.roi_dict[name].pen.color().getRgb()[-1], alpha)
+        self.assertEqual(self.spectrum_widget.roi_dict[name].hoverPen.color().getRgb()[-1], alpha)
+
+    @parameterized.expand([("Visible", "visible_roi", 1), ("Invisible", "invisible_roi", 0)])
+    def test_WHEN_set_roi_alpha_called_THEN_set_roi_visibility_flags_called(self, _, name, alpha):
+        spectrum_roi = SpectrumROI(name,
+                                   self.sensible_roi,
+                                   pos=(0, 0),
+                                   rotatable=False,
+                                   scaleSnap=True,
+                                   translateSnap=True)
+        self.spectrum_widget.roi_dict[name] = spectrum_roi
+        self.spectrum_widget.spectrum_data_dict[name] = np.array([0, 0, 0, 0])
+        with mock.patch.object(SpectrumWidget, "set_roi_visibility_flags") as mock_set_roi_visibility_flags:
+            self.spectrum_widget.set_roi_alpha(name, alpha)
+            mock_set_roi_visibility_flags.assert_called_once_with(name, alpha)
 
     @parameterized.expand([("range_100", 0, 100), ("range_200", 100, 300), ("range_300", 200, 500)])
     def test_WHEN_add_range_called_THEN_region_and_label_set_correctly(self, _, range_min, range_max):

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from PyQt5.QtGui import QPixmap
-from PyQt5.QtWidgets import QCheckBox, QVBoxLayout, QFileDialog, QPushButton, QLabel, QAbstractItemView
+from PyQt5.QtWidgets import QCheckBox, QVBoxLayout, QFileDialog, QPushButton, QLabel, QAbstractItemView, QHeaderView
 
 from mantidimaging.core.utility import finder
 from mantidimaging.gui.mvp_base import BaseMainWindowView
@@ -15,10 +15,11 @@ from mantidimaging.gui.widgets import RemovableRowTableView
 from .spectrum_widget import SpectrumWidget
 from mantidimaging.gui.windows.spectrum_viewer.roi_table_model import TableModel
 
+import numpy as np
+
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
     from uuid import UUID
-    import numpy as np
 
 
 class SpectrumViewerWindowView(BaseMainWindowView):
@@ -68,15 +69,13 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.exportButton.clicked.connect(self.presenter.handle_export_csv)
 
         # Point table
-        self.tableView.horizontalHeader().setStretchLastSection(True)
         self.tableView.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.tableView.setSelectionMode(QAbstractItemView.SingleSelection)
-
         self.tableView.setAlternatingRowColors(True)
 
-        self.selected_row_data: list = []
         self.selected_row: int = 0
         self.current_roi: str = ""
+        self.selected_row_data: Optional[list] = None
 
         self.roi_table_model  # Initialise model
 
@@ -88,37 +87,56 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             @param item: item in table
             """
             self.removeBtn.setEnabled(False)
-            self.selected_row_data = self.roi_table_model.row_data(item.row())
+            selected_row_data = self.roi_table_model.row_data(item.row())
 
-            if self.selected_row_data[0] != self.presenter.roi_name:
+            if selected_row_data[0] != self.presenter.roi_name:
                 self.removeBtn.setEnabled(True)
             self.selected_row = item.row()
-            self.current_roi = self.selected_row_data[0]
+            self.current_roi = selected_row_data[0]
 
         self.tableView.selectionModel().currentRowChanged.connect(on_row_change)
 
-        def on_data_change() -> None:
+        def on_visibility_change() -> None:
             """
-            Handle ROI name change for a selected ROI and update the ROI name in the spectrum widget
-
-            If the ROI name is empty or already exists in the table that is not the selected row,
-            a warning popup will be displayed and the ROI name will be reverted to the previous name
+            When the visibility of an ROI is changed, update the visibility of the ROI in the spectrum widget
             """
-            if self.selected_row_data[0].lower() not in ["", "all"]:
-                for roi_item in range(self.roi_table_model.rowCount()):
-                    existing_roi_name = self.roi_table_model.row_data(roi_item)[0].lower()
-                    if existing_roi_name == self.selected_row_data[0].lower() and roi_item != self.selected_row:
-                        self.show_warning_dialog("Duplication Warning\nROI name already exists")
-                        self.selected_row_data[0] = self.current_roi
-                        return
-                self.presenter.rename_roi(self.current_roi, str(self.selected_row_data[0]))
-                self.current_roi = str(self.selected_row_data[0])
-                return
-            self.show_warning_dialog("ROI Name Warning\n"
-                                     "ROI name cannot be empty or equal to default names: 'all', 'roi'")
-            self.selected_row_data[0] = self.current_roi
+            for roi_item in range(self.roi_table_model.rowCount()):
+                if self.roi_table_model.row_data(roi_item)[2] is False:
+                    self.set_roi_alpha(0, roi_item)
+                else:
+                    self.set_roi_alpha(255, roi_item)
+                    self.presenter.redraw_spectrum(self.roi_table_model.row_data(roi_item)[0])
+            return
 
-        self.roi_table_model.dataChanged.connect(on_data_change)
+        def on_data_in_table_change() -> None:
+            """
+            Check if an ROI name has changed in the table or if the visibility of an ROI has changed.
+            If the ROI name has changed, update the ROI name in the spectrum widget.
+            If the visibility of an ROI has changed, update the visibility of the ROI in the spectrum widget.
+            """
+            selected_row_data = self.roi_table_model.row_data(self.selected_row)
+            if self.current_roi in ["", " "]:
+                self.current_roi = selected_row_data[0]
+            if selected_row_data[0].lower() not in ["", " ", "all"] and selected_row_data[0] != self.current_roi:
+                if selected_row_data[0] in self.presenter.get_roi_names():
+                    selected_row_data[0] = self.current_roi
+                    return
+                else:
+                    self.presenter.rename_roi(self.current_roi, selected_row_data[0])
+                    self.current_roi = selected_row_data[0]
+                    return
+            else:
+                selected_row_data[0] = self.current_roi
+
+            selected_row_data[0] = self.current_roi
+            on_visibility_change()
+            return
+
+        self.roi_table_model.dataChanged.connect(on_data_in_table_change)
+        header = self.tableView.horizontalHeader()
+        header.setSectionResizeMode(0, QHeaderView.Stretch)
+        header.setSectionResizeMode(1, QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(2, QHeaderView.ResizeToContents)
 
     def cleanup(self):
         self.sampleStackSelector.unsubscribe_from_main_window()
@@ -168,11 +186,14 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.spectrum.image.setImage(image_data, autoLevels=autoLevels)
 
     def set_spectrum(self, name: str, spectrum_data: 'np.ndarray'):
+        """
+        Try to set the spectrum data for a given ROI assuming the
+        roi may not exist in the spectrum widget yet depending on when method is called
+        """
         self.spectrum.spectrum_data_dict[name] = spectrum_data
         self.spectrum.spectrum.clearPlots()
 
         for key, value in self.spectrum.spectrum_data_dict.items():
-            # roi_dict may not be populated with yet on method call
             if key in self.spectrum.roi_dict:
                 self.spectrum.spectrum.plot(value, name=key, pen=self.spectrum.roi_dict[key].colour)
 
@@ -210,6 +231,27 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         """
         self.exportButton.setEnabled(enabled)
 
+    def set_roi_alpha(self, alpha: float, roi) -> None:
+        """
+        Set the alpha value for the selected ROI and update the spectrum to reflect the change.
+        A check is made on the spectrum to see if it exists as it may not have been created yet.
+
+        @param alpha: The alpha value
+        """
+        self.presenter.do_set_roi_alpha(self.roi_table_model.row_data(roi)[0], alpha)
+        if alpha == 0:
+            self.spectrum.spectrum_data_dict[self.roi_table_model.row_data(roi)[0]] = np.zeros(
+                self.spectrum.spectrum_data_dict[self.roi_table_model.row_data(roi)[0]].shape)
+        else:
+            self.spectrum.spectrum_data_dict[self.roi_table_model.row_data(roi)[0]] = self.spectrum.spectrum_data_dict[
+                self.roi_table_model.row_data(roi)[0]]
+
+        self.spectrum.spectrum.clearPlots()
+        self.spectrum.spectrum.update()
+        for key, value in self.spectrum.spectrum_data_dict.items():
+            if key in self.spectrum.roi_dict:
+                self.spectrum.spectrum.plot(value, name=key, pen=self.spectrum.roi_dict[key].colour)
+
     def add_roi_table_row(self, row: int, name: str, colour: str):
         """
         Add a new row to the ROI table
@@ -220,20 +262,23 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         """
         circle_label = QLabel()
         circle_label.setStyleSheet(f"background-color: {colour}; border-radius: 5px;")
-        self.roi_table_model.appendNewRow(name, colour)
+        self.roi_table_model.appendNewRow(name, colour, True)
         self.tableView.selectRow(row)
 
     def remove_roi(self) -> None:
         """
         Clear the selected ROI in the table view
         """
-        if self.selected_row_data:
+        selected_row = self.roi_table_model.row_data(self.selected_row)
+        if selected_row:
             self.roi_table_model.remove_row(self.selected_row)
-            self.presenter.do_remove_roi(self.selected_row_data[0])
+            self.presenter.do_remove_roi(selected_row[0])
             self.removeBtn.setEnabled(False)
-            self.spectrum.spectrum_data_dict.pop(self.selected_row_data[0])
-            self.spectrum.spectrum.removeItem(self.selected_row_data[0])
-            self.presenter.handle_roi_moved()  # Update plot View
+            self.spectrum.spectrum_data_dict.pop(selected_row[0])
+            self.spectrum.spectrum.removeItem(selected_row[0])
+            self.presenter.handle_roi_moved()
+            self.selected_row = 0
+            self.tableView.selectRow(0)
 
     def clear_all_rois(self) -> None:
         """


### PR DESCRIPTION
### Issue

Closes #1694 

### Description

Allow users to toggle visibility of ROI within the spectrum viewer to reduce clutter when working with multiple ROIs for a more user friendly experience which reduces the likelihood of accidentally moving/resizing the wrong ROI.

### Testing 

- `mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py`

### Acceptance Criteria 
-  [ ] Using the table of ROIs within the spectrum viewer, a user can toggle the visibility of multiple ROIs.
-  [ ] When the visibility of a given ROI is toggled, the ROI and corresponding spectrum line plot become invisible.
-  [ ] Invisible ROI and corresponding spectrum line plot are not intractable. 
-  [ ] Exporting a mixture of visible and invisible ROI exports all ROI as expected. 

*How should the reviewer test your changes*?

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*

![Screenshot 2023-05-16 at 18 13 03](https://github.com/mantidproject/mantidimaging/assets/32413847/0bc6237e-4e33-4e97-8a37-c916e873ee1b)

