### PR TITLE
Use "Rotate Image" operation in the Live Viewer

### DIFF
--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from mantidimaging.gui.windows.live_viewer.view import LiveViewerWindowView  # pragma: no cover
     from mantidimaging.gui.windows.main.view import MainWindowView  # pragma: no cover
 
-
 logger = getLogger(__name__)
 
 
@@ -89,7 +88,7 @@ class LiveViewerWindowPresenter(BasePresenter):
                 with fits.open(image_path.__str__()) as fit:
                     image_data = fit[0].data
 
-            image_data = self.rotate_image(image_data, 90)
+            image_data = self.rotate_image(image_data)
         except (IOError, KeyError, ValueError, TiffFileError, DeflateError) as error:
             message = f"{type(error).__name__} reading image: {image_path}: {error}"
             logger.error(message)
@@ -113,10 +112,15 @@ class LiveViewerWindowPresenter(BasePresenter):
         if self.selected_image and image_path == self.selected_image.image_path:
             self.load_and_display_image(image_path)
 
-    def rotate_image(self, image_data, ang: int):
+    def rotate_image(self, image_data):
+        ang = self.view.image_rotation_angle
         image_data_shape = image_data.shape
         image_data_temp = np.zeros(shape=(1, image_data_shape[0], image_data_shape[1]))
         image_data_temp[0] = image_data
         image_stack_temp = ImageStack(image_data_temp)
         rotated_imaged = RotateFilter().filter_func(image_stack_temp, angle=ang)
         return rotated_imaged.data[0].astype(int)
+
+    def update_image_operation(self):
+        """ Reload the current image if an operation has been performed on the current image"""
+        self.load_and_display_image(self.selected_image.image_path)

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from PyQt5.QtCore import QSignalBlocker
+from PyQt5.QtCore import QSignalBlocker, QCoreApplication
 from PyQt5.QtWidgets import QVBoxLayout
+from PyQt5.Qt import QAction, QActionGroup
 
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from .live_view_widget import LiveViewWidget
@@ -15,6 +16,8 @@ import numpy as np
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
+
+translate = QCoreApplication.translate
 
 
 class LiveViewerWindowView(BaseMainWindowView):
@@ -34,6 +37,23 @@ class LiveViewerWindowView(BaseMainWindowView):
         self.live_viewer = LiveViewWidget()
         self.imageLayout.addWidget(self.live_viewer)
         self.live_viewer.z_slider.valueChanged.connect(self.presenter.select_image)
+        self.image_rotation_angle = 0
+        self.right_click_menu = self.live_viewer.image.vb.menu
+        rotate_menu = self.right_click_menu.addMenu(translate("ViewBox", "Rotate Image"))
+        rotate_angles_group = QActionGroup(self)
+        rotate_0 = QAction(translate("ViewBox", "0" + u'\N{DEGREE SIGN}'), rotate_angles_group)
+        rotate_90 = QAction(translate("ViewBox", "90" + u'\N{DEGREE SIGN}'), rotate_angles_group)
+        rotate_180 = QAction(translate("ViewBox", "180" + u'\N{DEGREE SIGN}'), rotate_angles_group)
+        rotate_270 = QAction(translate("ViewBox", "270" + u'\N{DEGREE SIGN}'), rotate_angles_group)
+        rotate_0.setCheckable(True)
+        rotate_90.setCheckable(True)
+        rotate_180.setCheckable(True)
+        rotate_270.setCheckable(True)
+        rotate_menu.addActions(rotate_angles_group.actions())
+        rotate_0.triggered.connect(lambda: self.set_image_rotation_angle(0))
+        rotate_90.triggered.connect(lambda: self.set_image_rotation_angle(90))
+        rotate_180.triggered.connect(lambda: self.set_image_rotation_angle(180))
+        rotate_270.triggered.connect(lambda: self.set_image_rotation_angle(270))
 
     def show(self) -> None:
         """Show the window"""
@@ -74,3 +94,8 @@ class LiveViewerWindowView(BaseMainWindowView):
         self.live_viewer.handle_deleted()
         super().closeEvent(e)
         self.presenter = None  # type: ignore # View instance to be destroyed -type can be inconsistent
+
+    def set_image_rotation_angle(self, angle: int):
+        """Set the image rotation angle which will be read in by the presenter"""
+        self.image_rotation_angle = angle
+        self.presenter.update_image_operation()


### PR DESCRIPTION
### Issue

Closes #2003 

### Description

The images in the Live Viewer can now be rotated by 90, 180, or 270 degrees via a right-click menu option. Once selected, this is apply to all images shown in the Live Viewer so the option only needs to be chosen once.
This functionality uses the existing framework in `mantidimaging.core.operations.rotate_stack.rotate_stack.py` successfully suggesting that other operations could be implemented in the Live Viewer in the future.

![image](https://github.com/mantidproject/mantidimaging/assets/30868085/121b94a3-3de3-4311-a2c8-332200bd6e94)

![image](https://github.com/mantidproject/mantidimaging/assets/30868085/62825611-a185-4eca-abc9-50663f398d79)



### Testing 

`make check` runs successfully but unit tests will be added in the future. Currently no testing exists for the Live Viewer window.

### Acceptance Criteria 

Load images into the Live Viewer and check that the data is rotated as expected.

### Documentation

Will be added in release notes
