### PR TITLE
Performance logging

### DIFF
--- a/docs/developer_guide/documentation.rst
+++ b/docs/developer_guide/documentation.rst
@@ -77,3 +77,13 @@ These will be included into the relent section in :file:`docs/release_notes/next
 and added to the release notes. The individual files can then be deleted.
 
 When fixes are backported to a release branch, they can be added to the notes for that release, in an updates section.
+
+Logging
+-------
+
+Logging can be controlled using the QSettings configuration file :file:`.config/mantidproject/Mantid Imaging.conf` on Linux or the equivalent registry keys on windows (See `QSettings <https://doc.qt.io/qtforpython-5/PySide2/QtCore/QSettings.html>`_). For example::
+
+    [logging]
+    log_level=DEBUG
+    log_dir=/tmp/mantid_imaging_logs
+    performance_log=true

--- a/docs/release_notes/next/dev-1853-perf-logging
+++ b/docs/release_notes/next/dev-1853-perf-logging
@@ -1,0 +1,1 @@
+#1853 : Add performance logger

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -23,7 +23,6 @@ from mantidimaging.core.io import saver
 from mantidimaging.core.io.saver import _rescale_recon_data, _save_recon_to_nexus, _save_processed_data_to_nexus, \
     _save_image_stacks_to_nexus, _convert_float_to_int
 from mantidimaging.core.utility.version_check import CheckVersion
-from mantidimaging.helper import initialise_logging
 from mantidimaging.test_helpers import FileOutputtingTestCase
 
 NX_CLASS = "NX_class"
@@ -55,9 +54,6 @@ class IOTest(FileOutputtingTestCase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        # force silent outputs
-        initialise_logging()
 
         self.sample_path = "sample/file/path.tiff"
 

--- a/mantidimaging/gui/__init__.py
+++ b/mantidimaging/gui/__init__.py
@@ -2,4 +2,4 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from .gui import execute, setup_application  # noqa: F401  # noqa:F821
+from .gui import execute  # noqa: F401  # noqa:F821

--- a/mantidimaging/gui/gui.py
+++ b/mantidimaging/gui/gui.py
@@ -7,20 +7,11 @@ import os
 import sys
 import traceback
 
-from PyQt5.QtWidgets import QApplication, QMessageBox
+from PyQt5.QtWidgets import QMessageBox
 import pyqtgraph
 
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.core.parallel import manager as pm
-
-
-def setup_application():
-    q_application = QApplication(sys.argv)
-    q_application.setStyle('Fusion')
-    q_application.setApplicationName("Mantid Imaging")
-    q_application.setOrganizationName("mantidproject")
-    q_application.setOrganizationDomain("mantidproject.org")
-    return q_application, MainWindowView()
 
 
 def execute():
@@ -28,7 +19,7 @@ def execute():
     pyqtgraph.setConfigOptions(imageAxisOrder="row-major")
 
     # create the GUI event loop
-    q_application, application_window = setup_application()
+    application_window = MainWindowView()
 
     sys.excepthook = lambda exc_type, exc_value, exc_traceback: application_window.uncaught_exception(
         "".join(traceback.format_exception_only(exc_type, exc_value)), "".join(
@@ -67,5 +58,3 @@ def execute():
                     done.exec()
 
     clean_up_old_memory()
-
-    return sys.exit(q_application.exec_())

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -205,6 +205,7 @@ class ReconstructWindowView(BaseMainWindowView):
         self.lbhc_enabled.toggled.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
 
     def showEvent(self, e):
+        super().showEvent(e)
         if self.presenter.stack_selection_change_pending:
             self.presenter.set_stack_uuid(self.stackSelector.current())
             self.presenter.stack_selection_change_pending = False

--- a/mantidimaging/helper.py
+++ b/mantidimaging/helper.py
@@ -10,18 +10,11 @@ import sys
 
 from mantidimaging.core.data import ImageStack
 
-_log_file_handler = None
-_log_formatter = None
 
-_time_start = None
+def initialise_logging(arg_level: str) -> None:
+    log_formatter = logging.Formatter("%(asctime)s [%(name)s:L%(lineno)d] %(levelname)s: %(message)s")
 
-
-def initialise_logging(default_level=logging.DEBUG):
-    global _log_formatter
-    _log_formatter = logging.Formatter("%(asctime)s [%(name)s:L%(lineno)d] %(levelname)s: %(message)s")
-
-    # Add a very verbose logging level
-    logging.addLevelName(5, 'TRACE')
+    log_level = logging.getLevelName(arg_level)
 
     # Capture all warnings
     logging.captureWarnings(True)
@@ -32,11 +25,11 @@ def initialise_logging(default_level=logging.DEBUG):
 
     # Stdout handler
     console_handler = logging.StreamHandler(sys.stdout)
-    console_handler.setFormatter(_log_formatter)
+    console_handler.setFormatter(log_formatter)
     root_logger.addHandler(console_handler)
 
     # Default log level for mantidimaging only
-    logging.getLogger('mantidimaging').setLevel(default_level)
+    logging.getLogger('mantidimaging').setLevel(log_level)
 
 
 def check_data_stack(data, expected_dims=3, expected_class=ImageStack):

--- a/mantidimaging/helper.py
+++ b/mantidimaging/helper.py
@@ -8,13 +8,21 @@ from __future__ import annotations
 import logging
 import sys
 
+from PyQt5.QtCore import QSettings
+
 from mantidimaging.core.data import ImageStack
 
 
 def initialise_logging(arg_level: str) -> None:
     log_formatter = logging.Formatter("%(asctime)s [%(name)s:L%(lineno)d] %(levelname)s: %(message)s")
 
-    log_level = logging.getLevelName(arg_level)
+    settings = QSettings()
+    setting_level = settings.value("logging/log_level", defaultValue="INFO")
+
+    if arg_level:
+        log_level = logging.getLevelName(arg_level)
+    else:
+        log_level = logging.getLevelName(setting_level)
 
     # Capture all warnings
     logging.captureWarnings(True)

--- a/mantidimaging/helper.py
+++ b/mantidimaging/helper.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import logging
 import sys
+from datetime import datetime
+from pathlib import Path
 
 from PyQt5.QtCore import QSettings
 
@@ -35,6 +37,15 @@ def initialise_logging(arg_level: str) -> None:
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setFormatter(log_formatter)
     root_logger.addHandler(console_handler)
+
+    # File handler
+    if log_directory := settings.value("logging/log_dir", defaultValue=""):
+        filename = f"mantid_imaging_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.log"
+        if not Path(log_directory).exists():
+            Path(log_directory).mkdir()
+        file_log = logging.FileHandler(Path(log_directory) / filename)
+        file_log.setFormatter(log_formatter)
+        root_logger.addHandler(file_log)
 
     # Default log level for mantidimaging only
     logging.getLogger('mantidimaging').setLevel(log_level)

--- a/mantidimaging/helper.py
+++ b/mantidimaging/helper.py
@@ -39,16 +39,26 @@ def initialise_logging(arg_level: str) -> None:
     root_logger.addHandler(console_handler)
 
     # File handler
-    if log_directory := settings.value("logging/log_dir", defaultValue=""):
+    log_directory = Path(settings.value("logging/log_dir", defaultValue=""))
+    if log_directory != Path(""):
         filename = f"mantid_imaging_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.log"
-        if not Path(log_directory).exists():
-            Path(log_directory).mkdir()
-        file_log = logging.FileHandler(Path(log_directory) / filename)
+        if not log_directory.exists():
+            log_directory.mkdir()
+        file_log = logging.FileHandler(log_directory / filename)
         file_log.setFormatter(log_formatter)
         root_logger.addHandler(file_log)
 
     # Default log level for mantidimaging only
     logging.getLogger('mantidimaging').setLevel(log_level)
+
+    perf_logger = logging.getLogger('perf')
+    perf_logger.setLevel(100)
+    perf_logger.propagate = False
+    if settings.value("logging/performance_log", defaultValue=False):
+        perf_logger.setLevel(1)
+        perf_logger.addHandler(console_handler)
+        if log_directory != Path(""):
+            perf_logger.addHandler(file_log)
 
 
 def check_data_stack(data, expected_dims=3, expected_class=ImageStack):

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 import argparse
 import sys
 import warnings
+
+from PyQt5.QtWidgets import QApplication
+
 import mantidimaging.core.parallel.manager as pm
 
 from mantidimaging import helper as h
@@ -39,6 +42,15 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def setup_application() -> QApplication:
+    q_application = QApplication(sys.argv)
+    q_application.setStyle('Fusion')
+    q_application.setApplicationName("Mantid Imaging")
+    q_application.setOrganizationName("mantidproject")
+    q_application.setOrganizationDomain("mantidproject.org")
+    return q_application
+
+
 def main() -> None:
     args = parse_args()
     # Print version number and exit
@@ -47,6 +59,8 @@ def main() -> None:
 
         print(version_no)
         return
+
+    q_application = setup_application()
 
     path = args.path if args.path else ""
     operation = args.operation if args.operation else ""
@@ -59,12 +73,15 @@ def main() -> None:
     try:
         pm.create_and_start_pool()
         gui.execute()
+        result = q_application.exec_()
     except BaseException as e:
         if sys.platform == 'linux':
             pm.clear_memory_from_current_process_linux()
         raise e
     finally:
         pm.end_pool()
+
+    return result
 
 
 if __name__ == "__main__":

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import logging
 import sys
 import warnings
 import mantidimaging.core.parallel.manager as pm
@@ -25,7 +24,7 @@ def parse_args() -> argparse.Namespace:
         type=str,
         default="INFO",
         help="Log verbosity level. "
-        "Available options are: TRACE, DEBUG, INFO, WARN, CRITICAL",
+        "Available options are: DEBUG, INFO, WARN, CRITICAL",
     )
 
     parser.add_argument("--version", action="store_true", help="Print version number and exit.")
@@ -54,7 +53,7 @@ def main() -> None:
 
     CommandLineArguments(path=path, operation=operation, show_recon=args.recon)
 
-    h.initialise_logging(logging.getLevelName(args.log_level))
+    h.initialise_logging(args.log_level)
 
     from mantidimaging import gui
     try:


### PR DESCRIPTION
### Issue
Closes #1853 

### Description
Add a mechanism to optionally log performance.
Add option to write logs to file and specify log levels in a config file

### Testing & Acceptance Criteria 

Edit the file `~/.config/mantidproject/Mantid Imaging.conf`
add a section
```
[logging]
log_level=DEBUG
log_dir=/tmp/mantid_imaging_logs
performance_log=true`
```
Start mantid imaging.
Check that lines like
`2023-07-04 16:32:34,067 [perf.mantidimaging.gui.mvp_base.view:L59] INFO: MainWindowView shown in 0.2155805930015049`
are written to the log. There is should be an entry for each window.

### Documentation
Release notes
