### PR TITLE
Image scroller for live view

### DIFF
--- a/docs/release_notes/next/feature-1916-img_scroller_user_interface
+++ b/docs/release_notes/next/feature-1916-img_scroller_user_interface
@@ -1,0 +1,1 @@
+#1916 : Image scroller for live view

--- a/mantidimaging/gui/widgets/zslider/__init__.py
+++ b/mantidimaging/gui/widgets/zslider/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/widgets/zslider/zslider.py
+++ b/mantidimaging/gui/widgets/zslider/zslider.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from PyQt5.QtCore import pyqtSignal, Qt
+from PyQt5.QtWidgets import QGraphicsSceneMouseEvent
+from pyqtgraph import PlotItem, InfiniteLine
+
+
+class ZSlider(PlotItem):
+    z_line: InfiniteLine
+    valueChanged = pyqtSignal(int)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setFixedHeight(40)
+        self.hideAxis("left")
+        self.setXRange(0, 1)
+        self.setMouseEnabled(x=False, y=False)
+        self.hideButtons()
+
+        self.z_line = InfiniteLine(0, movable=True)
+        self.z_line.setPen((255, 255, 0, 200))
+        self.addItem(self.z_line)
+
+        self.z_line.sigPositionChanged.connect(self.value_changed)
+
+    def set_range(self, min: int, max: int):
+        self.z_line.setValue(min)
+        self.setXRange(min, max)
+        self.z_line.setBounds([min, max])
+
+    def set_value(self, value: int):
+        self.z_line.setValue(value)
+
+    def value_changed(self):
+        self.valueChanged.emit(int(self.z_line.value()))
+
+    def mousePressEvent(self, ev: 'QGraphicsSceneMouseEvent'):
+        if ev.button() == Qt.MouseButton.LeftButton:
+            x = round(self.vb.mapSceneToView(ev.scenePos()).x())
+            self.set_value(x)
+        super().mousePressEvent(ev)

--- a/mantidimaging/gui/widgets/zslider/zslider.py
+++ b/mantidimaging/gui/widgets/zslider/zslider.py
@@ -11,8 +11,8 @@ class ZSlider(PlotItem):
     z_line: InfiniteLine
     valueChanged = pyqtSignal(int)
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self) -> None:
+        super().__init__()
         self.setFixedHeight(40)
         self.hideAxis("left")
         self.setXRange(0, 1)
@@ -25,18 +25,18 @@ class ZSlider(PlotItem):
 
         self.z_line.sigPositionChanged.connect(self.value_changed)
 
-    def set_range(self, min: int, max: int):
+    def set_range(self, min: int, max: int) -> None:
         self.z_line.setValue(min)
         self.setXRange(min, max)
         self.z_line.setBounds([min, max])
 
-    def set_value(self, value: int):
+    def set_value(self, value: int) -> None:
         self.z_line.setValue(value)
 
-    def value_changed(self):
+    def value_changed(self) -> None:
         self.valueChanged.emit(int(self.z_line.value()))
 
-    def mousePressEvent(self, ev: 'QGraphicsSceneMouseEvent'):
+    def mousePressEvent(self, ev: 'QGraphicsSceneMouseEvent') -> None:
         if ev.button() == Qt.MouseButton.LeftButton:
             x = round(self.vb.mapSceneToView(ev.scenePos()).x())
             self.set_value(x)

--- a/mantidimaging/gui/widgets/zslider/zslider.py
+++ b/mantidimaging/gui/widgets/zslider/zslider.py
@@ -8,6 +8,17 @@ from pyqtgraph import PlotItem, InfiniteLine
 
 
 class ZSlider(PlotItem):
+    """
+    A plot item to draw a z-axis slider mimicking the slider in PyQtGraph's ImageView
+
+    This gives us flexibility to choose what happens when the user move through the z-axis. It can be combined with
+    the one or more :py:class:`~mantidimaging.gui.widgets.mi_mini_image_view.view.MIMiniImageView`'s in a
+    GraphicsLayoutWidget. It is used in the Operations window to choose the slice to preview a filter with,
+    and in the Live Viewer scroll through images.
+
+    Emits a :code:`valueChanged` signal when the user moves the slider
+    """
+
     z_line: InfiniteLine
     valueChanged = pyqtSignal(int)
 
@@ -37,6 +48,9 @@ class ZSlider(PlotItem):
         self.valueChanged.emit(int(self.z_line.value()))
 
     def mousePressEvent(self, ev: 'QGraphicsSceneMouseEvent') -> None:
+        """
+        Adjusts built in behaviour to allow user to click anywhere on the line to jump there.
+        """
         if ev.button() == Qt.MouseButton.LeftButton:
             x = round(self.vb.mapSceneToView(ev.scenePos()).x())
             self.set_value(x)

--- a/mantidimaging/gui/windows/live_viewer/live_view_widget.py
+++ b/mantidimaging/gui/windows/live_viewer/live_view_widget.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from pyqtgraph import GraphicsLayoutWidget
 from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
+from mantidimaging.gui.widgets.zslider.zslider import ZSlider
 
 if TYPE_CHECKING:
     import numpy as np
@@ -22,6 +23,10 @@ class LiveViewWidget(GraphicsLayoutWidget):
 
         self.image = MIMiniImageView(name="Projection")
         self.addItem(self.image, 0, 0)
+        self.nextRow()
+
+        self.z_slider = ZSlider()
+        self.addItem(self.z_slider)
 
     def show_image(self, image: np.ndarray) -> None:
         """

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -111,11 +111,7 @@ class LiveViewerWindowModel:
         :param image_files: list of image files
         """
         self.images = image_files
-        if not image_files:
-            self.presenter.handle_deleted()
-            self.presenter.update_image([])
-        else:
-            self.presenter.update_image(image_files)
+        self.presenter.update_image_list(image_files)
 
 
 class ImageWatcher(QObject):

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -48,13 +48,14 @@ class LiveViewerWindowPresenter(BasePresenter):
         """Handle the deletion of the image."""
         self.view.remove_image()
         self.clear_label()
+        self.view.live_viewer.z_slider.set_range(0, 1)
 
-    def update_image(self, images_list: list[Image_Data]) -> None:
+    def update_image_list(self, images_list: list[Image_Data]) -> None:
         """Update the image in the view."""
         if not images_list:
-            self.view.remove_image()
-            self.view.live_viewer.z_slider.set_range(0, 1)
+            self.handle_deleted()
             return
+
         latest_image = images_list[-1]
         try:
             with tifffile.TiffFile(latest_image.image_path) as tif:

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -53,6 +53,7 @@ class LiveViewerWindowPresenter(BasePresenter):
         """Update the image in the view."""
         if not images_list:
             self.view.remove_image()
+            self.view.live_viewer.z_slider.set_range(0, 1)
             return
         latest_image = images_list[-1]
         try:
@@ -64,3 +65,5 @@ class LiveViewerWindowPresenter(BasePresenter):
 
         self.view.show_most_recent_image(image_data)
         self.view.label_active_filename.setText(latest_image.image_name)
+
+        self.view.live_viewer.z_slider.set_range(0, len(images_list))

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -56,15 +56,21 @@ class LiveViewerWindowPresenter(BasePresenter):
             self.handle_deleted()
             return
 
-        latest_image = images_list[-1]
+        self.view.live_viewer.z_slider.set_range(0, len(images_list) - 1)
+        self.view.set_image_index(len(images_list) - 1)
+
+    def select_image(self, index: int) -> None:
+        if not self.model.images:
+            return
+        selected_image = self.model.images[index]
+        self.view.label_active_filename.setText(selected_image.image_name)
+
         try:
-            with tifffile.TiffFile(latest_image.image_path) as tif:
+            with tifffile.TiffFile(selected_image.image_path) as tif:
                 image_data = tif.asarray()
         except (IOError, KeyError, ValueError, DeflateError) as error:
-            logger.error("%s reading image: %s: %s", type(error).__name__, latest_image.image_path, error)
+            logger.error("%s reading image: %s: %s", type(error).__name__, selected_image.image_path, error)
+            self.view.remove_image()
             return
 
         self.view.show_most_recent_image(image_data)
-        self.view.label_active_filename.setText(latest_image.image_name)
-
-        self.view.live_viewer.z_slider.set_range(0, len(images_list))

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -36,6 +36,8 @@ class LiveViewerWindowView(BaseMainWindowView):
         # reposition to the right of the main window to be visible when launched from cli
         self.move(self.main_window.x() + self.main_window.width(), self.main_window.y())
 
+        self.live_viewer.z_slider.valueChanged.connect(self.presenter.select_image)
+
     def show_most_recent_image(self, image: np.ndarray) -> None:
         """
         Show the most recently modified image in the image view.
@@ -50,3 +52,6 @@ class LiveViewerWindowView(BaseMainWindowView):
     def remove_image(self) -> None:
         """Remove the image from the view."""
         self.live_viewer.handle_deleted()
+
+    def set_image_index(self, index: int) -> None:
+        self.live_viewer.z_slider.set_value(index)

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -3,19 +3,16 @@
 from __future__ import annotations
 
 from logging import getLogger
-from typing import TYPE_CHECKING
 
 import numpy as np
-from PyQt5.QtCore import Qt, QPoint, QRect, pyqtSignal
+from PyQt5.QtCore import QPoint, QRect
 from PyQt5.QtGui import QGuiApplication, QResizeEvent
-from pyqtgraph import ColorMap, GraphicsLayoutWidget, ImageItem, LegendItem, PlotItem, InfiniteLine
+from pyqtgraph import ColorMap, GraphicsLayoutWidget, ImageItem, LegendItem, PlotItem
 from pyqtgraph.graphicsItems.GraphicsLayout import GraphicsLayout
 
 from mantidimaging.core.utility.histogram import set_histogram_log_scale
 from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
-
-if TYPE_CHECKING:
-    from PyQt5.QtWidgets import QGraphicsSceneMouseEvent
+from mantidimaging.gui.widgets.zslider.zslider import ZSlider
 
 LOG = getLogger(__name__)
 
@@ -30,42 +27,6 @@ OVERLAY_COLOUR_DIFFERENCE = [0, 255, 0, 255]
 
 def _data_valid_for_histogram(data) -> bool:
     return data is not None and any(d is not None for d in data)
-
-
-class ZSlider(PlotItem):
-    z_line: InfiniteLine
-    valueChanged = pyqtSignal(int)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.setFixedHeight(40)
-        self.hideAxis("left")
-        self.setXRange(0, 1)
-        self.setMouseEnabled(x=False, y=False)
-        self.hideButtons()
-
-        self.z_line = InfiniteLine(0, movable=True)
-        self.z_line.setPen((255, 255, 0, 200))
-        self.addItem(self.z_line)
-
-        self.z_line.sigPositionChanged.connect(self.value_changed)
-
-    def set_range(self, min: int, max: int):
-        self.z_line.setValue(min)
-        self.setXRange(min, max)
-        self.z_line.setBounds([min, max])
-
-    def set_value(self, value: int):
-        self.z_line.setValue(value)
-
-    def value_changed(self):
-        self.valueChanged.emit(int(self.z_line.value()))
-
-    def mousePressEvent(self, ev: 'QGraphicsSceneMouseEvent'):
-        if ev.button() == Qt.MouseButton.LeftButton:
-            x = round(self.vb.mapSceneToView(ev.scenePos()).x())
-            self.set_value(x)
-        super().mousePressEvent(ev)
 
 
 class FilterPreviews(GraphicsLayoutWidget):


### PR DESCRIPTION
### Issue

Closes #1916

~Needs rebase after #1915 is merged~

### Description

Extract ZSlider into its own module, and add type annotations
Add a ZSlider to the live viewer
Hook up ZSlider to adjust range as images arrive, and to show the selected image
A bit of refactoring to move image list state into the model

### Testing & Acceptance Criteria 

Check that Live View still functions well as a non interactive tool, updating correctly as new images arrive
Check that the range of the zslider matches the number of images in the live directory
Check that it is possible to scroll through the images
Check that corrupt images do not cause problems (frame will just be blank for files that could not be read)

### Documentation
Release notes
