### PR TITLE
1922 live view emit dir structure on load

### DIFF
--- a/docs/release_notes/next/fix-1922-live_view_image_load_on_init
+++ b/docs/release_notes/next/fix-1922-live_view_image_load_on_init
@@ -1,0 +1,1 @@
+#1922 : Load images into live viewer on initialisation if images already present in selected directory.

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -100,7 +100,7 @@ class LiveViewerWindowModel:
         self._dataset_path = path
         self.image_watcher = ImageWatcher(path)
         self.image_watcher.image_changed.connect(self._handle_image_changed_in_list)
-        self.image_watcher.find_images()
+        self.image_watcher._handle_directory_change("")
 
     def _handle_image_changed_in_list(self, image_files: list[Image_Data]) -> None:
         """

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -32,14 +32,13 @@ class LiveViewerWindowView(BaseMainWindowView):
         self.presenter = LiveViewerWindowPresenter(self, main_window)
         self.live_viewer = LiveViewWidget()
         self.imageLayout.addWidget(self.live_viewer)
+        self.live_viewer.z_slider.valueChanged.connect(self.presenter.select_image)
 
     def show(self) -> None:
         """Show the window"""
         super().show()
         self.activateWindow()
         self.watch_directory()
-
-        self.live_viewer.z_slider.valueChanged.connect(self.presenter.select_image)
 
     def show_most_recent_image(self, image: np.ndarray) -> None:
         """


### PR DESCRIPTION
### Issue

Closes #1922 

### Description

View makes a call on initialisation to the model to emit a signal to load images so that if images are already present in the selected directory, they are loaded into the live viewer. Previously Images if present were not loaded into live viewer on initialisation. 

### Testing 

Try loading the image viewer with and without images already populated inside the selected directory. 
1. Create a empty directory
2. Load live viewer using CLI flag `python -W default -m mantidimaging --log-level DEBUG -lv <LIVE_DIR_OUT/>` or from the menu: `File>Live Viewer` select a folder.
3. Verify that the live viewer window opens with no data loaded successfully
4. Begin copying image files over to the live viewer using the utility script `scripts/simulate_live_data.py`: `python simulate_live_data.py -s ../<LIVE_DIR_IN/>/ -d <../LIVE_DIR_OUT/>/ --faulty`
and verify images display in the live viewer.
5. Close Mantid Imaging and repeat steps with the populated directory verifying that the live viewer shows loaded data on opening. 


### Acceptance Criteria 
* Live viewer opens successfully when selected with an empty directory.
* Live viewer displays images present in a selected directory that already contains images.

### Documentation

`docs/release_notes/next/fix-1922-live_view_image_load_on_init`