### PR TITLE
1932 core export rits format

### DIFF
--- a/docs/release_notes/next/dev-1932-RITS_export_backend
+++ b/docs/release_notes/next/dev-1932-RITS_export_backend
@@ -1,0 +1,1 @@
+#1932 : RITS Export Backend

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -7,6 +7,7 @@ from logging import getLogger
 from typing import List, Union, Optional, Dict, Callable, Tuple, TYPE_CHECKING
 
 import h5py
+from pathlib import Path
 import numpy as np
 from tifffile import tifffile
 
@@ -411,7 +412,7 @@ def generate_names(name_prefix: str,
     return names
 
 
-def make_dirs_if_needed(dirname: Optional[str] = None, overwrite_all: bool = False):
+def make_dirs_if_needed(dirname: Optional[str] = None, overwrite_all: bool = False) -> None:
     """
     Makes sure that the directory needed (for example to save a file)
     exists, otherwise creates it.
@@ -428,3 +429,31 @@ def make_dirs_if_needed(dirname: Optional[str] = None, overwrite_all: bool = Fal
     elif os.listdir(path) and not overwrite_all:
         raise RuntimeError("The output directory is NOT empty:{0}\nThis can be "
                            "overridden by specifying 'Overwrite on name conflict'.".format(path))
+
+
+def create_rits_format(tof: np.ndarray, transmission: np.ndarray, transmission_error: np.ndarray) -> str:
+    """
+    create a RITS format ready for exporting to a .dat file
+
+    :param tof: time of flight
+    :param transmission: transmission value
+    :param transmission_error: transmission_error value
+    :return: RITS format ascii
+
+    """
+    return '\n'.join(
+        ['\t'.join([str(x) for x in row]) for row in zip(tof, transmission, transmission_error, strict=True)])
+
+
+def export_to_dat_rits_format(rits_formatted_data: str, path: Path) -> None:
+    """
+    export a RITS formatted data to a .dat file
+
+    :param rits_formatted_data: RITS formatted data
+    :param path: path to save the .dat file
+    :return: None
+
+    """
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(rits_formatted_data)
+    LOG.info('RITS formatted data saved to: {}'.format(path))

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -483,6 +483,14 @@ class IOTest(FileOutputtingTestCase):
             close_arr = np.isclose(conv[i] / factors[i], float_arr[i], rtol=1e-5)
             self.assertTrue(np.count_nonzero(close_arr) >= len(close_arr) * 0.75)
 
+    def test_create_rits_format(self):
+        tof = np.array([1, 2, 3])
+        transmission = np.array([4, 5, 6])
+        absorption = np.array([7, 8, 9])
+        rits_formatted_data = saver.create_rits_format(tof, transmission, absorption)
+        expected = '1\t4\t7\n2\t5\t8\n3\t6\t9'
+        self.assertEqual(rits_formatted_data, expected)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
+from logging import getLogger
 from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.windows.spectrum_viewer.model import SpectrumViewerWindowModel, SpecType
@@ -12,6 +13,8 @@ if TYPE_CHECKING:
     from mantidimaging.gui.windows.main.view import MainWindowView  # pragma: no cover
     from mantidimaging.core.data import ImageStack
     from uuid import UUID
+
+LOG = getLogger(__name__)
 
 
 class SpectrumViewerWindowPresenter(BasePresenter):
@@ -157,6 +160,18 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             path = path.with_suffix(".csv")
 
         self.model.save_csv(path, self.spectrum_mode == SpecType.SAMPLE_NORMED)
+
+    def handle_rits_export(self) -> None:
+        """
+        Handle the export of the current spectrum to a RITS file format
+        """
+        path = self.view.get_rits_export_filename()
+        if path is None:
+            LOG.debug("No path selected, aborting export")
+            return
+        if path.suffix != ".dat":
+            path = path.with_suffix(".dat")
+        self.model.save_rits(path, self.spectrum_mode == SpecType.SAMPLE_NORMED)
 
     def handle_enable_normalised(self, enabled: bool) -> None:
         if enabled:

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -146,6 +146,18 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view.get_csv_filename.assert_called_once()
         mock_save_csv.assert_called_once_with(Path("/fake/path.csv"), False)
 
+    @parameterized.expand(["/fake/path", "/fake/path.dat"])
+    @mock.patch("mantidimaging.gui.windows.spectrum_viewer.model.SpectrumViewerWindowModel.save_rits")
+    def test_handle_rits_export(self, path_name: str, mock_save_rits: mock.Mock):
+        self.view.get_rits_export_filename = mock.Mock(return_value=Path(path_name))
+
+        self.presenter.model.set_stack(generate_images())
+
+        self.presenter.handle_rits_export()
+
+        self.view.get_rits_export_filename.assert_called_once()
+        mock_save_rits.assert_called_once_with(Path("/fake/path.dat"), False)
+
     def test_WHEN_do_add_roi_called_THEN_new_roi_added(self):
         self.presenter.model.set_stack(generate_images())
         self.presenter.do_add_roi()

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -175,6 +175,16 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         else:
             return None
 
+    def get_rits_export_filename(self) -> Optional[Path]:
+        """
+        Get the path to save the RITS file too
+        """
+        path = QFileDialog.getSaveFileName(self, "Save DAT file", "", "DAT file (*.dat)")[0]
+        if path:
+            return Path(path)
+        else:
+            return None
+
     def set_image(self, image_data: Optional['np.ndarray'], autoLevels: bool = True):
         self.spectrum.image.setImage(image_data, autoLevels=autoLevels)
 


### PR DESCRIPTION
### Issue

Closes #1932 

### Description

Backend for exporting RITS formatted spectrum data.

### Testing 

* Try adding the following to model.py:L42
```Python
self.export_spectrum_to_rits(Path('/path/to/save/test_rits_output.dat'),
                                                  np.arange(0, 10),
                                                  np.random.rand(10),
                                                  np.random.rand(10))
```
* Try opening data in RITS

**Alternatively:**
* Comment out view:L69 and replace with:
```Python
        self.exportButton.clicked.connect(self.presenter.handle_rits_export)
```
* Open spectrum viewer and export spectrum
* Try loading exported spectrum `.dat` file into RITS software


### Acceptance Criteria 

* Export RITS methods export data compatible with RITS software

### Documentation

`docs/release_notes/next/dev-1932-RITS_export_backend`
