### PR TITLE
SPDHG: Allow adjusting the percent of iterations used regularisation

### DIFF
--- a/docs/release_notes/next/feature-1722-reg-prob
+++ b/docs/release_notes/next/feature-1722-reg-prob
@@ -1,0 +1,2 @@
+#1722 : SPDHG: Allow adjusting the percent of iterations used regularisation
+

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -175,8 +175,8 @@ class CILRecon(BaseRecon):
             # this should set to a sensible number as evaluating the objective is costly
             update_objective_interval = 10
             if recon_params.stochastic:
-                # this sets the evaluation of the TV term with 1/3 probability at each iteration
-                probs = [(2 / 3) * 1 / num_subsets] * num_subsets + [1 / 3]
+                reg_percent = recon_params.regularisation_percent
+                probs = [(1 - reg_percent / 100) / num_subsets] * num_subsets + [reg_percent / 100]
                 algo = SPDHG(f=F,
                              g=G,
                              operator=K,
@@ -294,8 +294,8 @@ class CILRecon(BaseRecon):
             # this should set to a sensible number as evaluating the objective is costly
             update_objective_interval = 10
             if recon_params.stochastic:
-                # this sets the evaluation of the TV term with 1/3 probability at each iteration
-                probs = [(2 / 3) * 1 / num_subsets] * num_subsets + [1 / 3]
+                reg_percent = recon_params.regularisation_percent
+                probs = [(1 - reg_percent / 100) / num_subsets] * num_subsets + [reg_percent / 100]
                 algo = SPDHG(f=F,
                              g=G,
                              operator=K,

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -333,4 +333,7 @@ class CILRecon(BaseRecon):
 
 
 def allowed_recon_kwargs() -> dict[str, list[str]]:
-    return {'CIL: PDHG-TV': ['alpha', 'num_iter', 'non_negative', 'stochastic', 'projections_per_subset']}
+    return {
+        'CIL: PDHG-TV':
+        ['alpha', 'num_iter', 'non_negative', 'stochastic', 'projections_per_subset', 'regularisation_percent']
+    }

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -109,6 +109,7 @@ class ReconstructionParameters:
     beam_hardening_coefs: Optional[List[float]] = None
     stochastic: bool = False
     projections_per_subset: int = 50
+    regularisation_percent: int = 30
 
     def to_dict(self) -> dict:
         return {
@@ -121,6 +122,7 @@ class ReconstructionParameters:
             'alpha': self.alpha,
             'stochastic': self.stochastic,
             'projections_per_subset': self.projections_per_subset,
+            'regularisation_percent': self.regularisation_percent,
         }
 
 

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -538,16 +538,6 @@
              <layout class="QVBoxLayout" name="verticalLayout_6">
               <item>
                <layout class="QGridLayout" name="optionsLayout">
-                <item row="3" column="1">
-                 <widget class="QSpinBox" name="numIter">
-                  <property name="minimum">
-                   <number>1</number>
-                  </property>
-                  <property name="maximum">
-                   <number>99999</number>
-                  </property>
-                 </widget>
-                </item>
                 <item row="1" column="1">
                  <widget class="QComboBox" name="algorithmName">
                   <property name="enabled">
@@ -560,10 +550,128 @@
                   </item>
                  </widget>
                 </item>
+                <item row="5" column="1">
+                 <widget class="QCheckBox" name="nonNegativeCheckBox">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="1">
+                 <widget class="QSpinBox" name="numIter">
+                  <property name="minimum">
+                   <number>1</number>
+                  </property>
+                  <property name="maximum">
+                   <number>99999</number>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="0">
+                 <widget class="QLabel" name="filterNameLabel">
+                  <property name="text">
+                   <string>Reconstruction filter:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="5" column="0">
+                 <widget class="QLabel" name="nonNegativeLabel">
+                  <property name="text">
+                   <string>Non-negative</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="6" column="1">
+                 <widget class="QCheckBox" name="stochasticCheckBox">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="0">
+                 <widget class="QLabel" name="maxProjAngleLabel">
+                  <property name="text">
+                   <string>Maximum projection angle</string>
+                  </property>
+                 </widget>
+                </item>
                 <item row="1" column="0">
                  <widget class="QLabel" name="algorithmNameLabel">
                   <property name="text">
                    <string>Algorithm:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="4" column="0">
+                 <widget class="QLabel" name="alphaLabel">
+                  <property name="text">
+                   <string>Alpha</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="0">
+                 <widget class="QLabel" name="subsetsLabel">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
+                  <property name="text">
+                   <string>Projections per subsets</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="9" column="0">
+                 <widget class="QLabel" name="pixelSizeLabel">
+                  <property name="text">
+                   <string>Pixel size (microns)</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="1">
+                 <widget class="QSpinBox" name="subsetsSpinBox">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
+                  <property name="minimum">
+                   <number>2</number>
+                  </property>
+                  <property name="maximum">
+                   <number>1024</number>
+                  </property>
+                  <property name="value">
+                   <number>50</number>
+                  </property>
+                 </widget>
+                </item>
+                <item row="4" column="1">
+                 <widget class="QDoubleSpinBox" name="alphaSpinBox">
+                  <property name="decimals">
+                   <number>6</number>
+                  </property>
+                  <property name="minimum">
+                   <double>0.000001000000000</double>
+                  </property>
+                  <property name="maximum">
+                   <double>1000000.000000000000000</double>
+                  </property>
+                  <property name="singleStep">
+                   <double>0.010000000000000</double>
+                  </property>
+                  <property name="value">
+                   <double>1.000000000000000</double>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="0">
+                 <widget class="QLabel" name="numIterLabel">
+                  <property name="text">
+                   <string>Number of iterations:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="9" column="1">
+                 <widget class="QDoubleSpinBox" name="pixelSize">
+                  <property name="maximum">
+                   <double>99999.000000000000000</double>
                   </property>
                  </widget>
                 </item>
@@ -606,43 +714,10 @@
                   </item>
                  </widget>
                 </item>
-                <item row="8" column="0">
-                 <widget class="QLabel" name="pixelSizeLabel">
+                <item row="6" column="0">
+                 <widget class="QLabel" name="stochasticLabel">
                   <property name="text">
-                   <string>Pixel size (microns)</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="4" column="0">
-                 <widget class="QLabel" name="alphaLabel">
-                  <property name="text">
-                   <string>Alpha</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="8" column="1">
-                 <widget class="QDoubleSpinBox" name="pixelSize">
-                  <property name="maximum">
-                   <double>99999.000000000000000</double>
-                  </property>
-                 </widget>
-                </item>
-                <item row="4" column="1">
-                 <widget class="QDoubleSpinBox" name="alphaSpinBox">
-                  <property name="decimals">
-                   <number>6</number>
-                  </property>
-                  <property name="minimum">
-                   <double>0.000001000000000</double>
-                  </property>
-                  <property name="maximum">
-                   <double>1000000.000000000000000</double>
-                  </property>
-                  <property name="singleStep">
-                   <double>0.010000000000000</double>
-                  </property>
-                  <property name="value">
-                   <double>1.000000000000000</double>
+                   <string>Stochastic</string>
                   </property>
                  </widget>
                 </item>
@@ -656,78 +731,26 @@
                   </property>
                  </widget>
                 </item>
-                <item row="3" column="0">
-                 <widget class="QLabel" name="numIterLabel">
+                <item row="8" column="0">
+                 <widget class="QLabel" name="regPercentLabel">
                   <property name="text">
-                   <string>Number of iterations:</string>
+                   <string>Regularisation percent</string>
                   </property>
                  </widget>
                 </item>
-                <item row="0" column="0">
-                 <widget class="QLabel" name="maxProjAngleLabel">
-                  <property name="text">
-                   <string>Maximum projection angle</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="5" column="0">
-                 <widget class="QLabel" name="nonNegativeLabel">
-                  <property name="text">
-                   <string>Non-negative</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="5" column="1">
-                 <widget class="QCheckBox" name="nonNegativeCheckBox">
-                  <property name="text">
-                   <string/>
-                  </property>
-                 </widget>
-                </item>
-                <item row="2" column="0">
-                 <widget class="QLabel" name="filterNameLabel">
-                  <property name="text">
-                   <string>Reconstruction filter:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="6" column="0">
-                 <widget class="QLabel" name="stochasticLabel">
-                  <property name="text">
-                   <string>Stochastic</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="6" column="1">
-                 <widget class="QCheckBox" name="stochasticCheckBox">
-                  <property name="text">
-                   <string/>
-                  </property>
-                 </widget>
-                </item>
-                <item row="7" column="0">
-                 <widget class="QLabel" name="subsetsLabel">
-                  <property name="enabled">
-                   <bool>false</bool>
-                  </property>
-                  <property name="text">
-                   <string>Projections per subsets</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="7" column="1">
-                 <widget class="QSpinBox" name="subsetsSpinBox">
-                  <property name="enabled">
-                   <bool>false</bool>
+                <item row="8" column="1">
+                 <widget class="QSpinBox" name="regPercentSpinBox">
+                  <property name="suffix">
+                   <string> %</string>
                   </property>
                   <property name="minimum">
-                   <number>2</number>
+                   <number>1</number>
                   </property>
                   <property name="maximum">
-                   <number>1024</number>
+                   <number>50</number>
                   </property>
                   <property name="value">
-                   <number>50</number>
+                   <number>30</number>
                   </property>
                  </widget>
                 </item>

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -733,6 +733,9 @@
                 </item>
                 <item row="8" column="0">
                  <widget class="QLabel" name="regPercentLabel">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
                   <property name="text">
                    <string>Regularisation percent</string>
                   </property>
@@ -740,6 +743,9 @@
                 </item>
                 <item row="8" column="1">
                  <widget class="QSpinBox" name="regPercentSpinBox">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
                   <property name="suffix">
                    <string> %</string>
                   </property>

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -66,6 +66,7 @@ class ReconstructWindowPresenter(BasePresenter):
             'non_negative': [self.view.nonNegativeCheckBox, self.view.nonNegativeLabel],
             'stochastic': [self.view.stochasticCheckBox, self.view.stochasticLabel],
             'projections_per_subset': [self.view.subsetsSpinBox, self.view.subsetsLabel],
+            'regularisation_percent': [self.view.regPercentLabel, self.view.regPercentSpinBox],
         }
         self.main_window = main_window
 

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -47,6 +47,8 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.view.stochasticLabel = mock.Mock()
         self.view.subsetsLabel = mock.Mock()
         self.view.subsetsSpinBox = mock.Mock()
+        self.view.regPercentSpinBox = mock.Mock()
+        self.view.regPercentLabel = mock.Mock()
 
     @mock.patch('mantidimaging.gui.windows.recon.presenter.start_async_task_view')
     def test_set_stack_uuid(self, mock_start_async: mock.Mock):

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -193,6 +193,8 @@ class ReconstructWindowView(BaseMainWindowView):
 
         self.stochasticCheckBox.stateChanged.connect(self.subsetsSpinBox.setEnabled)
         self.stochasticCheckBox.stateChanged.connect(self.subsetsLabel.setEnabled)
+        self.stochasticCheckBox.stateChanged.connect(self.regPercentSpinBox.setEnabled)
+        self.stochasticCheckBox.stateChanged.connect(self.regPercentLabel.setEnabled)
 
         self.previewAutoUpdate.stateChanged.connect(self.handle_auto_update_preview_selection)
         self.updatePreviewButton.clicked.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_USER_CLICK))

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -187,6 +187,7 @@ class ReconstructWindowView(BaseMainWindowView):
         self.nonNegativeCheckBox.stateChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
         self.stochasticCheckBox.stateChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
         self.subsetsSpinBox.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
+        self.regPercentSpinBox.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
         self.reconHelpButton.clicked.connect(lambda: self.open_help_webpage("reconstructions/index"))
         self.corHelpButton.clicked.connect(lambda: self.open_help_webpage("reconstructions/center_of_rotation"))
 
@@ -414,6 +415,10 @@ class ReconstructWindowView(BaseMainWindowView):
         return self.subsetsSpinBox.value()
 
     @property
+    def regularisation_percent(self) -> int:
+        return self.regPercentSpinBox.value()
+
+    @property
     def beam_hardening_coefs(self) -> Optional[List[float]]:
         if not self.lbhc_enabled.isChecked():
             return None
@@ -437,6 +442,7 @@ class ReconstructWindowView(BaseMainWindowView):
                                         stochastic=self.stochastic,
                                         projections_per_subset=self.projections_per_subset,
                                         max_projection_angle=self.max_proj_angle,
+                                        regularisation_percent=self.regularisation_percent,
                                         beam_hardening_coefs=self.beam_hardening_coefs)
 
     def set_table_point(self, idx, slice_idx, cor):


### PR DESCRIPTION
### Issue
Closes #1722

### Description

Add a user control for the percentage of steps of regularisation done during an SPDHG run. A high percent means more time is spend running regularisation.

### Testing  Acceptance Criteria 

Enable stochastic
Set 100 iterations
Adjust regularisation percent from 1 to 50
At higher values the effect of regularisation should be stronger, so the output should be smoother.

### Documentation

Release notes
