### PR TITLE
Use environment file from source

### DIFF
--- a/docker/centos7.Dockerfile
+++ b/docker/centos7.Dockerfile
@@ -20,9 +20,10 @@ RUN wget -nv -O Mambaforge.sh https://github.com/conda-forge/miniforge/releases/
 
 SHELL ["/bin/bash", "-c"]
 
-RUN eval "$(/opt/miniconda/bin/conda shell.bash hook)" &&\
-    mamba env create -n mantidimaging_test -f https://raw.githubusercontent.com/mantidproject/mantidimaging/main/environment-dev.yml &&\
-    conda activate mantidimaging_test &&\
+RUN --mount=type=bind,target=/src \
+    cd /src &&\
+    eval "$(/opt/miniconda/bin/conda shell.bash hook)" &&\
+    python3 ./setup.py create_dev_env &&\
     mamba clean --all
 
 RUN mkdir /opt/mantidimaging

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,7 +6,7 @@
 # function correctly and that the root user is not used within the container.
 
 eval "$(/opt/miniconda/bin/conda shell.bash hook)"
-conda activate mantidimaging_test
+conda activate mantidimaging-dev
 
 set -x
 CMD=${1:-"bash"}

--- a/docker/ubuntu18.Dockerfile
+++ b/docker/ubuntu18.Dockerfile
@@ -29,9 +29,10 @@ RUN wget -nv -O Mambaforge.sh https://github.com/conda-forge/miniforge/releases/
 
 SHELL ["/bin/bash", "-c"]
 
-RUN eval "$(/opt/miniconda/bin/conda shell.bash hook)" &&\
-    mamba env create -n mantidimaging_test -f https://raw.githubusercontent.com/mantidproject/mantidimaging/main/environment-dev.yml &&\
-    conda activate mantidimaging_test &&\
+RUN --mount=type=bind,target=/src \
+    cd /src &&\
+    eval "$(/opt/miniconda/bin/conda shell.bash hook)" &&\
+    python3 ./setup.py create_dev_env &&\
     mamba clean --all
 
 RUN mkdir /opt/mantidimaging


### PR DESCRIPTION
### Issue

Closes #1824

### Description

When building docker files use dependencies from current source checkout. This solves some of the chicken and egg issues about updating dependencies.

### Testing & Acceptance Criteria 

I'll use the label to trigger this to build some test images at
https://github.com/mantidproject/mantidimaging/pkgs/container/mantidimaging
build logs at
https://github.com/mantidproject/mantidimaging/actions/runs/5154441747/jobs/9282907374?pr=1825

### Documentation
Not needed
