### PR TITLE
Upload to new conda repo

### DIFF
--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -4,6 +4,10 @@ inputs:
   repository:
     description: 'Anaconda repository'
     required: true
+    default: 'mantidimaging'
+  repository-old:
+    description: 'Anaconda repository - old'
+    required: true
     default: 'mantid'
   label:
     description: 'Label'
@@ -11,6 +15,9 @@ inputs:
     default: 'unstable'
   token:
     description: 'Anaconda API Token'
+    required: true
+  token-old:
+    description: 'Anaconda API Token - old'
     required: true
 
 description: Build conda package
@@ -35,8 +42,10 @@ runs:
     shell: bash -l {0}
     run: |
       conda activate build-env
-      conda config --set anaconda_upload yes
+      conda config --set anaconda_upload no
       # if the upload silently fails - check the token expiration. Conda can fail silently!
-      conda mambabuild --user ${{ inputs.repository }} --token ${{ inputs.token }} --label ${{ inputs.label }} $GITHUB_WORKSPACE/conda |& tee upload.log
+      conda mambabuild $GITHUB_WORKSPACE/conda
+      anaconda -t ${{ inputs.token }} upload --user ${{ inputs.repository }} --label ${{ inputs.label }} ${CONDA_PREFIX}/conda-bld/*/mantidimaging*.tar.bz2 |& tee upload.log
+      anaconda -t ${{ inputs.token-old }} upload --user ${{ inputs.repository-old }} --label ${{ inputs.label }} ${CONDA_PREFIX}/conda-bld/*/mantidimaging*.tar.bz2
       # Check that upload completed
       grep "Upload complete" upload.log

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -140,4 +140,5 @@ jobs:
         uses: ./.github/actions/publish-package
         with:
           label: unstable
-          token: ${{ secrets.ANACONDA_API_TOKEN }}
+          token: ${{ secrets.ANACONDA_API_TOKEN_MANTIDIMAGING }}
+          token-old: ${{ secrets.ANACONDA_API_TOKEN }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -126,4 +126,5 @@ jobs:
         uses: ./.github/actions/publish-package
         with:
           label: unstable
-          token: ${{ secrets.ANACONDA_API_TOKEN }}
+          token: ${{ secrets.ANACONDA_API_TOKEN_MANTIDIMAGING }}
+          token-old: ${{ secrets.ANACONDA_API_TOKEN }}


### PR DESCRIPTION
Upload to mantid and mantidimaging repos

### Issue
Part of #2011 

### Description

Modify the upload part of github actions to upload to the old and new repe

~~NOTE: needs second commit removed before merging~~

### Testing 

I have made a test commit [5cf6adf](https://github.com/mantidproject/mantidimaging/pull/2013/commits/5cf6adfc2be2359501a09143485f0acebc7e5ecc) to do a test upload with a test label.

### Acceptance Criteria 
Check that test packages get uploaded to
https://anaconda.org/mantidimaging/repo
and
https://anaconda.org/mantid/repo

### Documentation

Documentation to follow in a new PR, once we see this run on main
