### PR TITLE
Fix moving recon line profile by handles

### DIFF
--- a/docs/release_notes/next/fix-1937-recon-line-prof
+++ b/docs/release_notes/next/fix-1937-recon-line-prof
@@ -1,0 +1,1 @@
+#1937 : Fix adjusting recon line profile from handles

--- a/mantidimaging/gui/widgets/line_profile_plot/test/view_test.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/test/view_test.py
@@ -90,9 +90,8 @@ class ImageViewLineROITest(unittest.TestCase):
         self.roi_line._image_view.viewbox.autoRange.assert_called_once()
 
     def test_get_image_region_no_image_data(self):
-        image_region, coords = self.roi_line.get_image_region()
-        self.assertIsNone(image_region)
-        self.assertIsNone(coords)
+        region = self.roi_line.get_image_region()
+        self.assertIsNone(region)
 
     def test_get_image_region_no_visible_roi(self):
         self._set_image()

--- a/mantidimaging/gui/widgets/line_profile_plot/view.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/view.py
@@ -73,7 +73,7 @@ class ImageViewLineROI(LineSegmentROI):
             return True
 
         new_point = self.getViewBox().mapSceneToView(pos)
-        return self._checkpoint_bounds.contains(new_point.x(), new_point.y())
+        return self._checkpoint_bounds.contains(new_point.toPoint())
 
     def get_image_region(self) -> tuple[np.ndarray, np.ndarray] | None:
         if not self._image_data_exists():


### PR DESCRIPTION
### Issue

Closes #1937

### Description
Fix float to int conversion on coordinates in `checkPointMove()`

Added some type annotation, and a small refactor to make typing easier.

### Testing & Acceptance Criteria 

Check that the position of the line profile can be adjust by the handles
When dragging the handles, they are restricted to the image area

(Note, when dragging the line, the behaviour is not great, but this not a regression. Would be nice to fix one day. Also see #1511)

### Documentation
Release notes
