### PR TITLE
Fix FilenamePattern for extra leading digits case

### DIFF
--- a/docs/release_notes/next/fix-1870-load-all-files
+++ b/docs/release_notes/next/fix-1870-load-all-files
@@ -1,0 +1,1 @@
+#1870 : Load all file in the extra digits case

--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -32,7 +32,7 @@ class FilenamePattern:
             self.re_pattern = re.compile("^" + re.escape(prefix) + re.escape(suffix) + "$")
         else:
             # Note: allow extra leading digits, for data sets that go 001 ... 998, 999, 1000, 1001
-            self.re_pattern = re.compile("^" + re.escape(prefix) + "([1-9]*[0-9]{" + str(digit_count) + "})" +
+            self.re_pattern = re.compile("^" + re.escape(prefix) + "(([1-9][0-9]*)?[0-9]{" + str(digit_count) + "})" +
                                          re.escape(suffix) + "$")
 
         self.re_pattern_metadata = re.compile("^" + re.escape(prefix.rstrip("_ ")) + ".json$")
@@ -92,8 +92,8 @@ class FilenamePatternGolden(FilenamePattern):
         self.suffix = suffix
         self.name_store: dict[int, str] = {}
 
-        self.re_pattern = re.compile("^" + re.escape(prefix) + self.PATTERN_a + "([1-9]*[0-9]{" + str(digit_count) +
-                                     "})" + re.escape(suffix) + "$")
+        self.re_pattern = re.compile("^" + re.escape(prefix) + self.PATTERN_a + "(([1-9][0-9]*)?[0-9]{" +
+                                     str(digit_count) + "})" + re.escape(suffix) + "$")
 
         self.re_pattern_metadata = re.compile("^" + re.escape(prefix.rstrip("_ ")) + ".json$")
 

--- a/mantidimaging/core/io/test/filenames_test.py
+++ b/mantidimaging/core/io/test/filenames_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 import unittest
 
+import pytest
 from parameterized import parameterized
 
 from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
@@ -59,14 +60,18 @@ class FilenamePatternTest(unittest.TestCase):
         p1 = FilenamePattern.from_name("img_000.tif")
         self.assertTrue(p1.match("img_000.tif"))
         self.assertTrue(p1.match("img_001.tif"))
+        self.assertTrue(p1.match("img_100.tif"))
         self.assertTrue(p1.match("img_999.tif"))
         self.assertTrue(p1.match("img_1000.tif"))
         self.assertFalse(p1.match("img_0000.tif"))
 
+    @pytest.mark.xfail
     def test_pattern_match_different_digits_no_zeros(self):
         # Allow cases where index has grown above padding
         p1 = FilenamePattern.from_name("img_1.tif")
         self.assertTrue(p1.match("img_10.tif"))
+        self.assertTrue(p1.match("img_100.tif"))
+        self.assertTrue(p1.match("img_101.tif"))
         self.assertTrue(p1.match("img_1234.tif"))
         self.assertFalse(p1.match("img_0000.tif"))
 

--- a/mantidimaging/core/io/test/filenames_test.py
+++ b/mantidimaging/core/io/test/filenames_test.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 import unittest
 
-import pytest
 from parameterized import parameterized
 
 from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
@@ -65,7 +64,6 @@ class FilenamePatternTest(unittest.TestCase):
         self.assertTrue(p1.match("img_1000.tif"))
         self.assertFalse(p1.match("img_0000.tif"))
 
-    @pytest.mark.xfail
     def test_pattern_match_different_digits_no_zeros(self):
         # Allow cases where index has grown above padding
         p1 = FilenamePattern.from_name("img_1.tif")


### PR DESCRIPTION
### Issue

Closes #1870 

### Description
Fix the regular expression used find image files in the case where number of digits used varies.

### Testing 

Add test case for problem names

### Acceptance Criteria 
Create set of files using command on #1870
Check that the correct number are loaded


### Documentation
Release notes
