### PR TITLE
Update to python 3.10

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -15,12 +15,12 @@ requirements:
     - python=3.9.*
     - setuptools=62.*
   run:
-    - python=3.9.*
+    - python=3.10.*
     - pip
     - astropy=5.0.*
     - scipy=1.7.*
     - scikit-image=0.19.*
-    - numpy=1.20.*
+    - numpy=1.21.*
     - numexpr=2.8.*
     - algotom=1.0.*
     - tomopy=1.12.*

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -14,3 +14,4 @@ Developer Changes
 -----------------
 - #1796 : Add MyPy to pre-commit checks.
 - #1799 : Speed up packaged builds with boa
+- #1792 : Update python to 3.10

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -16,7 +16,7 @@ from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
 from mantidimaging.core.utility.data_containers import ProjectionAngles
 from mantidimaging.gui.dialogs.async_task import TaskWorkerThread
 from mantidimaging.gui.windows.image_load_dialog import ImageLoadDialog
-from mantidimaging.gui.windows.main import MainWindowView, MainWindowPresenter
+from mantidimaging.gui.windows.main import MainWindowView, MainWindowPresenter, MainWindowModel
 from mantidimaging.gui.windows.main.presenter import Notification, RECON_TEXT
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
@@ -41,7 +41,8 @@ class MainWindowPresenterTest(unittest.TestCase):
                                      flat_after=self.images[2],
                                      dark_before=self.images[3],
                                      dark_after=self.images[4])
-        self.presenter.model = self.model = mock.Mock()
+        self.model_datasets_mock = mock.create_autospec(dict)
+        self.presenter.model = self.model = mock.create_autospec(MainWindowModel, datasets=self.model_datasets_mock)
         self.model.get_recons_id = mock.Mock()
 
         self.view.create_stack_window.return_value = dock_mock = mock.Mock()
@@ -273,7 +274,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
     def test_add_log_to_sample(self):
         self.presenter.add_log_to_sample("doesn't exist", "log file")
-        self.presenter.model.add_log_to_sample.assrt_called_with("doesn't exist", "log file")
+        self.presenter.model.add_log_to_sample.assert_called_with("doesn't exist", "log file")
 
     def test_do_rename_stack(self):
         self.presenter.stack_visualisers["stack-id"] = mock_stack = mock.Mock()
@@ -802,7 +803,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
     def test_show_add_stack_to_dataset_dialog_called_with_stack_id(self):
         dataset_id = "dataset-id"
-        self.model.datasets.keys.return_value = []
+        self.model_datasets_mock.keys.return_value = []
         self.model.get_parent_dataset.return_value = dataset_id
         self.presenter.notify(Notification.SHOW_ADD_STACK_DIALOG, container_id="stack-id")
         self.view.show_add_stack_to_existing_dataset_dialog.assert_called_once_with(dataset_id)


### PR DESCRIPTION
### Issue

Closes #1792 

### Description
Updates python to 3.10, and also numpy to 1.21 (needed for the python update)
This is the most up to date supported by CIL

Also fixes a typo in the tests, that new python picked up. I have switched here to using autospec, to reduce the risk of typos here.

### Testing 

Existing tests should all still pass

### Acceptance Criteria 

Create a new dev environment 
`python ./setup.py create_dev_env`

Check that MI still starts

### Documentation

