### PR TITLE
1882 file signal emit efficiency

### DIFF
--- a/docs/release_notes/next/fix-1882-reduce_file_update_signal_emits
+++ b/docs/release_notes/next/fix-1882-reduce_file_update_signal_emits
@@ -1,0 +1,1 @@
+#1882 : Additional Logging of file change emit signals and reduction in file change emit signals

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -57,8 +57,6 @@ class ImageWatcher(QObject):
         image_changed signal for the last modified image.
         """
         self.images = self._get_image_files()
-        for image_file in self.images:
-            self.image_changed.emit(str(image_file))
 
     def find_last_modified_image(self):
         """
@@ -68,6 +66,7 @@ class ImageWatcher(QObject):
         if self.images:
             last_modified_image = max(self.images, key=lambda x: x.stat().st_mtime)
             self.image_changed.emit(str(last_modified_image))
+            LOG.debug('Last modified image: %s', last_modified_image)
 
     def _handle_directory_change(self, directory):
         LOG.debug('Directory changed: %s', directory)

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -42,6 +42,7 @@ class LiveViewerWindowPresenter(BasePresenter):
         if not Path(image_path).exists():
             return
         try:
+            logger.debug("Showing image in presenter: %s", image_path)
             with tifffile.TiffFile(image_path) as tif:
                 image_data = tif.asarray()
                 self.view.show_image(image_data)


### PR DESCRIPTION
### Issue

Closes #1882 

### Description

* Additional Logging
* Reduce file_change signal emits

### Testing 

Add logs proposed in PR changes to main and compare emit frequency (note that the additional emits for directory changes will be reduced in #1879)

### Acceptance Criteria 

* Compare number of file change emits to main.

### Documentation

docs/release_notes/next/fix-1882-reduce_file_update_signal_emits
