### PR TITLE
Profiling tools

### DIFF
--- a/docs/developer_guide/documentation.rst
+++ b/docs/developer_guide/documentation.rst
@@ -87,3 +87,15 @@ Logging can be controlled using the QSettings configuration file :file:`.config/
     log_level=DEBUG
     log_dir=/tmp/mantid_imaging_logs
     performance_log=true
+
+Benchmarking and profiling
+--------------------------
+
+Mantid imaging has some utilities to help with benchmarking and profiling.
+
+The context managers :py:class:`~mantidimaging.core.utility.execution_timer.ExecutionTimer` and :py:class:`~mantidimaging.core.utility.execution_timer.ExecutionProfiler` can be used to wrap some lines of code to record and log its run time. For example::
+
+    with ExecutionProfiler(msg="a_slow_function()"):
+        a_slow_function()
+
+will record and log a profile of function calls and times within :code:`a_slow_function()`.

--- a/docs/release_notes/next/dev-1901-profiling-tool
+++ b/docs/release_notes/next/dev-1901-profiling-tool
@@ -1,0 +1,1 @@
+#1901 : Add ExecutionProfiler context manager

--- a/mantidimaging/core/utility/__init__.py
+++ b/mantidimaging/core/utility/__init__.py
@@ -5,4 +5,4 @@ from __future__ import annotations
 from . import (  # noqa: F401
     progress_reporting, cor_interpolate, finder, histogram, memory_usage, projection_angles, size_calculator)
 
-from .execution_timer import ExecutionTimer  # noqa: F401
+from .execution_timer import ExecutionTimer, ExecutionProfiler  # noqa: F401

--- a/mantidimaging/core/utility/execution_timer.py
+++ b/mantidimaging/core/utility/execution_timer.py
@@ -1,5 +1,17 @@
 # Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+"""
+Context managers for logging execution time or profile of code.
+
+These are not used in the code, but are here as developer tools. They can be used by wrapping the code of interest::
+
+    with ExecutionProfiler(msg="a_slow_function()"):
+        a_slow_function()
+
+They will display to the performance log if a logger object is not given. See the developer docs to enable performance
+logging.
+"""
+
 from __future__ import annotations
 
 import cProfile
@@ -13,7 +25,7 @@ perf_logger = getLogger("perf." + __name__)
 
 class ExecutionTimer(object):
     """
-    Context handler used to time the execution of code in it's context.
+    Context manager used to time the execution of code in it's context.
     """
 
     def __init__(self, msg='Elapsed time', logger=perf_logger):
@@ -48,7 +60,7 @@ class ExecutionTimer(object):
 
 class ExecutionProfiler(object):
     """
-    Context handler used to profile the execution of code in it's context.
+    Context manager used to profile the execution of code in it's context.
     """
 
     def __init__(self, msg='Elapsed time', logger=perf_logger, max_lines=20):

--- a/mantidimaging/core/utility/execution_timer.py
+++ b/mantidimaging/core/utility/execution_timer.py
@@ -17,23 +17,23 @@ from __future__ import annotations
 import cProfile
 import time
 from io import StringIO
-from logging import getLogger
+from logging import getLogger, Logger
 from pstats import SortKey, Stats
 
 perf_logger = getLogger("perf." + __name__)
 
 
-class ExecutionTimer(object):
+class ExecutionTimer:
     """
     Context manager used to time the execution of code in it's context.
     """
 
-    def __init__(self, msg='Elapsed time', logger=perf_logger):
+    def __init__(self, msg: str = 'Elapsed time', logger: Logger = perf_logger):
         self.msg = msg
         self.logger = logger
 
-        self.time_start = None
-        self.time_end = None
+        self.time_start: float | None = None
+        self.time_end: float | None = None
 
     def __str__(self):
         prefix = f'{self.msg}: ' if self.msg else ''
@@ -58,12 +58,12 @@ class ExecutionTimer(object):
             self.time_start and self.time_end else None
 
 
-class ExecutionProfiler(object):
+class ExecutionProfiler:
     """
     Context manager used to profile the execution of code in it's context.
     """
 
-    def __init__(self, msg='Elapsed time', logger=perf_logger, max_lines=20):
+    def __init__(self, msg: str = 'Elapsed time', logger: Logger = perf_logger, max_lines: int = 20):
         self.msg = msg
         self.logger = logger
         self.max_lines = max_lines

--- a/mantidimaging/core/utility/execution_timer.py
+++ b/mantidimaging/core/utility/execution_timer.py
@@ -18,14 +18,14 @@ import cProfile
 import time
 from io import StringIO
 from logging import getLogger, Logger
-from pstats import SortKey, Stats
+from pstats import Stats
 
 perf_logger = getLogger("perf." + __name__)
 
 
 class ExecutionTimer:
     """
-    Context manager used to time the execution of code in it's context.
+    Context manager used to time the execution of code in its context.
     """
 
     def __init__(self, msg: str = 'Elapsed time', logger: Logger = perf_logger):
@@ -60,13 +60,20 @@ class ExecutionTimer:
 
 class ExecutionProfiler:
     """
-    Context manager used to profile the execution of code in it's context.
+    Context manager used to profile the execution of code in its context.
+
+
     """
 
-    def __init__(self, msg: str = 'Elapsed time', logger: Logger = perf_logger, max_lines: int = 20):
+    def __init__(self,
+                 msg: str = 'Elapsed time',
+                 logger: Logger = perf_logger,
+                 max_lines: int = 20,
+                 sort_by: str = "cumtime"):
         self.msg = msg
         self.logger = logger
         self.max_lines = max_lines
+        self.sort_by = sort_by
 
         self.pr = cProfile.Profile()
 
@@ -74,7 +81,7 @@ class ExecutionProfiler:
         out = StringIO()
         out.write(f'{self.msg}: \n' if self.msg else '')
 
-        ps = Stats(self.pr, stream=out).sort_stats(SortKey.CUMULATIVE)
+        ps = Stats(self.pr, stream=out).sort_stats(self.sort_by)
         ps.print_stats()
         return out.getvalue()
 

--- a/mantidimaging/core/utility/execution_timer.py
+++ b/mantidimaging/core/utility/execution_timer.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import time
+from logging import getLogger
+
+perf_logger = getLogger("perf." + __name__)
 
 
 class ExecutionTimer(object):
@@ -10,8 +13,9 @@ class ExecutionTimer(object):
     Context handler used to time the execution of code in it's context.
     """
 
-    def __init__(self, msg='Elapsed time'):
+    def __init__(self, msg='Elapsed time', logger=perf_logger):
         self.msg = msg
+        self.logger = logger
 
         self.time_start = None
         self.time_end = None
@@ -22,11 +26,12 @@ class ExecutionTimer(object):
         return f'{prefix}{sec if sec else "unknown"} seconds'
 
     def __enter__(self):
-        self.time_start = time.time()
+        self.time_start = time.monotonic()
         self.time_end = None
 
     def __exit__(self, *args):
-        self.time_end = time.time()
+        self.time_end = time.monotonic()
+        self.logger.info(str(self))
 
     @property
     def total_seconds(self):

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 RECON_GROUP_TEXT = "Recons"
 SINO_TEXT = "Sinograms"
 
-LOG = getLogger(__file__)
+LOG = getLogger(__name__)
 
 
 class QTreeDatasetWidgetItem(QTreeWidgetItem):

--- a/setup.py
+++ b/setup.py
@@ -84,9 +84,7 @@ class GenerateSphinxApidoc(Command):
         self.sphinx_options.append(self.module_dir)
         self.sphinx_options.append("**/test")
         self.sphinx_options.append("**/test_helpers")
-        self.sphinx_options.append("**/gui")
-        self.sphinx_options.append("**/core/utility")
-        self.sphinx_options.append("**/core/tools")
+        self.sphinx_options.append("**/eyes_tests")
 
         self.out_dir = "docs/api/"
         self.sphinx_options.extend(["-o", self.out_dir])

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ class GenerateSphinxApidoc(Command):
         self.sphinx_options.append("sphinx-apidoc")
         self.sphinx_options.extend(["-f", "-M", "-e", "-T"])
 
-        self.sphinx_options.extend(["-d", "10"])
+        self.sphinx_options.extend(["-d", "3"])
 
         self.module_dir = "mantidimaging"
         self.sphinx_options.append(self.module_dir)


### PR DESCRIPTION
### Issue

Work as part of #1828

### Description
Update `ExecutionTimer` and add `ExecutionProfiler`.
Improve documentation

### Testing 

Not needed

### Acceptance Criteria 

Try using these to time or profile some code.

For example in `mantidimaging/gui/windows/main/view.py`
```diff
@@ -389,8 +389,9 @@ class MainWindowView(BaseMainWindowView):
 
     def show_spectrum_viewer_window(self):
         if not self.spectrum_viewer:
-            self.spectrum_viewer = SpectrumViewerWindowView(self)
-            self.spectrum_viewer.show()
+            with ExecutionProfiler(logger=LOG):
+                self.spectrum_viewer = SpectrumViewerWindowView(self)
+                self.spectrum_viewer.show()
         else:
             self.spectrum_viewer.activateWindow()
             self.spectrum_viewer.raise_()
```

### Documentation
Added some documentation
