### PR TITLE
Live view menu entry

### DIFF
--- a/mantidimaging/gui/ui/main_window.ui
+++ b/mantidimaging/gui/ui/main_window.ui
@@ -27,7 +27,7 @@
      <x>0</x>
      <y>0</y>
      <width>1100</width>
-     <height>22</height>
+     <height>25</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -43,6 +43,8 @@
     <addaction name="separator"/>
     <addaction name="actionSaveImages"/>
     <addaction name="actionSaveNeXusFile"/>
+    <addaction name="separator"/>
+    <addaction name="actionLiveViewer"/>
     <addaction name="separator"/>
     <addaction name="actionExit"/>
    </widget>
@@ -227,6 +229,14 @@
   <action name="actionSpectrumViewer">
    <property name="text">
     <string>Spectrum Viewer</string>
+   </property>
+  </action>
+  <action name="actionLiveViewer">
+   <property name="text">
+    <string>Live Viewer</string>
+   </property>
+   <property name="toolTip">
+    <string>Open Live Viewer</string>
    </property>
   </action>
  </widget>

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
 from unittest.mock import DEFAULT, Mock
 from uuid import uuid4
 
@@ -545,3 +546,22 @@ class MainWindowViewTest(unittest.TestCase):
         ds_id = "ds-id"
         self.view.is_dataset_strict(ds_id)
         self.presenter.is_dataset_strict.assert_called_once_with(ds_id)
+
+    @mock.patch("PyQt5.QtWidgets.QFileDialog.getExistingDirectory")
+    @mock.patch("mantidimaging.gui.windows.main.MainWindowView.show_live_viewer")
+    def test_live_viewer_asks_for_data_dir(self, mock_show_live_viewer, mock_get_existing_dir):
+        mock_path = Path("/test/path")
+        mock_get_existing_dir.return_value = str(mock_path)
+
+        self.view.live_view_choose_directory()
+
+        mock_show_live_viewer.assert_called_once_with(mock_path)
+
+    @mock.patch("PyQt5.QtWidgets.QFileDialog.getExistingDirectory")
+    @mock.patch("mantidimaging.gui.windows.main.MainWindowView.show_live_viewer")
+    def test_live_viewer_asks_for_data_dir_no_path(self, mock_show_live_viewer, mock_get_existing_dir):
+        mock_get_existing_dir.return_value = ""
+
+        self.view.live_view_choose_directory()
+
+        mock_show_live_viewer.assert_not_called()

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -184,6 +184,7 @@ class MainWindowView(BaseMainWindowView):
         self.actionFilters.triggered.connect(self.show_filters_window)
         self.actionRecon.triggered.connect(self.show_recon_window)
         self.actionSpectrumViewer.triggered.connect(self.show_spectrum_viewer_window)
+        self.actionLiveViewer.triggered.connect(self.live_view_choose_directory)
 
         self.actionCompareImages.triggered.connect(self.show_stack_select_dialog)
 
@@ -389,6 +390,18 @@ class MainWindowView(BaseMainWindowView):
             self.spectrum_viewer.activateWindow()
             self.spectrum_viewer.raise_()
             self.spectrum_viewer.show()
+
+    def live_view_choose_directory(self) -> None:
+        caption = "Choose live data directory"
+        live_data_directory: str = QFileDialog.getExistingDirectory(self,
+                                                                    caption=caption,
+                                                                    options=QFileDialog.ShowDirsOnly)
+        if live_data_directory == "":
+            return
+        self.show_live_viewer(Path(live_data_directory))
+
+    def show_live_viewer(self, live_data_path: Path) -> None:
+        raise NotImplementedError(f"show_live_viewer({live_data_path!r})")
 
     @property
     def stack_list(self):

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -81,6 +81,7 @@ class MainWindowView(BaseMainWindowView):
     actionFilters: QAction
     actionCompareImages: QAction
     actionSpectrumViewer: QAction
+    actionLiveViewer: QAction
     actionSampleLoadLog: QAction
     actionLoadProjectionAngles: QAction
     actionLoad180deg: QAction


### PR DESCRIPTION
### Issue

Work towards #1846

Needs a rebase

### Description
Adds a *Live Viewer* menu entry
Triggers a file selector

Currently calls `show_live_viewer()` which just raised a `NotImplementedError`. this can be hooked up for #1845.

### Testing 

Added a simple test for the cases of user choosing or cancelling the file selector.

### Acceptance Criteria 

Open MI
File -> Live Viewer
If you select a directory, then you should see the `NotImplementedError` in the terminal showing the correct path.

### Documentation

Not needed yet
