### PR TITLE
1875 file validation

### DIFF
--- a/docs/release_notes/next/fix-1875-live_viewer_file_state_validation
+++ b/docs/release_notes/next/fix-1875-live_viewer_file_state_validation
@@ -1,0 +1,1 @@
+#1875 : Additional live viewer error handling for read operations on files and improved handling of slow copies to watched directory

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -73,14 +73,25 @@ class ImageWatcher(QObject):
         self.find_images()
         self.find_last_modified_image()
 
+    def _validate_file(self, file_path) -> bool:
+        """
+        Check if a file is valid.
+        """
+        return file_path.is_file() and self._is_image_file(file_path.name)
+
     def _get_image_files(self):
         image_files = []
         for file_path in Path(self.directory).iterdir():
-            if file_path.is_file() and self._is_image_file(file_path.name):
+            file_size = file_path.stat().st_size
+            if file_size > 45 and self._validate_file(file_path):
+                LOG.debug(f'VALID FILE: {file_path} is an image file and is not empty')
                 image_files.append(file_path)
+            else:
+                LOG.debug(f'INVALID FILE: {file_path} is not valid an image file or is empty')
         return image_files
 
     @staticmethod
     def _is_image_file(file_name):
         image_extensions = ['.tif', '.tiff']
-        return any(file_name.lower().endswith(ext) for ext in image_extensions)
+        file_names = any(file_name.lower().endswith(ext) for ext in image_extensions)
+        return file_names

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -49,3 +49,7 @@ class LiveViewerWindowPresenter(BasePresenter):
         except IOError as error:
             logger.error("Error reading image: %s", error)
             return
+        except KeyError as key_error:
+            logger.error("Error reading image: %s", key_error)
+        except ValueError as value_error:
+            logger.error("Error reading image: %s", value_error)

--- a/scripts/simulate_live_data.py
+++ b/scripts/simulate_live_data.py
@@ -32,7 +32,7 @@ def copy_dataset(source_dir, dest_dir, rate, slow_copy_mode):
 
             time.sleep(float(rate))
         if os.path.isdir(source_item):
-            copy_dataset(source_item, dest_item, rate)
+            copy_dataset(source_item, dest_item, rate, slow_copy_mode)
 
 
 def slow_copy(source, dest):


### PR DESCRIPTION
### Issue

Closes #1875 

### Description

* Add additional error handling when trying to read a file that may not have been fully written to directory being watched by Live Viewer.
* Check file size before read to only read files once past the ~minimum size a valid tif file can be (at least according to [this stackoverflow thread](https://stackoverflow.com/questions/42787235/smallest-possible-valid-tif-file))
* Fix minor issue with missed argument in `scripts/simulate_live_data.py`

### Testing 

Tested slow copy and quick copies of files into directory being watched by live viewer. 

### Acceptance Criteria 

* Slow copies work (run in debug mode to view file validation check status's)
* Fast copy still works
* Tests pass

### Documentation

* `docs/release_notes/next/fix-1875-live_viewer_file_state_validation`
