### PR TITLE
1945 binning

### DIFF
--- a/docs/release_notes/next/feature-1945-export_binned_rits_data
+++ b/docs/release_notes/next/feature-1945-export_binned_rits_data
@@ -1,0 +1,1 @@
+#1945 : Export Binned RITS Formatted Data within Spectrum Viewer.

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -255,7 +255,7 @@ class SpectrumViewerWindowModel:
             csv_output.write(outfile)
             self.save_roi_coords(self.get_roi_coords_filename(path))
 
-    def save_single_rits_spectrum(self, path: Path, normalized: bool, error_mode: ErrorMode, _, __) -> None:
+    def save_single_rits_spectrum(self, path: Path, normalized: bool, error_mode: ErrorMode) -> None:
         """
         Saves the spectrum for the RITS ROI to a RITS file.
 

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -255,7 +255,7 @@ class SpectrumViewerWindowModel:
             csv_output.write(outfile)
             self.save_roi_coords(self.get_roi_coords_filename(path))
 
-    def save_single_rits_spectrum(self, path: Path, normalized: bool, error_mode: ErrorMode) -> None:
+    def save_single_rits_spectrum(self, path: Path, error_mode: ErrorMode) -> None:
         """
         Saves the spectrum for the RITS ROI to a RITS file.
 
@@ -263,21 +263,20 @@ class SpectrumViewerWindowModel:
         @param normalized: Whether to save the normalized spectrum.
         @param error_mode: Which version (standard deviation or propagated) of the error to use in the RITS export
         """
-        self.save_rits_roi(path, normalized, error_mode, self.get_roi(ROI_RITS))
+        self.save_rits_roi(path, error_mode, self.get_roi(ROI_RITS))
 
-    def save_rits_roi(self, path: Path, normalized: bool, error_mode: ErrorMode, roi: SensibleROI) -> None:
+    def save_rits_roi(self, path: Path, error_mode: ErrorMode, roi: SensibleROI) -> None:
         """
         Saves the spectrum for one ROI to a RITS file.
 
         @param path: The path to save the CSV file to.
-        @param normalized: Whether to save the normalized spectrum.
         @param error_mode: Which version (standard deviation or propagated) of the error to use in the RITS export
         """
         if self._stack is None:
             raise ValueError("No stack selected")
 
-        if not normalized or self._normalise_stack is None:
-            raise ValueError("Normalisation must be enabled, and a normalise stack must be selected")
+        if self._normalise_stack is None:
+            raise ValueError("A normalise stack must be selected")
         tof = self.get_stack_time_of_flight()
         if tof is None:
             raise ValueError("No Time of Flights for sample. Make sure spectra log has been loaded")
@@ -316,7 +315,7 @@ class SpectrumViewerWindowModel:
         if bin_size and step_size > min(roi.width, roi.height):
             raise ValueError("Both bin size and step size must be less than or equal to the ROI size")
 
-    def save_rits_images(self, directory: Path, normalised: bool, error_mode: ErrorMode, bin_size, step) -> None:
+    def save_rits_images(self, directory: Path, error_mode: ErrorMode, bin_size, step) -> None:
         """
         Saves multiple Region of Interest (ROI) images to RITS files.
 
@@ -353,7 +352,7 @@ class SpectrumViewerWindowModel:
                 sub_right = min(sub_left + bin_size, right)
                 sub_roi = SensibleROI.from_list([sub_left, sub_top, sub_right, sub_bottom])
                 path = directory / f"rits_image_{x}_{y}.dat"
-                self.save_rits_roi(path, normalised, error_mode, sub_roi)
+                self.save_rits_roi(path, error_mode, sub_roi)
                 if sub_right == right:
                     break
             if sub_bottom == bottom:

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -135,6 +135,18 @@ class SpectrumViewerWindowModel:
 
     @staticmethod
     def get_stack_spectrum(stack: Optional[ImageStack], roi: SensibleROI):
+        """
+        Computes the mean spectrum of the given image stack within the specified region of interest (ROI).
+        If the image stack is None, an empty numpy array is returned.
+        Parameters:
+            stack (Optional[ImageStack]): The image stack to compute the spectrum from.
+                It can be None, in which case an empty array is returned.
+            roi (SensibleROI): The region of interest within the image stack.
+                It is a tuple or list of four integers specifying the left, top, right, and bottom coordinates.
+        Returns:
+            numpy.ndarray: The mean spectrum of the image stack within the ROI.
+                It is a 1D array where each element is the mean of the corresponding layer of the stack within the ROI.
+        """
         if stack is None:
             return np.array([])
         left, top, right, bottom = roi
@@ -282,10 +294,18 @@ class SpectrumViewerWindowModel:
 
     def validate_bin_and_step_size(self, roi, bin_size: int, step_size: int) -> None:
         """
-        Validates the bin and step size for saving RITS images.
-
-        @param bin_size: The bin size to validate.
-        @param step_size: The step size to validate.
+        Validates the bin size and step size for saving RITS images.
+        This method checks the following conditions:
+        - Both bin size and step size must be greater than 0.
+        - Bin size must be larger than or equal to step size.
+        - Both bin size and step size must be less than or equal to the smallest dimension of the ROI.
+        If any of these conditions are not met, a ValueError is raised.
+        Parameters:
+            roi: The region of interest (ROI) to which the bin size and step size should be compared.
+            bin_size (int): The size of the bins to be validated.
+            step_size (int): The size of the steps to be validated.
+        Raises:
+            ValueError: If any of the validation conditions are not met.
         """
         if bin_size and step_size < 1:
             raise ValueError("Both bin size and step size must be greater than 0")
@@ -300,7 +320,7 @@ class SpectrumViewerWindowModel:
 
         This method divides the ROI into multiple sub-regions of size 'bin_size' and saves each sub-region
         as a separate RITS image.
-        The sub-regions are created by sliding a windo of size 'bin_size' across the ROI with a step size of 'step'.
+        The sub-regions are created by sliding a window of size 'bin_size' across the ROI with a step size of 'step'.
 
         During each iteration on a given axis by the step size, a check is made to see if
         the sub_roi has reached the end of the ROI on that axis and if so, the iteration for that axis is stopped.

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -168,11 +168,13 @@ class SpectrumViewerWindowModel:
             return "Stack shapes must match"
         return ""
 
-    def get_spectrum(self, roi_name: str, mode: SpecType) -> 'np.ndarray':
+    def get_spectrum(self, roi: str | SensibleROI, mode: SpecType) -> 'np.ndarray':
         if self._stack is None:
             return np.array([])
 
-        roi = self.get_roi(roi_name)
+        if isinstance(roi, str):
+            roi = self.get_roi(roi)
+
         if mode == SpecType.SAMPLE:
             return self.get_stack_spectrum(self._stack, roi)
 
@@ -281,7 +283,7 @@ class SpectrumViewerWindowModel:
             raise ValueError("No Time of Flights for sample. Make sure spectra log has been loaded")
 
         tof *= 1e6  # RITS expects ToF in μs
-        transmission = self.get_spectrum(ROI_RITS, SpecType.SAMPLE_NORMED)
+        transmission = self.get_spectrum(roi, SpecType.SAMPLE_NORMED)
 
         if error_mode == ErrorMode.STANDARD_DEVIATION:
             transmission_error = self.get_transmission_error_standard_dev(roi)

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -279,6 +279,20 @@ class SpectrumViewerWindowModel:
 
         self.export_spectrum_to_rits(path, tof, transmission, transmission_error)
 
+    def validate_bin_and_step_size(self, roi, bin_size: int, step_size: int) -> None:
+        """
+        Validates the bin and step size for saving RITS images.
+
+        @param bin_size: The bin size to validate.
+        @param step_size: The step size to validate.
+        """
+        if bin_size and step_size < 1:
+            raise ValueError("Both bin size and step size must be greater than 0")
+        if bin_size <= step_size:
+            raise ValueError("Bin size must be larger than or equal to step size")
+        if bin_size and step_size > min(roi.width, roi.height):
+            raise ValueError("Both bin size and step size must be less than or equal to the ROI size")
+
     def save_rits_images(self, directory: Path, normalised: bool, error_mode: ErrorMode, bin_size, step) -> None:
         """
         Saves multiple Region of Interest (ROI) images to RITS files.
@@ -289,7 +303,7 @@ class SpectrumViewerWindowModel:
 
 
         Parameters:
-        directory (Optional[Path]): The directory where the RITS images will be saved. If None, no images will be saved.
+        directory ([Path): The directory where the RITS images will be saved. If None, no images will be saved.
         normalised (bool): If True, the images will be normalised.
         error_mode (ErrorMode): The error mode to use when saving the images.
         bin_size (int): The size of the sub-regions.
@@ -301,6 +315,7 @@ class SpectrumViewerWindowModel:
         left, top, right, bottom = self.get_roi(ROI_RITS)
         new_right, new_bottom = left + bin_size, top + bin_size
         x_iterations, y_iterations = (right - left) - bin_size + 1, (bottom - top) - bin_size + 1
+        self.validate_bin_and_step_size(self.get_roi(ROI_RITS), bin_size, step)
         for y in range(y_iterations):
             for x in range(x_iterations):
                 sub_left = left + x * step

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -179,19 +179,18 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
         if self.binned and self.bin_size > 0 and self.bin_step > 0:
             path = self.view.get_rits_export_directory()
-            save_method = self.model.save_rits_images
-            args = (path, is_sample_normed, error_mode, self.bin_size, self.bin_step)
+            if path is None:
+                LOG.debug("No path selected, aborting export")
+                return
+            self.model.save_rits_images(path, is_sample_normed, error_mode, self.bin_size, self.bin_step)
         else:
             path = self.view.get_rits_export_filename()
+            if path is None:
+                LOG.debug("No path selected, aborting export")
+                return
             if path and path.suffix != ".dat":
                 path = path.with_suffix(".dat")
-            save_method = self.model.save_single_rits_spectrum  # type: ignore
-            args = (path, is_sample_normed, error_mode, None, None)  # type: ignore
-        if path is None:
-            LOG.debug("No path selected, aborting export")
-            return
-
-        save_method(*args)  # type: ignore
+            self.model.save_single_rits_spectrum(path, is_sample_normed, error_mode)
 
     def handle_enable_normalised(self, enabled: bool) -> None:
         if enabled:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -46,9 +46,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.main_window = main_window
         self.model = SpectrumViewerWindowModel(self)
         self.export_mode = ExportMode.ROI_MODE
-        self.binned: bool = False
-        self.bin_size: int = 0
-        self.bin_step: int = 0
 
     def handle_sample_change(self, uuid: Optional['UUID']) -> None:
         if uuid == self.current_stack_uuid:
@@ -176,12 +173,12 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         error_mode = ErrorMode.get_by_value(self.view.transmission_error_mode)
 
-        if self.binned and self.bin_size > 0 and self.bin_step > 0:
+        if self.view.image_output_mode == "2D Binned":
             path = self.view.get_rits_export_directory()
             if path is None:
                 LOG.debug("No path selected, aborting export")
                 return
-            self.model.save_rits_images(path, error_mode, self.bin_size, self.bin_step)
+            self.model.save_rits_images(path, error_mode, self.view.bin_size, self.view.bin_step)
         else:
             path = self.view.get_rits_export_filename()
             if path is None:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -175,14 +175,13 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         Handle the export of the current spectrum to a RITS file format
         """
         error_mode = ErrorMode.get_by_value(self.view.transmission_error_mode)
-        is_sample_normed = self.spectrum_mode == SpecType.SAMPLE_NORMED
 
         if self.binned and self.bin_size > 0 and self.bin_step > 0:
             path = self.view.get_rits_export_directory()
             if path is None:
                 LOG.debug("No path selected, aborting export")
                 return
-            self.model.save_rits_images(path, is_sample_normed, error_mode, self.bin_size, self.bin_step)
+            self.model.save_rits_images(path, error_mode, self.bin_size, self.bin_step)
         else:
             path = self.view.get_rits_export_filename()
             if path is None:
@@ -190,7 +189,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                 return
             if path and path.suffix != ".dat":
                 path = path.with_suffix(".dat")
-            self.model.save_single_rits_spectrum(path, is_sample_normed, error_mode)
+            self.model.save_single_rits_spectrum(path, error_mode)
 
     def handle_enable_normalised(self, enabled: bool) -> None:
         if enabled:

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -196,7 +196,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
 
         mock_stream, mock_path = self._make_mock_path_stream()
         with mock.patch.object(self.model, "save_roi_coords"):
-            self.model.save_rits_roi(mock_path, True, ErrorMode.STANDARD_DEVIATION, self.model.get_roi("rits_roi"))
+            self.model.save_rits_roi(mock_path, ErrorMode.STANDARD_DEVIATION, self.model.get_roi("rits_roi"))
 
         mock_path.open.assert_called_once_with("w")
         self.assertIn("0.0\t0.0\t0.0", mock_stream.captured[0])
@@ -214,7 +214,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
 
         mock_stream, mock_path = self._make_mock_path_stream()
         with mock.patch.object(self.model, "save_roi_coords"):
-            self.model.save_rits_roi(mock_path, True, ErrorMode.STANDARD_DEVIATION, self.model.get_roi("rits_roi"))
+            self.model.save_rits_roi(mock_path, ErrorMode.STANDARD_DEVIATION, self.model.get_roi("rits_roi"))
 
         mock_path.open.assert_called_once_with("w")
         self.assertIn("0.0\t0.0\t0.0", mock_stream.captured[0])
@@ -238,7 +238,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         mock_stream, mock_path = self._make_mock_path_stream()
         with mock.patch.object(self.model, "save_roi_coords"):
             with mock.patch.object(self.model, "export_spectrum_to_rits") as mock_export:
-                self.model.save_rits_roi(mock_path, True, error_mode, self.model.get_roi("rits_roi"))
+                self.model.save_rits_roi(mock_path, error_mode, self.model.get_roi("rits_roi"))
 
         calculated_errors = mock_export.call_args[0][3]
         np.testing.assert_allclose(expected_error, calculated_errors, atol=1e-4)
@@ -251,8 +251,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
 
         mock_stream, mock_path = self._make_mock_path_stream()
         with mock.patch.object(self.model, "save_roi_coords"):
-            self.assertRaises(ValueError, self.model.save_rits_roi, mock_path, True, None,
-                              self.model.get_roi("rits_roi"))
+            self.assertRaises(ValueError, self.model.save_rits_roi, mock_path, None, self.model.get_roi("rits_roi"))
         mock_path.open.assert_not_called()
 
     def test_save_rits_no_norm_err(self):
@@ -268,7 +267,6 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
                 ValueError,
                 self.model.save_rits_roi,
                 mock_path,
-                False,
                 ErrorMode.STANDARD_DEVIATION,
                 self.model.get_roi("rits_roi"),
             )
@@ -287,7 +285,6 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
                 ValueError,
                 self.model.save_rits_roi,
                 mock_path,
-                True,
                 ErrorMode.STANDARD_DEVIATION,
                 self.model.get_roi("rits_roi"),
             )
@@ -466,7 +463,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
 
         _, mock_path = self._make_mock_path_stream()
         with mock.patch.object(self.model, "save_roi_coords"):
-            self.model.save_rits_images(mock_path, True, ErrorMode.STANDARD_DEVIATION, bin_size, step)
+            self.model.save_rits_images(mock_path, ErrorMode.STANDARD_DEVIATION, bin_size, step)
         self.assertEqual(mock_save_rits_roi.call_count, expected_number_of_calls)
 
     @mock.patch.object(SpectrumViewerWindowModel, "save_rits_roi")
@@ -480,7 +477,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
 
         _, mock_path = self._make_mock_path_stream()
         with mock.patch.object(self.model, "save_roi_coords"):
-            self.model.save_single_rits_spectrum(mock_path, True, ErrorMode.STANDARD_DEVIATION)
+            self.model.save_single_rits_spectrum(mock_path, ErrorMode.STANDARD_DEVIATION)
         mock_save_rits_roi.assert_called_once()
 
     @mock.patch.object(SpectrumViewerWindowModel, "export_spectrum_to_rits")
@@ -494,7 +491,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         self.model.set_normalise_stack(norm)
         mock_path = mock.create_autospec(Path)
 
-        self.model.save_rits_images(mock_path, True, ErrorMode.STANDARD_DEVIATION, 3, 1)
+        self.model.save_rits_images(mock_path, ErrorMode.STANDARD_DEVIATION, 3, 1)
 
         self.assertEqual(6, len(mock_save_rits_roi.call_args_list))
         expected_means = [1, 1.5, 2, 1, 1.5, 2]  # running average of [1, 2, 3, 4, 5], divided by 2 for normalisation

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -195,7 +195,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
 
         mock_stream, mock_path = self._make_mock_path_stream()
         with mock.patch.object(self.model, "save_roi_coords"):
-            self.model.save_rits(mock_path, True, ErrorMode.STANDARD_DEVIATION)
+            self.model.save_rits_roi(mock_path, True, ErrorMode.STANDARD_DEVIATION, self.model.get_roi("rits_roi"))
 
         mock_path.open.assert_called_once_with("w")
         self.assertIn("0.0\t0.0\t0.0", mock_stream.captured[0])
@@ -213,7 +213,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
 
         mock_stream, mock_path = self._make_mock_path_stream()
         with mock.patch.object(self.model, "save_roi_coords"):
-            self.model.save_rits(mock_path, True, ErrorMode.STANDARD_DEVIATION)
+            self.model.save_rits_roi(mock_path, True, ErrorMode.STANDARD_DEVIATION, self.model.get_roi("rits_roi"))
 
         mock_path.open.assert_called_once_with("w")
         self.assertIn("0.0\t0.0\t0.0", mock_stream.captured[0])
@@ -237,7 +237,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         mock_stream, mock_path = self._make_mock_path_stream()
         with mock.patch.object(self.model, "save_roi_coords"):
             with mock.patch.object(self.model, "export_spectrum_to_rits") as mock_export:
-                self.model.save_rits(mock_path, True, error_mode)
+                self.model.save_rits_roi(mock_path, True, error_mode, self.model.get_roi("rits_roi"))
 
         calculated_errors = mock_export.call_args[0][3]
         np.testing.assert_allclose(expected_error, calculated_errors, atol=1e-4)
@@ -250,7 +250,8 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
 
         mock_stream, mock_path = self._make_mock_path_stream()
         with mock.patch.object(self.model, "save_roi_coords"):
-            self.assertRaises(ValueError, self.model.save_rits, mock_path, True, None)
+            self.assertRaises(ValueError, self.model.save_rits_roi, mock_path, True, None,
+                              self.model.get_roi("rits_roi"))
         mock_path.open.assert_not_called()
 
     def test_save_rits_no_norm_err(self):
@@ -262,7 +263,14 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
 
         mock_stream, mock_path = self._make_mock_path_stream()
         with mock.patch.object(self.model, "save_roi_coords"):
-            self.assertRaises(ValueError, self.model.save_rits, mock_path, False, ErrorMode.STANDARD_DEVIATION)
+            self.assertRaises(
+                ValueError,
+                self.model.save_rits_roi,
+                mock_path,
+                False,
+                ErrorMode.STANDARD_DEVIATION,
+                self.model.get_roi("rits_roi"),
+            )
         mock_path.open.assert_not_called()
 
     def test_save_rits_no_tof_err(self):
@@ -274,7 +282,14 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
 
         mock_stream, mock_path = self._make_mock_path_stream()
         with mock.patch.object(self.model, "save_roi_coords"):
-            self.assertRaises(ValueError, self.model.save_rits, mock_path, True, ErrorMode.STANDARD_DEVIATION)
+            self.assertRaises(
+                ValueError,
+                self.model.save_rits_roi,
+                mock_path,
+                True,
+                ErrorMode.STANDARD_DEVIATION,
+                self.model.get_roi("rits_roi"),
+            )
         mock_path.open.assert_not_called()
 
     def test_WHEN_save_csv_called_THEN_save_roi_coords_called_WITH_correct_args(self):

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -480,7 +480,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
 
         _, mock_path = self._make_mock_path_stream()
         with mock.patch.object(self.model, "save_roi_coords"):
-            self.model.save_single_rits_spectrum(mock_path, True, ErrorMode.STANDARD_DEVIATION, _, _)
+            self.model.save_single_rits_spectrum(mock_path, True, ErrorMode.STANDARD_DEVIATION)
         mock_save_rits_roi.assert_called_once()
 
     @mock.patch.object(SpectrumViewerWindowModel, "export_spectrum_to_rits")

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -200,7 +200,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.handle_rits_export()
 
         self.view.get_rits_export_filename.assert_called_once()
-        mock_save_rits_roi.assert_called_once_with(Path("/fake/path.dat"), False, ErrorMode.STANDARD_DEVIATION,
+        mock_save_rits_roi.assert_called_once_with(Path("/fake/path.dat"), ErrorMode.STANDARD_DEVIATION,
                                                    self.presenter.model.get_roi("rits_roi"))
 
     def test_WHEN_do_add_roi_called_THEN_new_roi_added(self):

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -189,17 +189,19 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         mock_save_csv.assert_called_once_with(Path("/fake/path.csv"), False)
 
     @parameterized.expand(["/fake/path", "/fake/path.dat"])
-    @mock.patch("mantidimaging.gui.windows.spectrum_viewer.model.SpectrumViewerWindowModel.save_rits")
-    def test_handle_rits_export(self, path_name: str, mock_save_rits: mock.Mock):
+    @mock.patch("mantidimaging.gui.windows.spectrum_viewer.model.SpectrumViewerWindowModel.save_rits_roi")
+    def test_handle_rits_export(self, path_name: str, mock_save_rits_roi: mock.Mock):
         self.view.get_rits_export_filename = mock.Mock(return_value=Path(path_name))
         self.view.transmission_error_mode = "Standard Deviation"
+        self.presenter.model.set_new_roi("rits_roi")
 
         self.presenter.model.set_stack(generate_images())
 
         self.presenter.handle_rits_export()
 
         self.view.get_rits_export_filename.assert_called_once()
-        mock_save_rits.assert_called_once_with(Path("/fake/path.dat"), False, ErrorMode.STANDARD_DEVIATION)
+        mock_save_rits_roi.assert_called_once_with(Path("/fake/path.dat"), False, ErrorMode.STANDARD_DEVIATION,
+                                                   self.presenter.model.get_roi("rits_roi"))
 
     def test_WHEN_do_add_roi_called_THEN_new_roi_added(self):
         self.presenter.model.set_stack(generate_images())

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -198,7 +198,17 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         else:
             return None
 
-    def get_rits_export_filename(self) -> Optional[Path]:
+    def get_rits_export_directory(self) -> Path | None:
+        """
+        Get the path to save the RITS file too
+        """
+        path = QFileDialog.getExistingDirectory(self, "Select Directory", "", QFileDialog.ShowDirsOnly)
+        if path:
+            return Path(path)
+        else:
+            return None
+
+    def get_rits_export_filename(self) -> Path | None:
         """
         Get the path to save the RITS file too
         """
@@ -334,3 +344,21 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.bin_size_spinBox.setHidden(hide_binning)
         self.bin_step_label.setHidden(hide_binning)
         self.bin_step_spinBox.setHidden(hide_binning)
+        self.set_binning()
+
+    def set_binning(self) -> None:
+        """
+        Sets the binning configuration for image output.
+
+        If the image output mode is set to "2D Binned", the bin size and bin
+        step are set within the presenter.
+        The presenter's 'binned' attribute is set to True.
+        If the image output mode is not "2D Binned", it will
+        simply set the presenter's 'binned' attribute to False.
+        """
+        if self.image_output_mode == "2D Binned":
+            self.presenter.bin_size = self.bin_size_spinBox.value()
+            self.presenter.bin_step = self.bin_step_spinBox.value()
+            self.presenter.binned = True
+        else:
+            self.presenter.binned = False

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2023 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
+
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
@@ -332,11 +333,11 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
     @property
     def bin_size(self) -> int:
-        return self.bin_size_spinbox.value()
+        return self.bin_size_spinBox.value()
 
     @property
     def bin_step(self) -> int:
-        return self.bin_step_spinbox.value()
+        return self.bin_step_spinBox.value()
 
     def set_binning_visibility(self) -> None:
         hide_binning = self.image_output_mode != "2D Binned"
@@ -344,21 +345,3 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.bin_size_spinBox.setHidden(hide_binning)
         self.bin_step_label.setHidden(hide_binning)
         self.bin_step_spinBox.setHidden(hide_binning)
-        self.set_binning()
-
-    def set_binning(self) -> None:
-        """
-        Sets the binning configuration for image output.
-
-        If the image output mode is set to "2D Binned", the bin size and bin
-        step are set within the presenter.
-        The presenter's 'binned' attribute is set to True.
-        If the image output mode is not "2D Binned", it will
-        simply set the presenter's 'binned' attribute to False.
-        """
-        if self.image_output_mode == "2D Binned":
-            self.presenter.bin_size = self.bin_size_spinBox.value()
-            self.presenter.bin_step = self.bin_step_spinBox.value()
-            self.presenter.binned = True
-        else:
-            self.presenter.binned = False


### PR DESCRIPTION
### Issue

Closes #1945 

### Description

* Connects Front-end RITS binned export to back-end
* Bin RITS spectrum data taking a bin size and step size  as input
* Bin input validation
* Refactor existing test
* Write additional tests for new methods.

### Testing 

* Manual Testing:
    * Check that the correct number of files are exported
    * Added print statements within `save_rits_images()` to validate ROI size and sub-ROI position through each iteration as sub-ROI steps across and down each row and column of ROI.
    * Checked output files
*  Reviewed automated tests.

### Acceptance Criteria 

* Tests (`mantidimaging/gui/windows/spectrum_viewer/test` ) pass
* Within the spectrum viewer, binned RITS data can now be exported to a folder.
* Binned data is correct for standard deviation and propagated modes

### Documentation

See: `docs/release_notes/next/feature-1945-export_binned_rits_data`
