### PR TITLE
Fix showing most recent image

### DIFF
--- a/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
+++ b/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
@@ -2,7 +2,6 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from collections import OrderedDict
 from typing import Callable, List, Optional, Tuple
 
 import numpy as np
@@ -13,6 +12,7 @@ from mantidimaging.core.utility import finder
 
 OVERLAY_COLOUR_NAN = [255, 0, 0, 255]
 OVERLAY_COLOUR_NONPOSITVE = [255, 192, 0, 255]
+OVERLAY_COLOUR_MESSAGE = [255, 0, 0, 255]
 
 
 class BadDataCheck:
@@ -59,10 +59,11 @@ class BadDataOverlay:
     Mixin class to be used with MIImageView and MIMiniImageView
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
-        self.enabled_checks = OrderedDict()
+        self.enabled_checks: dict[str, BadDataCheck] = {}
+        self.message_indicator: IndicatorIconView | None = None
 
         if hasattr(self, "sigTimeChanged"):
             self.sigTimeChanged.connect(self.check_for_bad_data)
@@ -123,3 +124,20 @@ class BadDataOverlay:
     def clear_overlays(self):
         for check in self.enabled_checks.values():
             check.clear()
+
+    def enable_message(self, enable: bool = True):
+        if enable:
+            icon_path = finder.ROOT_PATH + "/gui/ui/images/exclamation-triangle-red.png"
+            self.message_indicator = IndicatorIconView(self.viewbox, icon_path, 0, OVERLAY_COLOUR_MESSAGE, "")
+            self.message_indicator.setVisible(False)
+        else:
+            self.message_indicator = None
+
+    def show_message(self, message: str | None) -> None:
+        if self.message_indicator is None:
+            return
+        if message:
+            self.message_indicator.set_message(message)
+            self.message_indicator.setVisible(True)
+        else:
+            self.message_indicator.setVisible(False)

--- a/mantidimaging/gui/widgets/indicator_icon/view.py
+++ b/mantidimaging/gui/widgets/indicator_icon/view.py
@@ -111,3 +111,7 @@ class IndicatorIconView(QGraphicsPixmapItem):  # type: ignore
                 qm.addAction(action)
 
             qm.exec(event.screenPos().toQPoint())
+
+    def set_message(self, message):
+        self.label.setText(message)
+        self.position_icon()

--- a/mantidimaging/gui/widgets/indicator_icon/view.py
+++ b/mantidimaging/gui/widgets/indicator_icon/view.py
@@ -115,3 +115,8 @@ class IndicatorIconView(QGraphicsPixmapItem):  # type: ignore
     def set_message(self, message):
         self.label.setText(message)
         self.position_icon()
+
+    def setVisible(self, visible: bool):
+        if not visible:
+            self.label.setVisible(False)
+        super().setVisible(visible)

--- a/mantidimaging/gui/windows/live_viewer/live_view_widget.py
+++ b/mantidimaging/gui/windows/live_viewer/live_view_widget.py
@@ -28,6 +28,8 @@ class LiveViewWidget(GraphicsLayoutWidget):
         self.z_slider = ZSlider()
         self.addItem(self.z_slider)
 
+        self.image.enable_message()
+
     def show_image(self, image: np.ndarray) -> None:
         """
         Show the image in the image view.
@@ -40,3 +42,6 @@ class LiveViewWidget(GraphicsLayoutWidget):
         Handle the deletion of the image.
         """
         self.image.clear()
+
+    def show_error(self, message: str | None):
+        self.image.show_message(message)

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -50,11 +50,6 @@ class Image_Data:
         return self._stat
 
     @property
-    def image_size(self) -> int:
-        """Return the image size"""
-        return self._stat.st_size
-
-    @property
     def image_modified_time(self) -> float:
         """Return the image modified time"""
         return self._stat.st_mtime
@@ -170,8 +165,7 @@ class ImageWatcher(QObject):
             if self._is_image_file(file_path.name):
                 try:
                     image_obj = Image_Data(file_path)
-                    if image_obj.image_size > 45:
-                        image_files.append(image_obj)
+                    image_files.append(image_obj)
                 except FileNotFoundError:
                     continue
 

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -220,6 +220,11 @@ class ImageWatcher(QObject):
         Remove the currently set path
         """
         self.watcher.removePath(str(self.directory))
+        self.recent_file_watcher.removePaths(self.recent_file_watcher.files())
+        assert len(self.watcher.files()) == 0
+        assert len(self.watcher.directories()) == 0
+        assert len(self.recent_file_watcher.files()) == 0
+        assert len(self.recent_file_watcher.directories()) == 0
 
     def update_recent_watcher(self, images: list[Image_Data]) -> None:
         self.recent_file_watcher.removePaths(self.recent_file_watcher.files())

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -62,7 +62,7 @@ class LiveViewerWindowPresenter(BasePresenter):
             self.handle_deleted()
             return
 
-        self.view.live_viewer.z_slider.set_range(0, len(images_list) - 1)
+        self.view.set_image_range((0, len(images_list) - 1))
         self.view.set_image_index(len(images_list) - 1)
 
     def select_image(self, index: int) -> None:

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -56,6 +56,7 @@ class LiveViewerWindowPresenter(BasePresenter):
         self.view.remove_image()
         self.clear_label()
         self.view.live_viewer.z_slider.set_range(0, 1)
+        self.view.live_viewer.show_error(None)
 
     def update_image_list(self, images_list: list[Image_Data]) -> None:
         """Update the image in the view."""
@@ -79,14 +80,20 @@ class LiveViewerWindowPresenter(BasePresenter):
             with tifffile.TiffFile(image_path) as tif:
                 image_data = tif.asarray()
         except (IOError, KeyError, ValueError, TiffFileError, DeflateError) as error:
-            logger.error("%s reading image: %s: %s", type(error).__name__, image_path, error)
+            message = f"{type(error).__name__} reading image: {image_path}: {error}"
+            logger.error(message)
             self.view.remove_image()
+            self.view.live_viewer.show_error(message)
             return
         if image_data.size == 0:
+            message = "reading image: {image_path}: Image has zero size"
             logger.error("reading image: %s: Image has zero size", image_path)
+            self.view.remove_image()
+            self.view.live_viewer.show_error(message)
             return
 
         self.view.show_most_recent_image(image_data)
+        self.view.live_viewer.show_error(None)
 
     def update_image_modified(self, image_path: Path):
         """

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from PyQt5.QtCore import QSignalBlocker
 from PyQt5.QtWidgets import QVBoxLayout
 
 from mantidimaging.gui.mvp_base import BaseMainWindowView
@@ -55,8 +56,14 @@ class LiveViewerWindowView(BaseMainWindowView):
         """Remove the image from the view."""
         self.live_viewer.handle_deleted()
 
+    def set_image_range(self, index_range: tuple[int, int]) -> None:
+        with QSignalBlocker(self.live_viewer.z_slider):
+            self.live_viewer.z_slider.set_range(*index_range)
+
     def set_image_index(self, index: int) -> None:
-        self.live_viewer.z_slider.set_value(index)
+        with QSignalBlocker(self.live_viewer.z_slider):
+            self.live_viewer.z_slider.set_value(index)
+        self.live_viewer.z_slider.valueChanged.emit(index)
 
     def closeEvent(self, e) -> None:
         """Close the window and remove it from the main window list"""

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -57,10 +57,12 @@ class LiveViewerWindowView(BaseMainWindowView):
         self.live_viewer.handle_deleted()
 
     def set_image_range(self, index_range: tuple[int, int]) -> None:
+        """Set the range on the z-slider, without triggering valueChanged signal"""
         with QSignalBlocker(self.live_viewer.z_slider):
             self.live_viewer.z_slider.set_range(*index_range)
 
     def set_image_index(self, index: int) -> None:
+        """Set the position on the z-slider, triggering valueChanged signal once"""
         with QSignalBlocker(self.live_viewer.z_slider):
             self.live_viewer.z_slider.set_value(index)
         self.live_viewer.z_slider.valueChanged.emit(index)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -501,8 +501,8 @@ class MainWindowView(BaseMainWindowView):
             stack.shared_array = None
 
     def uncaught_exception(self, user_error_msg: str, log_error_msg: str) -> None:
-        self.show_error_dialog(f"Uncaught exception {user_error_msg}")
         getLogger(__name__).error(log_error_msg)
+        self.show_error_dialog(f"Uncaught exception {user_error_msg}")
 
     def show_stack_select_dialog(self):
         dialog = MultipleStackSelect(self)


### PR DESCRIPTION
### Issue

Closes #1933

### Description
This resolves 2 issues that prevent the most recent image being shown.
- A signalling issue, where a new image was only shown if its arrival had caused the position on the z-slider to change
- Lack of notification when an image file is modified. So the loading was being trigged at the start of writing the file, so we try to load it before it is complete.

I have also added an indicator when the image cannot be loaded. We get this situation a bit more now, because we don't filter out sub 45 byte files.

Should also fix the snap folder issue, as we keep a watch on the most recent file.


### Testing & Acceptance Criteria 

Use the `simulate_live_data.py` script with `--slow`.
Now the image should be shown as soon as writing is complete.

Note, that during the slow write, we display a blank image, as the most recent image is not loadable.

### Documentation

Not needed
