### PR TITLE
Find flat and dark when names differ

### DIFF
--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 from pathlib import Path
 import re
-from typing import List, Iterator, Optional, Union
+from typing import List, Iterator, Optional, Union, Final
 from logging import getLogger
 
 from mantidimaging.core.utility.data_containers import FILE_TYPES
 
 LOG = getLogger(__name__)
+
+IMAGE_FORMAT_EXTENSIONS: Final = ['fits', 'fit', 'tif', 'tiff']
 
 
 class FilenamePattern:
@@ -147,6 +149,20 @@ class FilenameGroup:
         return new_filename_group
 
     @classmethod
+    def from_directory(cls, path: Union[Path, str]) -> FilenameGroup | None:
+        path = Path(path)
+        if not path.is_dir():
+            raise ValueError(f"path is a file: {path}")
+
+        for file in sorted(path.iterdir()):
+            if file.suffix.lstrip(".") not in IMAGE_FORMAT_EXTENSIONS:
+                continue
+            fg = cls.from_file(file)
+            return fg
+
+        return None
+
+    @classmethod
     def get_pattern_class(cls, path):
         if 'grtomo' in path.name.lower():
             return FilenamePatternGolden
@@ -183,22 +199,23 @@ class FilenameGroup:
             self.log_path = self.directory / shortest
 
     def find_related(self, file_type: FILE_TYPES) -> Optional[FilenameGroup]:
+        if self.directory.name not in ["Tomo", "tomo"]:
+            return None
+
         if file_type == FILE_TYPES.PROJ_180:
             return self._find_related_180_proj()
-
-        sample_first_name = self.first_file().name
 
         test_names = [file_type.fname.replace(" ", "_")]
         if file_type.suffix == "Before":
             test_names.append(file_type.tname)
         test_names.extend([s.lower() for s in test_names])
-        if self.directory.name in ["Tomo", "tomo"]:
-            for test_name in test_names:
-                new_dir = self.directory.parent / test_name
-                if new_dir.exists():
-                    new_path = new_dir / sample_first_name.replace("Tomo", test_name).replace("tomo", test_name)
-                    if new_path.exists():
-                        return self.from_file(new_path)
+
+        for test_name in test_names:
+            new_dir = self.directory.parent / test_name
+            if new_dir.exists():
+                fg = self.from_directory(new_dir)
+                if fg is not None:
+                    return fg
 
         return None
 
@@ -206,17 +223,17 @@ class FilenameGroup:
         sample_first_name = self.first_file().name
 
         test_name = "180deg"
-        if self.directory.name in ["Tomo", "tomo"]:
-            new_dir = self.directory.parent / test_name
-            if new_dir.exists():
-                for trim_numbers in [True, False]:
-                    if trim_numbers:
-                        new_name = re.sub(r'_([0-9]+)', "", sample_first_name)
-                    else:
-                        new_name = sample_first_name
-                    new_name = new_name.replace("Tomo", test_name).replace("tomo", test_name)
-                    new_path = new_dir / new_name
-                    if new_path.exists():
-                        return self.from_file(new_path)
+
+        new_dir = self.directory.parent / test_name
+        if new_dir.exists():
+            for trim_numbers in [True, False]:
+                if trim_numbers:
+                    new_name = re.sub(r'_([0-9]+)', "", sample_first_name)
+                else:
+                    new_name = sample_first_name
+                new_name = new_name.replace("Tomo", test_name).replace("tomo", test_name)
+                new_path = new_dir / new_name
+                if new_path.exists():
+                    return self.from_file(new_path)
 
         return None

--- a/mantidimaging/core/io/loader/__init__.py
+++ b/mantidimaging/core/io/loader/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import annotations
 
 from .loader import (  # noqa: F401
-    load, load_log, supported_formats, load_stack_from_group, load_stack_from_image_params)
+    load, load_log, load_stack_from_group, load_stack_from_image_params)

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -72,10 +72,6 @@ def _imread(filename: Union[Path, str]) -> np.ndarray:
     return tifffile.imread(filename)
 
 
-def supported_formats() -> List[str]:
-    return ['fits', 'fit', 'tif', 'tiff']
-
-
 def get_loader(in_format: str) -> Callable[[Union[Path, str]], np.ndarray]:
     if in_format in ['fits', 'fit']:
         load_func = _fitsread

--- a/mantidimaging/core/io/test/filenames_test.py
+++ b/mantidimaging/core/io/test/filenames_test.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 import unittest
 
-import pytest
 from parameterized import parameterized
 
 from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
@@ -109,6 +108,19 @@ class FilenameGroupTest(FakeFSTestCase):
         all_files = list(f1.all_files())
         self._file_list_count_equal(all_files, [p1])
 
+    def test_pattern_from_dir(self):
+        test_dir = Path("/foo")
+
+        for i in [9, 2, 1, 6, 8, 7, 0, 5, 3, 4]:
+            self.fs.create_file(test_dir / f"bbb_{i:06d}.tif")
+            self.fs.create_file(test_dir / f"ccc_{i:06d}.tif")
+        self.fs.create_file(test_dir / "otherfile")
+        self.fs.create_file(test_dir / "anotherfile")
+
+        f1 = FilenameGroup.from_directory(test_dir)
+
+        self._files_equal(f1.first_file(), "/foo/bbb_000000.tif")
+
     def test_first_files(self):
         filename = "IMAT_Flower_Tomo_000001.tif"
         f1 = FilenameGroup.from_file(filename)
@@ -188,7 +200,6 @@ class FilenameGroupTest(FakeFSTestCase):
         ("/foo/Tomo/IMAT00026734_Tomo_CoinCell_7_Angled_PH40_Tomo_%03d.tif",
          "/foo/Flat_Before/IMAT00026732_Tomo_CoinCell_7_Angled_PH40_Flat_Before_%03d.tif"),
     ])
-    @pytest.mark.xfail
     def test_find_related(self, tomo_pattern, flat_pattern):
         tomo_list = [Path(tomo_pattern % i) for i in range(10)]
         flat_before_list = [Path(flat_pattern % i) for i in range(10)]

--- a/mantidimaging/core/io/test/filenames_test.py
+++ b/mantidimaging/core/io/test/filenames_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 import unittest
 
+import pytest
 from parameterized import parameterized
 
 from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
@@ -184,7 +185,10 @@ class FilenameGroupTest(FakeFSTestCase):
         ("/a/Tomo/foo_Tomo_%06d.tif", "/a/Flat_Before/foo_Flat_Before_%06d.tif"),
         ("/a/Tomo/foo_Tomo_%06d.tif", "/a/Flat/foo_Flat_%06d.tif"),
         ("/a/tomo/foo_tomo_%06d.tif", "/a/flat_before/foo_flat_before_%06d.tif"),
+        ("/foo/Tomo/IMAT00026734_Tomo_CoinCell_7_Angled_PH40_Tomo_%03d.tif",
+         "/foo/Flat_Before/IMAT00026732_Tomo_CoinCell_7_Angled_PH40_Flat_Before_%03d.tif"),
     ])
+    @pytest.mark.xfail
     def test_find_related(self, tomo_pattern, flat_pattern):
         tomo_list = [Path(tomo_pattern % i) for i in range(10)]
         flat_before_list = [Path(flat_pattern % i) for i in range(10)]

--- a/mantidimaging/gui/windows/main/image_save_dialog.py
+++ b/mantidimaging/gui/windows/main/image_save_dialog.py
@@ -6,7 +6,7 @@ from typing import Optional, TYPE_CHECKING
 
 from PyQt5.QtWidgets import QDialogButtonBox
 
-from mantidimaging.core.io.loader import supported_formats
+from mantidimaging.core.io.filenames import IMAGE_FORMAT_EXTENSIONS
 from mantidimaging.core.io.utility import DEFAULT_IO_FILE_FORMAT
 from mantidimaging.gui.mvp_base import BaseDialogView
 from mantidimaging.gui.utility import select_directory
@@ -35,7 +35,7 @@ class ImageSaveDialog(BaseDialogView):
         self.buttonBox.button(QDialogButtonBox.StandardButton.SaveAll).clicked.connect(self.save_all)
 
         # dynamically add all the supported formats
-        formats = supported_formats()
+        formats = IMAGE_FORMAT_EXTENSIONS
         self.formats.addItems(formats)
 
         # set the default to tiff


### PR DESCRIPTION
### Issue

Closes #1865

### Description
Make finding the flat and dark files less strict.

Now just look for the first image in a folder with the expected name.

### Testing 

*Describe the tests that were used to verify your changes*.

### Acceptance Criteria 

*How should the reviewer test your changes*?

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*
