### PR TITLE
Ignore files starting with dot when finding flat/dark

### DIFF
--- a/docs/release_notes/next/fix-1888-ignore-dotfiles
+++ b/docs/release_notes/next/fix-1888-ignore-dotfiles
@@ -1,0 +1,1 @@
+#1888 : Don't return files beginning with a dot when finding related

--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -157,6 +157,8 @@ class FilenameGroup:
         for file in sorted(path.iterdir()):
             if file.suffix.lstrip(".") not in IMAGE_FORMAT_EXTENSIONS:
                 continue
+            if file.name.startswith("."):
+                continue
             fg = cls.from_file(file)
             return fg
 

--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -154,13 +154,20 @@ class FilenameGroup:
         if not path.is_dir():
             raise ValueError(f"path is a file: {path}")
 
-        files = (f for f in path.iterdir() if f.name[0] != '.' and f.suffix[1:] in IMAGE_FORMAT_EXTENSIONS)
+        files = (f for f in path.iterdir() if cls.valid_image_filename(f))
 
         try:
             first_file = min(files)
         except ValueError:
             return None
         return cls.from_file(first_file)
+
+    @staticmethod
+    def valid_image_filename(f: Path) -> bool:
+        """
+        Check that file is not hidden (starts with a dot) and that it has an image extension
+        """
+        return f.name[0] != '.' and f.suffix[1:] in IMAGE_FORMAT_EXTENSIONS
 
     @classmethod
     def get_pattern_class(cls, path):

--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -154,15 +154,13 @@ class FilenameGroup:
         if not path.is_dir():
             raise ValueError(f"path is a file: {path}")
 
-        for file in sorted(path.iterdir()):
-            if file.suffix.lstrip(".") not in IMAGE_FORMAT_EXTENSIONS:
-                continue
-            if file.name.startswith("."):
-                continue
-            fg = cls.from_file(file)
-            return fg
+        files = (f for f in path.iterdir() if f.name[0] != '.' and f.suffix[1:] in IMAGE_FORMAT_EXTENSIONS)
 
-        return None
+        try:
+            first_file = min(files)
+        except ValueError:
+            return None
+        return cls.from_file(first_file)
 
     @classmethod
     def get_pattern_class(cls, path):

--- a/mantidimaging/core/io/test/filenames_test.py
+++ b/mantidimaging/core/io/test/filenames_test.py
@@ -233,6 +233,25 @@ class FilenameGroupTest(FakeFSTestCase):
 
         self._file_list_count_equal(proj_180_list, list(proj_180_fg.all_files()))
 
+    def test_find_related_dotfiles(self):
+        tomo_list = [Path("/Tomo/IMAT00021865_CMOS_LegoScan_EquiDis_PH60_Tomo_%3d.tif" % i) for i in range(10)]
+        flat_before_list = [
+            Path("/Flat_After/IMAT00021866_CMOS_LegoScan_EquiDis_PH60_Flat_After_%3d.tif" % i) for i in range(10)
+        ]
+        flat_bad_list = [
+            Path("/Flat_After/._IMAT00021866_CMOS_LegoScan_EquiDis_PH60_Flat_After_%3d.tif" % i) for i in range(10)
+        ]
+        for file_name in tomo_list + flat_before_list + flat_bad_list:
+            self.fs.create_file(file_name)
+
+        fg = FilenameGroup.from_file(tomo_list[0])
+        flat_before_fg = fg.find_related(FILE_TYPES.FLAT_AFTER)
+
+        self.assertIsNotNone(flat_before_fg)
+        flat_before_fg.find_all_files()
+        self._files_equal(flat_before_list[0], flat_before_fg.first_file())
+        self._file_list_count_equal(flat_before_list, flat_before_fg.all_files())
+
 
 class GoldenFilenameGroupTest(FakeFSTestCase):
 

--- a/mantidimaging/core/io/test/filenames_test.py
+++ b/mantidimaging/core/io/test/filenames_test.py
@@ -124,6 +124,12 @@ class FilenameGroupTest(FakeFSTestCase):
 
         self._files_equal(f1.first_file(), "/foo/bbb_000000.tif")
 
+    def test_pattern_from_dir_no_files(self):
+        test_dir = Path("/foo")
+        self.fs.create_dir(test_dir)
+        f1 = FilenameGroup.from_directory(test_dir)
+        self.assertIsNone(f1)
+
     def test_first_files(self):
         filename = "IMAT_Flower_Tomo_000001.tif"
         f1 = FilenameGroup.from_file(filename)


### PR DESCRIPTION
### Issue
Closes #1888

### Description

When searching for releated files, filter out files starting with a `.` these are unlikely to be actual image files.

### Testing 

Added some stronger tests

### Acceptance Criteria 

Follow instructions on the bug report. Check that the actual files get selected and opened.

### Documentation
release notes
