### PR TITLE
Change ROI Colour

### DIFF
--- a/docs/release_notes/next/feature-1992-ROI-colour
+++ b/docs/release_notes/next/feature-1992-ROI-colour
@@ -1,0 +1,1 @@
+#1992 : Spectrum Viewer: Change ROI Colour Through Right Click Dialog Menu

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -207,6 +207,17 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.auto_range_image()
         self.do_add_roi_to_table(roi_name)
 
+    def change_roi_colour(self, roi_name: str, new_colour: tuple) -> None:
+        """
+        Change the colour of a given ROI in both the spectrum widget and the table.
+
+        @param roi_name: Name of the ROI to change color.
+        @param new_colour: The new color for the ROI.
+        """
+        if roi_name in self.view.spectrum.roi_dict:
+            self.view.spectrum.roi_dict[roi_name].colour = new_colour
+        self.view.update_roi_color_in_table(roi_name, new_colour)
+
     def add_rits_roi(self) -> None:
         roi_name = ROI_RITS
         self.model.set_new_roi(roi_name)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -232,8 +232,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         @param roi_name: Name of the ROI to change color.
         @param new_colour: The new color for the ROI.
         """
-        if roi_name in self.view.spectrum.roi_dict:
-            self.view.spectrum.roi_dict[roi_name].colour = new_colour
+        if roi_name in self.view.spectrum_widget.roi_dict:
+            self.view.spectrum_widget.roi_dict[roi_name].colour = new_colour
         self.view.update_roi_color_in_table(roi_name, new_colour)
 
     def add_rits_roi(self) -> None:

--- a/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
@@ -170,8 +170,6 @@ class TableModel(QAbstractTableModel):
             self._data[row][0] = new_name
             self.layoutChanged.emit()
 
-
-
     def flags(self, index):
         """
         Handle selection of table rows to disable selection of ROI colour column
@@ -186,8 +184,6 @@ class TableModel(QAbstractTableModel):
             return Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsUserCheckable
         else:
             return Qt.ItemIsEnabled
-
-
 
     def roi_names(self) -> list:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
@@ -61,6 +61,14 @@ class TableModel(QAbstractTableModel):
                     return Qt.Checked
                 return Qt.Unchecked
 
+    def recolour_row(self, row, new_color):
+        print(f"recolour_row called for row {row} with new_color {new_color}")
+
+        if 0 <= row < len(self._data) and len(new_color) == 4:
+            for column in range(self.columnCount()):
+                index = self.index(row, column)
+                self.dataChanged.emit(index, index, [Qt.BackgroundRole])
+
     def setData(self, index, value, role):
         """
         Set data in table
@@ -164,6 +172,8 @@ class TableModel(QAbstractTableModel):
             self._data[row][0] = new_name
             self.layoutChanged.emit()
 
+
+
     def flags(self, index):
         """
         Handle selection of table rows to disable selection of ROI colour column
@@ -178,6 +188,8 @@ class TableModel(QAbstractTableModel):
             return Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsUserCheckable
         else:
             return Qt.ItemIsEnabled
+
+
 
     def roi_names(self) -> list:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
@@ -61,13 +61,11 @@ class TableModel(QAbstractTableModel):
                     return Qt.Checked
                 return Qt.Unchecked
 
-    def recolour_row(self, row, new_color):
-        print(f"recolour_row called for row {row} with new_color {new_color}")
-
-        if 0 <= row < len(self._data) and len(new_color) == 4:
-            for column in range(self.columnCount()):
-                index = self.index(row, column)
-                self.dataChanged.emit(index, index, [Qt.BackgroundRole])
+    def update_color(self, row, new_color):
+        if 0 <= row < len(self._data):
+            self._data[row][1] = new_color
+            index = self.index(row, 1)
+            self.dataChanged.emit(index, index, [Qt.DisplayRole, Qt.BackgroundRole])
 
     def setData(self, index, value, role):
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Optional
 from PyQt5.QtCore import pyqtSignal, Qt, QSignalBlocker
 from PyQt5 import QtGui, QtWidgets
 from pyqtgraph import ROI, GraphicsLayoutWidget, LinearRegionItem, PlotItem, mkPen
-from PyQt5.QtGui import QPen
+
 from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
@@ -53,8 +53,6 @@ class SpectrumROI(ROI):
                 new_color = (selected_color.red(), selected_color.green(), selected_color.blue(), 255)
                 self.colour = new_color  # Update the ROI color
                 self.sig_colour_change.emit(self._name, new_color)
-
-
 
     @property
     def name(self) -> str:
@@ -182,7 +180,7 @@ class SpectrumWidget(GraphicsLayoutWidget):
         @param alpha: The new alpha value of the ROI.
         """
 
-        self.roi_dict[name].colour = self.roi_dict[name].colour[:3] + (alpha,)
+        self.roi_dict[name].colour = self.roi_dict[name].colour[:3] + (alpha, )
         self.roi_dict[name].setPen(self.roi_dict[name].colour)
         self.roi_dict[name].hoverPen = mkPen(self.roi_dict[name].colour, width=3)
         self.set_roi_visibility_flags(name, bool(alpha))

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from PyQt5.QtCore import pyqtSignal, Qt, QSignalBlocker
-from PyQt5.QtGui import QColor
-from PyQt5.QtWidgets import QColorDialog, QAction, QMenu
+from PyQt5.QtGui import QColor, QCursor
+from PyQt5.QtWidgets import QColorDialog, QAction
 from pyqtgraph import ROI, GraphicsLayoutWidget, LinearRegionItem, PlotItem, mkPen
 
 from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint
@@ -41,20 +41,15 @@ class SpectrumROI(ROI):
         self.addScaleHandle([0, 1], [1, 0])
         self._selected_row = None
 
-        self.setAcceptedMouseButtons(Qt.RightButton)
-        self.setAcceptHoverEvents(True)
-
-    def contextMenuEvent(self, event):
-        menu = QMenu()
-        change_color_action = QAction("Change Color", self)
+        menu = self.getMenu()
+        change_color_action = QAction("Change ROI Colour", self)
         change_color_action.triggered.connect(self.onChangeColor)
         menu.addAction(change_color_action)
-        menu.exec_(event.screenPos())
+        menu.exec_(QCursor.pos())
 
     def onChangeColor(self):
         current_color = QColor(*self._colour)
         selected_color = QColorDialog.getColor(current_color)
-
         if selected_color.isValid():
             new_color = (selected_color.red(), selected_color.green(), selected_color.blue(), 255)
             self._colour = new_color

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from PyQt5.QtCore import pyqtSignal, Qt, QSignalBlocker
-from PyQt5.QtGui import QColor, QCursor
-from PyQt5.QtWidgets import QColorDialog, QAction
+from PyQt5.QtGui import QColor
+from PyQt5.QtWidgets import QColorDialog, QAction, QMenu
 from pyqtgraph import ROI, GraphicsLayoutWidget, LinearRegionItem, PlotItem, mkPen
 
 from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint
@@ -41,11 +41,10 @@ class SpectrumROI(ROI):
         self.addScaleHandle([0, 1], [1, 0])
         self._selected_row = None
 
-        menu = self.getMenu()
+        self.menu = QMenu()
         change_color_action = QAction("Change ROI Colour", self)
         change_color_action.triggered.connect(self.onChangeColor)
-        menu.addAction(change_color_action)
-        menu.exec_(QCursor.pos())
+        self.menu.addAction(change_color_action)
 
     def onChangeColor(self):
         current_color = QColor(*self._colour)
@@ -54,6 +53,9 @@ class SpectrumROI(ROI):
             new_color = (selected_color.red(), selected_color.green(), selected_color.blue(), 255)
             self._colour = new_color
             self.sig_colour_change.emit(self._name, new_color)
+
+    def contextMenuEnabled(self):
+        return True
 
     @property
     def name(self) -> str:

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -258,7 +258,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         if row is not None:
             self.roi_table_model.update_color(row, new_color)
 
-    def find_row_for_roi(self, roi_name: str) -> int:
+    def find_row_for_roi(self, roi_name: str) -> Optional[int]:
         """
         Returns row index for ROI name, or None if not found.
 
@@ -269,7 +269,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             if self.roi_table_model.index(row, 0).data() == roi_name:
                 return row
         return None
-
 
     def set_roi_alpha(self, alpha: float, roi_name: str) -> None:
         """
@@ -298,8 +297,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         @param name: The name of the ROI
         @param colour: The colour of the ROI
         """
-        circle_label = QLabel()
-        circle_label.setStyleSheet(f"background-color: {colour}; border-radius: 5px;")
         self.roi_table_model.appendNewRow(name, colour, True)
         self.selected_row = self.roi_table_model.rowCount() - 1
         self.tableView.selectRow(self.selected_row)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -57,6 +57,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         self.spectrum.range_changed.connect(self.presenter.handle_range_slide_moved)
         self.spectrum.roi_changed.connect(self.presenter.handle_roi_moved)
+        self.spectrum.roiColorChangeRequested.connect(self.presenter.change_roi_colour)
 
         self._current_dataset_id = None
         self.sampleStackSelector.stack_selected_uuid.connect(self.presenter.handle_sample_change)
@@ -245,6 +246,30 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         Set a new ROI on the image
         """
         self.presenter.do_add_roi()
+
+    def update_roi_color_in_table(self, roi_name: str, new_color: tuple):
+        """
+        Finds ROI by name in table and updates colour.
+
+        @param roi_name: Name of the ROI to update.
+        @param new_color: The new color for the ROI in (R, G, B) format.
+        """
+        row = self.find_row_for_roi(roi_name)
+        if row is not None:
+            self.roi_table_model.update_color(row, new_color)
+
+    def find_row_for_roi(self, roi_name: str) -> int:
+        """
+        Returns row index for ROI name, or None if not found.
+
+        @param roi_name: Name ROI find.
+        @return: Row index ROI or None.
+        """
+        for row in range(self.roi_table_model.rowCount()):
+            if self.roi_table_model.index(row, 0).data() == roi_name:
+                return row
+        return None
+
 
     def set_roi_alpha(self, alpha: float, roi_name: str) -> None:
         """


### PR DESCRIPTION
### Issue

Closes #1992

### Description

This pull request addresses the issue reported in #1992. This pull request introduces an enhancement to the Spectrum Viewer, targeting the functionality around ROIs. Previously, users could not easily change the colour of an ROI within the viewer. With this update, I have implemented a right-click context menu for ROIs, providing users with an interface to select new colours. This enhancement improves user interaction with the Spectrum Viewer

### Testing 

*Describe the tests that were used to verify your changes*.

### Acceptance Criteria 

Right-clicked on various ROIs within the Spectrum Viewer to ensure the context menu appears consistently.
Selected different colours from the colour dialog and verified that the selected ROI updated to the new colour immediately.
Tested with multiple ROIs to ensure that changing the colour of one ROI does not affect others.

### Documentation

Noted the changes in the appropriate file in docs/release_notes.