### PR TITLE
1776 fix compare img redraw

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -10,6 +10,7 @@ New Features
 Fixes
 -----
 - #1777 : More consistent menu and window naming for comparing image stack data.
+- #1776 : Fix Redrawing of ROIs within Compare Image Stack Window
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/windows/stack_choice/view.py
+++ b/mantidimaging/gui/windows/stack_choice/view.py
@@ -77,6 +77,8 @@ class StackChoiceView(BaseMainWindowView):
         # Hook the two plot ROIs together so that any changes are synced
         self.original_stack.roi.sigRegionChanged.connect(self._sync_roi_plot_for_new_stack_with_old_stack)
         self.new_stack.roi.sigRegionChanged.connect(self._sync_roi_plot_for_old_stack_with_new_stack)
+        self.original_stack.roi.sigRegionChanged.connect(self.original_stack.roiChanged)
+        self.new_stack.roi.sigRegionChanged.connect(self.new_stack.roiChanged)
 
         self._sync_both_image_axis()
         self._ensure_range_is_the_same()


### PR DESCRIPTION
### Issue

Closes #1776 

### Description

Update ROI on ROI changed to resolve ROI redrawing issue where ROI were not being redrawn correctly.

### Acceptance Criteria 

* From Image comparing window, with ROI selected, moving ROI does not leave ROI artefacts over image. 
* Moving ROI are correctly redrawn and remain in sync with one another across images. 

### Documentation


