### PR TITLE
1864 support old log format

### DIFF
--- a/docs/release_notes/next/fix-1833-support_older_log_formats
+++ b/docs/release_notes/next/fix-1833-support_older_log_formats
@@ -1,0 +1,1 @@
+#1864 : Add log file normalisation to support older log file formats

--- a/mantidimaging/core/utility/imat_log_file_parser.py
+++ b/mantidimaging/core/utility/imat_log_file_parser.py
@@ -6,6 +6,7 @@ import csv
 import re
 from enum import Enum, auto
 from itertools import zip_longest
+from logging import getLogger
 from typing import Dict, List, Optional, TYPE_CHECKING
 
 import numpy
@@ -14,6 +15,8 @@ from mantidimaging.core.utility.data_containers import Counts, ProjectionAngles
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+LOG = getLogger(__name__)
 
 
 def _get_projection_number(s: str) -> int:
@@ -52,20 +55,51 @@ class TextLogParser:
         }
         # ignores the headers (index 0) as they're not the same as the data anyway
         # and index 1 is an empty line
-        for line in self.data[2:]:
-            parsed_log[IMATLogColumn.TIMESTAMP].append(line[0])
-            parsed_log[IMATLogColumn.PROJECTION_NUMBER].append(_get_projection_number(line[1]))
-            parsed_log[IMATLogColumn.PROJECTION_ANGLE].append(float(_get_angle(line[1])))
-            parsed_log[IMATLogColumn.COUNTS_BEFORE].append(int(_get_angle(line[2])))
-            parsed_log[IMATLogColumn.COUNTS_AFTER].append(int(_get_angle(line[3])))
-
-        return parsed_log
+        try:
+            for line in self.data[2:]:
+                parsed_log[IMATLogColumn.TIMESTAMP].append(line[0])
+                parsed_log[IMATLogColumn.PROJECTION_NUMBER].append(_get_projection_number(line[1]))
+                parsed_log[IMATLogColumn.PROJECTION_ANGLE].append(float(_get_angle(line[1])))
+                parsed_log[IMATLogColumn.COUNTS_BEFORE].append(int(_get_angle(line[2])))
+                parsed_log[IMATLogColumn.COUNTS_AFTER].append(int(_get_angle(line[3])))
+            return parsed_log
+        except ValueError as value_error:
+            raise ValueError(
+                f"Unable to parse value from log file to correct type for row: {line} {value_error}") from value_error
+        except IndexError as index_error:
+            raise IndexError(
+                f"Unable to parse value from log file to correct type for row: {line} {index_error}") from index_error
 
     @staticmethod
-    def validate(file_contents) -> bool:
-        if TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE != file_contents[0].rstrip() + "\n":
-            return False
-        return True
+    def try_insert_header(file_contents: List[str]) -> List[str]:
+        """
+        Attempt to normalise data where no header is present by inserting one.
+
+        @param file_contents: The file contents to be reformatted
+        @return: The reformatted file contents
+        """
+        first_row = file_contents[0].rstrip()
+        if TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE != first_row + "\n":
+            if len(first_row.split("   ")) < 4:
+                LOG.warning(f"\nInvalid log file header:\n{file_contents[0]}" +
+                            f"Replacing with:\n{TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE}")
+                file_contents.remove(file_contents[0])
+            file_contents.insert(0, TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE)
+            file_contents.insert(1, " ")
+        return file_contents
+
+    @staticmethod
+    def try_remove_invalid_lines(file_contents: List[str]) -> List[str]:
+        """
+        Attempt to normalise data where invalid lines are the incorrect number of columns are present.
+
+        @param file_contents: The file contents to be reformatted
+        @return: The reformatted file contents
+        """
+        for row in file_contents[2:]:
+            if len(row.rstrip().split("   ")) < 4:
+                file_contents.remove(row)
+        return file_contents
 
 
 class CSVLogParser:
@@ -88,26 +122,49 @@ class CSVLogParser:
 
         # skip headings
         next(reader)
+        try:
+            for row in reader:
 
-        for row in reader:
-            parsed_log[IMATLogColumn.TIMESTAMP].append(row[0])
-            parsed_log[IMATLogColumn.PROJECTION_NUMBER].append(int(row[2]))
-            angle_raw = row[3]
-            parsed_log[IMATLogColumn.PROJECTION_ANGLE].append(float(_get_angle(angle_raw)))
+                parsed_log[IMATLogColumn.TIMESTAMP].append(row[0])
+                parsed_log[IMATLogColumn.PROJECTION_NUMBER].append(int(row[2]))
+                angle_raw = row[3]
+                parsed_log[IMATLogColumn.PROJECTION_ANGLE].append(float(_get_angle(angle_raw)))
 
-            counts_before_raw = row[4]
-            parsed_log[IMATLogColumn.COUNTS_BEFORE].append(int(_get_angle(counts_before_raw)))
+                counts_before_raw = row[4]
+                parsed_log[IMATLogColumn.COUNTS_BEFORE].append(int(_get_angle(counts_before_raw)))
 
-            counts_after_raw = row[5]
-            parsed_log[IMATLogColumn.COUNTS_AFTER].append(int(_get_angle(counts_after_raw)))
-
-        return parsed_log
+                counts_after_raw = row[5]
+                parsed_log[IMATLogColumn.COUNTS_AFTER].append(int(_get_angle(counts_after_raw)))
+            return parsed_log
+        except ValueError as value_error:
+            raise ValueError(
+                f"Unable to parse value from log file to correct type for row: {row} {value_error}") from value_error
 
     @staticmethod
-    def validate(file_contents) -> bool:
+    def try_insert_header(file_contents: List[str]) -> List[str]:
+        """
+        Attempt to normalise data where no header is present by inserting one.
+
+        @param file_contents: The file contents to be reformatted
+        @return: The reformatted file contents
+        """
         if CSVLogParser.EXPECTED_HEADER_FOR_IMAT_CSV_LOG_FILE != file_contents[0]:
-            return False
-        return True
+            file_contents.insert(0, CSVLogParser.EXPECTED_HEADER_FOR_IMAT_CSV_LOG_FILE)
+
+        return file_contents
+
+    @staticmethod
+    def try_remove_invalid_lines(file_contents: List[str]) -> List[str]:
+        """
+        Attempt to normalise data where invalid lines are the incorrect number of columns are present.
+
+        @param file_contents: The file contents to be reformatted
+        @return: The reformatted file contents
+        """
+        for row in file_contents:
+            if len(row.split(",")) < 5:
+                file_contents.remove(row)
+        return file_contents
 
 
 class IMATLogFile:
@@ -120,10 +177,35 @@ class IMATLogFile:
 
     @staticmethod
     def find_parser(data: List[str]):
-        if TextLogParser.validate(data):
+        """
+        Try and determine the format of the log file by checking the first row. for the type of seperator used and then
+        attempting to normalise the data if needed before selecting the appropriate parser.
+        """
+
+        if IMATLogFile.get_seperator(data[0]):
+            data = TextLogParser.try_insert_header(data)
+            data = TextLogParser.try_remove_invalid_lines(data)
             return TextLogParser(data)
-        elif CSVLogParser.validate(data):
+        elif not IMATLogFile.get_seperator(data[0]):
+            data = CSVLogParser.try_insert_header(data)
+            data = CSVLogParser.try_remove_invalid_lines(data)
             return CSVLogParser(data)
+
+    @staticmethod
+    def get_seperator(first_row: str) -> bool:
+        """
+        Try and determine the seperator used in the log file.
+        If neither a tab or comma is found, then return a RuntimeError
+        as the format is not recognised.
+
+        @param data: The file contents to be checked
+        @return: The seperator used in the file
+        Exception: RuntimeError if the format is not recognised
+        """
+        if "   " in first_row:
+            return True
+        elif "," in first_row:
+            return False
         else:
             raise RuntimeError("The format of the log file is not recognised.")
 

--- a/mantidimaging/core/utility/test/imat_log_file_parser_test.py
+++ b/mantidimaging/core/utility/test/imat_log_file_parser_test.py
@@ -37,9 +37,48 @@ CSV_LOG_FILE = [
     "timestamp,Projection,1,angle:0.1,counts before: 45678,counts_after: 84678",
     "timestamp,Projection,2,angle:0.2,counts before: 84678,counts_after: 124333",
 ]
+TXT_LOG_FILE_NO_HEADER = [
+    "timestamp   Projection:  0  angle: 0.0   counts before: 12345   counts_after: 45678",
+    "timestamp   Projection:  1  angle: 0.1   counts before: 45678   counts_after: 84678",
+    "timestamp   Projection:  2  angle: 0.2   counts before: 84678   counts_after: 124333",
+]
+CSV_LOG_FILE_NO_HEADER = [
+    "timestamp,Projection,0,angle:0.0,counts before: 12345,counts_after: 45678",
+    "timestamp,Projection,1,angle:0.1,counts before: 45678,counts_after: 84678",
+    "timestamp,Projection,2,angle:0.2,counts before: 84678,counts_after: 124333",
+]
+TXT_LOG_FILE_NO_HEADER_EMPTY_SPACE = [
+    "timestamp   Projection:  0  angle: 0.0   counts before: 12345   counts_after: 45678",
+    "",
+    "timestamp   Projection:  1  angle: 0.1   counts before: 45678   counts_after: 84678",
+    "",
+    "timestamp   Projection:  2  angle: 0.2   counts before: 84678   counts_after: 124333",
+]
+CSV_LOG_FILE_NO_HEADER_EMPTY_SPACE = [
+    "timestamp,Projection,0,angle:0.0,counts before: 12345,counts_after: 45678",
+    ""
+    "timestamp,Projection,1,angle:0.1,counts before: 45678,counts_after: 84678",
+    ""
+    "timestamp,Projection,2,angle:0.2,counts before: 84678,counts_after: 124333",
+]
+TXT_LOG_FILE_SHORT_INVALID_HEADER_NO_SPACE = [
+    " TIME STAMP  IMAGE TYPE   LAST_HEADER\n"
+    "timestamp   Projection:  0  angle: 0.0   counts before: 12345   counts_after: 45678",
+    "timestamp   Projection:  1  angle: 0.1   counts before: 45678   counts_after: 84678",
+    "timestamp   Projection:  2  angle: 0.2   counts before: 84678   counts_after: 124333",
+]
+CSV_LOG_FILE_SHORT_INVALID_HEADER = [
+    "TIME STAMP,IMAGE TYPE,LAST_HEADER\n"
+    "timestamp,Projection,0,angle:0.0,counts before: 12345,counts_after: 45678",
+    "timestamp,Projection,1,angle:0.1,counts before: 45678,counts_after: 84678",
+    "timestamp,Projection,2,angle:0.2,counts before: 84678,counts_after: 124333",
+]
 
 
-@pytest.mark.parametrize('test_input', [TXT_LOG_FILE, CSV_LOG_FILE])
+@pytest.mark.parametrize('test_input', [
+    TXT_LOG_FILE, CSV_LOG_FILE, TXT_LOG_FILE_NO_HEADER, CSV_LOG_FILE_NO_HEADER, TXT_LOG_FILE_NO_HEADER_EMPTY_SPACE,
+    CSV_LOG_FILE_NO_HEADER_EMPTY_SPACE
+])
 def test_counts(test_input):
     logfile = IMATLogFile(test_input, "/tmp/fake")
     assert len(logfile.counts().value) == 3
@@ -68,7 +107,10 @@ def assert_raises(exc_type, callable, *args, **kwargs):
         raise AssertionError("Did not raise expected exception.") from exc
 
 
-@pytest.mark.parametrize('test_input', [TXT_LOG_FILE, CSV_LOG_FILE])
+@pytest.mark.parametrize('test_input', [
+    TXT_LOG_FILE, CSV_LOG_FILE, TXT_LOG_FILE_NO_HEADER, CSV_LOG_FILE_NO_HEADER, TXT_LOG_FILE_NO_HEADER_EMPTY_SPACE,
+    CSV_LOG_FILE_NO_HEADER_EMPTY_SPACE
+])
 def test_find_missing_projection_number(test_input):
     logfile = IMATLogFile(test_input, "/tmp/fake")
     assert len(logfile.projection_numbers()) == 3
@@ -87,7 +129,10 @@ def test_raise_if_angles_missing_returns_none_if_no_filename_list():
     assert logfile.raise_if_angle_missing(None) is None
 
 
-@pytest.mark.parametrize('test_input', [TXT_LOG_FILE, CSV_LOG_FILE])
+@pytest.mark.parametrize('test_input', [
+    TXT_LOG_FILE, CSV_LOG_FILE, TXT_LOG_FILE_NO_HEADER, CSV_LOG_FILE_NO_HEADER, TXT_LOG_FILE_NO_HEADER_EMPTY_SPACE,
+    CSV_LOG_FILE_NO_HEADER_EMPTY_SPACE
+])
 def test_source_file(test_input):
     logfile = IMATLogFile(test_input, "/tmp/fake")
     assert logfile.source_file == "/tmp/fake"


### PR DESCRIPTION
### Issue

Closes #1864 

### Description

Add basic normalisation to handle known older log file formats where the header may not be present and there may be empty spaces "" between log file entries.

If there are the correct number of columns, but the header length is not long enough, the header will be replaced with a valid header.

Additional validation has been added to parsers to return more descriptive errors if data can't be parsed correctly.

### Testing 

Created copies of logs which are known to work and modified to match older log file formats. Formats tested can also be seen in unit tests. A good dataset to use as a base is a trimmed flower dataset.

### Acceptance Criteria 
* Tests pass (`python -m pytest mantidimaging/core/utility/test/imat_log_file_parser_test.py`)
* When loading a given dataset, test the below log file formats by modifying copies of the original log file for both `.txt` and `.csv` (The length of the log file and image stack will need to be the same) - *See "Example Log Formats" below for reference*:
  * No Header
  * Spaces ("") between log entries
  * No Header and Spaces between log entries
  * invalid header shortened in column length than expected (this should be changes to the valid header and a log should be printed to the terminal stating this change has occurred)
  * Invalid header that is too long for dataset (This should raise and error in a dialog window detailing why the log file was invalid to the user)

### Documentation

See: `docs/release_notes/next/fix-1833-support_older_log_formats`

### Example Log Formats

**Python List Format (once read)**
```Python
EXPECTED_TXT_LOG_FILE = [
    ' TIME STAMP  IMAGE TYPE   IMAGE COUNTER   COUNTS BM3 before image   COUNTS BM3 after image\n',
    "ignored line",
    "timestamp   Projection:  0  angle: 0.0   counts before: 12345   counts_after: 45678",
    "timestamp   Projection:  1  angle: 0.1   counts before: 45678   counts_after: 84678",
    "timestamp   Projection:  2  angle: 0.2   counts before: 84678   counts_after: 124333",
]
EXPECTED_CSV_LOG_FILE = [
    "TIME STAMP,IMAGE TYPE,IMAGE COUNTER,COUNTS BM3 before image,COUNTS BM3 after image\n",
    "timestamp,Projection,0,angle:0.0,counts before: 12345,counts_after: 45678",
    "timestamp,Projection,1,angle:0.1,counts before: 45678,counts_after: 84678",
    "timestamp,Projection,2,angle:0.2,counts before: 84678,counts_after: 124333",
]
OLD_FORMST_TXT_LOG_FILE_NO_HEADER = [
    "timestamp   Projection:  0  angle: 0.0   counts before: 12345   counts_after: 45678",
    "timestamp   Projection:  1  angle: 0.1   counts before: 45678   counts_after: 84678",
    "timestamp   Projection:  2  angle: 0.2   counts before: 84678   counts_after: 124333",
]
OLD_FORMST_CSV_LOG_FILE_NO_HEADER = [
    "timestamp,Projection,0,angle:0.0,counts before: 12345,counts_after: 45678",
    "timestamp,Projection,1,angle:0.1,counts before: 45678,counts_after: 84678",
    "timestamp,Projection,2,angle:0.2,counts before: 84678,counts_after: 124333",
]
OLD_FORMST_TXT_LOG_FILE_NO_HEADER_EMPTY_SPACE = [
    "timestamp   Projection:  0  angle: 0.0   counts before: 12345   counts_after: 45678",
    "",
    "timestamp   Projection:  1  angle: 0.1   counts before: 45678   counts_after: 84678",
    "",
    "timestamp   Projection:  2  angle: 0.2   counts before: 84678   counts_after: 124333",
]
OLD_FORMST_CSV_LOG_FILE_NO_HEADER_EMPTY_SPACE = [
    "timestamp,Projection,0,angle:0.0,counts before: 12345,counts_after: 45678",
    ""
    "timestamp,Projection,1,angle:0.1,counts before: 45678,counts_after: 84678",
    ""
    "timestamp,Projection,2,angle:0.2,counts before: 84678,counts_after: 124333",
]
```

**Example:  Older TXT Format (no header and spaces between entries**
```text
Wed Jul 10 00:22:04 2023   Projection:  0  angle: 0.0   Monitor 3 before:  4577907   Monitor 3 after:  4720271

Wed Jul 10 00:22:37 2023   Projection:  1  angle: 0.3152   Monitor 3 before:  4729337   Monitor 3 after:  4871319

Wed Jul 10 00:23:10 2023   Projection:  2  angle: 0.6304   Monitor 3 before:  4879923   Monitor 3 after:  5022689
```

**Example: Older CSV Format (no header and spaces between entries**
```csv
Wed Jul 10 00:22:04 2023, Projection, 0, Angle: 0, Monitor 3 before: 4577907, Monitor 3 after: 4720271

Wed Jul 10 00:22:37 2023, Projection, 1, Angle: 0.3152, Monitor 3 before: 4729337, Monitor 3 after: 4871319

Wed Jul 10 00:23:10 2023, Projection, 2, Angle: 0.6304, Monitor 3 before: 4879923, Monitor 3 after: 5022689
```

**Example: Invalid Short Header TXT**
```txt
 TIME STAMP  IMAGE TYPE   IMAGE COUNTER
 
Wed Jul 10 00:22:04 2023   Projection:  0  angle: 0.0   Monitor 3 before:  4577907   Monitor 3 after:  4720271

Wed Jul 10 00:22:37 2023   Projection:  1  angle: 0.3152   Monitor 3 before:  4729337   Monitor 3 after:  4871319

Wed Jul 10 00:23:10 2023   Projection:  2  angle: 0.6304   Monitor 3 before:  4879923   Monitor 3 after:  5022689
```

**Example: Invalid Short Header CSV**
```csv
TIME STAMP,IMAGE TYPE,IMAGE COUNTER

Wed Jul 10 00:22:04 2023, Projection, 0, Angle: 0, Monitor 3 before: 4577907, Monitor 3 after: 4720271

Wed Jul 10 00:22:37 2023, Projection, 1, Angle: 0.3152, Monitor 3 before: 4729337, Monitor 3 after: 4871319

Wed Jul 10 00:23:10 2023, Projection, 2, Angle: 0.6304, Monitor 3 before: 4879923, Monitor 3 after: 5022689
```