### PR TITLE
1876 display current filename

### DIFF
--- a/docs/release_notes/next/feature-1876-live_viewer_display_filename
+++ b/docs/release_notes/next/feature-1876-live_viewer_display_filename
@@ -1,0 +1,1 @@
+#1876 : Display filename of currently displayed image in the live viewer.

--- a/mantidimaging/gui/ui/live_viewer_window.ui
+++ b/mantidimaging/gui/ui/live_viewer_window.ui
@@ -16,7 +16,67 @@
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
-     <layout class="QVBoxLayout" name="imageLayout"/>
+     <layout class="QVBoxLayout" name="imageLayout">
+      <item alignment="Qt::AlignHCenter|Qt::AlignBottom">
+       <widget class="QLabel" name="label_active_filename">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>300</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="baseSize">
+         <size>
+          <width>300</width>
+          <height>10</height>
+         </size>
+        </property>
+        <property name="font">
+         <font>
+          <family>Arial</family>
+          <pointsize>14</pointsize>
+          <kerning>false</kerning>
+         </font>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+        <property name="accessibleName">
+         <string>Active Filename</string>
+        </property>
+        <property name="accessibleDescription">
+         <string>The most recent file loaded into the live viewer</string>
+        </property>
+        <property name="autoFillBackground">
+         <bool>false</bool>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
+        </property>
+        <property name="lineWidth">
+         <number>5</number>
+        </property>
+        <property name="midLineWidth">
+         <number>5</number>
+        </property>
+        <property name="text">
+         <string>Active Filename</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>5</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </item>
    </layout>
   </widget>

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -46,6 +46,7 @@ class LiveViewerWindowPresenter(BasePresenter):
             with tifffile.TiffFile(image_path) as tif:
                 image_data = tif.asarray()
                 self.view.show_image(image_data)
+                self.view.label_active_filename.setText(image_path.split("/")[-1])
         except IOError as error:
             logger.error("Error reading image: %s", error)
             return

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -33,8 +33,6 @@ class LiveViewerWindowView(BaseMainWindowView):
         self.live_viewer = LiveViewWidget()
         self.imageLayout.addWidget(self.live_viewer)
         self.watch_directory()
-        # self.label_active_filename.setText(se
-        # set text in label_active_filename to the name of the file last modified in the directory
         # reposition to the right of the main window to be visible when launched from cli
         self.move(self.main_window.x() + self.main_window.width(), self.main_window.y())
 

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -33,6 +33,8 @@ class LiveViewerWindowView(BaseMainWindowView):
         self.live_viewer = LiveViewWidget()
         self.imageLayout.addWidget(self.live_viewer)
         self.watch_directory()
+        # self.label_active_filename.setText(se
+        # set text in label_active_filename to the name of the file last modified in the directory
         # reposition to the right of the main window to be visible when launched from cli
         self.move(self.main_window.x() + self.main_window.width(), self.main_window.y())
 


### PR DESCRIPTION
### Issue

Closes #1876 

### Description

Show active file name being displayed in live viewer

### Testing 

* Tested with `simulate_live_data.py using various flags.
* Tested by deleting image displayed to current window.

### Acceptance Criteria 

The filename for the file being displayed in the live viewer window is correct'y synced.

### Documentation

` docs/release_notes/next/feature-1876-live_viewer_display_filename`
