### PR TITLE
Limit building docs for old versions

### DIFF
--- a/docs/_templates/versioning.html
+++ b/docs/_templates/versioning.html
@@ -13,7 +13,7 @@
 <h3>{{ _('Versions') }}</h3>
 <ul>
   <li><a href="{{ pathto("",1)}}index.html">Latest</a></li>
-  {%- for item in ['2.0.0', '2.1.0', '2.2.0', '2.3.0', '2.4.0', '2.5.0'] %}
+  {%- for item in ['2.3.0', '2.4.0', '2.5.0'] %}
   <li><a href="{{ pathto("",1)}}{{ item }}/index.html">{{ item }}</a></li>
   {%- endfor %}
 </ul>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -173,7 +173,7 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 html_use_smartypants = False
 
 # sphinx-multiversion
-smv_tag_whitelist = r'^2+\.\d+\.\d+$'  # tags that look like versions
+smv_tag_whitelist = r'^(2.3.0|2.4.0|2.5.0)$'
 smv_branch_whitelist = None  # No branches
 smv_released_pattern = r''
 smv_prebuild_command = "python setup.py docs_api || python setup.py internal_docs_api"


### PR DESCRIPTION
2.2 and older will not import with python 3.10

### Issue

Spotted on #1820, since updating to python 3.10, older version of the docs wont build

### Description

Limit to only building old docs back to 2.3.0

### Testing & Acceptance Criteria 
Tests should pass

### Documentation

Not needed
