### PR TITLE
1924 spectrum viewer cli launch

### DIFF
--- a/docs/release_notes/next/dev-1924-spectrum_viewer_cli_flag
+++ b/docs/release_notes/next/dev-1924-spectrum_viewer_cli_flag
@@ -1,0 +1,1 @@
+#1901 : Launch Spectrum Viewer from CLI with additional CLI argument

--- a/mantidimaging/core/utility/command_line_arguments.py
+++ b/mantidimaging/core/utility/command_line_arguments.py
@@ -28,8 +28,14 @@ class CommandLineArguments:
     _init_operation = ""
     _show_recon = False
     _show_live_viewer = ""
+    _show_spectrum_viewer = False
 
-    def __new__(cls, path: str = "", operation: str = "", show_recon: bool = False, show_live_viewer: str = ""):
+    def __new__(cls,
+                path: str = "",
+                operation: str = "",
+                show_recon: bool = False,
+                show_live_viewer: str = "",
+                show_spectrum_viewer: bool = False):
         """
         Creates a singleton for storing the command line arguments.
         """
@@ -58,6 +64,10 @@ class CommandLineArguments:
                 _log_and_exit("No path given for reconstruction. Exiting.")
             else:
                 cls._show_recon = show_recon
+            if show_spectrum_viewer and not path:
+                _log_and_exit("No path given for reconstruction. Exiting.")
+            else:
+                cls._show_spectrum_viewer = show_spectrum_viewer
             if show_live_viewer and show_live_viewer != cls._show_live_viewer:
                 if not os.path.exists(show_live_viewer):
                     _log_and_exit("Path given for live view does not exist. Exiting.")
@@ -86,6 +96,13 @@ class CommandLineArguments:
         Returns whether or not the recon window should be started.
         """
         return cls._show_recon
+
+    @classmethod
+    def spectrum_viewer(cls) -> bool:
+        """
+        Returns whether or not the recon window should be started.
+        """
+        return cls._show_spectrum_viewer
 
     @classmethod
     def live_viewer(cls) -> str:

--- a/mantidimaging/core/utility/command_line_arguments.py
+++ b/mantidimaging/core/utility/command_line_arguments.py
@@ -118,4 +118,5 @@ class CommandLineArguments:
         """
         cls._init_operation = ""
         cls._show_recon = False
+        cls._show_spectrum_viewer = False
         cls._show_live_viewer = ""

--- a/mantidimaging/core/utility/test/command_line_arguments_test.py
+++ b/mantidimaging/core/utility/test/command_line_arguments_test.py
@@ -25,6 +25,7 @@ class CommandLineArgumentsTest(unittest.TestCase):
         CommandLineArguments._init_operation = ""
         CommandLineArguments._show_recon = False
         CommandLineArguments._show_live_viewer = ""
+        CommandLineArguments._show_spectrum_viewer = False
 
     def test_bad_path_calls_exit(self):
         bad_path = "does/not/exist"

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -179,6 +179,9 @@ class MainWindowPresenter(BasePresenter):
         if self.view.args.recon() and self.view.recon is None:
             self.view.show_recon_window()
             self.view.args.clear_window_args()
+        if self.view.args.spectrum_viewer() and self.view.spectrum_viewer is None:
+            self.view.show_spectrum_viewer_window()
+            self.view.args.clear_window_args()
 
     def _on_dataset_load_done(self, task: 'TaskWorkerThread') -> None:
 

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -31,6 +31,7 @@ class MainWindowViewTest(unittest.TestCase):
                 command_line_args.return_value.operation.return_value = ""
                 command_line_args.return_value.recon.return_value = False
                 command_line_args.return_value.live_viewer.return_value = ""
+                command_line_args.return_value.spectrum_viewer.return_value = False
 
                 self.view = MainWindowView()
         self.presenter = mock.MagicMock()
@@ -329,6 +330,7 @@ class MainWindowViewTest(unittest.TestCase):
         command_line_args.return_value.recon.return_value = False
         command_line_args.return_value.operation.return_value = ""
         command_line_args.return_value.live_viewer.return_value = ""
+        command_line_args.return_value.spectrum_viewer.return_value = False
         MainWindowView()
         main_window_presenter.return_value.load_stacks_from_folder.assert_called_once_with(test_path)
 
@@ -341,6 +343,7 @@ class MainWindowViewTest(unittest.TestCase):
         command_line_args.return_value.recon.return_value = False
         command_line_args.return_value.operation.return_value = ""
         command_line_args.return_value.live_viewer.return_value = ""
+        command_line_args.return_value.spectrum_viewer.return_value = False
         MainWindowView()
         main_window_presenter.return_value.load_stacks_from_folder.assert_not_called()
 
@@ -352,6 +355,7 @@ class MainWindowViewTest(unittest.TestCase):
         command_line_args.return_value.recon.return_value = False
         command_line_args.return_value.operation.return_value = ""
         command_line_args.return_value.live_viewer.return_value = ""
+        command_line_args.return_value.spectrum_viewer.return_value = False
         MainWindowView()
         filters_window.assert_not_called()
 
@@ -363,6 +367,7 @@ class MainWindowViewTest(unittest.TestCase):
         command_line_args.return_value.recon.return_value = False
         command_line_args.return_value.operation.return_value = ""
         command_line_args.return_value.live_viewer.return_value = ""
+        command_line_args.return_value.spectrum_viewer.return_value = False
         MainWindowView()
         recon_window.assert_not_called()
 

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -148,9 +148,6 @@ class MainWindowView(BaseMainWindowView):
         if self.args.live_viewer() != "":
             self.show_live_viewer(live_data_path=Path(self.args.live_viewer()))
 
-        if args.spectrum_viewer():
-            self.show_spectrum_viewer_window()
-
         self.dataset_tree_widget = QTreeWidget()
         self.dataset_tree_widget.setContextMenuPolicy(Qt.CustomContextMenu)
         self.dataset_tree_widget.customContextMenuRequested.connect(self._open_tree_menu)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -148,6 +148,9 @@ class MainWindowView(BaseMainWindowView):
         if self.args.live_viewer() != "":
             self.show_live_viewer(live_data_path=Path(self.args.live_viewer()))
 
+        if args.spectrum_viewer():
+            self.show_spectrum_viewer_window()
+
         self.dataset_tree_widget = QTreeWidget()
         self.dataset_tree_widget.setContextMenuPolicy(Qt.CustomContextMenu)
         self.dataset_tree_widget.customContextMenuRequested.connect(self._open_tree_menu)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -134,6 +134,10 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         header.setSectionResizeMode(1, QHeaderView.ResizeToContents)
         header.setSectionResizeMode(2, QHeaderView.ResizeToContents)
 
+    def show(self):
+        super().show()
+        self.activateWindow()
+
     def cleanup(self):
         self.sampleStackSelector.unsubscribe_from_main_window()
         self.normaliseStackSelector.unsubscribe_from_main_window()

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -38,6 +38,11 @@ def parse_args() -> argparse.Namespace:
                         default=False,
                         action='store_true',
                         help="Opens the reconstruction window at start up.")
+    parser.add_argument("-sv",
+                        "--spectrum_viewer",
+                        default=False,
+                        action='store_true',
+                        help="Opens the spectrum viewer window at start up.")
     parser.add_argument("-lv",
                         "--live_viewer",
                         type=str,
@@ -69,7 +74,11 @@ def main() -> None:
     path = args.path if args.path else ""
     operation = args.operation if args.operation else ""
 
-    CommandLineArguments(path=path, operation=operation, show_recon=args.recon, show_live_viewer=args.live_viewer)
+    CommandLineArguments(path=path,
+                         operation=operation,
+                         show_recon=args.recon,
+                         show_live_viewer=args.live_viewer,
+                         show_spectrum_viewer=args.spectrum_viewer)
 
     h.initialise_logging(args.log_level)
 


### PR DESCRIPTION
### Issue

Closes #1924 

### Description

New CLI flag added to launch Spectrum Viewer.
Tests Updated to Include additional CLI argument

### Testing 

Manually tested that new CLI flags `-sv` and `--spectrum_viewer` launch Spectrum Viewer window on startup only if a valid path is passed as an argument `--path`

### Acceptance Criteria 

Spectrum Viewer can be launched from CLI if a valid path is provided if the flag `-sv` or `--spectrum_viewer` is included in the launch command. 

Example Commands:
```Python
python -X faulthandler -W default -m mantidimaging --log-level DEBUG --path <DATASET_DIR> --spectrum_viewer
```

```Python
python -X faulthandler -W default -m mantidimaging --log-level DEBUG --path <DATASET_DIR> -sv
```

### Documentation

`docs/release_notes/next/dev-1924-spectrum_viewer_cli_flag`
