### PR TITLE
1796 MyPy Pre-Commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,9 @@ repos:
         entry: python -m CheckLicensesInFiles
         language: python
         types: [python]
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v0.910'
+    hooks:
+    -   id: mypy
+        files: ^mantidimaging/
+        args: [--ignore-missing-imports, --no-site-packages]

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -12,3 +12,4 @@ Fixes
 
 Developer Changes
 -----------------
+- #1796 : Add MyPy to pre-commit checks.


### PR DESCRIPTION
### Issue

Closes #1796

### Description

Add MyPy Checks as Pre-Commit checks as extra validation that developers are producing MyPy compliant code and reducing the risk of type errors being introduced into the project.

### Testing 

- [ ] Checkout branch this branch locally and create some compliant MyPy code and try to commit it. Pre-commit should block the commit.

### Where
* `.pre-commit-config.yaml`

### Acceptance Criteria 

- [x] Only MyPy compliant code can be committed locally.

