### PR TITLE
Documentation: Document Spectrum Viewer and Live Viewer Window CLI Launch CLI Args

### DIFF
--- a/docs/developer_guide/index.rst
+++ b/docs/developer_guide/index.rst
@@ -45,11 +45,14 @@ Command Line Arguments
 - :code:`--log-level` - Set the log verbosity level. Available options are: TRACE, DEBUG, INFO, WARN, CRITICAL
 - :code:`--version` - Print the version number and exit.
 - :code:`--path` - Set the path for the data you wish to load.
+- :code:`-lv` `--live-view` - Set the directory to open the live view window on start up. The live view window will automatically update when new images are added to the directory.
 
 The following command line arguments will only work if a valid path containing images has been given:
 
 - :code:`--operation` - Opens the operation window on start up with the given operation selected in the combo box. The operation name should the same was what appears in Mantid Imaging but joined with hyphens in place of spaces. Case insensitive.
 - :code:`--recon` - Shows the recon window on start up.
+- :code:`-sv` `--spectrum_viewer` - Opens the spectrum viewer window on start up. A path to a dataset must be provided with the :code:`--path` argument for the spectrum viewer to open.
+
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
### Issue

Closes #1926 

### Description

Document Live Viewer and Spectrum Viewer CLI Arguments.

### Testing 

Build and view developer docs command line argument instructions.

### Acceptance Criteria 

* Documentation builds successfully
* Documentation follows the same format as existing documentation.
* No Grammar or spelling issues

### Documentation

Not needed as release notes for previous completed issues relating to work on spectrum viewer and live viewer document the changes. 
