### PR TITLE
Basic Script to Make Copy of Dataset at Specified Rate in Seconds

### DIFF
--- a/scripts/simulate_live_data.py
+++ b/scripts/simulate_live_data.py
@@ -1,0 +1,59 @@
+# Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+import os
+import shutil
+import argparse
+from tqdm import tqdm
+import time
+
+
+def copy_dataset(source_dir, dest_dir, rate):
+    """
+    Copy data from a source directory to a destination directory.
+    Files are copied one image at a time at a specified rate in seconds.
+
+    param source_dir: Source directory containing dataset to copy
+    param dest_dir: Destination directory to copy dataset to
+    param rate: Rate in seconds at which to copy files from dataset i.e. 1, 1.5, 2...
+    """
+    if not os.path.exists(dest_dir):
+        os.makedirs(dest_dir)
+    source_list = os.listdir(source_dir)
+    for item in tqdm(source_list):
+        source_item = os.path.join(source_dir, item)
+        dest_item = os.path.join(dest_dir, item)
+        if os.path.isfile(source_item):
+            shutil.copy(source_item, dest_item)
+
+            time.sleep(float(rate))
+        if os.path.isdir(source_item):
+            copy_dataset(source_item, dest_item, rate)
+
+
+def main():
+    """
+    Main function to copy dataset from a source directory to a destination directory
+    """
+    default_output_dir = os.path.join(os.getcwd(), "mock_dataset_copy")
+    parser = argparse.ArgumentParser(description="Make copy of dataset at a specified rate (s)")
+    parser.add_argument("-s", "--source_dir", required=True, help="Source directory containing dataset to copy")
+    parser.add_argument("-d",
+                        "--dest_dir",
+                        default=default_output_dir,
+                        required=False,
+                        help="Destination directory to copy dataset to")
+    parser.add_argument("-r",
+                        "--rate",
+                        default=0,
+                        type=float,
+                        required=False,
+                        help="Rate in seconds at which to copy files from dataset i.e. 1, 1.5, 2...")
+    args = parser.parse_args()
+    copy_dataset(args.source_dir, args.dest_dir, args.rate)
+    print("Copy complete")
+    os._exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Issue

Closes #1856 

### Description

Create simple script to copy an existing dataset one file at a time at an optionally specified delay rate (seconds) to a new optionally specified output directory. If no output directory specified, then create a new directory in `scripts/`. If no delay rate specified, delay rate set to 0 seconds to copy as quickly as possible.

### Acceptance Criteria 
Using the command: `python scripts/simulate_live_data.py -s <relative_to_script_dataset_path> -r 5`, the script copies files at a specified delay rate in seconds (5). This can be tested by adding a line such as:
```Python
print(time.strftime("%H:%M:%S", time.localtime()))
```
 as a new line on line 28.

### Documentation

N/A