### PR TITLE
Added environment settings and allowed variable scaling

### DIFF
--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -55,9 +55,6 @@ def parse_args() -> argparse.Namespace:
 
 
 def setup_application() -> QApplication:
-    os.environ["QT_ENABLE_HIGHDPI_SCALING"] = "1"
-    os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
-    os.environ["QT_SCALE_FACTOR"] = "1"
     QGuiApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
     q_application = QApplication(sys.argv)
     q_application.setStyle('Fusion')
@@ -66,6 +63,9 @@ def setup_application() -> QApplication:
     q_application.setOrganizationDomain("mantidproject.org")
     screens = q_application.screens()
     if sys.platform == 'win32':
+        os.environ["QT_ENABLE_HIGHDPI_SCALING"] = "1"
+        os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
+        os.environ["QT_SCALE_FACTOR"] = "1"
         base_font_size = int(q_application.font().pointSize() * 0.8)
         font_scale_factor = screens[0].physicalDotsPerInch() / 90
         font = QFont(q_application.font().family(), int(font_scale_factor * base_font_size))

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -58,6 +58,7 @@ def setup_application() -> QApplication:
     os.environ["QT_ENABLE_HIGHDPI_SCALING"] = "1"
     os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
     os.environ["QT_SCALE_FACTOR"] = "1"
+    QGuiApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
     q_application = QApplication(sys.argv)
     q_application.setStyle('Fusion')
     font = QFont("MS Shell Dlg 2", 10)
@@ -65,7 +66,6 @@ def setup_application() -> QApplication:
     q_application.setApplicationName("Mantid Imaging")
     q_application.setOrganizationName("mantidproject")
     q_application.setOrganizationDomain("mantidproject.org")
-    q_application.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
     return q_application
 
 

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -61,11 +61,15 @@ def setup_application() -> QApplication:
     QGuiApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
     q_application = QApplication(sys.argv)
     q_application.setStyle('Fusion')
-    font = QFont("MS Shell Dlg 2", 10)
-    q_application.setFont(font)
     q_application.setApplicationName("Mantid Imaging")
     q_application.setOrganizationName("mantidproject")
     q_application.setOrganizationDomain("mantidproject.org")
+    screens = q_application.screens()
+    if sys.platform == 'win32':
+        base_font_size = int(q_application.font().pointSize() * 0.8)
+        font_scale_factor = screens[0].physicalDotsPerInch() / 90
+        font = QFont(q_application.font().family(), int(font_scale_factor * base_font_size))
+        q_application.setFont(font)
     return q_application
 
 

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -6,8 +6,11 @@ from __future__ import annotations
 import argparse
 import sys
 import warnings
+import os
 
 from PyQt5.QtWidgets import QApplication
+from PyQt5 import QtCore
+from PyQt5.QtGui import QFont
 
 import mantidimaging.core.parallel.manager as pm
 
@@ -52,11 +55,17 @@ def parse_args() -> argparse.Namespace:
 
 
 def setup_application() -> QApplication:
+    os.environ["QT_ENABLE_HIGHDPI_SCALING"] = "1"
+    os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
+    os.environ["QT_SCALE_FACTOR"] = "1"
     q_application = QApplication(sys.argv)
     q_application.setStyle('Fusion')
+    font = QFont("MS Shell Dlg 2", 10)
+    q_application.setFont(font)
     q_application.setApplicationName("Mantid Imaging")
     q_application.setOrganizationName("mantidproject")
     q_application.setOrganizationDomain("mantidproject.org")
+    q_application.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
     return q_application
 
 

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -10,7 +10,7 @@ import os
 
 from PyQt5.QtWidgets import QApplication
 from PyQt5 import QtCore
-from PyQt5.QtGui import QFont
+from PyQt5.QtGui import QFont, QGuiApplication
 
 import mantidimaging.core.parallel.manager as pm
 


### PR DESCRIPTION
### Issue

closes #1975 and #1968 

### Description

During setup, environment variables are set to allow high dpi scaling and auto screen scaling. The font is also fixed, which then seems to scale well when changing monitors. The odd scaling on ultrawide monitors also now displays correctly.

### Testing 

Open on a HD and 4K monitor on Windows and Linux. If using multiple monitors with different resolutions, try changing your "main" or "primary" monitor in windows settings to see if the GUI still scales correctly.

### Acceptance Criteria 

Check that everything is readable when changing monitor resolutions/dragging across monitors.
