### PR TITLE
1833 rotate stack dropdown

### DIFF
--- a/docs/release_notes/next/fix-1833-rotate_stack_dropdown
+++ b/docs/release_notes/next/fix-1833-rotate_stack_dropdown
@@ -1,0 +1,1 @@
+#1833 : Create dropdown menu of default degrees of rotation within operations rotate stack 

--- a/mantidimaging/core/operations/rotate_stack/rotate_stack.py
+++ b/mantidimaging/core/operations/rotate_stack/rotate_stack.py
@@ -72,7 +72,7 @@ class RotateFilter(BaseFilter):
                                         form=form,
                                         on_change=on_change,
                                         tooltip="How much degrees to rotate counter-clockwise")
-        angle.setDecimals(7)
+        angle.setDecimals(3)
         angle.setEnabled(False)
         dropdown.currentTextChanged.connect(lambda text: RotateFilter._update_angle(angle, dropdown))
         return {"angle": angle}
@@ -89,11 +89,10 @@ class RotateFilter(BaseFilter):
         :param angle: angle widget
         :param dropdown: dropdown widget
         """
-        dropdown_angle = dropdown.currentText()
-        if dropdown_angle == 'Custom':
+        if dropdown.currentText() == 'Custom':
             angle.setEnabled(True)
         else:
-            angle.setValue(float(dropdown_angle))
+            angle.setValue(float(dropdown.currentText()))
             angle.setEnabled(False)
 
 


### PR DESCRIPTION
### Issue

Closes #1805 

### Description

Create Dropdown of default and custom angles of rotation within Rotate Stacks Operation window.
Angles: 0, 90, 180, 270, custom
Selecting custom will enable the custom angle spinbox so a user can select a more precise angle.

### Acceptance Criteria 

- [ ] A dropdown exists within the Operations window Rotate Stack selection containing the values: 0, 90, 180, 270, custom
- [ ] If any value within the dropdown is selected other than "custom" then the custom angle text entry spinbox is disabled.
- [ ] If a default value is selected from the dropdown, the spinbox value below is updated to show this angle

### Documentation

See: `docs/release_notes/next/fix-1833-rotate_stack_dropdown` : [972259e](https://github.com/mantidproject/mantidimaging/pull/1836/commits/972259ebcc54cc38f525fbf18571581354c98f40)
