### PR TITLE
Spec view refactoring

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -163,7 +163,7 @@ class SpectrumViewerWindowModel:
         else:
             return 0, 0
 
-    def can_export(self) -> bool:
+    def has_stack(self) -> bool:
         """
         Check if data is available to export
         @return: True if data is available to export and False otherwise

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -78,14 +78,13 @@ class SpectrumViewerWindowModel:
 
         @param stack: The new stack to be used by the model
         """
+
         self._stack = stack
         if stack is None:
             return
         self._roi_id_counter = 0
         self.tof_range = (0, stack.data.shape[0] - 1)
-        self.presenter.do_remove_roi()
         self.set_new_roi(self.default_roi_list[0])
-        self.presenter.do_add_roi()
 
     def set_new_roi(self, name: str) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -46,6 +46,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         else:
             self.view.current_dataset_id = None
 
+        self.do_remove_roi()
         if uuid is None:
             self.model.set_stack(None)
             self.view.clear()
@@ -61,6 +62,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                 norm_stack = None
             self.model.set_normalise_stack(norm_stack)
 
+        self.do_add_roi()
         self.view.set_normalise_error(self.model.normalise_issue())
         self.show_new_sample()
         self.handle_export_button_enabled()

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -50,7 +50,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         if uuid is None:
             self.model.set_stack(None)
             self.view.clear()
-            self.handle_export_button_enabled()
+            self.handle_button_enabled()
             return
 
         self.model.set_stack(self.main_window.get_stack(uuid))
@@ -65,7 +65,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.do_add_roi()
         self.view.set_normalise_error(self.model.normalise_issue())
         self.show_new_sample()
-        self.handle_export_button_enabled()
+        self.handle_button_enabled()
 
     def handle_normalise_stack_change(self, normalise_uuid: Optional['UUID']) -> None:
         if normalise_uuid == self.current_norm_stack_uuid:
@@ -143,11 +143,11 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         self.view.spectrum.set_roi_alpha(name, alpha)
 
-    def handle_export_button_enabled(self) -> None:
+    def handle_button_enabled(self) -> None:
         """
         Enable the export button if the current stack is not None
         """
-        self.view.set_export_button_enabled(self.model.can_export())
+        self.view.set_export_button_enabled(self.model.has_stack())
 
     def handle_export_csv(self) -> None:
         path = self.view.get_csv_filename()

--- a/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
@@ -15,14 +15,11 @@ class TableModel(QAbstractTableModel):
     A subclass of QAbstractTableModel.
     Model for table view of ROI names and colours in Spectrum Viewer window to allow
     user to select which ROIs to plot.
-
-
-    @param data: list of lists of ROI names and colours [str, tuple(int,int,int)]
     """
 
-    def __init__(self, data):
+    def __init__(self):
         super(TableModel, self).__init__()
-        self._data = data
+        self._data = []
 
     def selectRow(self, index: int):
         """
@@ -48,7 +45,7 @@ class TableModel(QAbstractTableModel):
 
         @return: number of columns in table
         """
-        return len(self._data[0])
+        return 3
 
     def data(self, index, role):
         """
@@ -95,7 +92,7 @@ class TableModel(QAbstractTableModel):
             self.dataChanged.emit(index, index)
             return False
 
-    def row_data(self, row: int) -> tuple:
+    def row_data(self, row: int) -> list:
         """
         Return data from selected row
 
@@ -152,7 +149,7 @@ class TableModel(QAbstractTableModel):
         """
         Clear all data in table except 'roi' (first element in _data list)
         """
-        self._data = self._data[:1]
+        self._data = []
         self.layoutChanged.emit()
 
     def remove_row(self, row: int) -> None:
@@ -161,7 +158,7 @@ class TableModel(QAbstractTableModel):
 
         @param row: row number
         """
-        if row > 0 and row < len(self._data):
+        if row >= 0 and row < len(self._data):
             self._data.pop(row)
             self.layoutChanged.emit()
 

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -149,9 +149,9 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.assertEqual(self.model.get_roi("all").right, 12)
         self.assertEqual(self.model.get_roi("all").bottom, 11)
 
-    def test_if_set_stack_called_THEN_do_remove_roi_called(self):
+    def test_if_set_stack_called_THEN_do_remove_roi_not_called(self):
         self.model.set_stack(generate_images())
-        self.presenter.do_remove_roi.assert_called_once()
+        self.presenter.do_remove_roi.assert_not_called()
 
     def test_get_spectrum_roi(self):
         stack = ImageStack(np.ones([10, 11, 12]))

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -255,7 +255,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     ])
     def test_WHEN_stack_value_set_THEN_can_export_returns_(self, _, image_stack, expected):
         self.model.set_stack(image_stack)
-        self.assertEqual(self.model.can_export(), expected)
+        self.assertEqual(self.model.has_stack(), expected)
 
     def test_WHEN_roi_removed_THEN_roi_name_removed_from_list_of_roi_names(self):
         self.model.set_stack(generate_images())

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -74,6 +74,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         spectrum = np.arange(0, 10)
         stack.data[:, :, :] = spectrum.reshape((10, 1, 1))
         self.model.set_stack(stack)
+        self.model.set_new_roi("roi")
 
         model_spec = self.model.get_spectrum("roi", SpecType.SAMPLE)
         self.assertEqual(model_spec.shape, (10, ))
@@ -84,6 +85,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         spectrum = np.arange(0, 10)
         stack.data[:, :, :] = spectrum.reshape((10, 1, 1))
         self.model.set_stack(stack)
+        self.model.set_new_roi("roi")
 
         normalise_stack = ImageStack(np.ones([10, 11, 12]) * 2)
         self.model.set_normalise_stack(normalise_stack)
@@ -101,6 +103,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         spectrum = np.arange(0, 10)
         stack.data[:, :, :] = spectrum.reshape((10, 1, 1))
         self.model.set_stack(stack)
+        self.model.set_new_roi("roi")
 
         normalise_stack = ImageStack(np.ones([10, 11, 12]) * 2)
         normalise_stack.data[5] = 0
@@ -119,7 +122,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         normalise_stack = ImageStack(np.ones([10, 11, 13]))
         self.model.set_normalise_stack(normalise_stack)
 
-        error_spectrum = self.model.get_spectrum("roi", SpecType.SAMPLE_NORMED)
+        error_spectrum = self.model.get_spectrum("all", SpecType.SAMPLE_NORMED)
         np.testing.assert_array_equal(error_spectrum, np.array([]))
 
     def test_normalise_issue(self):
@@ -139,28 +142,16 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     def test_set_stack_sets_roi(self):
         stack = ImageStack(np.ones([10, 11, 12]))
         self.model.set_stack(stack)
+        self.model.set_new_roi("roi")
         self.assertEqual(self.model.get_roi("all"), self.model.get_roi('roi'))
-        npt.assert_array_equal(self.model.get_roi("all").top, 0)
-        npt.assert_array_equal(self.model.get_roi("all").left, 0)
-        npt.assert_array_equal(self.model.get_roi("all").right, 12)
-        npt.assert_array_equal(self.model.get_roi("all").bottom, 11)
+        self.assertEqual(self.model.get_roi("all").top, 0)
+        self.assertEqual(self.model.get_roi("all").left, 0)
+        self.assertEqual(self.model.get_roi("all").right, 12)
+        self.assertEqual(self.model.get_roi("all").bottom, 11)
 
-    def test_if_set_stack_called_with_additional_rois_present_THEN_do_remove_roi_called(self):
-        self.model.set_stack(generate_images())
-        self.model.set_new_roi("new_roi")
-        self.model.set_new_roi("new_roi_2")
-
-        self.assertListEqual(self.model.get_list_of_roi_names(), ['all', 'roi', 'new_roi', 'new_roi_2'])
+    def test_if_set_stack_called_THEN_do_remove_roi_called(self):
         self.model.set_stack(generate_images())
         self.presenter.do_remove_roi.assert_called_once()
-
-    def test_if_set_stack_called_with_no_additional_rois_present_THEN_do_remove_roi_called_but_not_ROIs_removed(self):
-        self.model.set_stack(generate_images())
-
-        self.assertListEqual(self.model.get_list_of_roi_names(), ['all', 'roi'])
-        self.model.set_stack(generate_images())
-        self.presenter.do_remove_roi.assert_called_once()
-        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi"])
 
     def test_get_spectrum_roi(self):
         stack = ImageStack(np.ones([10, 11, 12]))
@@ -182,6 +173,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         spectrum = np.arange(0, 10) * 2
         stack.data[:, :, :] = spectrum.reshape((10, 1, 1))
         self.model.set_stack(stack)
+        self.model.set_new_roi("roi")
         self.model.set_normalise_stack(None)
 
         mock_stream = CloseCheckStream()
@@ -222,6 +214,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
         open_stack = ImageStack(np.ones([10, 11, 12]) * 2)
         self.model.set_stack(stack)
+        self.model.set_new_roi("roi")
         self.model.set_normalise_stack(open_stack)
 
         mock_stream = CloseCheckStream()
@@ -236,19 +229,20 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.assertTrue(mock_stream.is_closed)
 
     def test_WHEN_roi_name_generator_called_THEN_correct_names_returned_visible_to_model(self):
+        self.assertEqual(self.model.roi_name_generator(), "roi")
         self.assertEqual(self.model.roi_name_generator(), "roi_1")
         self.assertEqual(self.model.roi_name_generator(), "roi_2")
         self.assertEqual(self.model.roi_name_generator(), "roi_3")
 
     def test_WHEN_get_list_of_roi_names_called_THEN_correct_list_returned(self):
         self.model.set_stack(generate_images())
-        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi"])
+        self.assertListEqual(self.model.get_list_of_roi_names(), ["all"])
 
     def test_when_new_roi_set_THEN_roi_name_added_to_list_of_roi_names(self):
         self.model.set_stack(generate_images())
         self.model.set_new_roi("new_roi")
         self.assertTrue(self.model.get_roi("new_roi"))
-        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi", "new_roi"])
+        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "new_roi"])
 
     def test_WHEN_get_roi_called_with_non_existent_name_THEN_error_raised(self):
         self.model.set_stack(generate_images())
@@ -265,6 +259,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
     def test_WHEN_roi_removed_THEN_roi_name_removed_from_list_of_roi_names(self):
         self.model.set_stack(generate_images())
+        self.model.set_new_roi("roi")
         self.model.set_new_roi("new_roi")
         self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi", "new_roi"])
         self.model.remove_roi("new_roi")
@@ -274,7 +269,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.model.set_stack(generate_images())
         with self.assertRaises(RuntimeError):
             self.model.remove_roi("all")
-        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi"])
+        self.assertListEqual(self.model.get_list_of_roi_names(), ["all"])
 
     def test_WHEN_invalid_roi_removed_THEN_keyerror_raised(self):
         self.model.set_stack(generate_images())
@@ -285,20 +280,15 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.model.set_stack(generate_images())
         self.model.set_new_roi("new_roi")
         self.model.set_new_roi("new_roi_2")
-        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi", "new_roi", "new_roi_2"])
+        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "new_roi", "new_roi_2"])
         self.model.remove_all_roi()
-        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi"])
+        self.assertListEqual(self.model.get_list_of_roi_names(), ["all"])
 
     def test_WHEN_roi_renamed_THEN_roi_name_changed_in_list_of_roi_names(self):
         self.model.set_stack(generate_images())
         self.model.set_new_roi("new_roi")
-        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi", "new_roi"])
+        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "new_roi"])
         self.model.rename_roi("new_roi", "imaging_is_the_coolest")
-        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi", "imaging_is_the_coolest"])
-
-    def test_WHEN_default_roi_renamed_THEN_default_roi_renamed(self):
-        self.model.set_stack(generate_images())
-        self.model.rename_roi("roi", "imaging_is_the_coolest")
         self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "imaging_is_the_coolest"])
 
     def test_WHEN_invalid_roi_renamed_THEN_keyerror_raised(self):
@@ -308,6 +298,6 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
     def test_WHEN_default_roi_renamed_THEN_runtime_error_raised(self):
         self.model.set_stack(generate_images())
-        self.assertListEqual(self.model.get_list_of_roi_names(), ["all", "roi"])
+        self.assertListEqual(self.model.get_list_of_roi_names(), ["all"])
         with self.assertRaises(RuntimeError):
             self.model.rename_roi("all", "imaging_is_the_coolest")

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -148,12 +148,14 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
     def test_WHEN_do_add_roi_called_THEN_new_roi_added(self):
         self.presenter.model.set_stack(generate_images())
+        self.presenter.do_add_roi()
         self.assertEqual(["all", "roi"], self.presenter.model.get_list_of_roi_names())
         self.presenter.do_add_roi()
         self.assertEqual(["all", "roi", "roi_1"], self.presenter.model.get_list_of_roi_names())
 
     def test_WHEN_do_add_roi_to_table_called_THEN_roi_added_to_table(self):
         self.presenter.model.set_stack(generate_images())
+        self.presenter.do_add_roi()
         self.view.add_roi_table_row.assert_called_once_with(0, "roi", mock.ANY)
         self.view.add_roi_table_row.reset_mock()
 
@@ -165,12 +167,14 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     def test_WHEN_do_remove_roi_called_THEN_roi_removed(self):
         self.presenter.model.set_stack(generate_images())
         self.presenter.do_add_roi()
+        self.presenter.do_add_roi()
         self.assertEqual(["all", "roi", "roi_1"], self.presenter.model.get_list_of_roi_names())
         self.presenter.do_remove_roi("roi_1")
         self.assertEqual(["all", "roi"], self.presenter.model.get_list_of_roi_names())
 
     def test_WHEN_ROI_renamed_THEN_roi_renamed(self):
         self.presenter.model.set_stack(generate_images())
+        self.presenter.do_add_roi()
         self.presenter.do_add_roi()
         self.assertEqual(["all", "roi", "roi_1"], self.presenter.model.get_list_of_roi_names())
         self.presenter.rename_roi("roi_1", "imaging_is_the_best")
@@ -179,6 +183,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     def test_WHEN_default_ROI_renamed_THEN_default_roi_renamed(self):
         self.presenter.model.set_stack(generate_images())
         self.presenter.do_add_roi()
+        self.presenter.do_add_roi()
         self.assertEqual(["all", "roi", "roi_1"], self.presenter.model.get_list_of_roi_names())
         self.presenter.rename_roi("roi", "imaging_is_the_best")
         self.assertEqual(["all", "roi_1", "imaging_is_the_best"], self.presenter.model.get_list_of_roi_names())
@@ -186,6 +191,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     @parameterized.expand(["all", "roi"])
     def test_WHEN_ROI_renamed_to_existing_name_THEN_runtimeerror(self, name):
         self.presenter.model.set_stack(generate_images())
+        self.presenter.do_add_roi()
         self.assertEqual(["all", "roi"], self.presenter.model.get_list_of_roi_names())
         with self.assertRaises(KeyError):
             self.presenter.rename_roi("roi", name)
@@ -193,8 +199,8 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
     def test_WHEN_do_remove_roi_called_with_no_arguments_THEN_all_rois_removed(self):
         self.presenter.model.set_stack(generate_images())
-        self.presenter.do_add_roi()
-        self.presenter.do_add_roi()
+        for _ in range(3):
+            self.presenter.do_add_roi()
         self.assertEqual(["all", "roi", "roi_1", "roi_2"], self.presenter.model.get_list_of_roi_names())
         self.presenter.do_remove_roi()
         self.assertEqual(["all"], self.presenter.model.get_list_of_roi_names())

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -25,7 +25,8 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
             self.main_window = MainWindowView()
         self.view = mock.create_autospec(SpectrumViewerWindowView)
         self.view.current_dataset_id = uuid.uuid4()
-        self.view.spectrum = mock.create_autospec(SpectrumWidget)
+        mock_spectrum_roi_dict = mock.create_autospec(dict)
+        self.view.spectrum = mock.create_autospec(SpectrumWidget, roi_dict=mock_spectrum_roi_dict)
         self.presenter = SpectrumViewerWindowPresenter(self.view, self.main_window)
 
     def test_get_dataset_id_for_stack_no_stack_id(self):
@@ -111,21 +112,10 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.main_window.get_dataset.assert_called_once()
         self.view.try_to_select_relevant_normalise_stack.assert_not_called()
 
-    def test_show_sample(self):
-        self.view.spectrum.roi_dict = {}
-        image_stack = generate_images([10, 11, 12])
-        self.presenter.model.set_stack(image_stack)
-
+    def test_WHEN_show_sample_call_THEN_add_range_set(self):
+        self.presenter.model.tof_range = (0, 9)
         self.presenter.show_new_sample()
         self.view.spectrum.add_range.assert_called_once_with(0, 9)
-        self.view.set_spectrum.assert_called()
-
-    def test_roi_exists_WHEN_show_new_sample_called_THEN_add_roi_not_called(self):
-        image_stack = generate_images([10, 11, 12])
-        self.presenter.model.set_stack(image_stack)
-        self.view.spectrum.roi_dict = {"roi": mock.Mock()}
-        self.presenter.show_new_sample()
-        self.view.spectrum.add_roi.assert_not_called()
 
     def test_gui_changes_tof_range(self):
         image_stack = generate_images([30, 11, 12])
@@ -159,14 +149,14 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     def test_WHEN_do_add_roi_called_THEN_new_roi_added(self):
         self.presenter.model.set_stack(generate_images())
         self.assertEqual(["all", "roi"], self.presenter.model.get_list_of_roi_names())
-        with mock.patch(
-                "mantidimaging.gui.windows.spectrum_viewer.presenter.SpectrumViewerWindowPresenter.do_add_roi_to_table"
-        ):
-            self.presenter.do_add_roi()
+        self.presenter.do_add_roi()
         self.assertEqual(["all", "roi", "roi_1"], self.presenter.model.get_list_of_roi_names())
 
     def test_WHEN_do_add_roi_to_table_called_THEN_roi_added_to_table(self):
         self.presenter.model.set_stack(generate_images())
+        self.view.add_roi_table_row.assert_called_once_with(0, "roi", mock.ANY)
+        self.view.add_roi_table_row.reset_mock()
+
         self.assertEqual(["all", "roi"], self.presenter.model.get_list_of_roi_names())
         self.presenter.view.spectrum.roi_dict = {"roi_1": mock.Mock()}
         self.presenter.do_add_roi_to_table("roi_1")
@@ -174,30 +164,21 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
     def test_WHEN_do_remove_roi_called_THEN_roi_removed(self):
         self.presenter.model.set_stack(generate_images())
-        with mock.patch(
-                "mantidimaging.gui.windows.spectrum_viewer.presenter.SpectrumViewerWindowPresenter.do_add_roi_to_table"
-        ):
-            self.presenter.do_add_roi()
+        self.presenter.do_add_roi()
         self.assertEqual(["all", "roi", "roi_1"], self.presenter.model.get_list_of_roi_names())
         self.presenter.do_remove_roi("roi_1")
         self.assertEqual(["all", "roi"], self.presenter.model.get_list_of_roi_names())
 
     def test_WHEN_ROI_renamed_THEN_roi_renamed(self):
         self.presenter.model.set_stack(generate_images())
-        with mock.patch(
-                "mantidimaging.gui.windows.spectrum_viewer.presenter.SpectrumViewerWindowPresenter.do_add_roi_to_table"
-        ):
-            self.presenter.do_add_roi()
+        self.presenter.do_add_roi()
         self.assertEqual(["all", "roi", "roi_1"], self.presenter.model.get_list_of_roi_names())
         self.presenter.rename_roi("roi_1", "imaging_is_the_best")
         self.assertEqual(["all", "roi", "imaging_is_the_best"], self.presenter.model.get_list_of_roi_names())
 
     def test_WHEN_default_ROI_renamed_THEN_default_roi_renamed(self):
         self.presenter.model.set_stack(generate_images())
-        with mock.patch(
-                "mantidimaging.gui.windows.spectrum_viewer.presenter.SpectrumViewerWindowPresenter.do_add_roi_to_table"
-        ):
-            self.presenter.do_add_roi()
+        self.presenter.do_add_roi()
         self.assertEqual(["all", "roi", "roi_1"], self.presenter.model.get_list_of_roi_names())
         self.presenter.rename_roi("roi", "imaging_is_the_best")
         self.assertEqual(["all", "roi_1", "imaging_is_the_best"], self.presenter.model.get_list_of_roi_names())
@@ -212,11 +193,8 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
     def test_WHEN_do_remove_roi_called_with_no_arguments_THEN_all_rois_removed(self):
         self.presenter.model.set_stack(generate_images())
-        with mock.patch(
-                "mantidimaging.gui.windows.spectrum_viewer.presenter.SpectrumViewerWindowPresenter.do_add_roi_to_table"
-        ):
-            self.presenter.do_add_roi()
-            self.presenter.do_add_roi()
+        self.presenter.do_add_roi()
+        self.presenter.do_add_roi()
         self.assertEqual(["all", "roi", "roi_1", "roi_2"], self.presenter.model.get_list_of_roi_names())
         self.presenter.do_remove_roi()
-        self.assertEqual(["all", "roi"], self.presenter.model.get_list_of_roi_names())
+        self.assertEqual(["all"], self.presenter.model.get_list_of_roi_names())

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -86,11 +86,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
             @param item: item in table
             """
-            self.removeBtn.setEnabled(False)
             selected_row_data = self.roi_table_model.row_data(item.row())
-
-            if selected_row_data[0] != self.presenter.roi_name:
-                self.removeBtn.setEnabled(True)
             self.selected_row = item.row()
             self.current_roi = selected_row_data[0]
 
@@ -144,10 +140,9 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.main_window.spectrum_viewer = None
 
     @property
-    def roi_table_model(self):
-        default_state = self.presenter.get_default_table_state()
+    def roi_table_model(self) -> TableModel:
         if self.tableView.model() is None:
-            mdl = TableModel([default_state])
+            mdl = TableModel()
             self.tableView.setModel(mdl)
         return self.tableView.model()
 
@@ -253,7 +248,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             if key in self.spectrum.roi_dict:
                 self.spectrum.spectrum.plot(value, name=key, pen=self.spectrum.roi_dict[key].colour)
 
-    def add_roi_table_row(self, row: int, name: str, colour: str):
+    def add_roi_table_row(self, row: int, name: str, colour: tuple[int, int, int]):
         """
         Add a new row to the ROI table
 
@@ -265,6 +260,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         circle_label.setStyleSheet(f"background-color: {colour}; border-radius: 5px;")
         self.roi_table_model.appendNewRow(name, colour, True)
         self.tableView.selectRow(row)
+        self.removeBtn.setEnabled(True)
 
     def remove_roi(self) -> None:
         """
@@ -274,12 +270,14 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         if selected_row:
             self.roi_table_model.remove_row(self.selected_row)
             self.presenter.do_remove_roi(selected_row[0])
-            self.removeBtn.setEnabled(False)
             self.spectrum.spectrum_data_dict.pop(selected_row[0])
             self.spectrum.spectrum.removeItem(selected_row[0])
             self.presenter.handle_roi_moved()
             self.selected_row = 0
             self.tableView.selectRow(0)
+
+        if self.roi_table_model.rowCount() == 0:
+            self.removeBtn.setEnabled(False)
 
     def clear_all_rois(self) -> None:
         """
@@ -288,3 +286,4 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.roi_table_model.clear_table()
         self.spectrum.spectrum_data_dict = {}
         self.spectrum.spectrum.clearPlots()
+        self.removeBtn.setEnabled(False)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -226,6 +226,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         @param enabled: True to enable the button, False to disable it
         """
         self.exportButton.setEnabled(enabled)
+        self.addBtn.setEnabled(enabled)
 
     def set_roi_alpha(self, alpha: float, roi) -> None:
         """


### PR DESCRIPTION
### Issue
More enabling work for #1828

### Description

This does some refactoring to simplify things when there is no stack loaded. It removes some code to treat the first ROI specially.

This causes quite a lot of churn in the tests, as the first ROI is now added in the presenter.

This will be useful as it solves some issues I hit trying to get the spectrum window to display before calculating spectrums.

### Testing 

Updates to many tests

### Acceptance Criteria 

Check that spectrum viewer works. Check adding and removing ROIs.

Its now possible to remove all the ROI, as I don't think there is much value to preventing this.

Check that things are sensible when all the images stacks are removed from the main window.

You can also test opening the spectrum window without any datasets loaded. By changing `mantidimaging/gui/windows/main/view.py` line 218 to always enable the `menuWorkflow`.

### Documentation

I'll update the release notes when #1828 is done
