### PR TITLE
1891 handle all files deleted

### DIFF
--- a/docs/release_notes/next/fix-1891-fix-live_viewer_delete_all_files
+++ b/docs/release_notes/next/fix-1891-fix-live_viewer_delete_all_files
@@ -1,0 +1,1 @@
+#1891 : Fix LiveViewer handling of deleting all files from watched directory.

--- a/mantidimaging/gui/windows/live_viewer/live_view_widget.py
+++ b/mantidimaging/gui/windows/live_viewer/live_view_widget.py
@@ -34,6 +34,4 @@ class LiveViewWidget(GraphicsLayoutWidget):
         """
         Handle the deletion of the image.
         """
-        self.image.close()
-        self.image = None
-        self.close()
+        self.image.clear()

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -37,9 +37,22 @@ class LiveViewerWindowPresenter(BasePresenter):
         """Set the path to the dataset."""
         self.model.path = path
 
+    def clear_label(self):
+        """Clear the label."""
+        self.view.label_active_filename.setText("")
+
+    def handle_deleted(self):
+        """Handle the deletion of the image."""
+        self.view.remove_image()
+        self.clear_label()
+
     def update_image(self, image_path: str):
         """Update the image in the view."""
         if not Path(image_path).exists():
+            return
+        if image_path == '':
+            self.view.remove_image()
+
             return
         try:
             logger.debug("Showing image in presenter: %s", image_path)


### PR DESCRIPTION
### Issue

Closes #1891 

### Description

Allow for deletion of any and all files from directory being watched by live viewer. 

### Testing 

Tried deleting all files from watched directory in varying quantities and speeds to catch partial file state.

### Acceptance Criteria 

* Live viewer returns to default state (blank image) if all files in a watched directory are deleted.

### Documentation

`docs/release_notes/next/fix-1891-fix-live_viewer_delete_all_files`
