### PR TITLE
ROI name change

### DIFF
--- a/docs/release_notes/next/fix-1920-rename-roi
+++ b/docs/release_notes/next/fix-1920-rename-roi
@@ -1,0 +1,1 @@
+#1920 : Fix Renaming of ROIs

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -39,19 +39,7 @@ class SpectrumViewerWindowModel:
         self.presenter = presenter
         self._roi_id_counter = 0
         self._roi_ranges = {}
-        self._selected_row = 0
         self.default_roi_list = ["all"]
-
-    @property
-    def selected_row(self):
-        return self._selected_row
-
-    @selected_row.setter
-    def selected_row(self, value):
-        self._selected_row = value
-
-    def reset_selected_row(self):
-        self.selected_row = 0
 
     def roi_name_generator(self) -> str:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -191,9 +191,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
         @param roi_name: Name of the ROI to add
         """
-        row = self.model.selected_row
         roi_colour = self.view.spectrum.roi_dict[roi_name].colour
-        self.view.add_roi_table_row(row, roi_name, roi_colour)
+        self.view.add_roi_table_row(roi_name, roi_colour)
 
     def rename_roi(self, old_name: str, new_name: str) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 # and display it in the spectrum viewer.
 
 # Dependencies
-from PyQt5.QtCore import QAbstractTableModel, Qt, QItemSelectionModel
+from PyQt5.QtCore import QAbstractTableModel, Qt
 from PyQt5.QtGui import QColor, QBrush
 
 
@@ -18,18 +18,8 @@ class TableModel(QAbstractTableModel):
     """
 
     def __init__(self):
-        super(TableModel, self).__init__()
+        super().__init__()
         self._data = []
-
-    def selectRow(self, index: int):
-        """
-        Selects the row at the given index.
-
-        :param index: The index of the row to select.
-        """
-        selectionModel = self.tableView.selectionModel()
-        selectionModel.clearSelection()
-        selectionModel.select(self.createIndex(index + 1, 0), QItemSelectionModel.Select | QItemSelectionModel.Rows)
 
     def rowCount(self, *args, **kwargs):
         """
@@ -120,12 +110,6 @@ class TableModel(QAbstractTableModel):
         item_list = [roi_name, roi_colour, visible]
         self._data.append(item_list)
         self.layoutChanged.emit()
-
-    def sort_points(self):
-        """
-        Sort table by ROI name
-        """
-        self._data.sort(key=lambda x: x[0])
 
     def headerData(self, section, orientation, role):
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -156,13 +156,13 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     def test_WHEN_do_add_roi_to_table_called_THEN_roi_added_to_table(self):
         self.presenter.model.set_stack(generate_images())
         self.presenter.do_add_roi()
-        self.view.add_roi_table_row.assert_called_once_with(0, "roi", mock.ANY)
+        self.view.add_roi_table_row.assert_called_once_with("roi", mock.ANY)
         self.view.add_roi_table_row.reset_mock()
 
         self.assertEqual(["all", "roi"], self.presenter.model.get_list_of_roi_names())
         self.presenter.view.spectrum.roi_dict = {"roi_1": mock.Mock()}
         self.presenter.do_add_roi_to_table("roi_1")
-        self.view.add_roi_table_row.assert_called_once_with(0, "roi_1", mock.ANY)
+        self.view.add_roi_table_row.assert_called_once_with("roi_1", mock.ANY)
 
     def test_WHEN_do_remove_roi_called_THEN_roi_removed(self):
         self.presenter.model.set_stack(generate_images())

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -42,6 +42,10 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         icon_path = finder.ROOT_PATH + "/gui/ui/images/exclamation-triangle-red.png"
         self.normalise_error_icon_pixmap = QPixmap(icon_path)
 
+        self.selected_row: int = 0
+        self.current_roi: str = ""
+        self.selected_row_data: Optional[list] = None
+
         self.presenter = SpectrumViewerWindowPresenter(self, main_window)
 
         self.spectrum = SpectrumWidget()
@@ -72,10 +76,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.tableView.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.tableView.setSelectionMode(QAbstractItemView.SingleSelection)
         self.tableView.setAlternatingRowColors(True)
-
-        self.selected_row: int = 0
-        self.current_roi: str = ""
-        self.selected_row_data: Optional[list] = None
 
         _ = self.roi_table_model  # Initialise model
 
@@ -111,8 +111,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             If the visibility of an ROI has changed, update the visibility of the ROI in the spectrum widget.
             """
             selected_row_data = self.roi_table_model.row_data(self.selected_row)
-            if self.current_roi in ["", " "]:
-                self.current_roi = selected_row_data[0]
+
             if selected_row_data[0].lower() not in ["", " ", "all"] and selected_row_data[0] != self.current_roi:
                 if selected_row_data[0] in self.presenter.get_roi_names():
                     selected_row_data[0] = self.current_roi
@@ -260,7 +259,9 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         circle_label = QLabel()
         circle_label.setStyleSheet(f"background-color: {colour}; border-radius: 5px;")
         self.roi_table_model.appendNewRow(name, colour, True)
-        self.tableView.selectRow(0)
+        self.selected_row = self.roi_table_model.rowCount() - 1
+        self.tableView.selectRow(self.selected_row)
+        self.current_roi = name
         self.removeBtn.setEnabled(True)
 
     def remove_roi(self) -> None:

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -250,18 +250,17 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             if key in self.spectrum.roi_dict:
                 self.spectrum.spectrum.plot(value, name=key, pen=self.spectrum.roi_dict[key].colour)
 
-    def add_roi_table_row(self, row: int, name: str, colour: tuple[int, int, int]):
+    def add_roi_table_row(self, name: str, colour: tuple[int, int, int]):
         """
         Add a new row to the ROI table
 
-        @param row: The row number
         @param name: The name of the ROI
         @param colour: The colour of the ROI
         """
         circle_label = QLabel()
         circle_label.setStyleSheet(f"background-color: {colour}; border-radius: 5px;")
         self.roi_table_model.appendNewRow(name, colour, True)
-        self.tableView.selectRow(row)
+        self.tableView.selectRow(0)
         self.removeBtn.setEnabled(True)
 
     def remove_roi(self) -> None:


### PR DESCRIPTION
### Issue

Closes #1920 

### Description

Make sure `self.selected_row` and `self.current_roi` get initially set to the default ROI.
Select the new ROIs when they are made
Clean up some unused code

### Testing & Acceptance Criteria 

See test case on issue

### Documentation

Release notes
