### PR TITLE
Better error message when loading a corrupt TIFF file

### DIFF
--- a/docs/release_notes/next/fix-1887-corrupt-file-msg
+++ b/docs/release_notes/next/fix-1887-corrupt-file-msg
@@ -1,0 +1,1 @@
+#1887 : Better error message for corrupt TIFF file

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -69,7 +69,10 @@ def _fitsread(filename: Union[Path, str]) -> np.ndarray:
 
 
 def _imread(filename: Union[Path, str]) -> np.ndarray:
-    return tifffile.imread(filename)
+    try:
+        return tifffile.imread(filename)
+    except tifffile.TiffFileError as e:
+        raise RuntimeError(f"TiffFileError {e.args[0]}: {filename}") from e
 
 
 def get_loader(in_format: str) -> Callable[[Union[Path, str]], np.ndarray]:

--- a/mantidimaging/core/io/loader/test/loader_test.py
+++ b/mantidimaging/core/io/loader/test/loader_test.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from mantidimaging.core.io.filenames import FilenameGroup
 from mantidimaging.core.io.loader.loader import (DEFAULT_PIXEL_DEPTH, DEFAULT_PIXEL_SIZE, DEFAULT_IS_SINOGRAM,
-                                                 create_loading_parameters_for_file_path, get_loader, load)
+                                                 create_loading_parameters_for_file_path, get_loader, load, _imread)
 
 from mantidimaging.core.utility.data_containers import FILE_TYPES, ProjectionAngles
 from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
@@ -19,6 +19,12 @@ class LoaderTest(FakeFSTestCase):
 
     def test_raise_on_invalid_format(self):
         self.assertRaises(NotImplementedError, get_loader, in_format='txt')
+
+    def test_WHEN_tif_file_invalid_THEN_filename_in_exception_message(self):
+        filename = "/foo/bar/a.tif"
+        self.fs.create_file(filename, contents="BADDATA")
+
+        self.assertRaisesRegex(RuntimeError, filename, _imread, filename=filename)
 
     def test_create_loading_parameters_for_file_path(self):
         output_directory = Path("/b")


### PR DESCRIPTION
### Issue

Closes #1887

### Description

Include the file name in the error message when MI can't read a TIFF file

### Acceptance Criteria 

Load a dataset with a corrupt TIFF file (see issue for instructions)

Error message should give filename of bad file.

### Documentation

release notes
