### PR TITLE
Explicit tgv backend

### DIFF
--- a/docs/release_notes/next/dev-1985-tgv-backend
+++ b/docs/release_notes/next/dev-1985-tgv-backend
@@ -1,0 +1,1 @@
+#1985 : Backend work for TGV reconstruction

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from cil.framework import (AcquisitionData, AcquisitionGeometry, DataOrder, ImageGeometry, BlockGeometry, 
+from cil.framework import (AcquisitionData, AcquisitionGeometry, DataOrder, ImageGeometry, BlockGeometry,
                            BlockDataContainer)
 from cil.optimisation.algorithms import PDHG, SPDHG
 from cil.optimisation.operators import GradientOperator, BlockOperator
@@ -85,7 +85,6 @@ class CILRecon(BaseRecon):
 
         return (K, F, G)
 
-
     @staticmethod
     def set_up_TGV_regularisation(
             image_geometry: ImageGeometry, acquisition_data: AcquisitionData,
@@ -122,7 +121,7 @@ class CILRecon(BaseRecon):
             # mathematicians like to multiply 1/2 in front of L2NormSquared. This is not necessary
             # it will mean that the regularisation parameter alpha is doubled
             f1 = L2NormSquared(b=acquisition_data)
-    
+
             F = BlockFunction(f1, f2, f3)
 
         # Define BlockOperator K

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -102,7 +102,7 @@ class CILRecon(BaseRecon):
         # Define Gradient Operator and BlockOperator
         alpha = recon_params.alpha
         gamma = recon_params.gamma
-        beta = alpha / gamma
+        beta = alpha * gamma
 
         f2 = MixedL21Norm()
         f3 = MixedL21Norm() 

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -139,7 +139,8 @@ class CILRecon(BaseRecon):
         K = BlockOperator(K11, K12, K21, K22, K31, K32, shape=(3, 2))
 
         if recon_params.non_negative:
-            G = IndicatorBox(lower=0)
+            G = BlockFunction(IndicatorBox(lower=0, upper=None), ZeroFunction())
+
         else:
             # Define Function G simply as zero
             G = ZeroFunction()

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -229,7 +229,10 @@ class CILRecon(BaseRecon):
 
             ig = ag.get_ImageGeometry()
 
-            K, F, G = CILRecon.set_up_TV_regularisation(ig, data, recon_params)
+            if recon_params.regulariser == 'TV':
+                K, F, G = CILRecon.set_up_TV_regularisation(ig, data, recon_params)
+            elif recon_params.regulariser == 'TGV':
+                K, F, G = CILRecon.set_up_TGV_regularisation(ig, data, recon_params)
 
             max_iteration = 100000
             # this should set to a sensible number as evaluating the objective is costly
@@ -353,7 +356,11 @@ class CILRecon(BaseRecon):
                                      num_subsets)
 
             ig = ag.get_ImageGeometry()
-            K, F, G = CILRecon.set_up_TV_regularisation(ig, data, recon_params)
+
+            if recon_params.regulariser == 'TV':
+                K, F, G = CILRecon.set_up_TV_regularisation(ig, data, recon_params)
+            elif recon_params.regulariser == 'TGV':
+                K, F, G = CILRecon.set_up_TGV_regularisation(ig, data, recon_params)
 
             max_iteration = 100000
             # this should set to a sensible number as evaluating the objective is costly

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -130,7 +130,6 @@ class CILRecon(BaseRecon):
         # Set up the 3 operator A, Grad and Epsilon                           
         K11 = A2d
         K21 = alpha * GradientOperator(K11.domain)
-        # https://tomographicimaging.github.io/CIL/nightly/optimisation.html#cil.optimisation.operators.SymmetrisedGradientOperator
         K32 = beta * SymmetrisedGradientOperator(K21.range)
         # these define the domain and range of the other operators
         K12 = ZeroOperator(K32.domain, K11.range)

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -108,7 +108,7 @@ class CILRecon(BaseRecon):
         f3 = MixedL21Norm()
 
         if recon_params.stochastic:
-
+            raise ValueError("TGV reconstruction does not yet support stochastic mode")
             # now, A2d is a BlockOperator as acquisition_data is a BlockDataContainer
             fs = []
             for i, _ in enumerate(acquisition_data.geometry):

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -103,12 +103,14 @@ class ReconstructionParameters:
     tilt: Degrees | None = None
     pixel_size: float = 0.0
     alpha: float = 0.0
+    gamma: float = 1.0
     non_negative: bool = False
     max_projection_angle: float = 360.0
     beam_hardening_coefs: list[float] | None = None
     stochastic: bool = False
     projections_per_subset: int = 50
     regularisation_percent: int = 30
+    regulariser: str = ""
 
     def to_dict(self) -> dict:
         return {
@@ -119,9 +121,11 @@ class ReconstructionParameters:
             'tilt': str(self.tilt),
             'pixel_size': self.pixel_size,
             'alpha': self.alpha,
+            'gamma': self.gamma,
             'stochastic': self.stochastic,
             'projections_per_subset': self.projections_per_subset,
             'regularisation_percent': self.regularisation_percent,
+            'regulariser': self.regulariser,
         }
 
 

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -412,6 +412,10 @@ class ReconstructWindowView(BaseMainWindowView):
         return self.alphaSpinBox.value()
 
     @property
+    def gamma(self) -> float:
+        return 1
+
+    @property
     def non_negative(self) -> bool:
         return self.nonNegativeCheckBox.isChecked()
 
@@ -426,6 +430,10 @@ class ReconstructWindowView(BaseMainWindowView):
     @property
     def regularisation_percent(self) -> int:
         return self.regPercentSpinBox.value()
+
+    @property
+    def regulariser(self) -> str:
+        return "TV"
 
     @property
     def beam_hardening_coefs(self) -> list[float] | None:
@@ -447,11 +455,13 @@ class ReconstructWindowView(BaseMainWindowView):
                                         tilt=Degrees(self.tilt),
                                         pixel_size=self.pixel_size,
                                         alpha=self.alpha,
+                                        gamma=self.gamma,
                                         non_negative=self.non_negative,
                                         stochastic=self.stochastic,
                                         projections_per_subset=self.projections_per_subset,
                                         max_projection_angle=self.max_proj_angle,
                                         regularisation_percent=self.regularisation_percent,
+                                        regulariser=self.regulariser,
                                         beam_hardening_coefs=self.beam_hardening_coefs)
 
     def set_table_point(self, idx, slice_idx, cor):


### PR DESCRIPTION
I made a branch of #1986 within the MI repo so that the PR can access the secrets on actions (I can't see a simple way to give the fork access).

### Issue

closes #1985 

### Description
Implementation of a Total Generalised Variation regulariser for Least Squares problems. It works both with PDHG and the SPDHG algorithms.

Controls to from the interface that are required:

1. `alpha`, regularisation parameter as in Eq. 3.5 https://royalsocietypublishing.org/doi/10.1098/rsta.2020.0193
2. `gamma`, ratio `beta/alpha`, wrt to Eq. 3.5 https://royalsocietypublishing.org/doi/10.1098/rsta.2020.0193
3. `regulariser`, whether `TV` or `TGV`


### Testing 

Edit `ReconstructWindowView.regulariser` to return `"TGV"`. In the reconstruction window select CIL:PDHG-TV, and check that it still does a reconstruction.


### Documentation

Wait for the GUI side

