### PR TITLE
Pin tifffile=2023.7.18 imagecodecs=2023.1.23

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -20,6 +20,8 @@ requirements:
     - astropy=5.0.*
     - scipy=1.7.*
     - scikit-image=0.19.*
+    - tifffile=2023.7.18
+    - imagecodecs=2023.1.23
     - numpy=1.21.*
     - numexpr=2.8.*
     - algotom=1.0.*


### PR DESCRIPTION
### Issue
Quick fix with change used to get 2.5.1 release building. We need this for creating a valid environment on main as well.

### Description

```
    - tifffile=2023.7.18
    - imagecodecs=2023.1.23
```


### Acceptance Criteria 

Tests should pass

### Documentation

Not needed. Just being more specific than we were before.
