### PR TITLE
RITS transmission error GUI part

### DIFF
--- a/docs/release_notes/next/feature-1943-RITS-transmission-error
+++ b/docs/release_notes/next/feature-1943-RITS-transmission-error
@@ -1,0 +1,2 @@
+#1943 : RITS export transmission errors
+

--- a/mantidimaging/gui/ui/spectrum_viewer.ui
+++ b/mantidimaging/gui/ui/spectrum_viewer.ui
@@ -264,6 +264,27 @@
              </widget>
             </item>
             <item>
+             <widget class="QLabel" name="label_2">
+              <property name="text">
+               <string>Error mode</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="transmission_error_mode_combobox">
+              <item>
+               <property name="text">
+                <string>Standard Deviation</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Propagated</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item>
              <spacer name="verticalSpacer_2">
               <property name="orientation">
                <enum>Qt::Vertical</enum>

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -31,8 +31,15 @@ class SpecType(Enum):
 
 
 class ErrorMode(Enum):
-    STANDARD_DEVIATION = 1
-    PROPAGATED = 2
+    STANDARD_DEVIATION = "Standard Deviation"
+    PROPAGATED = "Propagated"
+
+    @classmethod
+    def get_by_value(cls, value: str) -> ErrorMode:
+        for element in cls:
+            if element.value == value:
+                return element
+        raise ValueError(f"Unknown error mode: {value}")
 
 
 class SpectrumViewerWindowModel:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -177,7 +177,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             return
         if path.suffix != ".dat":
             path = path.with_suffix(".dat")
-        self.model.save_rits(path, self.spectrum_mode == SpecType.SAMPLE_NORMED, ErrorMode.STANDARD_DEVIATION)
+        error_mode = ErrorMode.get_by_value(self.view.transmission_error_mode)
+        self.model.save_rits(path, self.spectrum_mode == SpecType.SAMPLE_NORMED, error_mode)
 
     def handle_enable_normalised(self, enabled: bool) -> None:
         if enabled:

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -406,3 +406,8 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         tof_result = self.model.get_stack_time_of_flight()
         self.assertIsInstance(tof_result, np.ndarray)
         npt.assert_array_equal(tof_result, np.arange(0, 10) * 0.1)
+
+    def test_error_modes(self):
+        self.assertEqual(ErrorMode.get_by_value("Standard Deviation"), ErrorMode.STANDARD_DEVIATION)
+        self.assertEqual(ErrorMode.get_by_value("Propagated"), ErrorMode.PROPAGATED)
+        self.assertRaises(ValueError, ErrorMode.get_by_value, "")

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -192,6 +192,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     @mock.patch("mantidimaging.gui.windows.spectrum_viewer.model.SpectrumViewerWindowModel.save_rits")
     def test_handle_rits_export(self, path_name: str, mock_save_rits: mock.Mock):
         self.view.get_rits_export_filename = mock.Mock(return_value=Path(path_name))
+        self.view.transmission_error_mode = "Standard Deviation"
 
         self.presenter.model.set_stack(generate_images())
 

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Optional
 
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import QCheckBox, QVBoxLayout, QFileDialog, QPushButton, QLabel, QAbstractItemView, QHeaderView, \
-    QTabWidget
+    QTabWidget, QComboBox
 
 from mantidimaging.core.utility import finder
 from mantidimaging.gui.mvp_base import BaseMainWindowView
@@ -36,6 +36,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     normaliseErrorIcon: QLabel
     _current_dataset_id: Optional['UUID']
     normalise_error_issue: str = ""
+    transmission_error_mode_combobox: QComboBox
 
     def __init__(self, main_window: 'MainWindowView'):
         super().__init__(None, 'gui/ui/spectrum_viewer.ui')
@@ -305,3 +306,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.spectrum.spectrum_data_dict = {}
         self.spectrum.spectrum.clearPlots()
         self.removeBtn.setEnabled(False)
+
+    @property
+    def transmission_error_mode(self) -> str:
+        return self.transmission_error_mode_combobox.currentText()


### PR DESCRIPTION
### Issue
Closes #1943 

### Description

Adds the GUI work for exporting the transmission errors for RITS.

Combox to select error mode. Hooked up to work in #1987

### Testing & Acceptance Criteria 

Open a ToF dataset in the spectrum viewer.
Enable normalise, and select the open beam
Choose the image tab.
For each of the error modes, run the export
Check that the exported files have values in the error column

### Documentation
Release notes
