### PR TITLE
Move to miniforge

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -25,7 +25,7 @@ jobs:
           echo "date=$(/bin/date -u "+%Y%V")" >> $GITHUB_OUTPUT
         shell: bash
 
-      - name: Cache Mambaforge and Pip packages
+      - name: Cache Miniforge and Pip packages
         uses: actions/cache@v3.2.5
         env:
           CACHE_NUMBER: 0
@@ -36,9 +36,9 @@ jobs:
           key:
             ${{runner.os}}-condapkg-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml')}}
 
-      - name: Cache Mambaforge environment
+      - name: Cache Miniforge environment
         uses: actions/cache@v3.2.5
-        id: cache-mambaforge-environment
+        id: cache-miniforge-environment
         env:
           CACHE_NUMBER: 0
         with:
@@ -46,17 +46,16 @@ jobs:
           key:
             ${{runner.os}}-condaenv-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml', 'setup.py')}}
 
-      - name: Setup Mambaforge
+      - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-version: latest
-          miniforge-variant: Mambaforge
           activate-environment: mantidimaging-dev
           auto-activate-base: false
           use-mamba: true
 
       - name: Mantid Imaging developer dependencies
-        if: steps.cache-mambaforge-environment.outputs.cache-hit != 'true'
+        if: steps.cache-miniforge-environment.outputs.cache-hit != 'true'
         shell: bash -l {0}
         run: |
           conda deactivate
@@ -64,7 +63,7 @@ jobs:
           cp -Ta /usr/share/miniconda3/envs/mantidimaging-dev /usr/share/miniconda3/envs/mantidimaging-dev.cache
 
       - name: Mantid Imaging developer dependencies - from cache
-        if: steps.cache-mambaforge-environment.outputs.cache-hit == 'true'
+        if: steps.cache-miniforge-environment.outputs.cache-hit == 'true'
         shell: bash -l {0}
         run: |
           cp -Ta /usr/share/miniconda3/envs/mantidimaging-dev.cache /usr/share/miniconda3/envs/mantidimaging-dev
@@ -79,7 +78,7 @@ jobs:
         shell: bash -l {0}
         run: |
           mamba env list
-          python --version; conda list ; pip list
+          python --version; mamba list ; pip list
 
       - name: Yapf
         shell: bash -l {0}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,7 +25,7 @@ jobs:
           echo "date=$(/bin/date -u "+%Y%V")" >> $GITHUB_OUTPUT
         shell: bash
 
-      - name: Cache Mambaforge and Pip packages
+      - name: Cache Miniforge and Pip packages
         uses: actions/cache@v3.2.5
         env:
           CACHE_NUMBER: 0
@@ -36,18 +36,17 @@ jobs:
           key:
             ${{runner.os}}-condapkg-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml')}}
 
-      - name: Setup Mambaforge
+      - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-version: latest
-          miniforge-variant: Mambaforge
           activate-environment: mantidimaging-dev
           auto-activate-base: false
           use-mamba: true
 
-      - name: Cache Mambaforge environment
+      - name: Cache Miniforge environment
         uses: actions/cache@v3.2.5
-        id: cache-mambaforge-environment
+        id: cache-miniforge-environment
         env:
           CACHE_NUMBER: 0
         with:
@@ -56,7 +55,7 @@ jobs:
             ${{runner.os}}-condaenv-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml')}}
 
       - name: Mantid Imaging developer dependencies
-        if: steps.cache-mambaforge-environment.outputs.cache-hit != 'true'
+        if: steps.cache-miniforge-environment.outputs.cache-hit != 'true'
         shell: bash -l {0}
         run: |
           conda deactivate
@@ -66,7 +65,7 @@ jobs:
         shell: bash -l {0}
         run: |
           mamba env list
-          python --version; conda list ; pip list
+          python --version; mamba list ; pip list
 
       - name: Yapf
         shell: bash -l {0}

--- a/docs/developer_guide/index.rst
+++ b/docs/developer_guide/index.rst
@@ -24,7 +24,7 @@ This will create a conda environment containing all the packages needed to run a
 
 Afterwards the environment can be activated by running:
 
-:code:`conda activate mantidimaging-dev`
+:code:`mamba activate mantidimaging-dev`
 
 To check that the set up was successful, try running the tests from the source directory:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -103,6 +103,7 @@ The latest nightly version can be installed with
 
   - :code:`mamba env create -f https://raw.githubusercontent.com/mantidproject/mantidimaging/main/environment.yml`
 
+
 This will make a `mantidimaging-nightly` environment.
 
 
@@ -110,7 +111,7 @@ Updating
 ~~~~~~~~
 To update to the latest version of Mantid Imaging run:
 
-:code:`conda activate mantidimaging && mamba update mantidimaging`
+:code:`mamba env update -n mantidimaging -f https://raw.githubusercontent.com/mantidproject/mantidimaging/stable/environment.yml`
 
 If you see any issues with package compatibility, the fastest solution is reinstalling the environment - see below.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -52,14 +52,14 @@ If Mantid Imaging has been installed using the Windows Installer, then it can be
 Installing with Mamba/Conda
 ---------------------------
 
-Mantid Imaging can be installed using the packages_ published to Anaconda Cloud, this
-can be done with an existing Conda or Mamba distribution if you already
-have one on your machine.
+Mantid Imaging can be installed using the packages_ published to Anaconda Cloud, this can be done with an existing Conda
+or Mamba distribution if you already have one on your machine. However if you have issues you may find it worth installing
+a fresh Miniforge3.
 
 .. _packages: https://anaconda.org/mantid/mantidimaging/
 
 1. Download and install CUDA Runtime version 10.2 - https://developer.nvidia.com/cuda-10.2-download-archive before installing the Mantid Imaging environment.
-2. Download and install `Mambaforge <https://github.com/conda-forge/miniforge>`_ or `Miniconda 3 <https://conda.io/miniconda.html>`_
+2. Download and install `Miniforge3 <https://github.com/conda-forge/miniforge#download>`_ (this is the conda distribution that we recommend).
 3. Make sure :code:`mamba` or :code:`conda` is available on your PATH. The steps below assume you are using mamba.
 4. Create a mantidimaging conda environment:
 
@@ -67,7 +67,7 @@ have one on your machine.
 
 (Specific versions can be installed by using the release url, e.g. `https://raw.githubusercontent.com/mantidproject/mantidimaging/release-2.2.0/environment.yml`)
 
-5. This creates an environment called :code:`mantidimaging` that you can activate via :code:`conda activate mantidimaging`
+5. This creates an environment called :code:`mantidimaging` that you can activate via :code:`mamba activate mantidimaging`
 6. **This step is required for Linux users only.** To ensure that MantidImaging can make full use of the memory available on your Linux machine, we need to set the shared memory size to an appropriate value. Please follow the steps below to do this:
 
   - Open the etc/fstab file on your computer. You can do this by opening a terminal and running this command (with sudo if needed to allow you to edit the file): :code:`gedit /etc/fstab`


### PR DESCRIPTION
### Issue
Closes #1949

### Description

Previously we used Mambaforge to create a conda setup which contained the `mamba` command. Recently the conda-forge devs have unified their Miniforge and Mambaforge installers, so the are now identical.

This PR:
* updates the docs to references Miniforge
* use Miniforge in the github workflows
* swap some old uses of the `conda` command to `mamba` (there are only a small number of cases where `conda` is still needed)

### Testing & Acceptance Criteria 

Check that the doc changes make sense

Check that the automated tests have successfully completed

### Documentation

Not needed
