### PR TITLE
1929 live view dir switch

### DIFF
--- a/docs/release_notes/next/fix-1929-live_view_window_closure
+++ b/docs/release_notes/next/fix-1929-live_view_window_closure
@@ -1,0 +1,1 @@
+#1929 : Handle Live Viewer window closure to resolve directory persistence when trying to switch directories.

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -113,6 +113,13 @@ class LiveViewerWindowModel:
         self.images = image_files
         self.presenter.update_image_list(image_files)
 
+    def close(self) -> None:
+        """Close the model."""
+        if self.image_watcher:
+            self.image_watcher.remove_path()
+            self.image_watcher = None
+        self.presenter = None  # type: ignore # Model instance to be destroyed -type can be inconsistent
+
 
 class ImageWatcher(QObject):
     """
@@ -204,3 +211,9 @@ class ImageWatcher(QObject):
         image_extensions = ['.tif', '.tiff']
         file_names = any(file_name.lower().endswith(ext) for ext in image_extensions)
         return file_names
+
+    def remove_path(self):
+        """
+        Remove the currently set path
+        """
+        self.watcher.removePath(str(self.directory))

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -36,6 +36,12 @@ class LiveViewerWindowPresenter(BasePresenter):
         self.main_window = main_window
         self.model = LiveViewerWindowModel(self)
 
+    def close(self) -> None:
+        """Close the window."""
+        self.model.close()
+        self.model = None  # type: ignore # Presenter instance to be destroyed -type can be inconsistent
+        self.view = None  # type: ignore # Presenter instance to be destroyed -type can be inconsistent
+
     def set_dataset_path(self, path: Path) -> None:
         """Set the path to the dataset."""
         self.model.path = path

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from logging import getLogger
 
 from imagecodecs._deflate import DeflateError
-from tifffile import tifffile
+from tifffile import tifffile, TiffFileError
 
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.windows.live_viewer.model import LiveViewerWindowModel, Image_Data
@@ -74,9 +74,12 @@ class LiveViewerWindowPresenter(BasePresenter):
         try:
             with tifffile.TiffFile(selected_image.image_path) as tif:
                 image_data = tif.asarray()
-        except (IOError, KeyError, ValueError, DeflateError) as error:
+        except (IOError, KeyError, ValueError, TiffFileError, DeflateError) as error:
             logger.error("%s reading image: %s: %s", type(error).__name__, selected_image.image_path, error)
             self.view.remove_image()
+            return
+        if image_data.size == 0:
+            logger.error("reading image: %s: Image has zero size", selected_image.image_path)
             return
 
         self.view.show_most_recent_image(image_data)

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -57,3 +57,8 @@ class LiveViewerWindowView(BaseMainWindowView):
 
     def set_image_index(self, index: int) -> None:
         self.live_viewer.z_slider.set_value(index)
+
+    def closeEvent(self, e) -> None:
+        """Close the window and remove it from the main window list"""
+        self.main_window.live_viewer = None
+        super().closeEvent(e)

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -61,4 +61,7 @@ class LiveViewerWindowView(BaseMainWindowView):
     def closeEvent(self, e) -> None:
         """Close the window and remove it from the main window list"""
         self.main_window.live_viewer = None
+        self.presenter.close()
+        self.live_viewer.handle_deleted()
         super().closeEvent(e)
+        self.presenter = None  # type: ignore # View instance to be destroyed -type can be inconsistent


### PR DESCRIPTION
### Issue

Closes #1929 

### Description

New method to handle closure of Live Viewer to resolve directory persistence preventing the live viewer from being closed and reopened to look at a new directory.

### Testing 

Load the live viewer with one dataset, close and re-open to look at another dataset. 
The new dataset should not be watched instead of the old dataset within the live viewer.

### Acceptance Criteria 

The Live viewer can be closed and re-opened from the main window menu to look at a new dataset.
See Issue #1929 description to reproduce.

### Documentation

`docs/release_notes/next/fix-1929-live_view_window_closure`
