### PR TITLE
cleanups for set_roi_alpha

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -144,15 +144,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             self.model.set_roi(name, self.view.spectrum.get_roi(name))
             self.view.set_spectrum(name, self.model.get_spectrum(name, self.spectrum_mode))
 
-    def do_set_roi_alpha(self, name: str, alpha: float) -> None:
-        """
-        Set the alpha value of the ROI with the given name
-
-        :param name: The name of the ROI
-        :param alpha: The new alpha value (0-255)
-        """
-        self.view.spectrum.set_roi_alpha(name, alpha)
-
     def handle_button_enabled(self) -> None:
         """
         Enable the export button if the current stack is not None and normalisation is valid

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -250,7 +250,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         @param alpha: The alpha value
         """
-        self.presenter.do_set_roi_alpha(roi_name, alpha)
+        self.spectrum.set_roi_alpha(roi_name, alpha)
         if alpha == 0:
             self.spectrum.spectrum_data_dict[roi_name] = np.zeros(self.spectrum.spectrum_data_dict[roi_name].shape)
         else:

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -146,12 +146,13 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             if self.presenter.export_mode == ExportMode.ROI_MODE:
                 roi_name, _, roi_visible = self.roi_table_model.row_data(roi_item)
                 if roi_visible is False:
-                    self.set_roi_alpha(0, roi_item)
+                    self.set_roi_alpha(0, roi_name)
                 else:
-                    self.set_roi_alpha(255, roi_item)
+                    self.set_roi_alpha(255, roi_name)
                     self.presenter.redraw_spectrum(roi_name)
             else:
-                self.set_roi_alpha(0, roi_item)
+                roi_name, _, _ = self.roi_table_model.row_data(roi_item)
+                self.set_roi_alpha(0, roi_name)
 
         return
 
@@ -242,20 +243,18 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         """
         self.presenter.do_add_roi()
 
-    def set_roi_alpha(self, alpha: float, roi) -> None:
+    def set_roi_alpha(self, alpha: float, roi_name: str) -> None:
         """
         Set the alpha value for the selected ROI and update the spectrum to reflect the change.
         A check is made on the spectrum to see if it exists as it may not have been created yet.
 
         @param alpha: The alpha value
         """
-        self.presenter.do_set_roi_alpha(self.roi_table_model.row_data(roi)[0], alpha)
+        self.presenter.do_set_roi_alpha(roi_name, alpha)
         if alpha == 0:
-            self.spectrum.spectrum_data_dict[self.roi_table_model.row_data(roi)[0]] = np.zeros(
-                self.spectrum.spectrum_data_dict[self.roi_table_model.row_data(roi)[0]].shape)
+            self.spectrum.spectrum_data_dict[roi_name] = np.zeros(self.spectrum.spectrum_data_dict[roi_name].shape)
         else:
-            self.spectrum.spectrum_data_dict[self.roi_table_model.row_data(roi)[0]] = self.spectrum.spectrum_data_dict[
-                self.roi_table_model.row_data(roi)[0]]
+            self.spectrum.spectrum_data_dict[roi_name] = self.spectrum.spectrum_data_dict[roi_name]
 
         self.spectrum.spectrum.clearPlots()
         self.spectrum.spectrum.update()


### PR DESCRIPTION
### Issue

Clean ups for #1957

### Description

This PR extracts some small cleanup from the larger PR  #1958 to make reviewing easier.

* `SpectrumViewerWindowPresenter.do_set_roi_alpha()` was a pass through function only called in the view and acting on the spectrum within the view. Its simpler to remove it and call the method in the spectrum directly.
*  `SpectrumViewerWindowView.set_roi_alpha` previously received an index and made multiple lookup of the ROI name. Simplify by passing in the name instead.

### Testing & Acceptance Criteria 
Load a dataset
Open the spectrum viewer
Add some additional ROIs (Region of Interest), resize them.
Toggle the visibility of them in the table

### Documentation

Not needed, the main PR updates the release notes.
