### PR TITLE
Live viewer brightness adjustment

### DIFF
--- a/mantidimaging/gui/windows/live_viewer/live_view_widget.py
+++ b/mantidimaging/gui/windows/live_viewer/live_view_widget.py
@@ -31,7 +31,7 @@ class LiveViewWidget(GraphicsLayoutWidget):
 
         self.image.enable_message()
 
-        self.image.set_brightness_percentiles(5, 95)
+        self.image.set_brightness_percentiles(0, 99)
 
     def show_image(self, image: np.ndarray) -> None:
         """


### PR DESCRIPTION
### Issue

Closes #2001 

### Description

Live Viewer brightness percentiles changed to 0 and 99 as requested by the IMAT Scientists as previous setting (5, 95) cut off too much of the data.

### Testing 

make check

### Acceptance Criteria 

Check that images look OK in the Live Viewer.
