### PR TITLE
1777 compare images window naming

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -9,6 +9,7 @@ New Features
 
 Fixes
 -----
+- #1777 : More consistent menu and window naming for comparing image stack data.
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/ui/main_window.ui
+++ b/mantidimaging/gui/ui/main_window.ui
@@ -169,12 +169,12 @@
   </action>
   <action name="actionCompare_Images">
    <property name="text">
-    <string>Compare Images</string>
+    <string>Compare Image Stacks</string>
    </property>
   </action>
   <action name="actionCompareImages">
    <property name="text">
-    <string>Compare Images</string>
+    <string>Compare Image Stacks</string>
    </property>
   </action>
   <action name="actionSampleLoadLog">

--- a/mantidimaging/gui/windows/stack_choice/compare_presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/compare_presenter.py
@@ -17,7 +17,7 @@ class StackComparePresenter(StackChoicePresenterMixin):
 
         # forces the view's closeEvent to not prompt any dialogs, but only free the image views
         self.view.choice_made = True
-        self.view.setWindowTitle("Comparing data")
+        self.view.setWindowTitle("Compare Image Stacks")
 
         self.view.originalStackLabel.setText(stack_one.name)
         self.view.newStackLabel.setText(stack_two.name)


### PR DESCRIPTION
### Issue

Closes #1777 

### Description

Compare Images window has inconsistent naming. Menu to access window is called "Compare Images" while window is called "Compare Data". This PR proposes changing the name of both the window and menu to be called "Compare Image Stacks" as this is a more descriptive name of the windows functionality.

### Testing 

Visually check renaming of window and from main window options

### Acceptance Criteria 

- [ ] "Compare Data" and "Compare Images" renamed to "Compare Image Stacks".

### Documentation

Updated release notes under "Fixes" subheading
