### PR TITLE
1778 compare imgs roi outside img

### DIFF
--- a/docs/release_notes/next/fix-1778-compare_imgs_roi_outsite_img
+++ b/docs/release_notes/next/fix-1778-compare_imgs_roi_outsite_img
@@ -1,0 +1,1 @@
+#1778 : Fix ROIs being drawn outside of the sample images within Compare Image Stack Window

--- a/mantidimaging/gui/windows/stack_choice/view.py
+++ b/mantidimaging/gui/windows/stack_choice/view.py
@@ -90,15 +90,21 @@ class StackChoiceView(BaseMainWindowView):
         new_range = self.new_stack.ui.histogram.getLevels()
         original_range = self.original_stack.ui.histogram.getLevels()
 
+        # Set Histograms to the same range
         new_max_y = max(new_range[0], new_range[1])
         new_min_y = min(new_range[0], new_range[1])
         original_max_y = max(original_range[0], original_range[1])
         original_min_y = min(original_range[0], original_range[1])
         y_range_min = min(new_min_y, original_min_y)
         y_range_max = max(new_max_y, original_max_y)
-
         self.new_stack.ui.histogram.vb.setRange(yRange=(y_range_min, y_range_max))
         self.original_stack.ui.histogram.vb.setRange(yRange=(y_range_min, y_range_max))
+
+        # Set ROI to the same range
+        self.original_stack.roi.setSize((self.original_stack.image.shape[1], self.original_stack.image.shape[2]))
+        self.new_stack.roi.setSize((self.new_stack.image.shape[1], self.new_stack.image.shape[2]))
+        self.original_stack.roi.maxBounds = self.original_stack.roi.parentBounds()
+        self.new_stack.roi.maxBounds = self.new_stack.roi.parentBounds()
 
     def _toggle_roi(self):
         if self.roi_shown:


### PR DESCRIPTION
### Issue

Closes #1778 

### Description

Fix the maxbounds of where an ROI can be drawn to restrict ROIs to being drawn only within the Image bounds compared to previously where ROIs could be moved outside of the image bounds.

### Acceptance Criteria 

* With loaded data, open the compare image stacks window within Mantid Imaging, select two images to be compared, select the ROI button. The ROIs should now be set to the image size by default. It should now also be impossible to drag the ROI outside of the image bounds

### Documentation

Added Release notes file `docs/release_notes/next/fix-1778_compare_imgs_roi_outsite_img`
