### PR TITLE
Rits transmission error model

### DIFF
--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -454,6 +454,6 @@ def export_to_dat_rits_format(rits_formatted_data: str, path: Path) -> None:
     :return: None
 
     """
-    with open(path, 'w', encoding='utf-8') as f:
+    with path.open('w') as f:
         f.write(rits_formatted_data)
     LOG.info('RITS formatted data saved to: {}'.format(path))

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -201,21 +201,17 @@ class SpectrumViewerWindowModel:
         if self._stack is None:
             raise ValueError("No stack selected")
 
+        if not normalized or self._normalise_stack is None:
+            raise ValueError("Normalisation must be enabled, and a normalise stack must be selected")
+
         tof = self.get_stack_time_of_flight()
         if tof is None:
             raise ValueError("No Time of Flights for sample. Make sure spectra log has been loaded")
 
-        # RITS expects ToF in μs
-        tof *= 1e6
-
+        tof *= 1e6  # RITS expects ToF in μs
         transmission_error = np.full_like(tof, 0.1)
-        if normalized:
-            if self._normalise_stack is None:
-                raise RuntimeError("No normalisation stack selected")
-            transmission = self.get_spectrum(ROI_RITS, SpecType.SAMPLE_NORMED)
-            self.export_spectrum_to_rits(path, tof, transmission, transmission_error)
-        else:
-            LOG.error("Data is not normalised to open beam. This will not export to a valid RITS format")
+        transmission = self.get_spectrum(ROI_RITS, SpecType.SAMPLE_NORMED)
+        self.export_spectrum_to_rits(path, tof, transmission, transmission_error)
 
     def get_stack_time_of_flight(self) -> np.array | None:
         if self._stack is None or self._stack.log_file is None:

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -30,6 +30,11 @@ class SpecType(Enum):
     SAMPLE_NORMED = 3
 
 
+class ErrorMode(Enum):
+    STANDARD_DEVIATION = 1
+    PROPAGATED = 2
+
+
 class SpectrumViewerWindowModel:
     """
     The model for the spectrum viewer window.
@@ -197,18 +202,26 @@ class SpectrumViewerWindowModel:
             csv_output.write(outfile)
             self.save_roi_coords(self.get_roi_coords_filename(path))
 
-    def save_rits(self, path: Path, normalized: bool) -> None:
+    def save_rits(self, path: Path, normalized: bool, error_mode: ErrorMode) -> None:
         """
         Saves the spectrum for one ROI to a RITS file.
 
         @param path: The path to save the CSV file to.
         @param normalized: Whether to save the normalized spectrum.
+        @param error_mode: Which version (standard deviation or propagated) of the error to use in the RITS export
         """
         if self._stack is None:
             raise ValueError("No stack selected")
 
         if not normalized or self._normalise_stack is None:
             raise ValueError("Normalisation must be enabled, and a normalise stack must be selected")
+
+        if error_mode == ErrorMode.STANDARD_DEVIATION:
+            pass
+        elif error_mode == ErrorMode.PROPAGATED:
+            pass
+        else:
+            raise ValueError("Invalid error_mode given")
 
         tof = self.get_stack_time_of_flight()
         if tof is None:

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -124,6 +124,12 @@ class SpectrumViewerWindowModel:
         roi_data = stack.data[:, top:bottom, left:right]
         return roi_data.mean(axis=(1, 2))
 
+    @staticmethod
+    def get_stack_spectrum_summed(stack: ImageStack, roi: SensibleROI):
+        left, top, right, bottom = roi
+        roi_data = stack.data[:, top:bottom, left:right]
+        return roi_data.sum(axis=(1, 2))
+
     def normalise_issue(self) -> str:
         if self._stack is None or self._normalise_stack is None:
             return "Need 2 selected stacks"

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 from logging import getLogger
 from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.gui.mvp_base import BasePresenter
-from mantidimaging.gui.windows.spectrum_viewer.model import SpectrumViewerWindowModel, SpecType, ROI_RITS
+from mantidimaging.gui.windows.spectrum_viewer.model import SpectrumViewerWindowModel, SpecType, ROI_RITS, ErrorMode
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.spectrum_viewer.view import SpectrumViewerWindowView  # pragma: no cover
@@ -177,7 +177,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             return
         if path.suffix != ".dat":
             path = path.with_suffix(".dat")
-        self.model.save_rits(path, self.spectrum_mode == SpecType.SAMPLE_NORMED)
+        self.model.save_rits(path, self.spectrum_mode == SpecType.SAMPLE_NORMED, ErrorMode.STANDARD_DEVIATION)
 
     def handle_enable_normalised(self, enabled: bool) -> None:
         if enabled:

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -42,6 +42,12 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         self.model.set_new_roi("roi")
         return stack, spectrum
 
+    def _make_mock_path_stream(self):
+        mock_stream = CloseCheckStream()
+        mock_path = mock.create_autospec(Path)
+        mock_path.open.return_value = mock_stream
+        return mock_stream, mock_path
+
     def test_set_stack(self):
         stack, _ = self._set_sample_stack()
 
@@ -166,9 +172,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         stack.data *= 2
         self.model.set_normalise_stack(None)
 
-        mock_stream = CloseCheckStream()
-        mock_path = mock.create_autospec(Path)
-        mock_path.open.return_value = mock_stream
+        mock_stream, mock_path = self._make_mock_path_stream()
         with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
             self.model.save_csv(mock_path, False)
 
@@ -189,9 +193,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         mock_inst_log.get_column.return_value = tof
         stack.log_file = mock_inst_log
 
-        mock_stream = CloseCheckStream()
-        mock_path = mock.create_autospec(Path)
-        mock_path.open.return_value = mock_stream
+        mock_stream, mock_path = self._make_mock_path_stream()
         with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
             self.model.save_rits(mock_path, True, ErrorMode.STANDARD_DEVIATION)
 
@@ -213,9 +215,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         mock_inst_log.get_column.return_value = tof
         stack.log_file = mock_inst_log
 
-        mock_stream = CloseCheckStream()
-        mock_path = mock.create_autospec(Path)
-        mock_path.open.return_value = mock_stream
+        mock_stream, mock_path = self._make_mock_path_stream()
         with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
             self.model.save_rits(mock_path, True, ErrorMode.STANDARD_DEVIATION)
 
@@ -238,9 +238,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         mock_inst_log.get_column.return_value = tof
         stack.log_file = mock_inst_log
 
-        mock_stream = CloseCheckStream()
-        mock_path = mock.create_autospec(Path)
-        mock_path.open.return_value = mock_stream
+        mock_stream, mock_path = self._make_mock_path_stream()
         with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
             self.model.save_rits(mock_path, True, error_mode)
 
@@ -254,9 +252,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         mock_inst_log.get_column.return_value = tof
         stack.log_file = mock_inst_log
 
-        mock_stream = CloseCheckStream()
-        mock_path = mock.create_autospec(Path)
-        mock_path.open.return_value = mock_stream
+        mock_stream, mock_path = self._make_mock_path_stream()
         with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
             self.assertRaises(ValueError, self.model.save_rits, mock_path, True, None)
         mock_path.open.assert_not_called()
@@ -268,9 +264,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         mock_inst_log = mock.create_autospec(InstrumentLog, source_file="")
         stack.log_file = mock_inst_log
 
-        mock_stream = CloseCheckStream()
-        mock_path = mock.create_autospec(Path)
-        mock_path.open.return_value = mock_stream
+        mock_stream, mock_path = self._make_mock_path_stream()
         with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
             self.assertRaises(ValueError, self.model.save_rits, mock_path, False, ErrorMode.STANDARD_DEVIATION)
         mock_path.open.assert_not_called()
@@ -282,9 +276,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         self.model.set_new_roi("rits_roi")
         self.model.set_normalise_stack(norm)
 
-        mock_stream = CloseCheckStream()
-        mock_path = mock.create_autospec(Path)
-        mock_path.open.return_value = mock_stream
+        mock_stream, mock_path = self._make_mock_path_stream()
         with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
             self.assertRaises(ValueError, self.model.save_rits, mock_path, True, ErrorMode.STANDARD_DEVIATION)
         mock_path.open.assert_not_called()
@@ -313,9 +305,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         open_stack = ImageStack(np.ones([10, 11, 12]) * 2)
         self.model.set_normalise_stack(open_stack)
 
-        mock_stream = CloseCheckStream()
-        mock_path = mock.create_autospec(Path)
-        mock_path.open.return_value = mock_stream
+        mock_stream, mock_path = self._make_mock_path_stream()
         with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
             self.model.save_csv(mock_path, True)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -177,7 +177,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         self.model.set_normalise_stack(None)
 
         mock_stream, mock_path = self._make_mock_path_stream()
-        with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
+        with mock.patch.object(self.model, "save_roi_coords"):
             self.model.save_csv(mock_path, False)
 
         mock_path.open.assert_called_once_with("w")
@@ -194,7 +194,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         self.model.set_normalise_stack(norm)
 
         mock_stream, mock_path = self._make_mock_path_stream()
-        with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
+        with mock.patch.object(self.model, "save_roi_coords"):
             self.model.save_rits(mock_path, True, ErrorMode.STANDARD_DEVIATION)
 
         mock_path.open.assert_called_once_with("w")
@@ -212,7 +212,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         self.model.set_normalise_stack(norm)
 
         mock_stream, mock_path = self._make_mock_path_stream()
-        with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
+        with mock.patch.object(self.model, "save_roi_coords"):
             self.model.save_rits(mock_path, True, ErrorMode.STANDARD_DEVIATION)
 
         mock_path.open.assert_called_once_with("w")
@@ -249,7 +249,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         self.model.set_normalise_stack(norm)
 
         mock_stream, mock_path = self._make_mock_path_stream()
-        with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
+        with mock.patch.object(self.model, "save_roi_coords"):
             self.assertRaises(ValueError, self.model.save_rits, mock_path, True, None)
         mock_path.open.assert_not_called()
 
@@ -261,7 +261,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         stack.log_file = mock_inst_log
 
         mock_stream, mock_path = self._make_mock_path_stream()
-        with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
+        with mock.patch.object(self.model, "save_roi_coords"):
             self.assertRaises(ValueError, self.model.save_rits, mock_path, False, ErrorMode.STANDARD_DEVIATION)
         mock_path.open.assert_not_called()
 
@@ -273,7 +273,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         self.model.set_normalise_stack(norm)
 
         mock_stream, mock_path = self._make_mock_path_stream()
-        with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
+        with mock.patch.object(self.model, "save_roi_coords"):
             self.assertRaises(ValueError, self.model.save_rits, mock_path, True, ErrorMode.STANDARD_DEVIATION)
         mock_path.open.assert_not_called()
 
@@ -302,7 +302,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         self.model.set_normalise_stack(open_stack)
 
         mock_stream, mock_path = self._make_mock_path_stream()
-        with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
+        with mock.patch.object(self.model, "save_roi_coords"):
             self.model.save_csv(mock_path, True)
 
         mock_path.open.assert_called_once_with("w")

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -12,7 +12,7 @@ from parameterized import parameterized
 
 from mantidimaging.core.io.instrument_log import InstrumentLog
 from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowPresenter, SpectrumViewerWindowModel
-from mantidimaging.gui.windows.spectrum_viewer.model import SpecType
+from mantidimaging.gui.windows.spectrum_viewer.model import SpecType, ErrorMode
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.utility.sensible_roi import SensibleROI
@@ -224,12 +224,54 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         mock_path = mock.create_autospec(Path)
         mock_path.open.return_value = mock_stream
         with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
-            self.model.save_rits(mock_path, True)
+            self.model.save_rits(mock_path, True, ErrorMode.STANDARD_DEVIATION)
 
         mock_path.open.assert_called_once_with("w")
         self.assertIn("0.0\t0.0\t0.1", mock_stream.captured[0])
         self.assertIn("100000.0\t3.0\t0.1", mock_stream.captured[1])
         self.assertTrue(mock_stream.is_closed)
+
+    @parameterized.expand([("standard_deviation", ErrorMode.STANDARD_DEVIATION), ("propagated", ErrorMode.PROPAGATED)])
+    def test_error_mode_rits(self, _, error_mode):
+        stack = ImageStack(np.ones([10, 11, 12]))
+        norm = ImageStack(np.ones([10, 11, 12]))
+        spectrum = np.arange(0, 10) * 2
+        tof = np.arange(0, 10) * 0.1
+        stack.data[:, :, 6:] = spectrum.reshape((10, 1, 1))
+        stack.data[:, :, :6] = spectrum.reshape((10, 1, 1)) * 2
+        self.model.set_stack(stack)
+        self.model.set_new_roi("rits_roi")
+        self.model.set_normalise_stack(norm)
+        mock_inst_log = mock.create_autospec(InstrumentLog, source_file="")
+        mock_inst_log.get_column.return_value = tof
+        stack.log_file = mock_inst_log
+
+        mock_stream = CloseCheckStream()
+        mock_path = mock.create_autospec(Path)
+        mock_path.open.return_value = mock_stream
+        with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
+            self.model.save_rits(mock_path, True, error_mode)
+
+    def test_invalid_error_mode_rits(self):
+        stack = ImageStack(np.ones([10, 11, 12]))
+        norm = ImageStack(np.ones([10, 11, 12]))
+        spectrum = np.arange(0, 10) * 2
+        tof = np.arange(0, 10) * 0.1
+        stack.data[:, :, 6:] = spectrum.reshape((10, 1, 1))
+        stack.data[:, :, :6] = spectrum.reshape((10, 1, 1)) * 2
+        self.model.set_stack(stack)
+        self.model.set_new_roi("rits_roi")
+        self.model.set_normalise_stack(norm)
+        mock_inst_log = mock.create_autospec(InstrumentLog, source_file="")
+        mock_inst_log.get_column.return_value = tof
+        stack.log_file = mock_inst_log
+
+        mock_stream = CloseCheckStream()
+        mock_path = mock.create_autospec(Path)
+        mock_path.open.return_value = mock_stream
+        with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
+            self.assertRaises(ValueError, self.model.save_rits, mock_path, True, None)
+        mock_path.open.assert_not_called()
 
     def test_save_rits_no_norm_err(self):
         stack = ImageStack(np.ones([10, 11, 12]))
@@ -243,7 +285,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         mock_path = mock.create_autospec(Path)
         mock_path.open.return_value = mock_stream
         with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
-            self.assertRaises(ValueError, self.model.save_rits, mock_path, False)
+            self.assertRaises(ValueError, self.model.save_rits, mock_path, False, ErrorMode.STANDARD_DEVIATION)
         mock_path.open.assert_not_called()
 
     def test_save_rits_no_tof_err(self):
@@ -258,7 +300,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         mock_path = mock.create_autospec(Path)
         mock_path.open.return_value = mock_stream
         with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
-            self.assertRaises(ValueError, self.model.save_rits, mock_path, True)
+            self.assertRaises(ValueError, self.model.save_rits, mock_path, True, ErrorMode.STANDARD_DEVIATION)
         mock_path.open.assert_not_called()
 
     def test_WHEN_save_csv_called_THEN_save_roi_coords_called_WITH_correct_args(self):

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -242,19 +242,6 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         calculated_errors = mock_export.call_args[0][3]
         np.testing.assert_allclose(expected_error, calculated_errors, atol=1e-4)
 
-    @parameterized.expand([("standard_deviation", ErrorMode.STANDARD_DEVIATION), ("propagated", ErrorMode.PROPAGATED)])
-    def test_error_mode_rits(self, _, error_mode):
-        stack, _ = self._set_sample_stack(with_tof=True)
-        norm = ImageStack(np.ones([10, 11, 12]))
-        stack.data[:, :, :6] *= 2
-        stack.data[:, :, 6:] *= 4
-        self.model.set_new_roi("rits_roi")
-        self.model.set_normalise_stack(norm)
-
-        mock_stream, mock_path = self._make_mock_path_stream()
-        with mock.patch("mantidimaging.gui.windows.spectrum_viewer.SpectrumViewerWindowModel.save_roi_coords"):
-            self.model.save_rits(mock_path, True, error_mode)
-
     def test_invalid_error_mode_rits(self):
         stack, _ = self._set_sample_stack(with_tof=True)
         norm = ImageStack(np.ones([10, 11, 12]))

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -172,6 +172,20 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         model_spec = self.model.get_spectrum("roi", SpecType.SAMPLE)
         npt.assert_array_equal(model_spec, spectrum * 2)
 
+    def test_get_stack_spectrum(self):
+        stack = ImageStack(np.ones([10, 11, 12]))
+        spectrum = np.arange(0, 10)
+        stack.data[:, :, :] = spectrum.reshape((10, 1, 1))
+        calculated_spectrum = self.model.get_stack_spectrum(stack, SensibleROI.from_list([0, 0, 12, 11]))
+        np.testing.assert_array_equal(spectrum, calculated_spectrum)
+
+    def test_get_stack_spectrum_summed(self):
+        stack = ImageStack(np.ones([10, 11, 12]))
+        spectrum = np.arange(0, 10, dtype=np.float32)
+        stack.data[:, :, :] = spectrum.reshape((10, 1, 1))
+        calculated_spectrum = self.model.get_stack_spectrum_summed(stack, SensibleROI.from_list([0, 0, 12, 11]))
+        np.testing.assert_array_equal(spectrum * 12 * 11, calculated_spectrum)
+
     def test_save_csv(self):
         stack = ImageStack(np.ones([10, 11, 12]))
         spectrum = np.arange(0, 10) * 2

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -12,6 +12,7 @@ from parameterized import parameterized
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowView, SpectrumViewerWindowPresenter
+from mantidimaging.gui.windows.spectrum_viewer.model import ErrorMode
 from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumWidget
 from mantidimaging.test_helpers import mock_versions, start_qapplication
 from mantidimaging.test_helpers.unit_test_helper import generate_images
@@ -197,7 +198,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.handle_rits_export()
 
         self.view.get_rits_export_filename.assert_called_once()
-        mock_save_rits.assert_called_once_with(Path("/fake/path.dat"), False)
+        mock_save_rits.assert_called_once_with(Path("/fake/path.dat"), False, ErrorMode.STANDARD_DEVIATION)
 
     def test_WHEN_do_add_roi_called_THEN_new_roi_added(self):
         self.presenter.model.set_stack(generate_images())


### PR DESCRIPTION
### Issue
Progresses #1943

### Description

This adds methods for calculating the error when exporting spectra for RITS. It implements both methods in the model.

Does not include GUI changes

### Testing 

Adds testing of the new work

### Acceptance Criteria 

Tests should pass

### Documentation

Will do with the GUI part.
