### PR TITLE
Fix loading a subset of a sample when there is a log with angles

### DIFF
--- a/docs/release_notes/next/fix-1940-load-subset-with-angles
+++ b/docs/release_notes/next/fix-1940-load-subset-with-angles
@@ -1,0 +1,1 @@
+#1940 : Fix loading a subset of a sample when there is a log with angles

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -139,13 +139,15 @@ def load(filename_group: FilenameGroup,
         log_data = load_log(log_file)
         angles = log_data.projection_angles().value
         angle_order = np.argsort(angles)
+        angles = angles[angle_order]
         file_names = [file_names[i] for i in angle_order]
 
     image_stack = img_loader.execute(load_func, file_names, in_format, dtype, indices, progress)
 
     if log_file is not None:
         image_stack.log_file = log_data
-        image_stack.set_projection_angles(ProjectionAngles(angles[angle_order]))
+        angles = angles[indices[0]:indices[1]:indices[2]] if indices else angles
+        image_stack.set_projection_angles(ProjectionAngles(angles))
 
     # Search for and load metadata file
     metadata_filename = filename_group.metadata_path

--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -12,7 +12,6 @@ import numpy
 from PyQt5.QtCore import Qt, QTimer, QEventLoop
 from PyQt5.QtTest import QTest
 from PyQt5.QtWidgets import QApplication, QDialogButtonBox
-from pytest import mark
 from parameterized import parameterized
 
 from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHORT_DELAY, LOAD_SAMPLE, SHOW_DELAY
@@ -193,7 +192,6 @@ class TestGuiSystemLoading(GuiSystemBase):
     ])
     @mock.patch("mantidimaging.gui.windows.image_load_dialog.view.ImageLoadDialog.select_file")
     @mock.patch("mantidimaging.core.io.loader.loader._imread")
-    @mark.xfail(reason="Issue #1940")
     def test_load_with_start_stop_inc(self, start_stop_inc, expected_count, mocked_imread, mocked_select_file):
         mocked_imread.return_value = numpy.zeros([128, 128])  # Don't need to actually load the files
         mocked_select_file.return_value = LOAD_SAMPLE

--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -12,8 +12,10 @@ import numpy
 from PyQt5.QtCore import Qt, QTimer, QEventLoop
 from PyQt5.QtTest import QTest
 from PyQt5.QtWidgets import QApplication, QDialogButtonBox
+from pytest import mark
+from parameterized import parameterized
 
-from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHORT_DELAY, LOAD_SAMPLE
+from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHORT_DELAY, LOAD_SAMPLE, SHOW_DELAY
 from mantidimaging.gui.widgets.dataset_selector_dialog.dataset_selector_dialog import DatasetSelectorDialog
 from mantidimaging.gui.windows.main.image_save_dialog import ImageSaveDialog
 from mantidimaging.test_helpers.qt_test_helpers import wait_until
@@ -182,3 +184,45 @@ class TestGuiSystemLoading(GuiSystemBase):
             wait_until(lambda: mock_save.call_count == 1)
             # Confirm that save has been called only once
             mock_save.assert_called_once()
+
+    @parameterized.expand([
+        (None, 100),
+        ((0, 10, 1), 10),
+        ((0, 100, 4), 25),
+        ((20, 30, 1), 10),
+    ])
+    @mock.patch("mantidimaging.gui.windows.image_load_dialog.view.ImageLoadDialog.select_file")
+    @mock.patch("mantidimaging.core.io.loader.loader._imread")
+    @mark.xfail(reason="Issue #1940")
+    def test_load_with_start_stop_inc(self, start_stop_inc, expected_count, mocked_imread, mocked_select_file):
+        mocked_imread.return_value = numpy.zeros([128, 128])  # Don't need to actually load the files
+        mocked_select_file.return_value = LOAD_SAMPLE
+        self.assertEqual(len(self.main_window.presenter.get_active_stack_visualisers()), 0)
+
+        self.main_window.actionLoadDataset.trigger()
+        QTest.qWait(SHOW_DELAY)
+        self.main_window.image_load_dialog.presenter.do_update_field(self.main_window.image_load_dialog.sample)
+        QTest.qWait(SHOW_DELAY)
+
+        if start_stop_inc is not None:
+            start, stop, inc = start_stop_inc
+            self.main_window.image_load_dialog.sample._start_spinbox.setValue(start)
+            self.main_window.image_load_dialog.sample._stop_spinbox.setValue(stop)
+            self.main_window.image_load_dialog.sample._increment_spinbox.setValue(inc)
+            QTest.qWait(SHOW_DELAY)
+
+        self.main_window.image_load_dialog.accept()
+
+        def test_func() -> bool:
+            current_stacks = len(self.main_window.presenter.get_active_stack_visualisers())
+            return current_stacks >= 5
+
+        wait_until(test_func, max_retry=600)
+
+        self.assertEqual(len(self.main_window.presenter.get_active_stack_visualisers()), 5)
+
+        sample = list(self.main_window.presenter.datasets)[0].sample
+        image_count, *image_shape = sample.data.shape
+        self.assertEqual(image_shape, [128, 128])
+        self.assertEqual(image_count, expected_count)
+        self.assertEqual(len(sample.real_projection_angles().value), expected_count)


### PR DESCRIPTION
### Issue

Closes #1940

### Description

When a user has set start, stop or increment in the load dataset dialog then only a subset of images are loaded. Previously we then set the angles, with the full list of angles in the log file. With this change the indices are applied to the angles as well.

### Testing 

Added a new system test with a range of cases

### Acceptance Criteria 

Follow test steps on issue

### Documentation

Release notes
