### PR TITLE
Flash Review: Add Init for Live Viewer

### DIFF
--- a/mantidimaging/gui/windows/live_viewer/__init__.py
+++ b/mantidimaging/gui/windows/live_viewer/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from .view import LiveViewerWindowView  # noqa: F401
+from .presenter import LiveViewerWindowPresenter  # noqa: F401
+from .model import LiveViewerWindowModel  # noqa: F401


### PR DESCRIPTION
### Issue

No Issue: Add `__init__.py` missed in #1861 to resolve nightly live viewer module visibility which currently causes import errors on attempted application start-up
* Existing error can be reproduced on IDAaaS by trying to run Mantid Imaging Unstable

### Description

Add `__init__.py` so that live viewer can be found by main when packaged.

### Acceptance Criteria 

* Build nightly package and ensure that no import errors exist when running nightly build such as 
```bash
File "/opt/mambaforge/envs/mantidimaging_unstable/lib/python3.10/site-packages/mantidimaging/gui/windows/main/view.py", line 40, in <module>
    from mantidimaging.gui.windows.live_viewer.view import LiveViewerWindowView
ModuleNotFoundError: No module named 'mantidimaging.gui.windows.live_viewer
```



### Documentation

N/A main release notes for this feature are included by #1861