### PR TITLE
Add InstrumentLog to unify instrument log file loading

### DIFF
--- a/docs/release_notes/next/dev-1955-instrument-log
+++ b/docs/release_notes/next/dev-1955-instrument-log
@@ -1,0 +1,1 @@
+#1955 : Add InstrumentLog as new log reader

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -311,7 +311,7 @@ class ImageStack:
         """
         if self._projection_angles is not None:
             return self._projection_angles
-        if self._log_file is not None:
+        if self._log_file is not None and self._log_file.has_projection_angles():
             return self._log_file.projection_angles()
         return None
 

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -19,7 +19,7 @@ from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.core.utility.leak_tracker import leak_tracker
 
 if TYPE_CHECKING:
-    from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
+    from mantidimaging.core.io.instrument_log import InstrumentLog
 
 
 class ImageStack:
@@ -55,7 +55,7 @@ class ImageStack:
         self._is_sinograms = sinograms
 
         self._proj180deg: Optional[ImageStack] = None
-        self._log_file: Optional[IMATLogFile] = None
+        self._log_file: InstrumentLog | None = None
         self._projection_angles: Optional[ProjectionAngles] = None
 
         if name is None:
@@ -286,11 +286,11 @@ class ImageStack:
         return self._is_sinograms
 
     @property
-    def log_file(self):
+    def log_file(self) -> InstrumentLog | None:
         return self._log_file
 
     @log_file.setter
-    def log_file(self, value: IMATLogFile):
+    def log_file(self, value: InstrumentLog | None) -> None:
         if value is not None:
             self.metadata[const.LOG_FILE] = str(value.source_file)
         elif value is None:

--- a/mantidimaging/core/data/test/fake_logfile.py
+++ b/mantidimaging/core/data/test/fake_logfile.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 from pathlib import Path
 
-from mantidimaging.core.utility.imat_log_file_parser import CSVLogParser, IMATLogFile, TextLogParser
+from mantidimaging.core.io.instrument_log import InstrumentLog
+from mantidimaging.core.utility.imat_log_file_parser import CSVLogParser, TextLogParser
 
 
-def generate_txt_logfile() -> IMATLogFile:
+def generate_txt_logfile() -> InstrumentLog:
     data = [
         TextLogParser.EXPECTED_HEADER_FOR_IMAT_TEXT_LOG_FILE,  # checked if exists, but skipped
         "",  # skipped when parsing
@@ -22,10 +23,10 @@ def generate_txt_logfile() -> IMATLogFile:
         "Sun Feb 10 00:26:29 2019   Projection:  8  angle: 2.5216   Monitor 3 before:  5786535   Monitor 3 after:  5929002",  # noqa: E501
         "Sun Feb 10 00:27:02 2019   Projection:  9  angle: 2.8368   Monitor 3 before:  5938142   Monitor 3 after:  6078866",  # noqa: E501
     ]
-    return IMATLogFile(data, Path("/tmp/fake"))
+    return InstrumentLog(data, Path("/tmp/fake.txt"))
 
 
-def generate_csv_logfile() -> IMATLogFile:
+def generate_csv_logfile() -> InstrumentLog:
     data = [
         CSVLogParser.EXPECTED_HEADER_FOR_IMAT_CSV_LOG_FILE,
         "Sun Feb 10 00:22:04 2019,Projection,0,angle: 0.0,Monitor 3 before: 4577907,Monitor 3 after:  4720271",
@@ -39,4 +40,4 @@ def generate_csv_logfile() -> IMATLogFile:
         "Sun Feb 10 00:26:29 2019,Projection,8,angle: 2.5216,Monitor 3 before: 5786535,Monitor 3 after:  5929002",
         "Sun Feb 10 00:27:02 2019,Projection,9,angle: 2.8368,Monitor 3 before: 5938142,Monitor 3 after:  6078866",
     ]
-    return IMATLogFile(data, Path("/tmp/fake"))
+    return InstrumentLog(data, Path("/tmp/fake.csv"))

--- a/mantidimaging/core/data/test/image_stack_test.py
+++ b/mantidimaging/core/data/test/image_stack_test.py
@@ -6,6 +6,7 @@ import io
 from pathlib import Path
 from unittest import mock
 
+from mantidimaging.core.io.instrument_log import InstrumentLog
 from mantidimaging.core.utility.data_containers import ProjectionAngles
 import unittest
 
@@ -15,7 +16,6 @@ from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.test.fake_logfile import generate_csv_logfile, generate_txt_logfile
 from mantidimaging.core.operations.crop_coords import CropCoordinatesFilter
 from mantidimaging.core.operation_history import const
-from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
@@ -73,7 +73,7 @@ class ImageStackTest(unittest.TestCase):
     def test_loading_metadata_preserves_existing_log(self):
         json_file = io.StringIO('{"pixel_size": 30.0, "log_file": "/old/logfile"}')
         mock_log_path = Path("/aaa/bbb")
-        mock_log_file = mock.create_autospec(IMATLogFile, source_file=mock_log_path)
+        mock_log_file = mock.create_autospec(InstrumentLog, source_file=mock_log_path)
 
         imgs = ImageStack(np.asarray([1]))
         self.assertEqual({}, imgs.metadata)

--- a/mantidimaging/core/io/__init__.py
+++ b/mantidimaging/core/io/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import annotations
 
 from . import (  # noqa: F401
-    saver, loader, utility)
+    saver, loader, utility, instrument_log, instrument_log_implmentations)

--- a/mantidimaging/core/io/instrument_log.py
+++ b/mantidimaging/core/io/instrument_log.py
@@ -49,6 +49,9 @@ class InstrumentLogParser(ABC):
         """Parse the log file"""
         ...
 
+    def cleaned_lines(self) -> list[str]:
+        return [line for line in self.lines if line.strip() != ""]
+
 
 class InstrumentLog:
     """Multiformat instrument log reader
@@ -64,14 +67,8 @@ class InstrumentLog:
         self.lines = lines
         self.source_file = source_file
 
-        self._clean_lines()
-
         self._find_parser()
         self.parse()
-
-    def _clean_lines(self) -> None:
-        """Remove blank lines"""
-        self.lines = [line for line in self.lines if line.strip() != ""]
 
     def _find_parser(self) -> None:
         for parser in self.parsers:

--- a/mantidimaging/core/io/instrument_log.py
+++ b/mantidimaging/core/io/instrument_log.py
@@ -104,6 +104,9 @@ class InstrumentLog:
     def projection_numbers(self) -> np.array:
         return np.array(self.get_column(LogColumn.PROJECTION_NUMBER), dtype=np.uint32)
 
+    def has_projection_angles(self) -> bool:
+        return LogColumn.PROJECTION_ANGLE in self.data
+
     def projection_angles(self) -> ProjectionAngles:
         angles = np.array(self.get_column(LogColumn.PROJECTION_ANGLE), dtype=np.float64)
         return ProjectionAngles(np.deg2rad(angles))

--- a/mantidimaging/core/io/instrument_log.py
+++ b/mantidimaging/core/io/instrument_log.py
@@ -1,0 +1,91 @@
+# Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from enum import Enum, auto
+from pathlib import Path
+from typing import ClassVar, Type
+
+
+class LogColumn(Enum):
+    TIMESTAMP = auto()
+    IMAGE_TYPE_IMAGE_COUNTER = auto()
+    PROJECTION_NUMBER = auto()
+    PROJECTION_ANGLE = auto()
+    COUNTS_BEFORE = auto()
+    COUNTS_AFTER = auto()
+    TIME_OF_FLIGHT = auto()
+    SPECTRUM_COUNTS = auto()
+
+
+LogDataType = dict[LogColumn, list[float | int]]
+
+
+class NoParserFound(RuntimeError):
+    pass
+
+
+class InstrumentLogParser(ABC):
+    """
+    Base class for parsers
+    """
+
+    def __init__(self, lines: list[str]):
+        self.lines = lines
+
+    def __init_subclass__(subcls) -> None:
+        """Automatically register subclasses"""
+        InstrumentLog.register_parser(subcls)
+
+    @classmethod
+    @abstractmethod
+    def match(cls, lines: list[str], filename: str) -> bool:
+        """Check if the name and content of the file is likely to be readable by this parser."""
+        ...
+
+    @abstractmethod
+    def parse(self) -> LogDataType:
+        """Parse the log file"""
+        ...
+
+
+class InstrumentLog:
+    """Multiformat instrument log reader
+
+    New parsers can be implemented by subclassing InstrumentLogParser
+    """
+    parsers: ClassVar[list[Type[InstrumentLogParser]]] = []
+
+    parser: Type[InstrumentLogParser]
+    data: LogDataType
+
+    def __init__(self, lines: list[str], source_file: Path):
+        self.lines = lines
+        self.source_file = source_file
+
+        self._clean_lines()
+
+        self._find_parser()
+        self.parse()
+
+    def _clean_lines(self) -> None:
+        """Remove blank lines"""
+        self.lines = [line for line in self.lines if line.strip() != ""]
+
+    def _find_parser(self) -> None:
+        for parser in self.parsers:
+            if parser.match(self.lines, self.source_file.name):
+                self.parser = parser
+                return
+        raise NoParserFound
+
+    def parse(self) -> None:
+        self.data = self.parser(self.lines).parse()
+
+    @classmethod
+    def register_parser(cls, parser: Type[InstrumentLogParser]) -> None:
+        cls.parsers.append(parser)
+
+    def get_column(self, key: LogColumn) -> list[float]:
+        return self.data[key]

--- a/mantidimaging/core/io/instrument_log_implmentations.py
+++ b/mantidimaging/core/io/instrument_log_implmentations.py
@@ -88,7 +88,7 @@ class LegacyIMATLogFile(InstrumentLogParser):
         except ValueError:
             return False
 
-        if not ("Projection:" in line or "Radiography:" in line):
+        if not ("Projection" in line or "Radiography" in line):
             return False
 
         return True

--- a/mantidimaging/core/io/instrument_log_implmentations.py
+++ b/mantidimaging/core/io/instrument_log_implmentations.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import csv
+import locale
+from datetime import datetime
+from pathlib import Path
 
 from mantidimaging.core.io.instrument_log import (InstrumentLogParser, LogColumn, LogDataType)
+from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile, IMATLogColumn
 
 
 class LegacySpectraLogParser(InstrumentLogParser):
@@ -31,3 +35,60 @@ class LegacySpectraLogParser(InstrumentLogParser):
             data[LogColumn.TIME_OF_FLIGHT].append(float(row[0]))
             data[LogColumn.SPECTRUM_COUNTS].append(int(row[1]))
         return data
+
+
+class LegacyIMATLogFile(InstrumentLogParser):
+    """Wrap existing IMATLogFile class"""
+
+    @classmethod
+    def match(cls, lines: list[str], filename: str) -> bool:
+        if filename.lower()[-4:] not in [".txt", ".csv"]:
+            return False
+
+        has_header = False
+        for line in lines:
+            if not has_header and cls._has_imat_header(line):
+                has_header = True
+            elif has_header and cls._has_imat_data_line(line):
+                return True
+
+        return False
+
+    def parse(self) -> LogDataType:
+        imat_log_file = IMATLogFile(self.lines, Path(""))
+        data: LogDataType = {}
+        data[LogColumn.TIMESTAMP] = imat_log_file._data[IMATLogColumn.TIMESTAMP]
+        data[LogColumn.PROJECTION_NUMBER] = imat_log_file._data[IMATLogColumn.PROJECTION_NUMBER]
+        data[LogColumn.PROJECTION_ANGLE] = imat_log_file._data[IMATLogColumn.PROJECTION_ANGLE]
+        data[LogColumn.COUNTS_BEFORE] = imat_log_file._data[IMATLogColumn.COUNTS_BEFORE]
+        data[LogColumn.COUNTS_AFTER] = imat_log_file._data[IMATLogColumn.COUNTS_AFTER]
+        return data
+
+    @staticmethod
+    def read_imat_date(time_stamp: str) -> datetime:
+        lc = locale.setlocale(locale.LC_TIME)
+        try:
+            locale.setlocale(locale.LC_TIME, "C")
+            return datetime.strptime(time_stamp, "%c")
+        finally:
+            locale.setlocale(locale.LC_TIME, lc)
+
+    @staticmethod
+    def _has_imat_header(line: str):
+        HEADERS = [
+            "TIME STAMP,IMAGE TYPE,IMAGE COUNTER,COUNTS BM3 before image,COUNTS BM3 after image",
+            "TIME STAMP  IMAGE TYPE   IMAGE COUNTER   COUNTS BM3 before image   COUNTS BM3 after image",
+        ]
+        return line.strip() in HEADERS
+
+    @classmethod
+    def _has_imat_data_line(cls, line: str):
+        try:
+            _ = cls.read_imat_date(line[:24])
+        except ValueError:
+            return False
+
+        if not ("Projection:" in line or "Radiography:" in line):
+            return False
+
+        return True

--- a/mantidimaging/core/io/instrument_log_implmentations.py
+++ b/mantidimaging/core/io/instrument_log_implmentations.py
@@ -27,7 +27,7 @@ class LegacySpectraLogParser(InstrumentLogParser):
 
     def parse(self) -> LogDataType:
         data: LogDataType = {LogColumn.TIME_OF_FLIGHT: [], LogColumn.SPECTRUM_COUNTS: []}
-        for row in csv.reader(self.lines, delimiter=self.delimiter):
+        for row in csv.reader(self.cleaned_lines(), delimiter=self.delimiter):
             data[LogColumn.TIME_OF_FLIGHT].append(float(row[0]))
             data[LogColumn.SPECTRUM_COUNTS].append(int(row[1]))
         return data

--- a/mantidimaging/core/io/instrument_log_implmentations.py
+++ b/mantidimaging/core/io/instrument_log_implmentations.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+import csv
+
+from mantidimaging.core.io.instrument_log import (InstrumentLogParser, LogColumn, LogDataType)
+
+
+class LegacySpectraLogParser(InstrumentLogParser):
+    """
+    Parser for spectra files without a header
+
+    Tab separated columns of Time of flight, Counts
+
+    """
+    delimiter = '\t'
+
+    @classmethod
+    def match(cls, lines: list[str], filename: str) -> bool:
+        if not filename.lower().endswith("spectra.txt"):
+            return False
+        for line in lines[:2]:
+            if not len(line.split(cls.delimiter)) == 2:
+                return False
+        return True
+
+    def parse(self) -> LogDataType:
+        data: LogDataType = {LogColumn.TIME_OF_FLIGHT: [], LogColumn.SPECTRUM_COUNTS: []}
+        for row in csv.reader(self.lines, delimiter=self.delimiter):
+            data[LogColumn.TIME_OF_FLIGHT].append(float(row[0]))
+            data[LogColumn.SPECTRUM_COUNTS].append(int(row[1]))
+        return data

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -137,17 +137,19 @@ def load(filename_group: FilenameGroup,
 
     if log_file is not None:
         log_data = load_log(log_file)
-        angles = log_data.projection_angles().value
-        angle_order = np.argsort(angles)
-        angles = angles[angle_order]
-        file_names = [file_names[i] for i in angle_order]
+        if log_data.has_projection_angles():
+            angles = log_data.projection_angles().value
+            angle_order = np.argsort(angles)
+            angles = angles[angle_order]
+            file_names = [file_names[i] for i in angle_order]
 
     image_stack = img_loader.execute(load_func, file_names, in_format, dtype, indices, progress)
 
     if log_file is not None:
         image_stack.log_file = log_data
-        angles = angles[indices[0]:indices[1]:indices[2]] if indices else angles
-        image_stack.set_projection_angles(ProjectionAngles(angles))
+        if log_data.has_projection_angles():
+            angles = angles[indices[0]:indices[1]:indices[2]] if indices else angles
+            image_stack.set_projection_angles(ProjectionAngles(angles))
 
     # Search for and load metadata file
     metadata_filename = filename_group.metadata_path

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -11,10 +11,10 @@ import numpy as np
 import astropy.io.fits as fits
 from tifffile import tifffile
 
+from mantidimaging.core.io.instrument_log import InstrumentLog
 from mantidimaging.core.io.loader import img_loader
 from mantidimaging.core.io.utility import find_first_file_that_is_possibly_a_sample
 from mantidimaging.core.utility.data_containers import Indices, FILE_TYPES, ProjectionAngles
-from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
 from mantidimaging.core.io.filenames import FilenameGroup
 
 if TYPE_CHECKING:
@@ -91,9 +91,9 @@ def read_image_dimensions(file_path: Path) -> Tuple[int, int]:
     return img.shape
 
 
-def load_log(log_file: Path) -> IMATLogFile:
+def load_log(log_file: Path) -> InstrumentLog:
     with open(log_file, 'r') as f:
-        return IMATLogFile(f.readlines(), log_file)
+        return InstrumentLog(f.readlines(), log_file)
 
 
 def load_stack_from_group(group: FilenameGroup, progress: Optional[Progress] = None) -> ImageStack:

--- a/mantidimaging/core/io/loader/test/instrument_log_data.py
+++ b/mantidimaging/core/io/loader/test/instrument_log_data.py
@@ -12,6 +12,17 @@ IMAT_2023_SPECTRA_LOG = [
 """
 ]
 
+IMAT_2019_TOMO_LOG = [
+    "TomoIMAT00010675_FlowerFine_log.txt",
+""" TIME STAMP  IMAGE TYPE   IMAGE COUNTER   COUNTS BM3 before image   COUNTS BM3 after image
+
+Sun Feb 10 00:22:04 2019   Projection:  0  angle: 0.0   Monitor 3 before:  4577907   Monitor 3 after:  4720271
+Sun Feb 10 00:22:37 2019   Projection:  1  angle: 0.3152   Monitor 3 before:  4729337   Monitor 3 after:  4871319
+Sun Feb 10 00:23:10 2019   Projection:  2  angle: 0.6304   Monitor 3 before:  4879923   Monitor 3 after:  5022689
+Sun Feb 10 00:23:43 2019   Projection:  3  angle: 0.9456   Monitor 3 before:  5031423   Monitor 3 after:  5172216
+"""
+]
+
 INVALID_FILE = [
     "foo.txt",
 """aaa

--- a/mantidimaging/core/io/loader/test/instrument_log_data.py
+++ b/mantidimaging/core/io/loader/test/instrument_log_data.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+# yapf: disable
+IMAT_2023_SPECTRA_LOG = [
+    "IMAT00003717_Brass_sphere_d99mm_000_Spectra.txt",
+"""0.012	334937
+0.012041	331913
+0.0120819	331737
+0.0121229	331161
+"""
+]
+
+INVALID_FILE = [
+    "foo.txt",
+"""aaa
+bbb ccc
+"""
+]

--- a/mantidimaging/core/io/loader/test/instrument_log_test.py
+++ b/mantidimaging/core/io/loader/test/instrument_log_test.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from numpy.testing import assert_allclose
+
+from .instrument_log_data import IMAT_2023_SPECTRA_LOG, INVALID_FILE
+from mantidimaging.core.io.instrument_log import LogColumn, InstrumentLog, NoParserFound
+
+
+class FilenamePatternTest(unittest.TestCase):
+
+    def check_parse_data(self, log_data, key, expected_values):
+        filename, data = log_data
+        log = InstrumentLog(data.split("\n"), Path(filename))
+        assert_allclose(log.get_column(key), expected_values)
+
+    def test_WHEN_read_spectra_file_THEN_expected_values_read(self):
+        self.check_parse_data(IMAT_2023_SPECTRA_LOG, LogColumn.TIME_OF_FLIGHT, [0.012, 0.012041, 0.0120819, 0.0121229])
+        self.check_parse_data(IMAT_2023_SPECTRA_LOG, LogColumn.SPECTRUM_COUNTS, [334937, 331913, 331737, 331161])
+
+    def test_WHEN_invalid_file_THEN_exception(self):
+        filename, data = INVALID_FILE
+        self.assertRaises(NoParserFound, InstrumentLog, data, Path(filename))

--- a/mantidimaging/core/io/loader/test/instrument_log_test.py
+++ b/mantidimaging/core/io/loader/test/instrument_log_test.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from numpy.testing import assert_allclose
 
-from .instrument_log_data import IMAT_2023_SPECTRA_LOG, INVALID_FILE
+from .instrument_log_data import IMAT_2023_SPECTRA_LOG, INVALID_FILE, IMAT_2019_TOMO_LOG
 from mantidimaging.core.io.instrument_log import LogColumn, InstrumentLog, NoParserFound
 
 
@@ -21,6 +21,10 @@ class FilenamePatternTest(unittest.TestCase):
     def test_WHEN_read_spectra_file_THEN_expected_values_read(self):
         self.check_parse_data(IMAT_2023_SPECTRA_LOG, LogColumn.TIME_OF_FLIGHT, [0.012, 0.012041, 0.0120819, 0.0121229])
         self.check_parse_data(IMAT_2023_SPECTRA_LOG, LogColumn.SPECTRUM_COUNTS, [334937, 331913, 331737, 331161])
+
+    def test_WHEN_read_imat_2019_file_THEN_expected_values_read(self):
+        self.check_parse_data(IMAT_2019_TOMO_LOG, LogColumn.PROJECTION_NUMBER, [0, 1, 2, 3])
+        self.check_parse_data(IMAT_2019_TOMO_LOG, LogColumn.PROJECTION_ANGLE, [0, 0.3152, 0.6304, 0.9456])
 
     def test_WHEN_invalid_file_THEN_exception(self):
         filename, data = INVALID_FILE

--- a/mantidimaging/core/io/loader/test/loader_test.py
+++ b/mantidimaging/core/io/loader/test/loader_test.py
@@ -7,11 +7,11 @@ from unittest import mock
 import numpy as np
 
 from mantidimaging.core.io.filenames import FilenameGroup
+from mantidimaging.core.io.instrument_log import InstrumentLog
 from mantidimaging.core.io.loader.loader import (DEFAULT_PIXEL_DEPTH, DEFAULT_PIXEL_SIZE, DEFAULT_IS_SINOGRAM,
                                                  create_loading_parameters_for_file_path, get_loader, load, _imread)
 
 from mantidimaging.core.utility.data_containers import FILE_TYPES, ProjectionAngles
-from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
 from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
 
 
@@ -81,7 +81,7 @@ class LoaderTest(FakeFSTestCase):
         mock_filename_group.all_files.return_value = filenames
         mock_filename_group.first_file.return_value = filenames[0]
 
-        mock_log_data = mock.create_autospec(IMATLogFile)
+        mock_log_data = mock.create_autospec(InstrumentLog)
         mock_log_data.projection_angles.return_value = ProjectionAngles(np.deg2rad(angles))
 
         mock_load_log.return_value = mock_log_data

--- a/mantidimaging/core/io/loader/test/loader_test.py
+++ b/mantidimaging/core/io/loader/test/loader_test.py
@@ -82,6 +82,7 @@ class LoaderTest(FakeFSTestCase):
         mock_filename_group.first_file.return_value = filenames[0]
 
         mock_log_data = mock.create_autospec(InstrumentLog)
+        mock_log_data.has_projection_angles.return_value = True
         mock_log_data.projection_angles.return_value = ProjectionAngles(np.deg2rad(angles))
 
         mock_load_log.return_value = mock_log_data

--- a/mantidimaging/core/utility/imat_log_file_parser.py
+++ b/mantidimaging/core/utility/imat_log_file_parser.py
@@ -96,10 +96,9 @@ class TextLogParser:
         @param file_contents: The file contents to be reformatted
         @return: The reformatted file contents
         """
-        for row in file_contents[2:]:
-            if len(row.rstrip().split("   ")) < 4:
-                file_contents.remove(row)
-        return file_contents
+        cleaned = file_contents[:2]  # parser expect second like to be blank
+        cleaned += [row for row in file_contents[2:] if len(row.rstrip().split("   ")) >= 4]
+        return cleaned
 
 
 class CSVLogParser:
@@ -161,10 +160,8 @@ class CSVLogParser:
         @param file_contents: The file contents to be reformatted
         @return: The reformatted file contents
         """
-        for row in file_contents:
-            if len(row.split(",")) < 5:
-                file_contents.remove(row)
-        return file_contents
+        cleaned = [row for row in file_contents if len(row.split(",")) >= 5]
+        return cleaned
 
 
 class IMATLogFile:

--- a/mantidimaging/gui/windows/image_load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/image_load_dialog/test/presenter_test.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from unittest import mock
 
 from mantidimaging.core.io.filenames import FilenameGroup
-from mantidimaging.core.utility.imat_log_file_parser import IMATLogFile
+from mantidimaging.core.io.instrument_log import InstrumentLog
 from mantidimaging.gui.windows.image_load_dialog.field import Field
 from mantidimaging.gui.windows.image_load_dialog.presenter import LoadPresenter
 from mantidimaging.core.utility.data_containers import FILE_TYPES, Indices
@@ -165,7 +165,7 @@ class ImageLoadDialogPresenterTest(unittest.TestCase):
         """
         Test behaviour when the number of projection angles and files matches
         """
-        mock_log = mock.create_autospec(IMATLogFile)
+        mock_log = mock.create_autospec(InstrumentLog)
         mock_load_log.return_value = mock_log
         file_name = "file_name"
         field = mock.MagicMock()
@@ -182,7 +182,7 @@ class ImageLoadDialogPresenterTest(unittest.TestCase):
 
     @mock.patch("mantidimaging.gui.windows.image_load_dialog.presenter.load_log")
     def test_ensure_sample_log_consistency_exits_when_none_or_empty_str(self, mock_load_log):
-        mock_log = mock.create_autospec(IMATLogFile)
+        mock_log = mock.create_autospec(InstrumentLog)
         mock_load_log.return_value = mock_log
         file_name = None
         field = mock.MagicMock()

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -139,12 +139,13 @@ class MainWindowModel(object):
     def raise_error_when_parent_strict_dataset_not_found(self, images_id: uuid.UUID) -> NoReturn:
         raise RuntimeError(f"Failed to find strict dataset containing ImageStack with ID {images_id}")
 
-    def add_log_to_sample(self, images_id: uuid.UUID, log_file: Path):
+    def add_log_to_sample(self, images_id: uuid.UUID, log_file: Path) -> None:
         images = self.get_images_by_uuid(images_id)
         if images is None:
             raise RuntimeError
         log = loader.load_log(log_file)
-        log.raise_if_angle_missing(images.filenames)
+        if images.filenames is not None:
+            log.raise_if_angle_missing(images.filenames)
         images.log_file = log
 
     def _remove_dataset(self, dataset_id: uuid.UUID):


### PR DESCRIPTION
### Issue

First part of #1944

### Description

Create a plugable `InstrumentLog`. Parser can be implemented by sub-classing `InstrumentLogParser`.

`LegacyIMATLogFile` which using the existing `IMATLogFile` for the actual parsing.
`LegacySpectraLogParser` parser for `spectra.txt` files from IMAT ??? camera.
(Note these are labelled legacy as they either do not have headers, or the headers do not always match the data columns. See #1869)

Switch loading to use `InstrumentLog`

### Testing & Acceptance Criteria 
Check that loading datasets with log files still works

Add the following line to `SpectrumViewerWindowModel.save_rits()`
```python
print(self._stack.log_file.get_column(LogColumn.TIME_OF_FLIGHT))
```
Load the Brass dataset  sample and open stacks with a spectra file as the sample log file.

In spectrum view export to RITS, check that the ToFs get exported in to the terminal.

### Documentation

Release notes
