### PR TITLE
1805 rotate stack aspect ratio

### DIFF
--- a/docs/release_notes/next/fix-1805-rotate_stack_aspect_ratio
+++ b/docs/release_notes/next/fix-1805-rotate_stack_aspect_ratio
@@ -1,0 +1,1 @@
+#1833 : Rotate image stack by cardinal or non-cardinal Angle. Image aspect ratio snaps to closest cardinal angle.

--- a/mantidimaging/core/operations/rotate_stack/rotate_stack.py
+++ b/mantidimaging/core/operations/rotate_stack/rotate_stack.py
@@ -10,6 +10,7 @@ from PyQt5.QtWidgets import QComboBox
 from mantidimaging import helper as h
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.parallel import shared as ps
+from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.core.parallel import utility as pu
 from mantidimaging.gui.utility.qt_helpers import Type
 

--- a/mantidimaging/core/operations/rotate_stack/rotate_stack.py
+++ b/mantidimaging/core/operations/rotate_stack/rotate_stack.py
@@ -4,15 +4,16 @@ from __future__ import annotations
 
 from functools import partial
 from typing import TYPE_CHECKING
-
 from skimage.transform import rotate
 from PyQt5.QtWidgets import QComboBox
 
 from mantidimaging import helper as h
 from mantidimaging.core.operations.base_filter import BaseFilter
 from mantidimaging.core.parallel import shared as ps
-from mantidimaging.core.utility.progress_reporting import Progress
+from mantidimaging.core.parallel import utility as pu
 from mantidimaging.gui.utility.qt_helpers import Type
+
+import numpy as np
 
 if TYPE_CHECKING:
     from mantidimaging.core.data import ImageStack
@@ -37,20 +38,16 @@ class RotateFilter(BaseFilter):
         """
         Rotates images by an arbitrary degree.
 
-        :param data: stack of sample images
-        :param angle: The rotation to be performed, in degrees
+        param data: stack of sample images
+        param angle: The rotation to be performed, in degrees
 
-        :return: The rotated images
+        return: The rotated images
         """
         h.check_data_stack(data)
-
         if angle is None:
             raise ValueError('Value must be provided for angle parameter')
-
-        # No need to run the filter for an angle of 0 as it won't have any effect
-        if not angle == 0:
-            _execute(data, angle, progress)
-
+        progress = Progress.ensure_instance(progress, task_name='Rotate Stack')
+        _do_rotation(data, round(angle, 3), progress)
         return data
 
     @staticmethod
@@ -96,15 +93,89 @@ class RotateFilter(BaseFilter):
             angle.setEnabled(False)
 
 
-def _rotate_image_inplace(data, angle=None):
-    data[:, :] = rotate(data[:, :], angle)
+def _get_cardinal_angle(general_angle) -> int:
+    """
+    Calculates the cardinal angle based on the general input angle by rounding to
+    the nearest 90 degree and then mod 360. Ths is used to determine if the angle
+    is a cardinal angle or not and also return a cardinal angle for in-place rotations.
+
+    param: value: general angle of rotation
+    return: angle: cardinal angle of rotation
+    """
+    return (round(general_angle / 90) * 90) % 360
 
 
-def _execute(images: ImageStack, angle: float, progress: Progress):
-    progress = Progress.ensure_instance(progress, task_name='Rotate Stack')
+def _do_rotation(data, angle, progress) -> np.ndarray:
+    """
+    Handle rotation of image slice by angle. This includes rotation of aspect
+    ratio and in place rotation depending on angle.
 
-    with progress:
-        f = ps.create_partial(_rotate_image_inplace, ps.inplace1, angle=angle)
-        ps.execute(f, [images.shared_array], images.data.shape[0], progress, msg=f"Rotating by {angle} degrees")
+    param array_index: index of array in array_list
+    param data: current image data array
+    param angle: angle of rotation
+    return: new_data: rotated image data array
+    """
+    angle = angle % 360
+    if angle == _get_cardinal_angle(angle):
+        data.shared_array = _cardinal_rotation_per_slice(data, angle, progress)
+    else:
+        data.shared_array = _cardinal_rotation_per_slice(data, _get_cardinal_angle(angle), progress)
+        data.shared_array = _inplace_rotation(data.data.shape[0], data, angle - _get_cardinal_angle(angle), progress)
+    return data
 
-    return images
+
+def _cardinal_rotation_per_slice(data: ImageStack, angle: float, progress) -> 'pu.SharedArray':
+    """
+    Perform a cardinal rotation of the image stack by angle if angle is cardinal and additionally
+    in-place rotation if general angle.
+
+    param: data: current image data array
+    param: angle: angle of rotation
+    param: progress: progress bar
+    return: new_data: rotated image data array
+    """
+    z_axis, y_axis, x_axis = data.data.shape
+    rotated_shape: tuple = (z_axis, x_axis, y_axis)
+
+    if angle == 0 or angle == 180:
+        new_data = _inplace_rotation(z_axis, data, angle, progress)
+    else:
+        new_data = pu.create_array(rotated_shape, data.data.dtype)
+        ps.run_compute_func(_compute_cardinal_rotation_per_slice, z_axis, [data.shared_array, new_data],
+                            {"angle": angle}, progress)
+    return new_data
+
+
+def _inplace_rotation(number_of_slices: int, data, angle: float, progress) -> 'pu.SharedArray':
+    """
+    In-place rotation of image slices by angle.
+
+    param: number_of_slices: array slices
+    param: data: current image data array
+    param: angle: angle of rotation
+    param: progress: progress bar
+    return: new_data: rotated image data array
+    """
+    ps.run_compute_func(_compute_rotation_per_slice_inplace, number_of_slices, data.shared_array, {"angle": angle},
+                        progress)
+    return data.shared_array
+
+
+def _compute_cardinal_rotation_per_slice(array_index, array_list, angle):
+    """
+    Rotate array in increments of 90 degrees.
+    param: array_index: index of array in array_list
+    param: array_list: list of arrays - [old_array, new_array]
+    param: angle: angle of rotation
+    """
+    cardinal_rotation = {0: 0, 90: 1, 180: 2, 270: 3}
+    array_list[1][array_index] = np.rot90(array_list[0][array_index], k=cardinal_rotation[angle["angle"]])
+
+
+def _compute_rotation_per_slice_inplace(array_index, array_list, angle):
+    """
+    Rotate array in-place so that aspect ratio is not changed
+    param: array_list: list of arrays - [array]
+    param: angle: angle of rotation
+    """
+    array_list[array_index] = rotate(array_list[array_index], angle["angle"])

--- a/mantidimaging/core/operations/rotate_stack/test/rotate_stack_test.py
+++ b/mantidimaging/core/operations/rotate_stack/test/rotate_stack_test.py
@@ -6,10 +6,12 @@ import unittest
 from unittest import mock
 
 import numpy.testing as npt
+from parameterized import parameterized
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.rotate_stack import RotateFilter
 from mantidimaging.test_helpers.start_qapplication import start_multiprocessing_pool
+from mantidimaging.core.operations.rotate_stack.rotate_stack import _get_cardinal_angle, _do_rotation
 
 
 @start_multiprocessing_pool
@@ -59,6 +61,42 @@ class RotateStackTest(unittest.TestCase):
         execute_func(images)
 
         self.assertEqual(rotation_count.value.call_count, 1)
+
+    @parameterized.expand([
+        ("0_deg", 0, 0),
+        ("44_deg", 44, 0),
+        ("45_deg", 45, 0),
+        ("46_deg", 46, 90),
+        ("134_deg", 134, 90),
+        ("135_deg", 135, 180),
+        ("136_deg", 136, 180),
+        ("224_deg", 224, 180),
+        ("225_deg", 225, 180),
+        ("226_deg", 226, 270),
+        ("314_deg", 314, 270),
+        ("316_deg", 316, 0),
+        ("360_deg", 360, 0),
+    ])
+    def test_WHEN_trivial_angle_THEN_closest_cardinal_angle_returned(self, _, general_angle, cardinal_angle):
+        self.assertEqual(_get_cardinal_angle(general_angle), cardinal_angle)
+
+    def test_WHEN_compute_rotation_called_WITH_angle_THEN_data_rotated_and_aspect_ratio_changed(self):
+        """
+        Test that when _compute_rotation is called with an angle then the data is rotated
+        """
+
+        images = th.generate_images([5, 6, 7])
+        _do_rotation(images, 90, mock.Mock())
+        self.assertNotEqual([5, 7, 6], images.data.shape)
+
+    def test_WHEN_compute_rotation_called_WITH_angle_THEN_data_aspect_ratio_remains_the_same(self):
+        """
+        Test that when _compute_rotation is called with an angle then the data is rotated
+        """
+        data = th.generate_images()
+        shape = data.data.shape
+        result = _do_rotation(data, 180, mock.Mock())
+        self.assertEqual(result.data.shape, shape)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Issue

Closes #1805 

### Description

- Allow for rotating of image in-place and not in-place.
- If image is rotated using default dropdown cardinal angles, image and image aspect ration is rotated to corresponding cardinal angle.
- If image is rotated to a custom general angle, the aspect ratio is snapped to the closest cardinal angle rounding down i.e. 45 would snap to 0 rotation and 46 would snap to 90.
- Allow to rotating in clockwise and counter-clockwise directions.


### Testing 

Added basic unit test to check that aspect ratio is correctly reshaped if out or place rotations and stays the same for in_place rotations, testing that for a given general angle, the correct cardinal angle is returned.

### Acceptance Criteria 

- [ ] Can rotate using dropdown menu to a default cardinal angle
- [ ] If rotated to a default cardinal angle, then select custom, angle starts from angle last set.
- [ ] Can rotate custom angle
- [ ] If image angle is <=45, aspect ration is 0. if image angle is 46, aspect ration is rotated by 90
- [ ] If image angle is <=134, aspect ration is 90, if image angle is >=136, aspect ration is rotated by 180
- [ ] If image angle is <=225, aspect ration is 180, if image angle is >=226, aspect ration is rotated by 270
- [ ] If image angle is <=315, aspect ration is 270, if image angle is >=316, aspect ration is rotated by 0
- [ ] If rotating image into negative values, image rotates clockwise following similar behaviour if rotated using positive values.

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*
