### PR TITLE
1871 show cuda recon alg if disabled

### DIFF
--- a/docs/release_notes/next/feature-1871-disable_cuda_recon_alg_if_no_cuda
+++ b/docs/release_notes/next/feature-1871-disable_cuda_recon_alg_if_no_cuda
@@ -1,0 +1,1 @@
+#1871 : Show Cuda enabled reconstruction algorithms in disabled state if no gpu is available

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -88,12 +88,16 @@ class ReconstructWindowView(BaseMainWindowView):
         self.main_window = main_window
         self.presenter = ReconstructWindowPresenter(self, main_window)
 
-        if CudaChecker().cuda_is_present():
-            self.algorithmName.insertItem(0, "FBP_CUDA")
-            self.algorithmName.insertItem(1, "SIRT_CUDA")
-            self.algorithmName.insertItem(2, "CIL: PDHG-TV")
+        self.algorithmName.insertItem(1, "FBP_CUDA")
+        self.algorithmName.insertItem(2, "SIRT_CUDA")
+        self.algorithmName.insertItem(3, "CIL: PDHG-TV")
+        self.algorithmName.setCurrentIndex(1)
+        if not CudaChecker().cuda_is_present():
+            self.algorithmName.model().item(1).setEnabled(False)
+            self.algorithmName.model().item(2).setEnabled(False)
+            self.algorithmName.model().item(3).setEnabled(False)
             self.algorithmName.setCurrentIndex(0)
-            self.algorithmName.setEnabled(True)
+        self.algorithmName.setEnabled(True)
 
         self.update_recon_hist_needed = False
         self.stackSelector.presenter.show_stacks = True


### PR DESCRIPTION
### Issue

Closes #1871 

### Description

If CUDA is not found, show reconstruction algorithms in disabled state so users with no CUDA are aware the algorithms exist. 
If CUDA is found, the algorithms should be enabled.

![image](https://github.com/mantidproject/mantidimaging/assets/32413847/754cb24e-d53b-4320-8cdb-b475d2d4f649)

### Testing 

Ran Mantid Imaging on a machine with no GPU

### Acceptance Criteria 

* Recon algorithms disabled if CUDA is not found and gridrec selected
* Recon Algorithms enabled if CUDA is found
* If CUDA found, Recon Window selects CUDA algorithm over gridrec on opening window.
* Tests pass

### Documentation

`docs/release_notes/next/feature-1871-disable_cuda_recon_alg_if_no_cuda`
