### PR TITLE
added fits compatibility for live viewer

### DIFF
--- a/docs/release_notes/next/feature-1996-fits-compatibility
+++ b/docs/release_notes/next/feature-1996-fits-compatibility
@@ -1,0 +1,1 @@
+#1996 : Added .fits file compatibility for Live Viewer

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -259,7 +259,7 @@ class ImageWatcher(QObject):
         :param file_name: name of file
         :return: True if file is an image file
         """
-        image_extensions = ['.tif', '.tiff']
+        image_extensions = ['.tif', '.tiff', '.fits']
         file_names = any(file_name.lower().endswith(ext) for ext in image_extensions)
         return file_names
 

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -259,9 +259,8 @@ class ImageWatcher(QObject):
         :param file_name: name of file
         :return: True if file is an image file
         """
-        image_extensions = ['.tif', '.tiff', '.fits']
-        file_names = any(file_name.lower().endswith(ext) for ext in image_extensions)
-        return file_names
+        image_extensions = ('tif', 'tiff', 'fits')
+        return file_name.rpartition(".")[2].lower() in image_extensions
 
     def remove_path(self):
         """

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -78,10 +78,10 @@ class LiveViewerWindowPresenter(BasePresenter):
 
     def load_and_display_image(self, image_path: Path):
         try:
-            if image_path.__str__().lower().endswith('.tif') or image_path.__str__().lower().endswith('.tiff'):
+            if image_path.suffix.lower() in [".tif", ".tiff"]:
                 with tifffile.TiffFile(image_path) as tif:
                     image_data = tif.asarray()
-            elif image_path.__str__().lower().endswith('.fits'):
+            elif image_path.suffix.lower() == ".fits":
                 with fits.open(image_path.__str__()) as fit:
                     image_data = fit[0].data
         except (IOError, KeyError, ValueError, TiffFileError, DeflateError) as error:

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -8,6 +8,7 @@ from logging import getLogger
 
 from imagecodecs._deflate import DeflateError
 from tifffile import tifffile, TiffFileError
+from astropy.io import fits
 
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.windows.live_viewer.model import LiveViewerWindowModel, Image_Data
@@ -77,8 +78,12 @@ class LiveViewerWindowPresenter(BasePresenter):
 
     def load_and_display_image(self, image_path: Path):
         try:
-            with tifffile.TiffFile(image_path) as tif:
-                image_data = tif.asarray()
+            if image_path.__str__().lower().endswith('.tif') or image_path.__str__().lower().endswith('.tiff'):
+                with tifffile.TiffFile(image_path) as tif:
+                    image_data = tif.asarray()
+            elif image_path.__str__().lower().endswith('.fits'):
+                with fits.open(image_path.__str__()) as fit:
+                    image_data = fit[0].data
         except (IOError, KeyError, ValueError, TiffFileError, DeflateError) as error:
             message = f"{type(error).__name__} reading image: {image_path}: {error}"
             logger.error(message)


### PR DESCRIPTION
### Issue

Closes #1995 

### Description

.fits files can now be loaded into the Live Viewer

### Testing 

The brass dataset at (\\isis\shares\IMAT\ExampleData\Brass\Corrected_Sample_PH20) was loaded into the Live Viewer and displayed correctly.

### Acceptance Criteria 

Check that .fits files can be loaded into the live viewer either directly or by simulating live data.

