### PR TITLE
Refresh README, add mailing list link to README and Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,28 @@
+<div align="center">
+  <a href="https://mantidproject.github.io/mantidimaging/">
+    <img src="images/mantid_imaging_64px.ico" alt="Logo" width="80" height="80">
+  </a>
+
+  <h1 align="center">MantidImaging</h1>
+
+  <p align="center" style="font-size: 18px">
+    <strong>A graphical toolkit for 3D reconstruction of neutron tomography data</strong>
+    <br />
+     <br />
+    <a href="https://mantidproject.github.io/mantidimaging/"><strong>Explore the docs »</strong></a>
+    <br />
+    <br />
+    <a href="https://anaconda.org/mantid/mantidimaging"><b>Anaconda Package</b></a>
+    ·
+    <a href="https://github.com/mantidproject/mantidimaging"><b>Code Repository</b></a>
+    ·
+    <a href="https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=MANTID-IMAGING-ANNOUNCE&A=1"><b>Release Mailing List</b></a>
+  </p>
+</div>
+
 # MantidImaging
 
 Mantid Imaging is a graphical toolkit for performing 3D reconstruction of neutron tomography data. It provides an easy-to-use graphical interface to a wide range of pre/post-processing operations, tilt correction and reconstruction algorithms, accommodating for tomography users with varying data complexity and image analysis background knowledge. It utilises a flexible plugin system that allows easy integration of external software, and has allowed us to re-use software widely known in the neutron tomography community.
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4728059.svg)](https://doi.org/10.5281/zenodo.4728059)
 [![Coverage Status](https://coveralls.io/repos/github/mantidproject/mantidimaging/badge.svg?branch=main)](https://coveralls.io/github/mantidproject/mantidimaging?branch=main)
-
-## Links
-
- - Documentation: https://mantidproject.github.io/mantidimaging/
- - Anaconda package: https://anaconda.org/mantid/mantidimaging
- - Code repository: https://github.com/mantidproject/mantidimaging

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,3 +32,5 @@ Please cite as:
 Tasev, Dimitar; Akello-Egwel, Dolica; Allen, Jack; Baust, Rachel; Gigg, Martyn; Jones, Samuel; Nixon, Daniel; Stock, Samuel; Taylor, Will; Tygier, Sam. (2023). Mantid Imaging (2.5.0), Zenodo https://doi.org/10.5281/zenodo.4728059
 
 (See `Zenodo <https://doi.org/10.5281/zenodo.4728059>`_ for citing specific versions).
+
+Sign up to our `mailing list <https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=MANTID-IMAGING-ANNOUNCE&A=1>`_ to receive updates on the project

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -5,3 +5,8 @@ Issues can be reported on the `Github project page <https://github.com/mantidpro
 
 The developers can be contacted at
 mantidimagingsupport@stfc365.onmicrosoft.com
+
+Release Updates
+===============
+
+Sign up to our `mailing list <https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=MANTID-IMAGING-ANNOUNCE&A=1>`_ to receive updates on the project


### PR DESCRIPTION
### Issue

Closes #2006 

### Description

Refresh to look of README
Add mailing list link to README to increase visibility of signup link to users
Add mailing list link to Documentation to increase visibility of signup link to users

### Testing 

- Built Docs and checked Links in index page and support page work
- Checked all URLs in README work
- Proof read README

### Acceptance Criteria 

* Docs build successfully (`make build-docs`)
* Index page URL to mailing list takes users to mailing list signup
* Support page link to mailing list takes users to mailing list signup
* [README](https://github.com/mantidproject/mantidimaging/tree/2006_docs_mailing_list) has no grammatical errors
* All [README](https://github.com/mantidproject/mantidimaging/tree/2006_docs_mailing_list) links take users to the correct locations
* Links to release mailing list are easy to find

### Documentation

N/A - change is non-consequential. 
