### PR TITLE
Create Roadmap Project Issue Assigner Action

### DIFF
--- a/.github/workflows/roadmap_assigner.yml
+++ b/.github/workflows/roadmap_assigner.yml
@@ -1,0 +1,18 @@
+name: Add EPICs to Roadmap Project
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/mantidproject/projects/24
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          labeled: EPIC


### PR DESCRIPTION
### Description

Create a GitHub action to automatically assign issues created using the EPICs issue template #1810 or issues with the label `EPIC` assigned to them

### Acceptance Criteria 

Workflow automatically adds issues with the label `EPIC` to the Roadmap Project Board

### Documentation

N/A
