### PR TITLE
Spec viewer performance part 1

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -81,17 +81,11 @@ class SpectrumViewerWindowModel:
         if stack is None:
             return
         self.tof_range = (0, stack.data.shape[0] - 1)
-        height, width = self.get_image_shape()
-        self.set_roi(self.default_roi_list[0], SensibleROI.from_list([0, 0, width, height]))
+        self.set_new_roi(self.default_roi_list[0])
         # Remove additional ROIs if they exist on sample change and reset
         if len(self._roi_ranges) > 1:
             self.presenter.do_remove_roi()
-            self.set_roi(self.default_roi_list[1], SensibleROI.from_list([0, 0, width, height]))
-        else:
-            self.set_roi(self.default_roi_list[1], SensibleROI.from_list([0, 0, width, height]))
-        if self.default_roi_list[1] not in self._roi_ranges.keys():
-            self.set_new_roi(self.default_roi_list[1])
-        self.default_roi_list[1] = list(self._roi_ranges.keys())[1]
+        self.set_new_roi(self.default_roi_list[1])
 
     def set_new_roi(self, name: str) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -101,7 +101,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         if self.roi_name not in self.view.spectrum.roi_dict.keys():
             self.view.spectrum.add_roi(self.model.get_roi(self.roi_name), self.roi_name)
-            self.view.set_spectrum(self.roi_name, self.model.get_spectrum(self.roi_name, self.spectrum_mode))
         self.view.set_image(self.model.get_averaged_image())
         self.view.set_spectrum(self.roi_name, self.model.get_spectrum(self.roi_name, self.spectrum_mode))
         self.view.spectrum.add_range(*self.model.tof_range)


### PR DESCRIPTION
### Issue

Progress #1828 

### Description

First steps on the issue. Removes some redundant work, and bits that should never happen.

Reduces call to `get_spectrum()` from 4 to 3. saving about 25% of window start time.

There is still more to do, but may as well get this merged.

### Testing 

Starting the spectrum viewer and using it should still work.

### Acceptance Criteria 

Enable performance logging. Check time with this vs on main

### Documentation
Not needed yet.
