### PR TITLE
Move release notes to one change per file

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,6 +52,7 @@ extensions = [
 # Add custom extensions
 sys.path.append(os.path.abspath("./ext"))
 extensions.append("operations_user_doc")
+extensions.append("release_notes")
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/developer_guide/documentation.rst
+++ b/docs/developer_guide/documentation.rst
@@ -66,6 +66,14 @@ Release Notes
 
 Release notes should be continuously updated during developement. Almost all pull requests should have an update to the relevant file and section in :file:`docs/release_notes`
 
-If the next release name is not yet chosen this will be :file:`next.rts`, and renamed closer to release.
+For the current development work, new release notes go in an individual file for each pull request. This prevents merge conflicts that would occur if two PRs directly edited the same release note file. For example the PR fixing issue #1792 by updating Python would have its change note placed in :file:`docs/release_notes/next/dev-1792-python-310`. The content would be a line::
+
+    #1792 : Update python to 3.10
+
+These will be included into the relent section in :file:`docs/release_notes/next.rst`. At release time the notes can be collected up using::
+
+	python setup.py release_notes
+
+and added to the release notes. The individual files can then be deleted.
 
 When fixes are backported to a release branch, they can be added to the notes for that release, in an updates section.

--- a/docs/ext/release_notes.py
+++ b/docs/ext/release_notes.py
@@ -27,6 +27,11 @@ class ReleaseNotes(Directive):
         note_paths = (Path() / 'docs' / 'release_notes' / 'next').glob(note_type + '*')
 
         rst = ViewList()
+        try:
+            note_paths = sorted(list(note_paths), key=lambda p: int(p.name.split('-')[1]))
+        except ValueError:
+            raise cls.severe('Could not sort release notes, check filenames.')
+
         for n, note_path in enumerate(note_paths):
             note_content = note_path.read_text().strip().split('\n')
             if len(note_content) != 1:

--- a/docs/ext/release_notes.py
+++ b/docs/ext/release_notes.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from pathlib import Path
+
+from docutils import nodes
+from docutils.statemachine import ViewList
+from docutils.parsers.rst import Directive
+from sphinx.errors import SphinxError
+from sphinx.util.nodes import nested_parse_with_titles
+"""Custom extension to collect release notes from separate files
+
+Use one of:
+.. release_notes:: feature
+.. release_notes:: fix
+.. release_notes:: dev
+
+"""
+
+
+class ReleaseNotes(Directive):
+    has_content = True
+
+    @classmethod
+    def make_rst(cls, note_type: str) -> ViewList:
+        note_paths = (Path() / 'docs' / 'release_notes' / 'next').glob(note_type + '*')
+
+        rst = ViewList()
+        for n, note_path in enumerate(note_paths):
+            note_content = note_path.read_text().strip().split('\n')
+            if len(note_content) != 1:
+                raise cls.severe(f'Release note file should have 1 line: {note_path}.')
+
+            rst.append(f"- {note_content[0]}", "generated.rst", n)
+
+        return rst
+
+    def run(self) -> list[nodes.Node]:
+        if len(self.content) != 1:
+            raise self.severe('Directive release_notes needs a value.')
+        if not self.content[0].isalnum():
+            raise self.severe(f'Value should be single word. Got "{self.content[0]}".')
+
+        note_type = self.content[0]
+        rst = self.make_rst(note_type)
+
+        node = nodes.section()
+        node.document = self.state.document
+        nested_parse_with_titles(self.state, rst, node)
+
+        return node.children
+
+    @staticmethod
+    def severe(message):
+        """Override with an error strong enough to stop build"""
+        return SphinxError(f'ReleaseNotes: {message}')
+
+
+def setup(app):
+    app.add_directive("release_notes", ReleaseNotes)
+
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/docs/release_notes/next.rst
+++ b/docs/release_notes/next.rst
@@ -5,17 +5,12 @@ This contains changes for the next not yet released Mantid Imaging versions.
 
 New Features
 ------------
-- #1798 : Allow for toggling of ROI visibility in the table of ROIs within the spectrum viewer.
+.. release_notes:: feature
 
 Fixes
 -----
-- #1777 : More consistent menu and window naming for comparing image stack data.
-- #1776 : Fix Redrawing of ROIs within Compare Image Stack Window
-- #1815 : Improve handling of NaN data within Spectrum Viewer, resolving exception error dialog pop-up within Spectrum Viewer if only dataset loaded into Mantid Imaging is removed.
+.. release_notes:: fix
 
 Developer Changes
 -----------------
-- #1796 : Add MyPy to pre-commit checks.
-- #1799 : Speed up packaged builds with boa
-- #1792 : Update python to 3.10
-- #962 : Type annotation improvements
+.. release_notes:: dev

--- a/docs/release_notes/next/dev-1792-python-310
+++ b/docs/release_notes/next/dev-1792-python-310
@@ -1,0 +1,1 @@
+#1792 : Update python to 3.10

--- a/docs/release_notes/next/dev-1796-mypy-precommit
+++ b/docs/release_notes/next/dev-1796-mypy-precommit
@@ -1,0 +1,1 @@
+#1796 : Add MyPy to pre-commit checks.

--- a/docs/release_notes/next/dev-1799-boa
+++ b/docs/release_notes/next/dev-1799-boa
@@ -1,0 +1,1 @@
+#1799 : Speed up packaged builds with boa

--- a/docs/release_notes/next/dev-1803-release-notes
+++ b/docs/release_notes/next/dev-1803-release-notes
@@ -1,0 +1,2 @@
+#1803 : Separate files for release notes
+

--- a/docs/release_notes/next/dev-962-types
+++ b/docs/release_notes/next/dev-962-types
@@ -1,0 +1,2 @@
+#962 : Type annotation improvements
+

--- a/docs/release_notes/next/feature-1798-roi
+++ b/docs/release_notes/next/feature-1798-roi
@@ -1,0 +1,1 @@
+#1798 : Allow for toggling of ROI visibility in the table of ROIs within the spectrum viewer.

--- a/docs/release_notes/next/fix-1776-redraw-roi
+++ b/docs/release_notes/next/fix-1776-redraw-roi
@@ -1,0 +1,1 @@
+#1776 : Fix Redrawing of ROIs within Compare Image Stack Window

--- a/docs/release_notes/next/fix-1777-compare-image-stack
+++ b/docs/release_notes/next/fix-1777-compare-image-stack
@@ -1,0 +1,1 @@
+#1777 : More consistent menu and window naming for comparing image stack data.

--- a/docs/release_notes/next/fix-1815-spec-viewer
+++ b/docs/release_notes/next/fix-1815-spec-viewer
@@ -1,0 +1,1 @@
+#1815 : Improve handling of NaN data within Spectrum Viewer, resolving exception error dialog pop-up within Spectrum Viewer if only dataset loaded into Mantid Imaging is removed.

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import fnmatch
+import importlib
 import os
 import platform
 import subprocess
@@ -118,6 +119,32 @@ class GenerateSphinxVersioned(Command):
         command_sphinx_multiversion = [self.sphinx_multiversion_executable]
         command_sphinx_multiversion.extend(self.sphinx_multiversion_options)
         subprocess.check_call(command_sphinx_multiversion)
+
+
+class GenerateReleaseNotes(Command):
+    description = "Generate release notes"
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        spec = importlib.util.spec_from_file_location('release_notes', 'docs/ext/release_notes.py')
+        release_notes = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(release_notes)
+
+        print("\nNew Features\n------------")
+        for line in release_notes.ReleaseNotes.make_rst("feature"):
+            print(line)
+        print("\nFixes\n-----")
+        for line in release_notes.ReleaseNotes.make_rst("fix"):
+            print(line)
+        print("\nDeveloper Changes\n-----------------")
+        for line in release_notes.ReleaseNotes.make_rst("dev"):
+            print(line)
 
 
 class CompilePyQtUiFiles(Command):
@@ -253,5 +280,6 @@ setup(
         "docs_publish": PublishDocsToGitHubPages,
         "compile_ui": CompilePyQtUiFiles,
         "create_dev_env": CreateDeveloperEnvironment,
+        "release_notes": GenerateReleaseNotes,
     },
 )


### PR DESCRIPTION
### Issue
Closes #1803

### Description
Use individual files for release note changes.

A sphinx extension to combine them at doc build time.
A setup.py rule to join them for release

### Testing & Acceptance Criteria 

`python3 ./setup.py internal_docs`
and check that the release note page is built correctly

`python3 ./setup.py release_notes`
And check that the release notes are shown correctly

### Documentation

Updated the release notes and documentation
