### PR TITLE
Updated sphinx to 6.2

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
   - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774
   - pip
   - pip:
-      - sphinx==4.2.*
+      - sphinx==6.2.*
       - git+https://github.com/samtygier-stfc/sphinx-multiversion.git@prebuild_command
       - eyes-images==5.20.*
   - yapf==0.40.*


### PR DESCRIPTION
### Issue

Progresses #1961 

### Description

sphinx version has been changed to sphinx==6.2.* in environment-dev.yml.

Note: upgrading to the latest version of 7 of Sphinx causes the documentation building in the setup.py file to break. This is because Sphinx has stopping supporting `BuildDoc ` in `from sphinx.setup_command import BuildDoc` and have removed it.

### Testing 

Check that Documentation still builds
