### PR TITLE
Fix ROI Colour Clash

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -114,7 +114,7 @@ class SpectrumWidget(GraphicsLayoutWidget):
         r_min, r_max = self.range_control.getRegion()
         return int(r_min), int(r_max)
 
-    def random_colour_generator(self) -> tuple[int, int, int, int]:
+    def colour_generator(self) -> tuple[int, int, int, int]:
         """
         A random colour generator to colour ROIs boarders.
         Generates colours that are easy to see for colour blind people if colour_blind_friendly is True.
@@ -122,8 +122,8 @@ class SpectrumWidget(GraphicsLayoutWidget):
 
         @return: A random colour in RGBA format. (0-255, 0-255, 0-255, 0-255)
         """
-        accessible_colours = [(255, 194, 10), (12, 123, 220), (153, 79, 0), (64, 176, 166), (230, 97, 0), (93, 58, 155),
-                              (26, 255, 26), (254, 254, 98), (211, 95, 183), (220, 50, 43)]
+        accessible_colours = [(255, 194, 10), (153, 79, 0), (64, 176, 166), (230, 97, 0), (93, 58, 155), (26, 255, 26),
+                              (12, 123, 220), (254, 254, 98), (211, 95, 183), (220, 50, 43)]
         if self.colour_index == len(accessible_colours):
             self.colour_index = 0
         colour = accessible_colours[self.colour_index]
@@ -175,7 +175,7 @@ class SpectrumWidget(GraphicsLayoutWidget):
         @param name: The name of the ROI.
         """
         roi_object = SpectrumROI(name, roi, pos=(0, 0), rotatable=False, scaleSnap=True, translateSnap=True)
-        roi_object.colour = self.random_colour_generator()
+        roi_object.colour = self.colour_generator()
 
         self.roi_dict[name] = roi_object.roi
         self.max_roi_size = roi_object.size()

--- a/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
@@ -33,15 +33,15 @@ class SpectrumWidgetTest(unittest.TestCase):
         del self.spectrum_widget
 
     def test_WHEN_colour_generator_called_THEN_return_value_of_length_3(self):
-        colour = self.spectrum_widget.random_colour_generator()
+        colour = self.spectrum_widget.colour_generator()
         self.assertEqual(len(colour), 4)
 
     def test_WHEN_colour_generator_called_THEN_valid_rgb_tuple_returned(self):
-        colour = self.spectrum_widget.random_colour_generator()
+        colour = self.spectrum_widget.colour_generator()
         self.assertTrue(all(0 <= c <= 255 for c in colour))
 
     def test_WHEN_colour_generator_called_THEN_different_colours_returned(self):
-        colour_list = [self.spectrum_widget.random_colour_generator() for _ in range(10)]
+        colour_list = [self.spectrum_widget.colour_generator() for _ in range(10)]
         self.assertEqual(len(colour_list), len({tuple(c) for c in colour_list}))
 
     def test_WHEN_change_roi_colour_called_THEN_roi_colour_changed(self):


### PR DESCRIPTION
### Issue

Avoids ROI colour clashes if one ROI is added after another. Previously the first two ROI colours were hard to distinguish between each other.

### Description

* Refactor ROI colour generator method name to be more descriptive
* Moved second ROI colour (12, 123, 220) to another location in array where it does not clash with other ROI colours

### Testing 

* manually tested adding ROIs and check they were distinguishable from each other in image view and spectrum line plot.
* Executed unit tests. 

### Acceptance Criteria 

Check that ROIs added are distinguishable from one another (in most cases, usually 2-3 ROIs are added) in the image view and spectrum line plot when moved around.

### Documentation

N/A - Update documentation as part of #1992 which will enable right clicking of an ROI to change the colour of the ROI.
