### PR TITLE
brightness percentiles set in live viewer images

### DIFF
--- a/mantidimaging/gui/widgets/mi_mini_image_view/test/__init__.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/test/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/widgets/mi_mini_image_view/test/view_test.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/test/view_test.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+import numpy as np
+import unittest
+
+from mantidimaging.test_helpers.unit_test_helper import generate_images
+from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
+from mantidimaging.test_helpers import start_qapplication
+
+
+@start_qapplication
+class MIMiniImageViewTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.view = MIMiniImageView()
+
+    def test_set_image_uses_brightness_percentile(self):
+        image = generate_images(seed=2023, shape=(20, 10, 10))
+        self.view.set_brightness_percentiles(1, 99)
+        self.view.setImage(image.data)
+        np.testing.assert_array_equal(self.view.im.getLevels().round(5),
+                                      np.array(self.view.levels).round(5), 'Brightness levels not set correctly')

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -15,8 +15,9 @@ from mantidimaging.gui.utility.qt_helpers import BlockQtSignals
 from mantidimaging.gui.widgets.auto_colour_menu.auto_color_menu import AutoColorMenu
 from mantidimaging.gui.widgets.bad_data_overlay.bad_data_overlay import BadDataOverlay
 
+import numpy as np
+
 if TYPE_CHECKING:
-    import numpy as np
     from PyQt5.QtWidgets import QWidget
 
 graveyard = []
@@ -32,6 +33,9 @@ def pairwise(iterable):
 
 
 class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
+    brightLevels: None | list = None
+    lowerLevel: float
+    higherLevel: float
 
     def __init__(self, name: str = "MIMiniImageView", parent: 'Optional[QWidget]' = None, recon_mode: bool = False):
         super().__init__()
@@ -166,3 +170,8 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
         for img_view in self.histogram_siblings:
             with BlockQtSignals(img_view.hist):
                 img_view.hist.setLevels(*hist_range)
+
+    def use_brightness_percentiles(self, image: np.ndarray, percent_low: int, percent_high: int, *args, **kwargs):
+        self.lowerLevel = np.percentile(image, percent_low)
+        self.higherLevel = np.percentile(image, percent_high)
+        self.brightLevels = [self.lowerLevel, self.higherLevel]

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -33,9 +33,8 @@ def pairwise(iterable):
 
 
 class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
-    brightLevels: None | list = None
-    lowerLevel: float
-    higherLevel: float
+    bright_levels: None | list[int] = None
+    levels: list[float]
 
     def __init__(self, name: str = "MIMiniImageView", parent: 'Optional[QWidget]' = None, recon_mode: bool = False):
         super().__init__()
@@ -97,7 +96,11 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
         self.details.setText("")
 
     def setImage(self, image: np.ndarray, *args, **kwargs):
-        self.im.setImage(image, *args, **kwargs)
+        if self.bright_levels is not None:
+            self.levels = [np.percentile(image, x) for x in self.bright_levels]
+            self.im.setImage(image, *args, **kwargs, levels=self.levels)
+        else:
+            self.im.setImage(image, *args, **kwargs)
         self.check_for_bad_data()
         self.set_auto_color_enabled(image is not None)
 
@@ -171,7 +174,5 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
             with BlockQtSignals(img_view.hist):
                 img_view.hist.setLevels(*hist_range)
 
-    def use_brightness_percentiles(self, image: np.ndarray, percent_low: int, percent_high: int, *args, **kwargs):
-        self.lowerLevel = np.percentile(image, percent_low)
-        self.higherLevel = np.percentile(image, percent_high)
-        self.brightLevels = [self.lowerLevel, self.higherLevel]
+    def set_brightness_percentiles(self, percent_low: int, percent_high: int):
+        self.bright_levels = [percent_low, percent_high]

--- a/mantidimaging/gui/windows/live_viewer/live_view_widget.py
+++ b/mantidimaging/gui/windows/live_viewer/live_view_widget.py
@@ -35,7 +35,8 @@ class LiveViewWidget(GraphicsLayoutWidget):
         Show the image in the image view.
         @param image: The image to show
         """
-        self.image.setImage(image)
+        self.image.use_brightness_percentiles(image, 5, 95)
+        self.image.setImage(image, levels=self.image.brightLevels)
 
     def handle_deleted(self) -> None:
         """

--- a/mantidimaging/gui/windows/live_viewer/live_view_widget.py
+++ b/mantidimaging/gui/windows/live_viewer/live_view_widget.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 from pyqtgraph import GraphicsLayoutWidget
+
 from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
 from mantidimaging.gui.widgets.zslider.zslider import ZSlider
 
@@ -30,13 +31,14 @@ class LiveViewWidget(GraphicsLayoutWidget):
 
         self.image.enable_message()
 
+        self.image.set_brightness_percentiles(5, 95)
+
     def show_image(self, image: np.ndarray) -> None:
         """
         Show the image in the image view.
         @param image: The image to show
         """
-        self.image.use_brightness_percentiles(image, 5, 95)
-        self.image.setImage(image, levels=self.image.brightLevels)
+        self.image.setImage(image)
 
     def handle_deleted(self) -> None:
         """

--- a/mantidimaging/gui/windows/live_viewer/test/__init__.py
+++ b/mantidimaging/gui/windows/live_viewer/test/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations


### PR DESCRIPTION
### Issue

Closes #1964 

### Description

In the Live Viewer, the brightness of the image is now set using the 5th and 95th percentiles rather than min/max. This removes outliers and makes the brightness of the images consistent and easier to compare as data is read in.
Percentiles can be changed via `self.image.use_brightness_percentiles(image, low, high)` in `mantidimaging/gui/windows/live_viewer/live_view_widget.py` where `low` and `high` are the lower and higher percentiles respectively. The brightness levels are then passed though `self.image.setImage(image, levels=self.image.brightLevels)` in the Live Viewer only put are left as min/max elsewhere.

No slowdown has been noticed due to the percentile calculations.

### Testing 

Data was fed through the Live Viewer to verify the outliers where left out and the image brightness was consistent. This auto levelling is not done in normal operations outside of the Live Viewer.

### Acceptance Criteria 

Check standard tests and check brightness levels are correct in the Live Viewer.
