### PR TITLE
Mark TestGuiSystemReconstruction.test_minimise as xfail

### DIFF
--- a/mantidimaging/gui/test/gui_system_reconstruction_test.py
+++ b/mantidimaging/gui/test/gui_system_reconstruction_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 from unittest import mock
 
+import pytest
 from PyQt5.QtTest import QTest
 from PyQt5.QtCore import Qt, QTimer
 
@@ -49,6 +50,7 @@ class TestGuiSystemReconstruction(GuiSystemBase):
             wait_until(lambda: self.recon_window.correlateBtn.isEnabled())
             wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
 
+    @pytest.mark.xfail(reason="Unresolved, see #1641")
     def test_minimise(self):
         for i in range(2, 6):
             QTimer.singleShot(SHORT_DELAY, lambda i=i: self._click_InputDialog(set_int=i))
@@ -86,6 +88,7 @@ class TestGuiSystemReconstruction(GuiSystemBase):
 
         QTest.qWait(SHOW_DELAY)
 
+    @pytest.mark.xfail(reason="Unresolved, see #1641")
     def test_refine_stress(self):
         for i in range(5):
             print(f"test_refine_stress iteration {i}")


### PR DESCRIPTION
### Issue
Avoid #1641 

### Description

Use an xfail to allow test to fail.

Error is not longer a timeout, so it should be possible to xfail it. It has been common recently, so disable until this is resolved.

### Testing 

See the windows automated tests
https://github.com/mantidproject/mantidimaging/actions/runs/5949456581/job/16135275435?pr=1910
Got to view raw logs and search for xfail
You can see that the unreliable test can fail without causing the whole test to fail.

```
2023-08-23T09:52:36.0483395Z   File "C:\Miniconda3\envs\mantidimaging-dev\lib\site-packages\numpy\lib\histograms.py", line 426, in _get_bin_edges
2023-08-23T09:52:36.0483996Z     first_edge, last_edge = _get_outer_edges(a, range)
2023-08-23T09:52:36.0484746Z   File "C:\Miniconda3\envs\mantidimaging-dev\lib\site-packages\numpy\lib\histograms.py", line 315, in _get_outer_edges
2023-08-23T09:52:36.0485292Z     raise ValueError(
2023-08-23T09:52:36.0485714Z ValueError: supplied range of [nan, nan] is not finite
2023-08-23T09:52:37.3871533Z XFAIL (Unresolved, see #1641)
...
2023-08-23T09:57:02.5159388Z ====== 39 passed, 1 xfailed, 1 xpassed, 2 warnings in 497.95s (0:08:17) =======
```

### Documentation

Not needed