### PR TITLE
1859 select log if found

### DIFF
--- a/docs/release_notes/next/feature-1859-select_sample_log
+++ b/docs/release_notes/next/feature-1859-select_sample_log
@@ -1,0 +1,1 @@
+#1859 : Select Sample Log if found when loading a dataset

--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -108,11 +108,11 @@ class TestGuiSystemLoading(GuiSystemBase):
 
         self.assertEqual(len(self.main_window.presenter.datasets), 1)
         sample = list(self.main_window.presenter.datasets)[0].sample
-        self.assertNotIn("log_file", sample.metadata)
+        self.assertIn("log_file", sample.metadata)
 
-        # Initial angles are just evenly spaced from 0 to 2*pi
-        stack_len = sample.num_images
-        self.assertAlmostEqual(sample.projection_angles().value[1], 2 * math.pi / (stack_len - 1), 12)
+        # Assert initial angles are the same as log_file angles
+        log_angle = math.radians(self._get_log_angle(log_path))
+        self.assertAlmostEqual(sample.projection_angles().value[1], log_angle, 12)
 
         # Load sample log
         QTimer.singleShot(SHORT_DELAY, lambda: self._click_stack_selector())
@@ -140,11 +140,12 @@ class TestGuiSystemLoading(GuiSystemBase):
 
         self.assertEqual(len(self.main_window.presenter.datasets), 1)
         sample = list(self.main_window.presenter.datasets)[0].sample
-        self.assertNotIn("log_file", sample.metadata)
+        self.assertIn("log_file", sample.metadata)
 
-        # Initial angles are just evenly spaced from 0 to 2*pi
+        # Assert initial angles are the same as log_file angles
         stack_len = sample.num_images
-        self.assertAlmostEqual(sample.projection_angles().value[1], 2 * math.pi / (stack_len - 1), 12)
+        log_angle = math.radians(self._get_log_angle(sample.metadata['log_file']))
+        self.assertAlmostEqual(sample.projection_angles().value[1], log_angle, 12)
 
         test_angles = numpy.linspace(0, 100, stack_len)
         angle_file = self._make_angles_file(test_angles)

--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -110,9 +110,13 @@ class TestGuiSystemLoading(GuiSystemBase):
         sample = list(self.main_window.presenter.datasets)[0].sample
         self.assertIn("log_file", sample.metadata)
 
-        # Assert initial angles are the same as log_file angles
-        log_angle = math.radians(self._get_log_angle(log_path))
-        self.assertAlmostEqual(sample.projection_angles().value[1], log_angle, 12)
+        # Initial angles are just evenly spaced from 0 to 2*pi
+        sample.metadata["log_file"] = None
+        # sample.log_file = None
+        # sample.projection_angles = None
+        self.assertNotIn("log_file", sample.metadata)
+        stack_len = sample.num_images
+        self.assertAlmostEqual(sample.projection_angles().value[1], 2 * math.pi / (stack_len - 1), 12)
 
         # Load sample log
         QTimer.singleShot(SHORT_DELAY, lambda: self._click_stack_selector())
@@ -142,10 +146,13 @@ class TestGuiSystemLoading(GuiSystemBase):
         sample = list(self.main_window.presenter.datasets)[0].sample
         self.assertIn("log_file", sample.metadata)
 
-        # Assert initial angles are the same as log_file angles
+        # Initial angles are just evenly spaced from 0 to 2*pi
+        sample.metadata["log_file"] = None
+        # sample.log_file = None
+        # sample.projection_angles = None
+        self.assertNotIn("log_file", sample.metadata)
         stack_len = sample.num_images
-        log_angle = math.radians(self._get_log_angle(sample.metadata['log_file']))
-        self.assertAlmostEqual(sample.projection_angles().value[1], log_angle, 12)
+        self.assertAlmostEqual(sample.projection_angles().value[1], 2 * math.pi / (stack_len - 1), 12)
 
         test_angles = numpy.linspace(0, 100, stack_len)
         angle_file = self._make_angles_file(test_angles)

--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -110,11 +110,10 @@ class TestGuiSystemLoading(GuiSystemBase):
         sample = list(self.main_window.presenter.datasets)[0].sample
         self.assertIn("log_file", sample.metadata)
 
-        # Initial angles are just evenly spaced from 0 to 2*pi
-        sample.metadata["log_file"] = None
-        # sample.log_file = None
-        # sample.projection_angles = None
+        sample.log_file = None
+        sample._projection_angles = None
         self.assertNotIn("log_file", sample.metadata)
+
         stack_len = sample.num_images
         self.assertAlmostEqual(sample.projection_angles().value[1], 2 * math.pi / (stack_len - 1), 12)
 
@@ -146,11 +145,10 @@ class TestGuiSystemLoading(GuiSystemBase):
         sample = list(self.main_window.presenter.datasets)[0].sample
         self.assertIn("log_file", sample.metadata)
 
-        # Initial angles are just evenly spaced from 0 to 2*pi
-        sample.metadata["log_file"] = None
-        # sample.log_file = None
-        # sample.projection_angles = None
+        sample.log_file = None
+        sample._projection_angles = None
         self.assertNotIn("log_file", sample.metadata)
+
         stack_len = sample.num_images
         self.assertAlmostEqual(sample.projection_angles().value[1], 2 * math.pi / (stack_len - 1), 12)
 

--- a/mantidimaging/gui/windows/image_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/image_load_dialog/presenter.py
@@ -83,7 +83,7 @@ class LoadPresenter:
             if file_group.log_path:
                 log_field = self.view.fields[log_for_file_type[file_info].fname]
                 log_field.path = file_group.log_path
-                log_field.use = False
+                log_field.use = True
 
     def do_update_flat_or_dark(self, field: Field, selected_file: str) -> None:
         fg = FilenameGroup.from_file(Path(selected_file))


### PR DESCRIPTION
### Issue

Closes #1859 

### Description

If sample log is found, it is selected by default now in load dialog when loading a new dataset into MI

### Testing 

Tried Loading a dataset where sample log is found

### Acceptance Criteria 

- Compare against main branch.
- Load a dataset within MI using the menu.
- [ ] If the sample log file is found, the sample log is selected by default.
- [ ] Flat and Dark log files if detected are not selected by default.

### Documentation

`docs/release_notes/next/feature-1859-select_sample_log`
