### PR TITLE
GUI side for RITS export 2d binned mode

### DIFF
--- a/mantidimaging/gui/ui/spectrum_viewer.ui
+++ b/mantidimaging/gui/ui/spectrum_viewer.ui
@@ -255,10 +255,15 @@
              </widget>
             </item>
             <item>
-             <widget class="QComboBox" name="image_output_mode">
+             <widget class="QComboBox" name="image_output_mode_combobox">
               <item>
                <property name="text">
                 <string>Single Spectrum</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>2D Binned</string>
                </property>
               </item>
              </widget>
@@ -266,7 +271,7 @@
             <item>
              <widget class="QLabel" name="label_2">
               <property name="text">
-               <string>Error mode</string>
+               <string>Error Mode</string>
               </property>
              </widget>
             </item>
@@ -282,6 +287,43 @@
                 <string>Propagated</string>
                </property>
               </item>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_3">
+              <property name="text">
+               <string>Bin Size</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="bin_size_spinBox">
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>1000</number>
+              </property>
+              <property name="value">
+               <number>10</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_4">
+              <property name="text">
+               <string>Bin Step</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="bin_step_spinBox">
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>1000</number>
+              </property>
              </widget>
             </item>
             <item>

--- a/mantidimaging/gui/ui/spectrum_viewer.ui
+++ b/mantidimaging/gui/ui/spectrum_viewer.ui
@@ -290,7 +290,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="label_3">
+             <widget class="QLabel" name="bin_size_label">
               <property name="text">
                <string>Bin Size</string>
               </property>
@@ -310,7 +310,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="label_4">
+             <widget class="QLabel" name="bin_step_label">
               <property name="text">
                <string>Bin Step</string>
               </property>

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Optional
 
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import QCheckBox, QVBoxLayout, QFileDialog, QPushButton, QLabel, QAbstractItemView, QHeaderView, \
-    QTabWidget, QComboBox
+    QTabWidget, QComboBox, QSpinBox
 
 from mantidimaging.core.utility import finder
 from mantidimaging.gui.mvp_base import BaseMainWindowView
@@ -36,7 +36,10 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     normaliseErrorIcon: QLabel
     _current_dataset_id: Optional['UUID']
     normalise_error_issue: str = ""
+    image_output_mode_combobox: QComboBox
     transmission_error_mode_combobox: QComboBox
+    bin_size_spinBox: QSpinBox
+    bin_step_spinBox: QSpinBox
 
     def __init__(self, main_window: 'MainWindowView'):
         super().__init__(None, 'gui/ui/spectrum_viewer.ui')
@@ -310,3 +313,15 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     @property
     def transmission_error_mode(self) -> str:
         return self.transmission_error_mode_combobox.currentText()
+
+    @property
+    def image_output_mode(self) -> str:
+        return self.image_output_mode_combobox.currentText()
+
+    @property
+    def bin_size(self) -> int:
+        return self.bin_size_spinbox.value()
+
+    @property
+    def bin_step(self) -> int:
+        return self.bin_step_spinbox.value()

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -71,6 +71,8 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.normaliseCheckBox.stateChanged.connect(self.presenter.handle_button_enabled)
 
         self.exportTabs.currentChanged.connect(self.presenter.handle_export_tab_change)
+        self.image_output_mode_combobox.currentTextChanged.connect(self.set_binning_visibility)
+        self.set_binning_visibility()
 
         # ROI action buttons
         self.addBtn.clicked.connect(self.set_new_roi)
@@ -325,3 +327,10 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     @property
     def bin_step(self) -> int:
         return self.bin_step_spinbox.value()
+
+    def set_binning_visibility(self) -> None:
+        hide_binning = self.image_output_mode != "2D Binned"
+        self.bin_size_label.setHidden(hide_binning)
+        self.bin_size_spinBox.setHidden(hide_binning)
+        self.bin_step_label.setHidden(hide_binning)
+        self.bin_step_spinBox.setHidden(hide_binning)


### PR DESCRIPTION
### Issue

Work on #1945 

### Description

Add GUI part for 2d binned RITS export.
New option in Output Mode.
When 2D Binned is selected, then show Bin Size and Bin Step options.

### Testing & Acceptance Criteria 
Check that new output mode option is there, and new params show when it is selected

### Documentation
Not needed yet
