### PR TITLE
Reduce get_spectrum() calls when opening the spectrum viewer

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -78,7 +78,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             return
         self.model.set_normalise_stack(self.main_window.get_stack(normalise_uuid))
         self.view.set_normalise_error(self.model.normalise_issue())
-        self.redraw_all_rois()
+        if self.view.normalisation_enabled():
+            self.redraw_all_rois()
 
     def auto_find_flat_stack(self, new_dataset_id):
         if self.view.current_dataset_id != new_dataset_id:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -103,8 +103,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.set_image(self.model.get_averaged_image())
         self.view.spectrum.add_range(*self.model.tof_range)
         self.view.auto_range_image()
-        self.view.spectrum.reset_roi_size(self.model.get_image_shape())
-        self.handle_roi_moved(True)
 
     def handle_range_slide_moved(self, tof_range) -> None:
         self.model.tof_range = tof_range
@@ -181,8 +179,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         roi_name = self.model.roi_name_generator()
         self.model.set_new_roi(roi_name)
-        self.view.set_spectrum(roi_name, self.model.get_spectrum(roi_name, self.spectrum_mode))
         self.view.spectrum.add_roi(self.model.get_roi(roi_name), roi_name)
+        self.view.set_spectrum(roi_name, self.model.get_spectrum(roi_name, self.spectrum_mode))
         self.view.auto_range_image()
         self.do_add_roi_to_table(roi_name)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -228,18 +228,3 @@ class SpectrumWidget(GraphicsLayoutWidget):
         if old_name in self.roi_dict.keys() and new_name not in self.roi_dict.keys():
             self.roi_dict[new_name] = self.roi_dict.pop(old_name)
             self.spectrum_data_dict[new_name] = self.spectrum_data_dict.pop(old_name)
-
-    def reset_roi_size(self, image_shape) -> None:
-        """
-        Reset the size of the ROI to the maximum size of the image.
-
-        @param image_shape: The shape of the image.
-        """
-        roi_name = list(self.roi_dict.keys())[0]
-        height, width = image_shape
-
-        self.roi_dict[roi_name].setSize([width, height])
-        self.roi_dict[roi_name].setPos([0, 0])
-        self.roi_dict[roi_name].maxBounds = self.roi_dict[roi_name].parentBounds()
-        self.image.vb.addItem(self.roi_dict[roi_name])
-        self.roi_dict[roi_name].sigRegionChanged.connect(self.roi_changed.emit)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
@@ -161,17 +161,3 @@ class SpectrumWidgetTest(unittest.TestCase):
         self.assertIn("roi_1", self.spectrum_widget.roi_dict.keys())
         self.spectrum_widget.rename_roi("roi_1", "roi")
         self.assertIn("roi_1", self.spectrum_widget.roi_dict)
-
-    def test_WHEN_reset_size_called_THEN_roi_size_reset(self):
-        image_shape = (100, 100)
-        spectrum_roi = SpectrumROI("roi",
-                                   self.sensible_roi,
-                                   pos=(0, 0),
-                                   rotatable=False,
-                                   scaleSnap=True,
-                                   translateSnap=True)
-        self.spectrum_widget.roi_dict["roi"] = spectrum_roi
-        self.spectrum_widget.spectrum_data_dict["roi"] = np.array([0, 0, 0, 0])
-        self.spectrum_widget.reset_roi_size(image_shape)
-        img_x, img_y = spectrum_roi.size()
-        self.assertEqual((img_x, img_y), (100, 100))

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -53,7 +53,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self._current_dataset_id = None
         self.sampleStackSelector.stack_selected_uuid.connect(self.presenter.handle_sample_change)
         self.normaliseStackSelector.stack_selected_uuid.connect(self.presenter.handle_normalise_stack_change)
-        self.normaliseCheckBox.stateChanged.connect(self.set_normalise_dropdown_state)
+        self.normaliseCheckBox.stateChanged.connect(self.normaliseStackSelector.setEnabled)
         self.normaliseCheckBox.stateChanged.connect(self.presenter.handle_enable_normalised)
 
         # ROI action buttons
@@ -158,12 +158,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         selector.presenter.show_stacks = True
         selector.subscribe_to_main_window(self.main_window)
 
-    def set_normalise_dropdown_state(self) -> None:
-        if self.normaliseCheckBox.isChecked():
-            self.normaliseStackSelector.setEnabled(True)
-        else:
-            self.normaliseStackSelector.setEnabled(False)
-
     def try_to_select_relevant_normalise_stack(self, name: str) -> None:
         self.normaliseStackSelector.try_to_select_relevant_stack(name)
 
@@ -206,12 +200,15 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.display_normalise_error()
 
     def display_normalise_error(self):
-        if self.normalise_error_issue and self.normaliseCheckBox.isChecked():
+        if self.normalise_error_issue and self.normalisation_enabled():
             self.normaliseErrorIcon.setPixmap(self.normalise_error_icon_pixmap)
             self.normaliseErrorIcon.setToolTip(self.normalise_error_issue)
         else:
             self.normaliseErrorIcon.setPixmap(QPixmap())
             self.normaliseErrorIcon.setToolTip("")
+
+    def normalisation_enabled(self):
+        return self.normaliseCheckBox.isChecked()
 
     def set_new_roi(self) -> None:
         """


### PR DESCRIPTION
### Issue

Work on #1828

### Description

Now `get_spectrum()` is only called a single time on opening the spectrum viewer. (was originally 4 times).

### Testing & Acceptance Criteria 

Check that the spectrum viewer loads with data.
Check ROIs can be added and removed
Check that changing stacks resets to a single ROI
Check swapping back and forth between stacks with different dimensions
Check enabling and disabling normalisation

### Documentation

Not need yet, have some more PRs to come.
