### PR TITLE
Use initializer to ensure that all worker run worker_setup()

### DIFF
--- a/docs/release_notes/next/fix-1918-pool-start
+++ b/docs/release_notes/next/fix-1918-pool-start
@@ -1,0 +1,1 @@
+#1918 : Use initializer to ensure worker pool do setup

--- a/mantidimaging/core/parallel/manager.py
+++ b/mantidimaging/core/parallel/manager.py
@@ -31,12 +31,10 @@ def create_and_start_pool():
     global cores
     cores = context.cpu_count()
     global pool
-    pool = context.Pool(cores)
-
-    pool.map(worker_setup, range(cores))
+    pool = context.Pool(cores, initializer=worker_setup)
 
 
-def worker_setup(_):
+def worker_setup():
     # Required to import modules for running operations
     load_filter_packages()
 


### PR DESCRIPTION
### Issue
Closes #1918

### Description

When creating the multiprocessing pool we want to have each work run the `worker_setup()` function which ensure that it is started, and that it has the operation modules loaded.

For low core counts calling `pool.map()` usually did the job. But it does not guarantee that each task goes to a different worker. So on machines with large numbers of CPU its possible for some workers to run the task multiple times, and others to not run it at all.

Instead use the `initializer` which runs a task on each worker.

"If initializer is not None then each worker process will call initializer(*initargs) when it starts." --
https://docs.python.org/3/library/multiprocessing.html#module-multiprocessing.pool

We no longer need to pass a dummy argument to `setup_worker()`.

### Testing & Acceptance Criteria 

I can't reliably trigger this issue, even on the large 60-core IDAaaS workspaces.

Best is to check that it does not make things worse. I.e. check that MI starts up and an operations such as Rotate Stack work.

### Documentation

Release notes
