### PR TITLE
Build deps and setup to Python 3.10

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 requirements:
   build:
-    - python=3.9.*
+    - python=3.10.*
     - setuptools=62.*
   run:
     - python=3.10.*

--- a/setup.py
+++ b/setup.py
@@ -238,7 +238,7 @@ setup(
     long_description=open("README.md").read(),
     test_suite="nose.collector",
     classifiers=[
-        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Natural Language :: English",
         "Intended Audience :: Science/Research",
         "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
### Issue

Closes #1792

### Description

Missed a few bits for python 3.10. Causes the package build to fail.

Update to 3.10 in the build deps and the setup file

### Testing & Acceptance Criteria 

Check for any more missed references to python 3.9

`git grep '3\.9'`

### Documentation

Already done in previous PR
