### PR TITLE
Don't overwrite exisitng metadata when loading metadata from json

### DIFF
--- a/docs/release_notes/next/fix-1784-dont-overwrite-metadata
+++ b/docs/release_notes/next/fix-1784-dont-overwrite-metadata
@@ -1,0 +1,1 @@
+#1784 : Don't overwrite new metadata when loading old metadata

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -104,7 +104,10 @@ class ImageStack:
         return self._id
 
     def load_metadata(self, f: TextIO):
-        self.metadata = json.load(f)
+        """
+        Load metadata json without overwriting existing values
+        """
+        self.metadata = json.load(f) | self.metadata
         self._is_sinograms = self.metadata.get(const.SINOGRAMS, False)
 
     def save_metadata(self, f: TextIO, rescale_params: Optional[Dict[str, Union[str, float]]] = None):

--- a/mantidimaging/core/data/test/image_stack_test.py
+++ b/mantidimaging/core/data/test/image_stack_test.py
@@ -6,8 +6,6 @@ import io
 from pathlib import Path
 from unittest import mock
 
-import pytest
-
 from mantidimaging.core.utility.data_containers import ProjectionAngles
 import unittest
 
@@ -61,7 +59,6 @@ class ImageStackTest(unittest.TestCase):
         imgs.metadata[const.OPERATION_HISTORY][0].pop(const.TIMESTAMP)
         self.assertEqual(imgs.metadata, expected)
 
-    @pytest.mark.xfail
     def test_loading_metadata_preserves_existing(self):
         json_file = io.StringIO('{"a": 30.0, "b": 2}')
 
@@ -73,7 +70,6 @@ class ImageStackTest(unittest.TestCase):
         self.assertEqual(1, imgs.metadata['b'])
         self.assertEqual(5, imgs.metadata['c'])
 
-    @pytest.mark.xfail
     def test_loading_metadata_preserves_existing_log(self):
         json_file = io.StringIO('{"pixel_size": 30.0, "log_file": "/old/logfile"}')
         mock_log_path = Path("/aaa/bbb")


### PR DESCRIPTION
### Issue
Closes #1784 

### Description

Merge the new metadata with existing metadata preferring the existing. This ensure that log_file entry does not get blanked as before or overwritten (if the json file listed a log file).

### Testing 

Added 2 unit tests

### Acceptance Criteria 

Open a data set that has a sample log file and json metadata files. (make sure sample log is ticked)
Open Image -> Show history and metadata
Check that the log file is listed.

### Documentation
Release notes
