### PR TITLE
Fix Clear Method within View to Handle NaN Data

### DIFF
--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -11,6 +11,7 @@ Fixes
 -----
 - #1777 : More consistent menu and window naming for comparing image stack data.
 - #1776 : Fix Redrawing of ROIs within Compare Image Stack Window
+- #1815 : Improve handling of NaN data within Spectrum Viewer, resolving exception error dialog pop-up within Spectrum Viewer if only dataset loaded into Mantid Imaging is removed.
 
 Developer Changes
 -----------------

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -198,8 +198,9 @@ class SpectrumViewerWindowView(BaseMainWindowView):
                 self.spectrum.spectrum.plot(value, name=key, pen=self.spectrum.roi_dict[key].colour)
 
     def clear(self) -> None:
-        self.spectrum.clear_data()
         self.spectrum.spectrum_data_dict = {}
+        self.spectrum.image.setImage(np.zeros((1, 1)))
+        self.spectrum.spectrum.clearPlots()
 
     def auto_range_image(self):
         self.spectrum.image.vb.autoRange()


### PR DESCRIPTION
### Issue

Closes #1815 

### Description

Fix `clear()` method within `view.py` to handle NaN data should there only be one dataset loaded in Mantid imaging if the dataset is deleted while the Spectrum Viewer Window is open.

### Testing

Manually tested in GUI with one and multiple datasets loaded by deleting datasets while Spectrum Viewer window is open.

### Acceptance Criteria 
If all datasets are deleted in the main window while the Spectrum Viewer window is open, no errors are raised in logs or dialog box. The Spectrum Viewer should set image to NaNs to display a black image.

### Documentation

Added to fix description "Fixes" subheading within upcoming release notes
