### PR TITLE
updated default values in Remove all stripes

### DIFF
--- a/docs/release_notes/next/fix-2002-default-values
+++ b/docs/release_notes/next/fix-2002-default-values
@@ -1,0 +1,2 @@
+#2002 : Better default values in Remove all stripes
+

--- a/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
+++ b/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
@@ -84,7 +84,7 @@ class RemoveAllStripesFilter(BaseFilter):
 
         _, la_size = add_property_to_form('Large stripe kernel',
                                           Type.INT,
-                                          default_value=61,
+                                          default_value=21,
                                           valid_values=(1, 100),
                                           form=form,
                                           on_change=on_change,
@@ -92,7 +92,7 @@ class RemoveAllStripesFilter(BaseFilter):
 
         _, sm_size = add_property_to_form('Small stripe kernel',
                                           Type.INT,
-                                          default_value=21,
+                                          default_value=7,
                                           valid_values=(1, 100),
                                           form=form,
                                           on_change=on_change,
@@ -100,7 +100,7 @@ class RemoveAllStripesFilter(BaseFilter):
 
         _, dim = add_property_to_form('Dimension of the window',
                                       Type.INT,
-                                      default_value=1,
+                                      default_value=2,
                                       valid_values=(1, 2),
                                       form=form,
                                       on_change=on_change,


### PR DESCRIPTION
### Issue

Update Default Values for "Remove all stripes" Filter - Resolves #2002

### Description

This pull request updates the default values for the "Remove all stripes" filter in the Operations window. After evaluating feedback and conducting tests on typical datasets, it became evident that the current default settings were not optimal. The changes include:

Stripe Ratio: Updated from default to 3.
Large Stripe Kernel: Changed from default to 21.
Small Stripe Kernel: Adjusted from default to 7.
Dimensions of the Window: Set to 2 from the default value.

### Testing 

not needed

### Acceptance Criteria 

Reviewers should test the changes by applying the "Remove all stripes" filter on diverse datasets, particularly those where stripe interference is a known issue. 


### Documentation

The changes have been documented in the docs/release_notes under the upcoming release section. 
