### PR TITLE
Operations test fixes

### DIFF
--- a/scripts/operations_tests/operations_tests.py
+++ b/scripts/operations_tests/operations_tests.py
@@ -64,6 +64,8 @@ def compare_mode():
         for test_number, case in enumerate(cases):
             sub_test_name = case["test_name"]
             test_name = f"{operation.lower()}_{sub_test_name}"
+            if args.match and args.match not in test_name:
+                continue
             params = case["params"] | test_case_info["params"]
             op_class = FILTERS[operation]
             op_func = op_class.filter_func
@@ -257,6 +259,7 @@ def main():
     parser.add_argument("-r", "--runs", type=int, default=5, help="number of times to run each test case")
     parser.add_argument("-v", "--verbose", action="store_true", help="print verbose output")
     parser.add_argument("-g", "--graphs", action="store_true", help="print verbose output")
+    parser.add_argument("-k", dest="match", type=str, help="only run tests which match the given substring expression")
 
     global args
     args = parser.parse_args()

--- a/scripts/operations_tests/operations_tests.py
+++ b/scripts/operations_tests/operations_tests.py
@@ -14,8 +14,13 @@ from statistics import stdev
 
 import numpy as np
 import pandas as pd
-from plotly import graph_objs as go
-from plotly.subplots import make_subplots
+try:
+    from plotly import graph_objs as go
+    from plotly.subplots import make_subplots
+except ModuleNotFoundError:
+    print("Approval tests require plotly")
+    print("Try: mamba install plotly")
+    exit(1)
 
 from mantidimaging.core.io.filenames import FilenameGroup
 from mantidimaging.core.io.loader import loader

--- a/scripts/operations_tests/operations_tests.py
+++ b/scripts/operations_tests/operations_tests.py
@@ -249,14 +249,14 @@ def create_plots():
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-M",
+    parser.add_argument("-m",
                         "--mode",
                         type=str,
                         choices=["compare", "time"],
                         help="what mode to run in (compare or time)")
-    parser.add_argument("-R", "--runs", type=int, default=5, help="number of times to run each test case")
-    parser.add_argument("-V", "--verbose", action="store_true", help="print verbose output")
-    parser.add_argument("-G", "--graphs", action="store_true", help="print verbose output")
+    parser.add_argument("-r", "--runs", type=int, default=5, help="number of times to run each test case")
+    parser.add_argument("-v", "--verbose", action="store_true", help="print verbose output")
+    parser.add_argument("-g", "--graphs", action="store_true", help="print verbose output")
 
     global args
     args = parser.parse_args()

--- a/scripts/operations_tests/operations_tests.py
+++ b/scripts/operations_tests/operations_tests.py
@@ -35,7 +35,7 @@ FILTERS = {f.filter_name: f for f in load_filter_packages()}
 TEST_CASE_RESULTS = []
 GIT_TOKEN = subprocess.check_output(["git", "describe"], encoding="utf_8").strip()
 COMMIT_DATE = subprocess.check_output(["git", "log", "--pretty=format:%ai", "-n1"], encoding="utf_8").strip()
-with open("test_cases.json", "r", encoding="UTF-8") as f:
+with open(Path(__file__).parent / "test_cases.json", encoding="UTF-8") as f:
     TEST_CASES = json.load(f)
 
 

--- a/scripts/operations_tests/operations_tests.py
+++ b/scripts/operations_tests/operations_tests.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import os
 import subprocess
 import sys
 import time
@@ -28,9 +29,10 @@ from mantidimaging.core.io.filenames import FilenameGroup  # noqa: E402
 from mantidimaging.core.io.loader import loader  # noqa: E402
 from mantidimaging.core.operations.loader import load_filter_packages  # noqa: E402
 
-LOAD_SAMPLE = Path.home() / ""  # sample location
-SAVE_DIR = Path.home() / ""  # baseline output location
-SAVE_DIR.mkdir(exist_ok=True)
+LOAD_SAMPLE = (Path.home() / "mantidimaging-data" / "ISIS" / "IMAT" / "IMAT00010675" / "Tomo" /
+               "IMAT_Flower_Tomo_000000.tif")
+SAVE_DIR = Path(os.getenv("MANTIDIMAGING_APPROVAL_TESTS_DIR"))
+
 FILTERS = {f.filter_name: f for f in load_filter_packages()}
 TEST_CASE_RESULTS = []
 GIT_TOKEN = subprocess.check_output(["git", "describe"], encoding="utf_8").strip()

--- a/scripts/operations_tests/operations_tests.py
+++ b/scripts/operations_tests/operations_tests.py
@@ -16,6 +16,7 @@ from statistics import stdev
 
 import numpy as np
 import pandas as pd
+
 try:
     from plotly import graph_objs as go
     from plotly.subplots import make_subplots
@@ -31,7 +32,15 @@ from mantidimaging.core.operations.loader import load_filter_packages  # noqa: E
 
 LOAD_SAMPLE = (Path.home() / "mantidimaging-data" / "ISIS" / "IMAT" / "IMAT00010675" / "Tomo" /
                "IMAT_Flower_Tomo_000000.tif")
-SAVE_DIR = Path(os.getenv("MANTIDIMAGING_APPROVAL_TESTS_DIR"))
+
+if path := os.getenv("MANTIDIMAGING_APPROVAL_TESTS_DIR"):
+    SAVE_DIR = Path(path)
+else:
+    print("Set MANTIDIMAGING_APPROVAL_TESTS_DIR for output path")
+    exit(1)
+if not SAVE_DIR.exists():
+    print(f"Creating directory: {SAVE_DIR}")
+    SAVE_DIR.mkdir()
 
 FILTERS = {f.filter_name: f for f in load_filter_packages()}
 TEST_CASE_RESULTS = []

--- a/scripts/operations_tests/operations_tests.py
+++ b/scripts/operations_tests/operations_tests.py
@@ -5,6 +5,7 @@ import argparse
 import csv
 import json
 import subprocess
+import sys
 import time
 from collections import defaultdict
 from dataclasses import dataclass
@@ -22,9 +23,10 @@ except ModuleNotFoundError:
     print("Try: mamba install plotly")
     exit(1)
 
-from mantidimaging.core.io.filenames import FilenameGroup
-from mantidimaging.core.io.loader import loader
-from mantidimaging.core.operations.loader import load_filter_packages
+sys.path.append(str(Path(__file__).parent.parent.parent))
+from mantidimaging.core.io.filenames import FilenameGroup  # noqa: E402
+from mantidimaging.core.io.loader import loader  # noqa: E402
+from mantidimaging.core.operations.loader import load_filter_packages  # noqa: E402
 
 LOAD_SAMPLE = Path.home() / ""  # sample location
 SAVE_DIR = Path.home() / ""  # baseline output location

--- a/scripts/operations_tests/operations_tests.py
+++ b/scripts/operations_tests/operations_tests.py
@@ -189,8 +189,7 @@ def load_post_operation_image_stack(filepath):
 def load_image_stack():
     filename_group = FilenameGroup.from_file(Path(LOAD_SAMPLE))
     filename_group.find_all_files()
-    filenames = [str(p) for p in filename_group.all_files()]
-    image_stack = loader.load(file_names=filenames)
+    image_stack = loader.load(filename_group=filename_group)
     return image_stack
 
 


### PR DESCRIPTION
### Issue

No issue

### Description
This makes the operations acceptance test script a more usable and updates it for some API changes.
* import warning for plotly (I don't want to add this as a package dependency yet if its only used for plotting here)
* make importing mantidimaging and finding the test cases and data more robust (can be run from git root or folder)
* Env var for output
* -k option like pytest

### Testing & Acceptance Criteria 

Should run with something like (you'll need to create directory):
`MANTIDIMAGING_APPROVAL_TESTS_DIR=/var/tmp/mantidimaging_acc_tests python operations_tests.py -m compare`
on second run it will compare to the existing baseline

### Documentation

Not needed
