### PR TITLE
Fix python 3.10 walk_packages needing a str not a path

### DIFF
--- a/docs/release_notes/next/fix-1894-fix-pyinstaller-path
+++ b/docs/release_notes/next/fix-1894-fix-pyinstaller-path
@@ -1,0 +1,1 @@
+#1894 : Fix for path in PackageWithPyInstaller

--- a/packaging/PackageWithPyInstaller.py
+++ b/packaging/PackageWithPyInstaller.py
@@ -36,7 +36,8 @@ def add_hidden_imports(run_options):
 
     # Operations modules must be added as hidden imports because most are imported programmatically in MantidImaging
     path_to_operations = Path(__file__).parent.parent.joinpath('mantidimaging/core/operations')
-    for _, ops_module, _ in pkgutil.walk_packages([path_to_operations]):
+    # COMPAT python 3.10 won't accept a Path: github.com/python/cpython/issues/88227
+    for _, ops_module, _ in pkgutil.walk_packages([str(path_to_operations)]):
         imports.append(f'mantidimaging.core.operations.{ops_module}')
 
     run_options.extend([f'--hidden-import={name}' for name in imports])


### PR DESCRIPTION
### Issue

Closes #1894

### Description

In python 3.10 pkgutil.walk_packages() fails if the path is a pathlib.Path on linux.

Convert it to a string, and add a `COMPAT` message so the workaround can be removed in the future

### Testing 
Not needed

### Acceptance Criteria 

Check that PackageWithPyInstaller.py runs on Linux

### Documentation

release notes
