### PR TITLE
-n auto added to make test in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ install-dev-requirements:
 	python ./setup.py create_dev_env
 
 test:
-	python -m pytest
+	python -m pytest -n auto
 
 test-verbose:
 	python -m pytest -vs -o log_cli=true


### PR DESCRIPTION
### Issue

Continues #1965 

### Description

Added "-n auto" to the "make test" command in the Makefile. This reduces the time to run pytest on windows by a factor of ~5-10,

### Testing 

Check "make test" in Windows and Linux

### Acceptance Criteria 

See if the make test still runs in an acceptable amount of time.
