### PR TITLE
main_window no longer passed to BaseMainWindowView

### DIFF
--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -26,7 +26,7 @@ class LiveViewerWindowView(BaseMainWindowView):
     imageLayout: QVBoxLayout
 
     def __init__(self, main_window: 'MainWindowView', live_dir_path: Path) -> None:
-        super().__init__(main_window, 'gui/ui/live_viewer_window.ui')
+        super().__init__(None, 'gui/ui/live_viewer_window.ui')
         self.setWindowTitle("Mantid Imaging - Live Viewer")
         self.main_window = main_window
         self.path = live_dir_path

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -490,6 +490,15 @@ class MainWindowView(BaseMainWindowView):
         if should_close:
             # Pass close event to parent
             super().closeEvent(event)
+            # Close additional windows which do not have the MainWindow as parent
+            if self.recon:
+                self.recon.close()
+            if self.live_viewer:
+                self.live_viewer.close()
+            if self.spectrum_viewer:
+                self.spectrum_viewer.close()
+            if self.filters:
+                self.filters.close()
 
         else:
             # Ignore the close event, keeping window open

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -59,7 +59,7 @@ class FiltersWindowView(BaseMainWindowView):
     filterSelector: QComboBox
 
     def __init__(self, main_window: 'MainWindowView'):
-        super().__init__(main_window, 'gui/ui/filters_window.ui')
+        super().__init__(None, 'gui/ui/filters_window.ui')
 
         self.main_window = main_window
         self.presenter = FiltersWindowPresenter(self, main_window)

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -83,7 +83,7 @@ class ReconstructWindowView(BaseMainWindowView):
     stackSelector: DatasetSelectorWidgetView
 
     def __init__(self, main_window: 'MainWindowView'):
-        super().__init__(main_window, 'gui/ui/recon_window.ui')
+        super().__init__(None, 'gui/ui/recon_window.ui')
 
         self.main_window = main_window
         self.presenter = ReconstructWindowPresenter(self, main_window)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -38,7 +38,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     normalise_error_issue: str = ""
 
     def __init__(self, main_window: 'MainWindowView'):
-        super().__init__(main_window, 'gui/ui/spectrum_viewer.ui')
+        super().__init__(None, 'gui/ui/spectrum_viewer.ui')
 
         self.main_window = main_window
 

--- a/mantidimaging/gui/windows/wizard/view.py
+++ b/mantidimaging/gui/windows/wizard/view.py
@@ -15,7 +15,7 @@ from .model import EnablePredicateFactory
 class WizardStage(QWidget):
 
     def __init__(self, name, parent: QWidget = None) -> None:
-        super().__init__(parent)
+        super().__init__(None)
 
         self.layout = QVBoxLayout(self)
         self.title_label = QLabel("Stage: " + name)
@@ -34,7 +34,7 @@ class WizardStage(QWidget):
 class WizardStep(QWidget):
 
     def __init__(self, step: dict, wizard: WizardView, parent: QWidget = None) -> None:
-        super().__init__(parent)
+        super().__init__(None)
 
         self.wizard_view = wizard
 


### PR DESCRIPTION
### Issue

Closes #1429.

### Description

In the Views for the additional windows (operations, spectrum viewer, reconstruct, etc), `self.main_window` is no longer passed to the `BaseMainWindowView` through `super().__init__()` but is still passed to the view for access. This stops the parent/child relationship between the two QMainWindows.
A side effect of this is that the additional windows do not close with the MainWindow is this is now done manually in the Main views `closeEvent()`.

### Acceptance Criteria 

Open branch in Windows, load in data and then open the Operations, Live Viewer, Spectrum Viewer, and Reconstruction windows and check that the Main window can now sit on top when clicked. All interactions between the additional windows and the main windows should work the same as before.

Check that the program still behaves as it did before in Linux.
