### PR TITLE
1881 live view cli args

### DIFF
--- a/docs/release_notes/next/feature-1881-live_liew_cli_launch_argument
+++ b/docs/release_notes/next/feature-1881-live_liew_cli_launch_argument
@@ -1,0 +1,1 @@
+#1881 : Allow Live Viewer to be launched using cli argument with a specific directory

--- a/mantidimaging/core/utility/command_line_arguments.py
+++ b/mantidimaging/core/utility/command_line_arguments.py
@@ -38,8 +38,9 @@ class CommandLineArguments:
     _images_path: list[str] = []
     _init_operation = ""
     _show_recon = False
+    _show_live_viewer = ""
 
-    def __new__(cls, path: str = "", operation: str = "", show_recon: bool = False):
+    def __new__(cls, path: str = "", operation: str = "", show_recon: bool = False, show_live_viewer: str = ""):
         """
         Creates a singleton for storing the command line arguments.
         """
@@ -67,6 +68,11 @@ class CommandLineArguments:
                 _log_and_exit("No path given for reconstruction. Exiting.")
             else:
                 cls._show_recon = show_recon
+            if show_live_viewer and show_live_viewer != cls._show_live_viewer:
+                if not os.path.exists(show_live_viewer):
+                    _log_and_exit("Path given for live view does not exist. Exiting.")
+                else:
+                    cls._show_live_viewer = show_live_viewer
 
         return cls._instance
 
@@ -90,3 +96,10 @@ class CommandLineArguments:
         Returns whether or not the recon window should be started.
         """
         return cls._show_recon
+
+    @classmethod
+    def live_viewer(cls) -> str:
+        """
+        Returns live view path.
+        """
+        return cls._show_live_viewer

--- a/mantidimaging/core/utility/test/command_line_arguments_test.py
+++ b/mantidimaging/core/utility/test/command_line_arguments_test.py
@@ -25,6 +25,7 @@ class CommandLineArgumentsTest(unittest.TestCase):
         CommandLineArguments._images_path = ""
         CommandLineArguments._init_operation = ""
         CommandLineArguments._show_recon = False
+        CommandLineArguments._show_live_viewer = ""
 
     def test_bad_path_calls_exit(self):
         bad_path = "does/not/exist"

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -33,6 +33,8 @@ class LiveViewerWindowView(BaseMainWindowView):
         self.live_viewer = LiveViewWidget()
         self.imageLayout.addWidget(self.live_viewer)
         self.watch_directory()
+        # reposition to the right of the main window to be visible when launched from cli
+        self.move(self.main_window.x() + self.main_window.width(), self.main_window.y())
 
     def show_image(self, image: np.ndarray) -> None:
         """

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -30,6 +30,8 @@ class MainWindowViewTest(unittest.TestCase):
                 command_line_args.return_value.path.return_value = ""
                 command_line_args.return_value.operation.return_value = ""
                 command_line_args.return_value.recon.return_value = False
+                command_line_args.return_value.live_viewer.return_value = ""
+
                 self.view = MainWindowView()
         self.presenter = mock.MagicMock()
         self.view.presenter = self.presenter
@@ -326,6 +328,7 @@ class MainWindowViewTest(unittest.TestCase):
         command_line_args.return_value.path.return_value = [test_path]
         command_line_args.return_value.recon.return_value = False
         command_line_args.return_value.operation.return_value = ""
+        command_line_args.return_value.live_viewer.return_value = ""
         MainWindowView()
         main_window_presenter.return_value.load_stacks_from_folder.assert_called_once_with(test_path)
 
@@ -337,6 +340,7 @@ class MainWindowViewTest(unittest.TestCase):
         command_line_args.return_value.path.return_value = ""
         command_line_args.return_value.recon.return_value = False
         command_line_args.return_value.operation.return_value = ""
+        command_line_args.return_value.live_viewer.return_value = ""
         MainWindowView()
         main_window_presenter.return_value.load_stacks_from_folder.assert_not_called()
 
@@ -347,6 +351,7 @@ class MainWindowViewTest(unittest.TestCase):
         command_line_args.return_value.path.return_value = ""
         command_line_args.return_value.recon.return_value = False
         command_line_args.return_value.operation.return_value = command_line_filter = "Median"
+        command_line_args.return_value.live_viewer.return_value = ""
 
         MainWindowView()
         main_window_presenter.return_value.show_operation.assert_called_once_with(command_line_filter)
@@ -358,6 +363,7 @@ class MainWindowViewTest(unittest.TestCase):
         command_line_args.return_value.path.return_value = ""
         command_line_args.return_value.recon.return_value = False
         command_line_args.return_value.operation.return_value = ""
+        command_line_args.return_value.live_viewer.return_value = ""
         MainWindowView()
         filters_window.assert_not_called()
 
@@ -368,6 +374,7 @@ class MainWindowViewTest(unittest.TestCase):
         command_line_args.return_value.path.return_value = ""
         command_line_args.return_value.recon.return_value = True
         command_line_args.return_value.operation.return_value = ""
+        command_line_args.return_value.live_viewer.return_value = ""
         view = MainWindowView()
         recon_window.assert_called_once_with(view)
 
@@ -378,6 +385,7 @@ class MainWindowViewTest(unittest.TestCase):
         command_line_args.return_value.path.return_value = ""
         command_line_args.return_value.recon.return_value = False
         command_line_args.return_value.operation.return_value = ""
+        command_line_args.return_value.live_viewer.return_value = ""
         MainWindowView()
         recon_window.assert_not_called()
 

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -150,6 +150,9 @@ class MainWindowView(BaseMainWindowView):
         if args.recon():
             self.show_recon_window()
 
+        if args.live_viewer() != "":
+            self.show_live_viewer(live_data_path=Path(args.live_viewer()))
+
         self.dataset_tree_widget = QTreeWidget()
         self.dataset_tree_widget.setContextMenuPolicy(Qt.CustomContextMenu)
         self.dataset_tree_widget.customContextMenuRequested.connect(self._open_tree_menu)

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -38,6 +38,10 @@ def parse_args() -> argparse.Namespace:
                         default=False,
                         action='store_true',
                         help="Opens the reconstruction window at start up.")
+    parser.add_argument("-lv",
+                        "--live_viewer",
+                        type=str,
+                        help="Path of directory to watch for new files in live viewer.")
 
     return parser.parse_args()
 
@@ -65,7 +69,7 @@ def main() -> None:
     path = args.path if args.path else ""
     operation = args.operation if args.operation else ""
 
-    CommandLineArguments(path=path, operation=operation, show_recon=args.recon)
+    CommandLineArguments(path=path, operation=operation, show_recon=args.recon, show_live_viewer=args.live_viewer)
 
     h.initialise_logging(args.log_level)
 


### PR DESCRIPTION
### Issue

Closes #1881 

### Description

Allow for CLI argument to be passed to launch the live viewer

### Testing 

Manually tested various cli argument combinations

### Acceptance Criteria 

* Verify Live viewer can be loaded using cli args using long and short flag and a path i.e. `python -m mantidimaging -lv <directory>`
* If Live viewer launched from CLI, Live viewer window is launches slightly to the right of main window to improve window visibility as nearly entirely hidden by main windows otherwise. 
* Existing combinations of CLI arguments still work as expected (setting path; launches recon window etc.)
* Tests pass

### Documentation

`docs/release_notes/next/feature-1881-live_liew_cli_launch_argument`
