### PR TITLE
1889 main window priority cli

### DIFF
--- a/docs/release_notes/next/dev-1889-cli_launched_window_focus
+++ b/docs/release_notes/next/dev-1889-cli_launched_window_focus
@@ -1,0 +1,1 @@
+#1889 : Refactor how focus is set for windows launched by cli so they open above the main window.

--- a/mantidimaging/core/utility/command_line_arguments.py
+++ b/mantidimaging/core/utility/command_line_arguments.py
@@ -93,3 +93,12 @@ class CommandLineArguments:
         Returns live view path.
         """
         return cls._show_live_viewer
+
+    @classmethod
+    def clear_window_args(cls) -> None:
+        """
+        Clears the command line arguments.
+        """
+        cls._init_operation = ""
+        cls._show_recon = False
+        cls._show_live_viewer = ""

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -32,9 +32,12 @@ class LiveViewerWindowView(BaseMainWindowView):
         self.presenter = LiveViewerWindowPresenter(self, main_window)
         self.live_viewer = LiveViewWidget()
         self.imageLayout.addWidget(self.live_viewer)
+
+    def show(self) -> None:
+        """Show the window"""
+        super().show()
+        self.activateWindow()
         self.watch_directory()
-        # reposition to the right of the main window to be visible when launched from cli
-        self.move(self.main_window.x() + self.main_window.width(), self.main_window.y())
 
     def show_most_recent_image(self, image: np.ndarray) -> None:
         """

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -168,12 +168,25 @@ class MainWindowPresenter(BasePresenter):
         else:
             self._handle_task_error(self.LOAD_ERROR_STRING, task)
 
+    def _open_window_if_not_open(self) -> None:
+        """
+        Launches windows that requires loaded data if the CLI flags are set.
+        Resets args after window has opened.
+        """
+        if self.view.args.operation() != "" and self.view.filters is None:
+            self.show_operation(self.view.args.operation())
+            self.view.args.clear_window_args()
+        if self.view.args.recon() and self.view.recon is None:
+            self.view.show_recon_window()
+            self.view.args.clear_window_args()
+
     def _on_dataset_load_done(self, task: 'TaskWorkerThread') -> None:
 
         if task.was_successful():
             self._add_strict_dataset_to_view(task.result)
             self.view.model_changed.emit()
             task.result = None
+            self._open_window_if_not_open()
         else:
             self._handle_task_error(self.LOAD_ERROR_STRING, task)
 

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -522,13 +522,16 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.create_mixed_dataset_stack_windows.assert_called_once_with(result_mock)
         self.view.model_changed.emit.assert_called_once()
 
-    def test_on_dataset_load_done_success(self):
+    @mock.patch("mantidimaging.gui.windows.main.view.CommandLineArguments")
+    def test_on_dataset_load_done_success(self, command_line_args):
         task = mock.Mock()
         task.result = result_mock = mock.Mock()
         task.was_successful.return_value = True
         self.presenter._add_strict_dataset_to_view = mock.Mock()
 
-        self.presenter._on_dataset_load_done(task)
+        with mock.patch.object(self.presenter, "_open_window_if_not_open") as _:
+            self.presenter._on_dataset_load_done(task)
+
         self.presenter._add_strict_dataset_to_view.assert_called_once_with(result_mock)
         self.view.model_changed.emit.assert_called_once()
 

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -346,18 +346,6 @@ class MainWindowViewTest(unittest.TestCase):
 
     @mock.patch("mantidimaging.gui.windows.main.view.CommandLineArguments")
     @mock.patch("mantidimaging.gui.windows.main.view.WelcomeScreenPresenter")
-    @mock.patch("mantidimaging.gui.windows.main.view.MainWindowPresenter")
-    def test_command_line_show_filters_window(self, main_window_presenter, welcome_screen_presenter, command_line_args):
-        command_line_args.return_value.path.return_value = ""
-        command_line_args.return_value.recon.return_value = False
-        command_line_args.return_value.operation.return_value = command_line_filter = "Median"
-        command_line_args.return_value.live_viewer.return_value = ""
-
-        MainWindowView()
-        main_window_presenter.return_value.show_operation.assert_called_once_with(command_line_filter)
-
-    @mock.patch("mantidimaging.gui.windows.main.view.CommandLineArguments")
-    @mock.patch("mantidimaging.gui.windows.main.view.WelcomeScreenPresenter")
     @mock.patch("mantidimaging.gui.windows.main.view.FiltersWindowView")
     def test_command_line_dont_show_filters_window(self, filters_window, welcome_screen_presenter, command_line_args):
         command_line_args.return_value.path.return_value = ""
@@ -366,17 +354,6 @@ class MainWindowViewTest(unittest.TestCase):
         command_line_args.return_value.live_viewer.return_value = ""
         MainWindowView()
         filters_window.assert_not_called()
-
-    @mock.patch("mantidimaging.gui.windows.main.view.CommandLineArguments")
-    @mock.patch("mantidimaging.gui.windows.main.view.WelcomeScreenPresenter")
-    @mock.patch("mantidimaging.gui.windows.main.view.ReconstructWindowView")
-    def test_command_line_show_recon_window(self, recon_window, welcome_screen_presenter, command_line_args):
-        command_line_args.return_value.path.return_value = ""
-        command_line_args.return_value.recon.return_value = True
-        command_line_args.return_value.operation.return_value = ""
-        command_line_args.return_value.live_viewer.return_value = ""
-        view = MainWindowView()
-        recon_window.assert_called_once_with(view)
 
     @mock.patch("mantidimaging.gui.windows.main.view.CommandLineArguments")
     @mock.patch("mantidimaging.gui.windows.main.view.WelcomeScreenPresenter")

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -139,19 +139,14 @@ class MainWindowView(BaseMainWindowView):
 
         self.wizard = None
 
-        args = CommandLineArguments()
-        if args.path():
-            for filepath in list(args.path()):
+        # Recon and operation windows are launched from view using self.args
+        # if passed as flags through cli once data is loaded
+        self.args = CommandLineArguments()
+        if self.args.path():
+            for filepath in list(self.args.path()):
                 self.presenter.load_stacks_from_folder(filepath)
-
-        if args.operation():
-            self.presenter.show_operation(args.operation())
-
-        if args.recon():
-            self.show_recon_window()
-
-        if args.live_viewer() != "":
-            self.show_live_viewer(live_data_path=Path(args.live_viewer()))
+        if self.args.live_viewer() != "":
+            self.show_live_viewer(live_data_path=Path(self.args.live_viewer()))
 
         self.dataset_tree_widget = QTreeWidget()
         self.dataset_tree_widget.setContextMenuPolicy(Qt.CustomContextMenu)

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -133,6 +133,7 @@ class FiltersWindowView(BaseMainWindowView):
     def show(self):
         super().show()
         self.auto_update_triggered.emit()
+        self.activateWindow()
 
     def handle_filter_selection(self, filter_name: str):
         """

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -217,6 +217,7 @@ class ReconstructWindowView(BaseMainWindowView):
         elif self.presenter.stack_changed_pending:
             self.presenter.handle_stack_changed()
             self.presenter.stack_changed_pending = False
+        self.activateWindow()
 
     def closeEvent(self, e):
         if self.presenter.recon_is_running:


### PR DESCRIPTION
### Issue

Closes #1889 

### Description

When launching mantid imaging from the CLI with flags to launch windows such as: operations window; reconstruction window; live viewer - the specified window now stay on-top of the main window. 

Previously, the main window would display over the top of additional windows when launched from the CLI.

### Testing 
Checkout this branch locally and launch mantid imaging from the CLI with additional flags to open one of the following windows:
 * Operations window
 * Reconstruction window
 * Live viewer WIndow. 

Verify that the selected window from the CLI opens above the main window. 
 
#### **Example CLI Commands**
##### **Operations Window:**
```bash
python -m mantidimaging --path <DATASET_DIR> --operation crop-coordinates
```

##### **Reconstruction Window:**
```bash
python -m mantidimaging --path <DATASET_DIR> --recon
```

##### **Live Viewer Window:**
```bash
python -m mantidimaging -lv <LIVE_OUTPUT_DIR>
```

### Acceptance Criteria 

- Additional windows opened when mantid imaging is launched from the CLI open on top of main window
    - [ ] Operations Window
    - [ ] Reconstruction Window
    - [ ] Live View Window

### Documentation

- `docs/release_notes/next/dev-1889-cli_launched_window_focus`
