### PR TITLE
Live viewer operations pipeline

### DIFF
--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -130,8 +130,10 @@ class LiveViewerWindowPresenter(BasePresenter):
         return ImageStack(image_data_temp)
 
     def perform_operations(self, image_data):
+        if not self.view.filter_params:
+            return image_data
         image_stack = self.convert_image_to_imagestack(image_data)
-        for operation in self.view.activated_operations:
+        for operation in self.view.filter_params:
             op_class = self.filters[operation]
             op_func = op_class.filter_func
             op_params = self.view.filter_params[operation]["params"]

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from mantidimaging.gui.windows.live_viewer.view import LiveViewerWindowView  # pragma: no cover
     from mantidimaging.gui.windows.main.view import MainWindowView  # pragma: no cover
 
-
 logger = getLogger(__name__)
 
 
@@ -89,7 +88,7 @@ class LiveViewerWindowPresenter(BasePresenter):
                 with fits.open(image_path.__str__()) as fit:
                     image_data = fit[0].data
 
-            image_data = self.rotate_image(image_data, 90)
+            image_data = self.rotate_image(image_data)
         except (IOError, KeyError, ValueError, TiffFileError, DeflateError) as error:
             message = f"{type(error).__name__} reading image: {image_path}: {error}"
             logger.error(message)
@@ -113,10 +112,15 @@ class LiveViewerWindowPresenter(BasePresenter):
         if self.selected_image and image_path == self.selected_image.image_path:
             self.load_and_display_image(image_path)
 
-    def rotate_image(self, image_data, ang: int):
+    def rotate_image(self, image_data):
+        ang = self.view.image_rotation_angle
         image_data_shape = image_data.shape
         image_data_temp = np.zeros(shape=(1, image_data_shape[0], image_data_shape[1]))
         image_data_temp[0] = image_data
         image_stack_temp = ImageStack(image_data_temp)
         rotated_imaged = RotateFilter().filter_func(image_stack_temp, angle=ang)
         return rotated_imaged.data[0].astype(int)
+
+    def update_image_operation(self):
+        """ Reload the current image if an operation has been performed on the current image"""
+        self.load_and_display_image(self.selected_image.image_path)

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from pathlib import Path
-from typing import TYPE_CHECKING, Set, Dict
+from typing import TYPE_CHECKING, Dict
 
 from PyQt5.QtCore import QSignalBlocker
 from PyQt5.QtWidgets import QVBoxLayout
@@ -36,9 +36,7 @@ class LiveViewerWindowView(BaseMainWindowView):
         self.imageLayout.addWidget(self.live_viewer)
         self.live_viewer.z_slider.valueChanged.connect(self.presenter.select_image)
 
-        self.activated_operations: Set[str] = set()
         self.filter_params: Dict[str, Dict] = {}
-        self.image_rotation_angle = 0
         self.right_click_menu = self.live_viewer.image.vb.menu
         operations_menu = self.right_click_menu.addMenu("Operations")
         gaussian_menu = operations_menu.addMenu("Gaussian")
@@ -106,21 +104,17 @@ class LiveViewerWindowView(BaseMainWindowView):
     def set_image_rotation_angle(self):
         """Set the image rotation angle which will be read in by the presenter"""
         if self.rotate_angles_group.checkedAction().text() == "0°":
-            pass
-            if "Rotate Stack" in self.activated_operations:
-                self.activated_operations.remove("Rotate Stack")
+            if "Rotate Stack" in self.filter_params:
+                del self.filter_params["Rotate Stack"]
         else:
-            self.image_rotation_angle = int(self.rotate_angles_group.checkedAction().text().replace('°', ''))
-            self.filter_params["Rotate Stack"] = {"params": {"angle": self.image_rotation_angle}}
-            self.activated_operations.add('Rotate Stack')
+            image_rotation_angle = int(self.rotate_angles_group.checkedAction().text().replace('°', ''))
+            self.filter_params["Rotate Stack"] = {"params": {"angle": image_rotation_angle}}
         self.presenter.update_image_operation()
 
     def set_gaussian_params(self):
         if self.gaussian_group.checkedAction().text() == "Off":
-            pass
-            if "Gaussian" in self.activated_operations:
-                self.activated_operations.remove("Gaussian")
+            if "Gaussian" in self.filter_params:
+                del self.filter_params["Gaussian"]
         else:
             self.filter_params["Gaussian"] = {"params": {"size": 2, "order": 0, "mode": "reflect"}}
-            self.activated_operations.add('Gaussian')
         self.presenter.update_image_operation()

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -39,16 +39,6 @@ class LiveViewerWindowView(BaseMainWindowView):
         self.filter_params: Dict[str, Dict] = {}
         self.right_click_menu = self.live_viewer.image.vb.menu
         operations_menu = self.right_click_menu.addMenu("Operations")
-        gaussian_menu = operations_menu.addMenu("Gaussian")
-        self.gaussian_group = QActionGroup(self)
-        gaussian_options = ["Off", "size=2 order=0 mode=reflect"]
-        for gaussian_option in gaussian_options:
-            action = QAction(gaussian_option, self.gaussian_group)
-            action.setCheckable(True)
-            gaussian_menu.addAction(action)
-            action.triggered.connect(self.set_gaussian_params)
-            if gaussian_option == "Off":
-                action.setChecked(True)
 
         rotate_menu = operations_menu.addMenu("Rotate Image")
         self.rotate_angles_group = QActionGroup(self)
@@ -109,12 +99,4 @@ class LiveViewerWindowView(BaseMainWindowView):
         else:
             image_rotation_angle = int(self.rotate_angles_group.checkedAction().text().replace('°', ''))
             self.filter_params["Rotate Stack"] = {"params": {"angle": image_rotation_angle}}
-        self.presenter.update_image_operation()
-
-    def set_gaussian_params(self):
-        if self.gaussian_group.checkedAction().text() == "Off":
-            if "Gaussian" in self.filter_params:
-                del self.filter_params["Gaussian"]
-        else:
-            self.filter_params["Gaussian"] = {"params": {"size": 2, "order": 0, "mode": "reflect"}}
         self.presenter.update_image_operation()

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from PyQt5.QtCore import QSignalBlocker
+from PyQt5.QtCore import QSignalBlocker, QCoreApplication
 from PyQt5.QtWidgets import QVBoxLayout
+from PyQt5.Qt import QAction, QActionGroup
 
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from .live_view_widget import LiveViewWidget
@@ -15,6 +16,8 @@ import numpy as np
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
+
+translate = QCoreApplication.translate
 
 
 class LiveViewerWindowView(BaseMainWindowView):
@@ -34,6 +37,23 @@ class LiveViewerWindowView(BaseMainWindowView):
         self.live_viewer = LiveViewWidget()
         self.imageLayout.addWidget(self.live_viewer)
         self.live_viewer.z_slider.valueChanged.connect(self.presenter.select_image)
+        self.image_rotation_angle = 0
+        self.right_click_menu = self.live_viewer.image.vb.menu
+        rotate_menu = self.right_click_menu.addMenu(translate("ViewBox", "Rotate Image"))
+        rotate_angles_group = QActionGroup(self)
+        rotate_0 = QAction(translate("ViewBox", "0" + u'\N{DEGREE SIGN}'), rotate_angles_group)
+        rotate_90 = QAction(translate("ViewBox", "90" + u'\N{DEGREE SIGN}'), rotate_angles_group)
+        rotate_180 = QAction(translate("ViewBox", "180" + u'\N{DEGREE SIGN}'), rotate_angles_group)
+        rotate_270 = QAction(translate("ViewBox", "270" + u'\N{DEGREE SIGN}'), rotate_angles_group)
+        rotate_0.setCheckable(True)
+        rotate_90.setCheckable(True)
+        rotate_180.setCheckable(True)
+        rotate_270.setCheckable(True)
+        rotate_menu.addActions(rotate_angles_group.actions())
+        rotate_0.triggered.connect(lambda: self.set_image_rotation_angle(0))
+        rotate_90.triggered.connect(lambda: self.set_image_rotation_angle(90))
+        rotate_180.triggered.connect(lambda: self.set_image_rotation_angle(180))
+        rotate_270.triggered.connect(lambda: self.set_image_rotation_angle(270))
 
     def show(self) -> None:
         """Show the window"""
@@ -74,3 +94,8 @@ class LiveViewerWindowView(BaseMainWindowView):
         self.live_viewer.handle_deleted()
         super().closeEvent(e)
         self.presenter = None  # type: ignore # View instance to be destroyed -type can be inconsistent
+
+    def set_image_rotation_angle(self, angle: int):
+        """Set the image rotation angle which will be read in by the presenter"""
+        self.image_rotation_angle = angle
+        self.presenter.update_image_operation()


### PR DESCRIPTION
### Issue

Closes issue #2018

### Description

The process for adding and activating operations to be used in the Live Viewer is now generalised into a pipeline.

The operations you want to use can be activated via a right click menu and the appropriate settings are used with the existing Operations framework.

![image](https://github.com/mantidproject/mantidimaging/assets/30868085/31470c14-f804-4804-8735-e29b0a4506e3)

![image](https://github.com/mantidproject/mantidimaging/assets/30868085/50722ea9-a693-4c35-92ae-fba99778c047)



Right now, the Rotate Stack operation can be used via the right click menu "Operations".
An instance of a Gaussian filter can also be activated in order to test the generalisation and ease of adding operations to the pipeline as needed.
The Gaussian filter can be deleted before merging as it may not have much use in real operations.

Once activated, the operations can be deactivated via "0" or "Off" options to prevent slow down if a large number of operations are used concurrently.

Screenshot of both Gaussian and Rotate Stack operations in use: 

![image](https://github.com/mantidproject/mantidimaging/assets/30868085/85170086-2b80-43f5-9cbf-01e012e20522)


### Testing 

make check

### Acceptance Criteria 

Check that the Rotate Stack and Gaussian filters can be used as expected in the Live Viewer. They should be able to be used independently and simultaneously with no notable slow down

### Documentation

Documentation of this feature will be added in the release notes.
