### PR TITLE
Speed up package build

### DIFF
--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -26,9 +26,9 @@ runs:
       # We can't use the makefile target for this because the CONDA_ACTIVATE command is incompatible with GitHub Actions Windows runners
       conda create -n build-env
       conda activate build-env
-      conda install --yes conda-build anaconda-client conda-verify
+      conda install --yes boa anaconda-client conda-verify
       # Configure the conda channels
-      conda config --env $(cat environment-dev.yml | sed -ne '/channels:/,/dependencies:/{//!p}' | sed 's/ - / --append channels /g' | tr -d '\n')
+      conda config --env $(cat environment.yml | sed -ne '/channels:/,/dependencies:/{//!p}' | grep '^  -' | sed 's/ - / --append channels /g' | tr -d '\n')
 
   - name: Build package
     shell: bash -l {0}
@@ -36,6 +36,6 @@ runs:
       conda activate build-env
       conda config --set anaconda_upload yes
       # if the upload silently fails - check the token expiration. Conda can fail silently!
-      conda build --user ${{ inputs.repository }} --token ${{ inputs.token }} --label ${{ inputs.label }} $GITHUB_WORKSPACE/conda |& tee upload.log
+      conda mambabuild --user ${{ inputs.repository }} --token ${{ inputs.token }} --label ${{ inputs.label }} $GITHUB_WORKSPACE/conda |& tee upload.log
       # Check that upload completed
       grep "Upload complete" upload.log

--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -24,11 +24,12 @@ runs:
       conda config --set always_yes yes --set changeps1 no
       # Install build requirements
       # We can't use the makefile target for this because the CONDA_ACTIVATE command is incompatible with GitHub Actions Windows runners
-      conda create -n build-env
+      conda create -n build-env --yes boa anaconda-client conda-verify
       conda activate build-env
-      conda install --yes boa anaconda-client conda-verify
       # Configure the conda channels
       conda config --env $(cat environment.yml | sed -ne '/channels:/,/dependencies:/{//!p}' | grep '^  -' | sed 's/ - / --append channels /g' | tr -d '\n')
+      conda config --show channels
+
 
   - name: Build package
     shell: bash -l {0}

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,13 @@ install-conda-env:
 install-run-requirements:
 	conda install --yes --only-deps -c $$UPLOAD_USER mantidimaging
 
-CHANNELS:=$(shell cat environment.yml | sed -ne '/channels:/,/dependencies:/{//!p}' | grep '$  -' | sed 's/ - / --append channels /g' | tr -d '\n')
+CHANNELS:=$(shell cat environment.yml | sed -ne '/channels:/,/dependencies:/{//!p}' | grep '^  -' | sed 's/ - / --append channels /g' | tr -d '\n')
 
 install-build-requirements:
 	# intended for local use
 	@echo "Installing packages required for starting the build process"
 	conda create -n build-env
-	$(CONDA_ACTIVATE) build-env ; conda install --yes conda-build anaconda-client conda-verify
+	$(CONDA_ACTIVATE) build-env ; conda install --yes anaconda-client conda-verify boa
 	$(CONDA_ACTIVATE) build-env ; conda config --env $(CHANNELS)
 
 install-dev-requirements:
@@ -24,7 +24,7 @@ install-dev-requirements:
 
 build-conda-package: .remind-current install-build-requirements
 	# intended for local usage, does not install build requirements
-	$(CONDA_ACTIVATE) build-env ; conda-build ./conda --label unstable
+	$(CONDA_ACTIVATE) build-env ; conda mambabuild ./conda --label unstable
 
 build-conda-package-nightly: .remind-current .remind-for-user .remind-for-anaconda-api install-build-requirements
 	$(CONDA_ACTIVATE) build-env ; conda-build ./conda $(AUTHENTICATION_PARAMS) --label nightly

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ AUTHENTICATION_PARAMS=--user $$UPLOAD_USER --token $$ANACONDA_API_TOKEN
 
 #Needed because each command is run in a new shell
 SHELL=/bin/bash
-CONDA_ACTIVATE=source $$(conda info --base)/etc/profile.d/conda.sh ; conda activate ; conda activate
 
 install-conda-env:
 	conda env create -f environment.yml
@@ -15,22 +14,21 @@ CHANNELS:=$(shell cat environment.yml | sed -ne '/channels:/,/dependencies:/{//!
 install-build-requirements:
 	# intended for local use
 	@echo "Installing packages required for starting the build process"
-	conda create -n build-env
-	$(CONDA_ACTIVATE) build-env ; conda install --yes anaconda-client conda-verify boa
-	$(CONDA_ACTIVATE) build-env ; conda config --env $(CHANNELS)
+	conda create -n build-env anaconda-client conda-verify boa
+	conda run -n build-env conda config --env $(CHANNELS)
 
 install-dev-requirements:
 	conda env create -f environment-dev.yml
 
 build-conda-package: .remind-current install-build-requirements
 	# intended for local usage, does not install build requirements
-	$(CONDA_ACTIVATE) build-env ; conda mambabuild ./conda --label unstable
+	conda run -n build-env conda mambabuild conda --label unstable
 
 build-conda-package-nightly: .remind-current .remind-for-user .remind-for-anaconda-api install-build-requirements
-	$(CONDA_ACTIVATE) build-env ; conda-build ./conda $(AUTHENTICATION_PARAMS) --label nightly
+	conda run -n build-env conda-build conda $(AUTHENTICATION_PARAMS) --label nightly
 
 build-conda-package-release: .remind-current .remind-for-user .remind-for-anaconda-api install-build-requirements
-	$(CONDA_ACTIVATE) build-env ; conda-build ./conda $(AUTHENTICATION_PARAMS)
+	conda run -n build-env conda-build conda $(AUTHENTICATION_PARAMS)
 
 .remind-current:
 	@echo "Make sure the correct channels are added in \`conda config --get channels\`"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ install-conda-env:
 install-run-requirements:
 	conda install --yes --only-deps -c $$UPLOAD_USER mantidimaging
 
-CHANNELS:=$(shell cat environment-dev.yml | sed -ne '/channels:/,/dependencies:/{//!p}' | sed 's/ - / --append channels /g' | tr -d '\n')
+CHANNELS:=$(shell cat environment.yml | sed -ne '/channels:/,/dependencies:/{//!p}' | grep '$  -' | sed 's/ - / --append channels /g' | tr -d '\n')
 
 install-build-requirements:
 	# intended for local use

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -29,7 +29,6 @@ requirements:
     - astra-toolbox=2.0.*
     - requests=2.27.*
     - h5py=3.6.*
-    - sarepy=2020.07
     - psutil=5.9.*
     - cil=22.2.0
     - ccpi-regulariser

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -13,3 +13,4 @@ Fixes
 Developer Changes
 -----------------
 - #1796 : Add MyPy to pre-commit checks.
+- #1799 : Speed up packaged builds with boa

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -33,3 +33,4 @@ dependencies:
   - coverage==6.4.*
   - pyfakefs==5.0.*
   - pyinstaller==5.7.*
+  - sarepy=2020.07 # For building old docs

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,7 +8,7 @@ channels:
   - algotom
   - intel
 dependencies:
-  - mantidimaging
+  - mantidimaging>=2.5.0
   - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774
   - pip
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ channels:
   - intel
 # Dependencies that can be installed with conda should be in conda/meta.yaml
 dependencies:
-  - mantidimaging
+  - mantidimaging>=2.5.0
   - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: mantidimaging-nightly
 channels:
   - mantid/label/unstable
-  - dtasev
   - astra-toolbox
   - conda-forge
   - ccpi


### PR DESCRIPTION
### Issue
Closes #1793 

### Description

Remove sarepy from conda dependencies

Switch to boa for building

Clean ups to scripts: specify packages when creating the build-env. use conda run. 

Loose version constraint so that conda does not need to consider old versions

### Testing &  Acceptance Criteria 

Packages build on the PR are at:
https://anaconda.org/mantid/mantidimaging/files?channel=test

I have tested installing and running them on Linux and Windows

### Documentation

release notes