### PR TITLE
Cleanup image views

### DIFF
--- a/docs/release_notes/next/dev-1951-pytest-speed
+++ b/docs/release_notes/next/dev-1951-pytest-speed
@@ -1,0 +1,1 @@
+#1951 : Various fixes to speedup pytest

--- a/mantidimaging/core/utility/leak_tracker.py
+++ b/mantidimaging/core/utility/leak_tracker.py
@@ -5,6 +5,7 @@ import gc
 import sys
 import traceback
 import weakref
+from types import FunctionType
 from typing import NamedTuple, List, Set, Iterable
 
 from numpy import ndarray
@@ -36,6 +37,9 @@ def obj_to_string(obj, relative=None) -> str:
     if isinstance(obj, ndarray):
         extra_info += f" ndarray: {obj.shape} {obj.dtype}"
 
+    if isinstance(obj, FunctionType):
+        extra_info += f" function: {obj}"
+
     return f"{type(obj)} pyid={id(obj)} {extra_info}"
 
 
@@ -55,7 +59,7 @@ def find_owners(obj, depth: int, path: List[str] | None = None, ignore: Set[int]
     if len(new_refs) == 0:
         all_routes.append(path)
     for owner in new_refs:
-        if type(owner).__name__ in ['frame', 'function', 'list_iterator']:
+        if type(owner).__name__ in ['frame', 'list_iterator']:
             continue
         route = [obj_to_string(owner, obj)] + path
         ignore.add(id(route))

--- a/mantidimaging/gui/widgets/auto_colour_menu/auto_color_menu.py
+++ b/mantidimaging/gui/widgets/auto_colour_menu/auto_color_menu.py
@@ -40,13 +40,15 @@ class AutoColorMenu:
                                    recon_mode: bool = False,
                                    index: int = DEFAULT_MENU_POSITION,
                                    set_enabled: bool = True) -> QAction:
+        self.auto_color_parent = parent
+        self.auto_color_recon_mode = recon_mode
         self.auto_color_action = QAction("Auto")
         place = self.histogram.gradient.menu.actions()[index]
 
         self.histogram.gradient.menu.insertAction(place, self.auto_color_action)
         self.histogram.gradient.menu.insertSeparator(self.auto_color_action)
         self.set_auto_color_enabled(set_enabled)
-        self.auto_color_action.triggered.connect(lambda: self._on_colour_change_palette(parent, recon_mode))
+        self.auto_color_action.triggered.connect(self._on_colour_change_palette)
 
         return self.auto_color_action
 
@@ -54,13 +56,13 @@ class AutoColorMenu:
         if self.auto_color_action is not None:
             self.auto_color_action.setEnabled(enabled)
 
-    def _on_colour_change_palette(self, parent: 'Optional[QWidget]', recon_mode: bool) -> None:
+    def _on_colour_change_palette(self) -> None:
         """
         Opens the Palette Changer window
         """
-        change_colour_palette = PaletteChangerView(parent=parent,
+        change_colour_palette = PaletteChangerView(parent=self.auto_color_parent,
                                                    main_hist=self.histogram,
                                                    image=self.image_data,
                                                    other_hists=self.other_histograms,
-                                                   recon_mode=recon_mode)
+                                                   recon_mode=self.auto_color_recon_mode)
         change_colour_palette.show()

--- a/mantidimaging/gui/widgets/line_profile_plot/test/view_test.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/test/view_test.py
@@ -34,6 +34,12 @@ class ImageViewLineROITest(unittest.TestCase):
         self.image_view = MIMiniImageView()
         self.roi_line = ImageViewLineROI(self.image_view)
 
+    def tearDown(self):
+        self.roi_line.cleanup()
+        self.image_view.cleanup()
+        del self.roi_line
+        del self.image_view
+
     def test_reset_is_needed_no_image_data(self):
         self.assertFalse(self.roi_line.reset_is_needed())
 
@@ -118,6 +124,12 @@ class LineProfilePlotTest(unittest.TestCase):
     def setUp(self) -> None:
         self.image_view = MIMiniImageView()
         self.line_profile = LineProfilePlot(self.image_view)
+
+    def tearDown(self):
+        self.line_profile.cleanup()
+        self.image_view.cleanup()
+        del self.line_profile
+        del self.image_view
 
     def test_update_no_image_data(self):
         self.line_profile._line_profile.setData = mock.Mock()

--- a/mantidimaging/gui/widgets/line_profile_plot/view.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/view.py
@@ -26,6 +26,9 @@ class LineProfilePlot(GraphicsLayout):
         self._roi_line = ImageViewLineROI(image_view, reset_menu_name="Reset Profile Line")
         self._roi_line.sigRegionChanged.connect(self.update)
 
+    def cleanup(self):
+        self._roi_line.cleanup()
+
     def update(self) -> None:
         region = self._roi_line.get_image_region()
 
@@ -67,6 +70,9 @@ class ImageViewLineROI(LineSegmentROI):
         # We can't add the ROI line until we have some image data dimensions to position it
         if self._image_data_exists():
             self._add_roi_to_image()
+
+    def cleanup(self):
+        del self._image_view
 
     def checkPointMove(self, _handle, pos: QPoint, _modifiers) -> bool:
         if self._checkpoint_bounds is None:

--- a/mantidimaging/gui/widgets/mi_mini_image_view/test/view_test.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/test/view_test.py
@@ -16,6 +16,10 @@ class MIMiniImageViewTest(unittest.TestCase):
     def setUp(self) -> None:
         self.view = MIMiniImageView()
 
+    def tearDown(self):
+        self.view.cleanup()
+        del self.view
+
     def test_set_image_uses_brightness_percentile(self):
         image = generate_images(seed=2023, shape=(20, 10, 10))
         self.view.set_brightness_percentiles(1, 99)

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -95,6 +95,11 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
         self.clear_overlays()
         self.details.setText("")
 
+    def cleanup(self) -> None:
+        """Prepare for deletion when no longer needed"""
+        self.clear()
+        self.im.hoverEvent = None
+
     def setImage(self, image: np.ndarray, *args, **kwargs):
         if self.bright_levels is not None:
             self.levels = [np.percentile(image, x) for x in self.bright_levels]

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -96,6 +96,16 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.imageview_difference.clear()
         self.image_diff_overlay.clear()
 
+    def cleanup(self) -> None:
+        self.imageview_before.cleanup()
+        self.imageview_after.cleanup()
+        self.imageview_difference.cleanup()
+        del self.imageview_before
+        del self.imageview_after
+        del self.imageview_difference
+        del self.all_imageviews
+        self.image_layout.clear()
+
     def init_histogram(self) -> PlotItem:
         histogram = self.addPlot(labels=histogram_axes_labels, lockAspect=True, colspan=3)
 

--- a/mantidimaging/gui/windows/operations/test/view_test.py
+++ b/mantidimaging/gui/windows/operations/test/view_test.py
@@ -21,6 +21,10 @@ class OperationsWindowsViewTest(unittest.TestCase):
             self.main_window = MainWindowView()
         self.window = FiltersWindowView(self.main_window)
 
+    def tearDown(self):
+        self.window.cleanup()
+        del self.window
+
     def test_collapse(self):
         self.assertEqual("<<", self.window.collapseToggleButton.text())
         # check that left column is not 0

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -129,6 +129,8 @@ class FiltersWindowView(BaseMainWindowView):
         self.main_window.filters = None
         self.presenter.view = None
         self.presenter = None
+        self.previews.cleanup()
+        self.previews = None
 
     def show(self):
         super().show()

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -56,6 +56,7 @@ class ReconImagesView(GraphicsLayoutWidget):
         self.imageview_projection.cleanup()
         self.imageview_sinogram.cleanup()
         self.imageview_recon.cleanup()
+        self.recon_line_profile.cleanup()
         del self.imageview_projection
         del self.imageview_sinogram
         del self.imageview_recon

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -52,6 +52,14 @@ class ReconImagesView(GraphicsLayoutWidget):
         self.imageview_projection.enable_nonpositive_check()
         self.imageview_sinogram.enable_nonpositive_check()
 
+    def cleanup(self):
+        self.imageview_projection.cleanup()
+        self.imageview_sinogram.cleanup()
+        self.imageview_recon.cleanup()
+        del self.imageview_projection
+        del self.imageview_sinogram
+        del self.imageview_recon
+
     def slice_line_moved(self):
         self.slice_changed(int(self.slice_line.value()))
 

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -11,6 +11,7 @@ from mantidimaging.core.net.help_pages import SECTION_USER_GUIDE
 from mantidimaging.core.utility.data_containers import ScalarCoR, Degrees, Slope
 from mantidimaging.gui.utility.qt_helpers import INPUT_DIALOG_FLAGS
 from mantidimaging.gui.windows.recon import ReconstructWindowView
+from mantidimaging.gui.windows.recon.image_view import ReconImagesView
 from mantidimaging.gui.windows.recon.presenter import AutoCorMethod, Notifications
 from mantidimaging.test_helpers import start_qapplication
 
@@ -28,12 +29,15 @@ class MockMainWindow(QWidget):
 @start_qapplication
 class ReconstructWindowViewTest(unittest.TestCase):
 
-    def setUp(self) -> None:
+    @mock.patch("mantidimaging.gui.windows.recon.view.QVBoxLayout.addWidget")
+    def setUp(self, _) -> None:
         self.main_window = MockMainWindow()
-        self.view = ReconstructWindowView(self.main_window)
+        with mock.patch("mantidimaging.gui.windows.recon.view.ReconImagesView") as mock_riv:
+            self.image_view = mock.create_autospec(ReconImagesView, sigSliceIndexChanged=mock.Mock())
+            mock_riv.side_effect = [self.image_view]
+            self.view = ReconstructWindowView(self.main_window)
 
         self.view.presenter = self.presenter = mock.Mock()
-        self.view.image_view = self.image_view = mock.Mock()
         self.view.tableView = self.tableView = mock.Mock()
         self.view.autoFindMethod = self.autoFindMethod = mock.Mock()
 
@@ -169,8 +173,8 @@ class ReconstructWindowViewTest(unittest.TestCase):
 
     def test_reset_recon_and_sino_previews(self):
         self.view.reset_recon_and_sino_previews()
-        self.image_view.clear_recon.assert_called_once()
-        self.image_view.clear_sinogram.assert_called_once()
+        self.image_view.clear_recon.assert_called()
+        self.image_view.clear_sinogram.assert_called()
 
     def test_reset_slice_and_tilt(self):
         slice_index = 5

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -246,6 +246,7 @@ class ReconstructWindowView(BaseMainWindowView):
 
     def cleanup(self):
         self.stackSelector.unsubscribe_from_main_window()
+        self.image_view.cleanup()
         self.main_window.recon = None
 
     @property

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -100,6 +100,9 @@ class SpectrumWidget(GraphicsLayoutWidget):
         self.roi_dict: dict[Optional[str], ROI] = {}
         self.colour_index = 0
 
+    def cleanup(self):
+        self.image.cleanup()
+
     def add_range(self, range_min: int, range_max: int) -> None:
         with QSignalBlocker(self.range_control):
             self.range_control.setBounds((range_min, range_max))

--- a/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
@@ -28,6 +28,10 @@ class SpectrumWidgetTest(unittest.TestCase):
         self.spectrum_widget = SpectrumWidget()
         self.sensible_roi = SensibleROI.from_list([0, 0, 0, 0])
 
+    def tearDown(self):
+        self.spectrum_widget.cleanup()
+        del self.spectrum_widget
+
     def test_WHEN_colour_generator_called_THEN_return_value_of_length_3(self):
         colour = self.spectrum_widget.random_colour_generator()
         self.assertEqual(len(colour), 4)


### PR DESCRIPTION
### Issue
Work on #1951

### Description

Some changes to remove some reference cycles in the `MIMiniImageView` and classes that use them. The aim is reduce the number of objects that can't be delete, which may be slowing down tests. Its also possible that some of the tangle is responsible for #902 .

Avoid a lambdas that hold a reference to `self` in `auto_colour_menu` and `im.hoverEvent`.

Delete some references to the image views in the operations and recon windows

Better mocking in `ReconstructWindowViewTest`. Previously the `ReconImagesView` was created and then hidden with a mock. Now mock the creation.

On Linux this reduces single threaded pytest runtime from about 2:00 to 1:30. Also it eliminates about a 1 minute wait from pytest completing and output its results to returning to the prompt.


### Testing & Acceptance Criteria 

Checkout the commit `Add leak tracking fixture to conftest` which has the diagnostics but not the fixes
`git checkout b1b2166ea8483767f8301b9ef0e239f46d1db0f4`
In `conftest.py` set `autouse = True`  for `leak_test_stats`
In the constructor for `MIMiniImageView` add
`leak_tracker.add(self, msg=name)`
You will need the import `from mantidimaging.core.utility.leak_tracker import leak_tracker`
This will print the number of tracked objects that have not been garbage collected. You will see something like:
```
Leaked item stats:
<class 'numpy.ndarray'>: 36
<class 'mantidimaging.core.parallel.utility.SharedArray'>: 10
<class 'mantidimaging.gui.widgets.mi_mini_image_view.view.MIMiniImageView'>: 211
```
With the same changes on the head of this branch, there should be no leaked `MIMiniImageView` objects.

### Documentation

release notes
