### PR TITLE
Switch from load_module to exec_module

### DIFF
--- a/docs/release_notes/next/dev-1813-remove-load_module
+++ b/docs/release_notes/next/dev-1813-remove-load_module
@@ -1,0 +1,1 @@
+#1813 : Remove deprecated load_module()

--- a/mantidimaging/core/operation_history/operations.py
+++ b/mantidimaging/core/operation_history/operations.py
@@ -57,10 +57,7 @@ def deserialize_metadata(metadata: Dict[str, Any]) -> List[ImageOperation]:
 
 
 def ops_to_partials(filter_ops: Iterable[ImageOperation]) -> Iterable[partial]:
-    filter_funcs: Dict[str, Callable] = {
-        f.__name__: f.filter_func
-        for f in load_filter_packages(ignored_packages=['mantidimaging.core.operations.wip'])
-    }
+    filter_funcs: Dict[str, Callable] = {f.__name__: f.filter_func for f in load_filter_packages()}
     fixed_funcs = {
         const.OPERATION_NAME_AXES_SWAP: lambda img, **_: np.swapaxes(img, 0, 1),
         # const.OPERATION_NAME_TOMOPY_RECON: lambda img, **kwargs: TomopyReconWindowModel.do_recon(img, **kwargs),

--- a/mantidimaging/core/operations/loader.py
+++ b/mantidimaging/core/operations/loader.py
@@ -5,12 +5,9 @@ import os
 import pkgutil
 import sys
 from importlib.util import module_from_spec
-from importlib.machinery import FileFinder, ModuleSpec
 from typing import List, TYPE_CHECKING
-from importlib.abc import Loader
 
 if TYPE_CHECKING:
-    from PyInstaller.loader.pyimod02_importers import FrozenImporter
     from mantidimaging.core.operations.base_filter import BaseFilter
 
 _OPERATION_MODULES_LIST: List[BaseFilter] = []
@@ -26,12 +23,11 @@ def _find_operation_modules() -> List[BaseFilter]:
             # If we're running a PyInstaller executable then we need to use a full module path
             module_name = f'mantidimaging.core.operations.{module_name}'
 
-        if TYPE_CHECKING:
-            assert isinstance(finder, (FileFinder, FrozenImporter))
-        spec = finder.find_spec(module_name)
+        # near impossible to type check as find can be a pyinstaller specific type that we can't normally import
+        spec = finder.find_spec(module_name)  # type: ignore[call-arg]
 
-        assert isinstance(spec, ModuleSpec)
-        assert isinstance(spec.loader, Loader)
+        assert spec is not None
+        assert spec.loader is not None
         module = module_from_spec(spec)
         sys.modules[module_name] = module
         spec.loader.exec_module(module)

--- a/mantidimaging/core/operations/loader.py
+++ b/mantidimaging/core/operations/loader.py
@@ -4,33 +4,41 @@ from __future__ import annotations
 import os
 import pkgutil
 import sys
-from typing import List, Protocol, cast, Union, TYPE_CHECKING
+from importlib.util import module_from_spec
 from importlib.machinery import FileFinder, ModuleSpec
+from typing import List, TYPE_CHECKING
 from importlib.abc import Loader
 
 if TYPE_CHECKING:
     from PyInstaller.loader.pyimod02_importers import FrozenImporter
     from mantidimaging.core.operations.base_filter import BaseFilter
 
-MODULES_OPERATIONS: dict[str, Union['FrozenImporter', Loader]] = {}
-if not MODULES_OPERATIONS:
-    for finder, module_name, _ in pkgutil.walk_packages([os.path.dirname(__file__)]):
+_OPERATION_MODULES_LIST: List[BaseFilter] = []
+
+
+def _find_operation_modules() -> List[BaseFilter]:
+    module_list: List[BaseFilter] = []
+    for finder, module_name, ispkg in pkgutil.walk_packages([os.path.dirname(__file__)]):
+        if not ispkg:
+            continue
+
         if getattr(sys, 'frozen', False):
-            # If we're running a PyInstaller executable then we will get back a FrozenImporter object instead of a
-            # FileFinder. FrozenImporter implements load_module directly, but needs to use the full import name for
-            # the module to load it from the PYZ archive.
-            assert hasattr(finder, 'load_module')
-            MODULES_OPERATIONS[f'mantidimaging.core.operations.{module_name}'] = finder
-        else:
-            assert isinstance(finder, FileFinder)
-            spec = finder.find_spec(module_name)
-            assert isinstance(spec, ModuleSpec)
-            assert isinstance(spec.loader, Loader)
-            MODULES_OPERATIONS[module_name] = spec.loader
+            # If we're running a PyInstaller executable then we need to use a full module path
+            module_name = f'mantidimaging.core.operations.{module_name}'
 
+        if TYPE_CHECKING:
+            assert isinstance(finder, (FileFinder, FrozenImporter))
+        spec = finder.find_spec(module_name)
 
-class OperationModule(Protocol):
-    FILTER_CLASS: BaseFilter
+        assert isinstance(spec, ModuleSpec)
+        assert isinstance(spec.loader, Loader)
+        module = module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        if hasattr(module, 'FILTER_CLASS'):
+            module_list.append(module.FILTER_CLASS)
+
+    return module_list
 
 
 def load_filter_packages(ignored_packages=None) -> List[BaseFilter]:
@@ -42,12 +50,7 @@ def load_filter_packages(ignored_packages=None) -> List[BaseFilter]:
 
     :param ignored_packages: List of ignore rules
     """
-
-    operation_modules = []
-    for name in MODULES_OPERATIONS.keys():
-        if not ignored_packages or not any(ignore in name for ignore in ignored_packages):
-            module = MODULES_OPERATIONS[name].load_module(name)
-            if hasattr(module, 'FILTER_CLASS'):
-                operation_module = cast("OperationModule", module)
-                operation_modules.append(operation_module.FILTER_CLASS)
-    return operation_modules
+    global _OPERATION_MODULES_LIST
+    if not _OPERATION_MODULES_LIST:
+        _OPERATION_MODULES_LIST = _find_operation_modules()
+    return _OPERATION_MODULES_LIST

--- a/mantidimaging/core/operations/loader.py
+++ b/mantidimaging/core/operations/loader.py
@@ -41,7 +41,7 @@ def _find_operation_modules() -> List[BaseFilter]:
     return module_list
 
 
-def load_filter_packages(ignored_packages=None) -> List[BaseFilter]:
+def load_filter_packages() -> List[BaseFilter]:
     """
     Imports all subpackages with a FILTER_CLASS attribute, which should be an extension of BaseFilter.
 

--- a/mantidimaging/core/parallel/manager.py
+++ b/mantidimaging/core/parallel/manager.py
@@ -10,6 +10,8 @@ from typing import List, Optional, TYPE_CHECKING
 import psutil
 from psutil import NoSuchProcess, AccessDenied
 
+from mantidimaging.core.operations.loader import load_filter_packages
+
 if TYPE_CHECKING:
     from multiprocessing.pool import Pool
 
@@ -30,14 +32,13 @@ def create_and_start_pool():
     cores = context.cpu_count()
     global pool
     pool = context.Pool(cores)
-    # We need a function to call to start the processes but the function itself doesn't need to do anything
-    # If we don't do this then the processes start when the pool is first called later in the application
-    # which affects performance.
-    pool.map_async(_do_nothing, range(cores))
+
+    pool.map(worker_setup, range(cores))
 
 
-def _do_nothing(i):
-    pass
+def worker_setup(_):
+    # Required to import modules for running operations
+    load_filter_packages()
 
 
 def end_pool():

--- a/mantidimaging/core/utility/command_line_arguments.py
+++ b/mantidimaging/core/utility/command_line_arguments.py
@@ -8,20 +8,14 @@ from mantidimaging.core.operations.loader import load_filter_packages
 
 logger = getLogger(__name__)
 
-filter_names = [package.filter_name for package in load_filter_packages()]
-command_line_names = {}
 
-for filter_name in filter_names:
-    command_line_names[filter_name.replace(" ", "-").lower()] = filter_name
+def _get_filter_names():
+    filter_names = [package.filter_name for package in load_filter_packages()]
+    command_line_names = {}
 
-
-def _valid_operation(operation: str):
-    """
-    Checks if a given operation exists in Mantid Imaging.
-    :param operation: The name of the operation.
-    :return: True if it is a valid operation, False otherwise.
-    """
-    return operation.lower() in command_line_names.keys()
+    for filter_name in filter_names:
+        command_line_names[filter_name.replace(" ", "-").lower()] = filter_name
+    return command_line_names
 
 
 def _log_and_exit(msg: str):
@@ -55,15 +49,16 @@ class CommandLineArguments:
                         valid_paths.append(filepath)
                 cls._images_path = valid_paths
             if operation:
+                command_line_names = _get_filter_names()
                 if not cls._images_path:
                     _log_and_exit("No path given for initial operation. Exiting.")
-                elif not _valid_operation(operation):
+                elif operation.lower() not in command_line_names:
                     valid_filters = ", ".join(command_line_names.keys())
                     _log_and_exit(
                         f"{operation} is not a known operation. Available filters arguments are {valid_filters}."
                         " Exiting.")
                 else:
-                    cls._init_operation = command_line_names[operation]
+                    cls._init_operation = command_line_names[operation.lower()]
             if show_recon and not path:
                 _log_and_exit("No path given for reconstruction. Exiting.")
             else:

--- a/mantidimaging/core/utility/command_line_arguments.py
+++ b/mantidimaging/core/utility/command_line_arguments.py
@@ -10,12 +10,7 @@ logger = getLogger(__name__)
 
 
 def _get_filter_names():
-    filter_names = [package.filter_name for package in load_filter_packages()]
-    command_line_names = {}
-
-    for filter_name in filter_names:
-        command_line_names[filter_name.replace(" ", "-").lower()] = filter_name
-    return command_line_names
+    return {package.filter_name.replace(" ", "-").lower(): package.filter_name for package in load_filter_packages()}
 
 
 def _log_and_exit(msg: str):

--- a/mantidimaging/core/utility/test/command_line_arguments_test.py
+++ b/mantidimaging/core/utility/test/command_line_arguments_test.py
@@ -5,8 +5,7 @@ import logging
 import unittest
 from unittest import mock
 
-from mantidimaging.core.operations.loader import load_filter_packages
-from mantidimaging.core.utility.command_line_arguments import CommandLineArguments, _valid_operation, command_line_names
+from mantidimaging.core.utility.command_line_arguments import CommandLineArguments
 
 
 class CommandLineArgumentsTest(unittest.TestCase):
@@ -47,13 +46,6 @@ class CommandLineArgumentsTest(unittest.TestCase):
             CommandLineArguments()
         exists_mock.assert_not_called()
 
-    def test_user_input_in_filter_names(self):
-        user_inputs = [filter_package.filter_name.replace(" ", "-") for filter_package in load_filter_packages()]
-        print(command_line_names)
-        for filter_name in user_inputs:
-            with self.subTest(filter_name=filter_name):
-                assert _valid_operation(filter_name)
-
     def test_set_valid_operation_with_path(self):
         operation = "median"
         command_line_arguments = CommandLineArguments(path="./", operation=operation)
@@ -70,10 +62,7 @@ class CommandLineArgumentsTest(unittest.TestCase):
             with self.assertLogs(self.logger, level="ERROR") as mock_log:
                 bad_operation = "aaaaaa"
                 CommandLineArguments(path="./", operation=bad_operation)
-        valid_filters = ", ".join(command_line_names.keys())
-        self.assertIn(
-            f"{bad_operation} is not a known operation. Available filters arguments are {valid_filters}. Exiting.",
-            mock_log.output[0])
+        self.assertIn(f"{bad_operation} is not a known operation. Available filters arguments are ", mock_log.output[0])
 
     def test_set_show_recon(self):
         command_line_arguments = CommandLineArguments(path="./", show_recon=True)

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -26,7 +26,7 @@ class FiltersWindowModel(object):
 
         self.presenter = presenter
         # Update the local filter registry
-        self.filters = load_filter_packages(ignored_packages=['mantidimaging.core.operations.wip'])
+        self.filters = load_filter_packages()
 
         # Sort by name for PyInstaller
         def _name(ops):

--- a/mantidimaging/gui/windows/operations/test/model_test.py
+++ b/mantidimaging/gui/windows/operations/test/model_test.py
@@ -175,7 +175,7 @@ class FiltersWindowModelTest(unittest.TestCase):
 
     def test_filter_names(self):
 
-        filters = load_filter_packages(ignored_packages=['mantidimaging.core.operations.wip'])
+        filters = load_filter_packages()
         random.shuffle(filters)
 
         with mock.patch("mantidimaging.gui.windows.operations.model.load_filter_packages") as load_filter_packages_mock:


### PR DESCRIPTION
### Issue

Closes #1813

### Description
Switch away from deprecated load_module().

This required doing loading a bit differently.

Also needed to avoid the this happening at import time, otherwise we get issues like
```
ImportError: cannot import name 'RescaleFilter' from partially initialized module
'mantidimaging.core.operations.rescale.rescale' (most likely due to a circular import) (/home/sam/git/mantidimaging/packaging/dist/MantidImaging/mantidimaging/core/operations/rescale/rescale.pyc)
```
I think because rescale gets imported normally in `saver.py` so can be in a partially initialized state at the point we call `exec_module()`


### Testing 

Some tests updated

### Acceptance Criteria 

Check `--operation` command line option.
Check operations window opens normally.
Check that operations run.

Build with pyinstaller, and check that the excutable runs. On linux this needs a small patch that I'll make into a separate PR
```diff
--- packaging/PackageWithPyInstaller.py
+++ packaging/PackageWithPyInstaller.py
@@ -36,7 +36,7 @@ def add_hidden_imports(run_options):
 
     # Operations modules must be added as hidden imports because most are imported programmatically in MantidImaging
     path_to_operations = Path(__file__).parent.parent.joinpath('mantidimaging/core/operations')
-    for _, ops_module, _ in pkgutil.walk_packages([path_to_operations]):
+    for _, ops_module, _ in pkgutil.walk_packages([str(path_to_operations)]):
         imports.append(f'mantidimaging.core.operations.{ops_module}')

```

### Documentation
release_notes
