### PR TITLE
SpectrumWidget: Use QSignalBlocker to revent additional draws while creating range

### DIFF
--- a/docs/release_notes/next/feature-1828-spec-view-perf
+++ b/docs/release_notes/next/feature-1828-spec-view-perf
@@ -1,0 +1,1 @@
+#1828 : Performance improvements for the spectrum viewer

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from PyQt5.QtCore import pyqtSignal, Qt
+from PyQt5.QtCore import pyqtSignal, Qt, QSignalBlocker
 from pyqtgraph import ROI, GraphicsLayoutWidget, LinearRegionItem, PlotItem, mkPen
 
 from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint
@@ -101,8 +101,9 @@ class SpectrumWidget(GraphicsLayoutWidget):
         self.colour_index = 0
 
     def add_range(self, range_min: int, range_max: int) -> None:
-        self.range_control.setBounds((range_min, range_max))
-        self.range_control.setRegion((range_min, range_max))
+        with QSignalBlocker(self.range_control):
+            self.range_control.setBounds((range_min, range_max))
+            self.range_control.setRegion((range_min, range_max))
         self.spectrum.addItem(self.range_control)
         self._set_tof_range_label(range_min, range_max)
 


### PR DESCRIPTION
### Issue
Closes #1828 

### Description

Reduce unnecessary calls to get_averaged_image() while setting up the initial range.

Over the set of PRs for 1828 the time to open the window with a 512x512 flower dataset is reduced tom 1.0 to ~0.3 seconds.

### Testing & Acceptance Criteria 
Try opening spectrum viewer
Changing datasets
Adjusting range and ROI

### Documentation

Release notes
