### PR TITLE
Resizable tof spectrum viewer

### DIFF
--- a/docs/release_notes/next/feature-2026-resizable-tof-spectrum
+++ b/docs/release_notes/next/feature-2026-resizable-tof-spectrum
@@ -1,0 +1,1 @@
+#2026: Time of flight graph in the Spectrum Viewer is now resizable

--- a/mantidimaging/eyes_tests/spectrum_viewer_test.py
+++ b/mantidimaging/eyes_tests/spectrum_viewer_test.py
@@ -40,6 +40,6 @@ class SpectrumViewerWindowTest(BaseEyesTest):
         self.imaging.spectrum_viewer.normaliseCheckBox.setChecked(True)
         self.imaging.spectrum_viewer.normaliseStackSelector.try_to_select_relevant_stack("Open Beam Stack")
         self.imaging.spectrum_viewer.set_new_roi()
-        self.imaging.spectrum_viewer.spectrum.roi_dict["roi_1"].setSize(2, 2)
-        self.imaging.spectrum_viewer.spectrum.roi_dict["roi_1"].setPos(5, 5)
+        self.imaging.spectrum_viewer.spectrumWidget.roi_dict["roi_1"].setSize(2, 2)
+        self.imaging.spectrum_viewer.spectrumWidget.roi_dict["roi_1"].setPos(5, 5)
         self.check_target(widget=self.imaging.spectrum_viewer)

--- a/mantidimaging/eyes_tests/spectrum_viewer_test.py
+++ b/mantidimaging/eyes_tests/spectrum_viewer_test.py
@@ -40,6 +40,6 @@ class SpectrumViewerWindowTest(BaseEyesTest):
         self.imaging.spectrum_viewer.normaliseCheckBox.setChecked(True)
         self.imaging.spectrum_viewer.normaliseStackSelector.try_to_select_relevant_stack("Open Beam Stack")
         self.imaging.spectrum_viewer.set_new_roi()
-        self.imaging.spectrum_viewer.spectrumWidget.roi_dict["roi_1"].setSize(2, 2)
-        self.imaging.spectrum_viewer.spectrumWidget.roi_dict["roi_1"].setPos(5, 5)
+        self.imaging.spectrum_viewer.spectrum_widget.roi_dict["roi_1"].setSize(2, 2)
+        self.imaging.spectrum_viewer.spectrum_widget.roi_dict["roi_1"].setPos(5, 5)
         self.check_target(widget=self.imaging.spectrum_viewer)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -114,7 +114,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
 
         self.view.set_image(self.model.get_averaged_image())
-        self.view.spectrum.add_range(*self.model.tof_range)
+        self.view.spectrumWidget.spectrum_plot_widget.add_range(*self.model.tof_range)
         self.view.auto_range_image()
 
     def handle_range_slide_moved(self, tof_range) -> None:
@@ -126,7 +126,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         Handle changes to any ROI position and size.
         """
         for name in self.model.get_list_of_roi_names():
-            roi = self.view.spectrum.get_roi(name)
+            roi = self.view.spectrumWidget.get_roi(name)
             if force_new_spectrums or roi != self.model.get_roi(name):
                 self.model.set_roi(name, roi)
                 self.view.set_spectrum(name, self.model.get_spectrum(name, self.spectrum_mode))
@@ -142,7 +142,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         Redraw all ROIs and spectrum plots
         """
         for name in self.model.get_list_of_roi_names():
-            self.model.set_roi(name, self.view.spectrum.get_roi(name))
+            self.model.set_roi(name, self.view.spectrumWidget.get_roi(name))
             self.view.set_spectrum(name, self.model.get_spectrum(name, self.spectrum_mode))
 
     def handle_button_enabled(self) -> None:
@@ -202,7 +202,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         roi_name = self.model.roi_name_generator()
         self.model.set_new_roi(roi_name)
-        self.view.spectrum.add_roi(self.model.get_roi(roi_name), roi_name)
+        self.view.spectrumWidget.add_roi(self.model.get_roi(roi_name), roi_name)
         self.view.set_spectrum(roi_name, self.model.get_spectrum(roi_name, self.spectrum_mode))
         self.view.auto_range_image()
         self.do_add_roi_to_table(roi_name)
@@ -210,7 +210,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
     def add_rits_roi(self) -> None:
         roi_name = ROI_RITS
         self.model.set_new_roi(roi_name)
-        self.view.spectrum.add_roi(self.model.get_roi(roi_name), roi_name)
+        self.view.spectrumWidget.add_roi(self.model.get_roi(roi_name), roi_name)
         self.view.set_spectrum(roi_name, self.model.get_spectrum(roi_name, self.spectrum_mode))
         self.view.set_roi_alpha(0, ROI_RITS)
 
@@ -220,7 +220,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
         @param roi_name: Name of the ROI to add
         """
-        roi_colour = self.view.spectrum.roi_dict[roi_name].colour
+        roi_colour = self.view.spectrumWidget.roi_dict[roi_name].colour
         self.view.add_roi_table_row(roi_name, roi_colour)
 
     def rename_roi(self, old_name: str, new_name: str) -> None:
@@ -230,7 +230,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         @param old_name: Name of the ROI to rename
         @param new_name: New name of the ROI
         """
-        self.view.spectrum.rename_roi(old_name, new_name)
+        self.view.spectrumWidget.rename_roi(old_name, new_name)
         self.model.rename_roi(old_name, new_name)
 
     def do_remove_roi(self, roi_name: str | None = None) -> None:
@@ -243,10 +243,10 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         if roi_name is None:
             self.view.clear_all_rois()
             for roi in self.get_roi_names():
-                self.view.spectrum.remove_roi(roi)
+                self.view.spectrumWidget.remove_roi(roi)
             self.model.remove_all_roi()
         else:
-            self.view.spectrum.remove_roi(roi_name)
+            self.view.spectrumWidget.remove_roi(roi_name)
             self.view.set_spectrum(roi_name, self.model.get_spectrum(roi_name, self.spectrum_mode))
             self.model.remove_roi(roi_name)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -114,7 +114,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
 
         self.view.set_image(self.model.get_averaged_image())
-        self.view.spectrumWidget.spectrum_plot_widget.add_range(*self.model.tof_range)
+        self.view.spectrum_widget.spectrum_plot_widget.add_range(*self.model.tof_range)
         self.view.auto_range_image()
 
     def handle_range_slide_moved(self, tof_range) -> None:
@@ -126,7 +126,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         Handle changes to any ROI position and size.
         """
         for name in self.model.get_list_of_roi_names():
-            roi = self.view.spectrumWidget.get_roi(name)
+            roi = self.view.spectrum_widget.get_roi(name)
             if force_new_spectrums or roi != self.model.get_roi(name):
                 self.model.set_roi(name, roi)
                 self.view.set_spectrum(name, self.model.get_spectrum(name, self.spectrum_mode))
@@ -142,7 +142,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         Redraw all ROIs and spectrum plots
         """
         for name in self.model.get_list_of_roi_names():
-            self.model.set_roi(name, self.view.spectrumWidget.get_roi(name))
+            self.model.set_roi(name, self.view.spectrum_widget.get_roi(name))
             self.view.set_spectrum(name, self.model.get_spectrum(name, self.spectrum_mode))
 
     def handle_button_enabled(self) -> None:
@@ -202,7 +202,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         roi_name = self.model.roi_name_generator()
         self.model.set_new_roi(roi_name)
-        self.view.spectrumWidget.add_roi(self.model.get_roi(roi_name), roi_name)
+        self.view.spectrum_widget.add_roi(self.model.get_roi(roi_name), roi_name)
         self.view.set_spectrum(roi_name, self.model.get_spectrum(roi_name, self.spectrum_mode))
         self.view.auto_range_image()
         self.do_add_roi_to_table(roi_name)
@@ -210,7 +210,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
     def add_rits_roi(self) -> None:
         roi_name = ROI_RITS
         self.model.set_new_roi(roi_name)
-        self.view.spectrumWidget.add_roi(self.model.get_roi(roi_name), roi_name)
+        self.view.spectrum_widget.add_roi(self.model.get_roi(roi_name), roi_name)
         self.view.set_spectrum(roi_name, self.model.get_spectrum(roi_name, self.spectrum_mode))
         self.view.set_roi_alpha(0, ROI_RITS)
 
@@ -220,7 +220,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
         @param roi_name: Name of the ROI to add
         """
-        roi_colour = self.view.spectrumWidget.roi_dict[roi_name].colour
+        roi_colour = self.view.spectrum_widget.roi_dict[roi_name].colour
         self.view.add_roi_table_row(roi_name, roi_colour)
 
     def rename_roi(self, old_name: str, new_name: str) -> None:
@@ -230,7 +230,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         @param old_name: Name of the ROI to rename
         @param new_name: New name of the ROI
         """
-        self.view.spectrumWidget.rename_roi(old_name, new_name)
+        self.view.spectrum_widget.rename_roi(old_name, new_name)
         self.model.rename_roi(old_name, new_name)
 
     def do_remove_roi(self, roi_name: str | None = None) -> None:
@@ -243,10 +243,10 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         if roi_name is None:
             self.view.clear_all_rois()
             for roi in self.get_roi_names():
-                self.view.spectrumWidget.remove_roi(roi)
+                self.view.spectrum_widget.remove_roi(roi)
             self.model.remove_all_roi()
         else:
-            self.view.spectrumWidget.remove_roi(roi_name)
+            self.view.spectrum_widget.remove_roi(roi_name)
             self.view.set_spectrum(roi_name, self.model.get_spectrum(roi_name, self.spectrum_mode))
             self.model.remove_roi(roi_name)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -13,7 +13,7 @@ from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowView, SpectrumViewerWindowPresenter
 from mantidimaging.gui.windows.spectrum_viewer.model import ErrorMode
-from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumWidget
+from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumWidget, SpectrumPlotWidget
 from mantidimaging.test_helpers import mock_versions, start_qapplication
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
@@ -28,7 +28,10 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view = mock.create_autospec(SpectrumViewerWindowView)
         self.view.current_dataset_id = uuid.uuid4()
         mock_spectrum_roi_dict = mock.create_autospec(dict)
-        self.view.spectrum = mock.create_autospec(SpectrumWidget, roi_dict=mock_spectrum_roi_dict)
+        self.view.spectrumWidget = mock.create_autospec(SpectrumWidget, roi_dict=mock_spectrum_roi_dict)
+        self.view.spectrumWidget.spectrum_plot_widget = mock.create_autospec(SpectrumPlotWidget,
+                                                                             roi_dict=mock_spectrum_roi_dict)
+        #self.view.spectrum = mock.create_autospec(SpectrumPlotWidget, roi_dict=mock_spectrum_roi_dict)
         self.view.exportButton = mock.create_autospec(QPushButton)
         self.view.exportButtonRITS = mock.create_autospec(QPushButton)
         self.view.addBtn = mock.create_autospec(QPushButton)
@@ -157,7 +160,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     def test_WHEN_show_sample_call_THEN_add_range_set(self):
         self.presenter.model.tof_range = (0, 9)
         self.presenter.show_new_sample()
-        self.view.spectrum.add_range.assert_called_once_with(0, 9)
+        self.view.spectrumWidget.spectrum_plot_widget.add_range.assert_called_once_with(0, 9)
 
     def test_gui_changes_tof_range(self):
         image_stack = generate_images([30, 11, 12])
@@ -215,7 +218,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view.add_roi_table_row.reset_mock()
 
         self.assertEqual(["all", "roi"], self.presenter.model.get_list_of_roi_names())
-        self.presenter.view.spectrum.roi_dict = {"roi_1": mock.Mock()}
+        self.presenter.view.spectrumWidget.roi_dict = {"roi_1": mock.Mock()}
         self.presenter.do_add_roi_to_table("roi_1")
         self.view.add_roi_table_row.assert_called_once_with("roi_1", mock.ANY)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -28,10 +28,9 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view = mock.create_autospec(SpectrumViewerWindowView)
         self.view.current_dataset_id = uuid.uuid4()
         mock_spectrum_roi_dict = mock.create_autospec(dict)
-        self.view.spectrumWidget = mock.create_autospec(SpectrumWidget, roi_dict=mock_spectrum_roi_dict)
-        self.view.spectrumWidget.spectrum_plot_widget = mock.create_autospec(SpectrumPlotWidget,
-                                                                             roi_dict=mock_spectrum_roi_dict)
-        #self.view.spectrum = mock.create_autospec(SpectrumPlotWidget, roi_dict=mock_spectrum_roi_dict)
+        self.view.spectrum_widget = mock.create_autospec(SpectrumWidget, roi_dict=mock_spectrum_roi_dict)
+        self.view.spectrum_widget.spectrum_plot_widget = mock.create_autospec(SpectrumPlotWidget,
+                                                                              roi_dict=mock_spectrum_roi_dict)
         self.view.exportButton = mock.create_autospec(QPushButton)
         self.view.exportButtonRITS = mock.create_autospec(QPushButton)
         self.view.addBtn = mock.create_autospec(QPushButton)
@@ -160,7 +159,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     def test_WHEN_show_sample_call_THEN_add_range_set(self):
         self.presenter.model.tof_range = (0, 9)
         self.presenter.show_new_sample()
-        self.view.spectrumWidget.spectrum_plot_widget.add_range.assert_called_once_with(0, 9)
+        self.view.spectrum_widget.spectrum_plot_widget.add_range.assert_called_once_with(0, 9)
 
     def test_gui_changes_tof_range(self):
         image_stack = generate_images([30, 11, 12])
@@ -218,7 +217,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view.add_roi_table_row.reset_mock()
 
         self.assertEqual(["all", "roi"], self.presenter.model.get_list_of_roi_names())
-        self.presenter.view.spectrumWidget.roi_dict = {"roi_1": mock.Mock()}
+        self.presenter.view.spectrum_widget.roi_dict = {"roi_1": mock.Mock()}
         self.presenter.do_add_roi_to_table("roi_1")
         self.view.add_roi_table_row.assert_called_once_with("roi_1", mock.ANY)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
@@ -9,7 +9,7 @@ from parameterized import parameterized
 
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowView, SpectrumViewerWindowPresenter
-from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumWidget
+from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumWidget, SpectrumPlotWidget
 from mantidimaging.test_helpers import mock_versions, start_qapplication
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumROI
@@ -26,6 +26,7 @@ class SpectrumWidgetTest(unittest.TestCase):
         self.view.current_dataset_id = uuid.uuid4()
         self.view.parent = mock.create_autospec(SpectrumViewerWindowPresenter)
         self.spectrum_widget = SpectrumWidget()
+        self.spectrum_plot_widget = SpectrumPlotWidget()
         self.sensible_roi = SensibleROI.from_list([0, 0, 0, 0])
 
     def tearDown(self):
@@ -101,9 +102,9 @@ class SpectrumWidgetTest(unittest.TestCase):
 
     @parameterized.expand([("range_100", 0, 100), ("range_200", 100, 300), ("range_300", 200, 500)])
     def test_WHEN_add_range_called_THEN_region_and_label_set_correctly(self, _, range_min, range_max):
-        self.spectrum_widget.add_range(range_min, range_max)
-        self.assertEqual(self.spectrum_widget.range_control.getRegion(), (range_min, range_max))
-        self.assertEqual(self.spectrum_widget._tof_range_label.text, f"ToF range: {range_min} - {range_max}")
+        self.spectrum_plot_widget.add_range(range_min, range_max)
+        self.assertEqual(self.spectrum_plot_widget.range_control.getRegion(), (range_min, range_max))
+        self.assertEqual(self.spectrum_plot_widget._tof_range_label.text, f"ToF range: {range_min} - {range_max}")
 
     def test_WHEN_get_roi_called_THEN_SensibleROI_returned(self):
         spectrum_roi = SpectrumROI("roi",
@@ -135,8 +136,8 @@ class SpectrumWidgetTest(unittest.TestCase):
         self.assertNotIn(spectrum_roi, self.spectrum_widget.image.vb.addedItems)
 
     def test_WHEN_set_tof_range_called_THEN_range_control_set_correctly(self):
-        self.spectrum_widget._set_tof_range_label(0, 100)
-        self.assertEqual(self.spectrum_widget._tof_range_label.text, "ToF range: 0 - 100")
+        self.spectrum_plot_widget._set_tof_range_label(0, 100)
+        self.assertEqual(self.spectrum_plot_widget._tof_range_label.text, "ToF range: 0 - 100")
 
     def test_WHEN_rename_roi_called_THEN_roi_renamed(self):
         spectrum_roi = SpectrumROI("roi_1",

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -41,7 +41,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     bin_size_spinBox: QSpinBox
     bin_step_spinBox: QSpinBox
 
-    spectrumWidget: SpectrumWidget
+    spectrum_widget: SpectrumWidget
 
     def __init__(self, main_window: 'MainWindowView'):
         super().__init__(None, 'gui/ui/spectrum_viewer.ui')
@@ -57,13 +57,13 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         self.presenter = SpectrumViewerWindowPresenter(self, main_window)
 
-        self.spectrumWidget = SpectrumWidget()
-        self.spectrum = self.spectrumWidget.spectrum_plot_widget
+        self.spectrum_widget = SpectrumWidget()
+        self.spectrum = self.spectrum_widget.spectrum_plot_widget
 
-        self.imageLayout.addWidget(self.spectrumWidget)
+        self.imageLayout.addWidget(self.spectrum_widget)
 
         self.spectrum.range_changed.connect(self.presenter.handle_range_slide_moved)
-        self.spectrumWidget.roi_changed.connect(self.presenter.handle_roi_moved)
+        self.spectrum_widget.roi_changed.connect(self.presenter.handle_roi_moved)
 
         self._current_dataset_id = None
         self.sampleStackSelector.stack_selected_uuid.connect(self.presenter.handle_sample_change)
@@ -213,25 +213,25 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             return None
 
     def set_image(self, image_data: Optional['np.ndarray'], autoLevels: bool = True):
-        self.spectrumWidget.image.setImage(image_data, autoLevels=autoLevels)
+        self.spectrum_widget.image.setImage(image_data, autoLevels=autoLevels)
 
     def set_spectrum(self, name: str, spectrum_data: 'np.ndarray'):
         """
         Try to set the spectrum data for a given ROI assuming the
         roi may not exist in the spectrum widget yet depending on when method is called
         """
-        self.spectrumWidget.spectrum_data_dict[name] = spectrum_data
-        self.spectrumWidget.spectrum.clearPlots()
+        self.spectrum_widget.spectrum_data_dict[name] = spectrum_data
+        self.spectrum_widget.spectrum.clearPlots()
 
         self.show_visible_spectrums()
 
     def clear(self) -> None:
-        self.spectrumWidget.spectrum_data_dict = {}
-        self.spectrumWidget.image.setImage(np.zeros((1, 1)))
-        self.spectrumWidget.spectrum.clearPlots()
+        self.spectrum_widget.spectrum_data_dict = {}
+        self.spectrum_widget.image.setImage(np.zeros((1, 1)))
+        self.spectrum_widget.spectrum.clearPlots()
 
     def auto_range_image(self):
-        self.spectrumWidget.image.vb.autoRange()
+        self.spectrum_widget.image.vb.autoRange()
 
     def set_normalise_error(self, norm_issue: str):
         self.normalise_error_issue = norm_issue
@@ -262,18 +262,18 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         @param alpha: The alpha value
         """
-        self.spectrumWidget.set_roi_alpha(roi_name, alpha)
+        self.spectrum_widget.set_roi_alpha(roi_name, alpha)
         if alpha == 0:
-            self.spectrumWidget.spectrum_data_dict[roi_name] = None
+            self.spectrum_widget.spectrum_data_dict[roi_name] = None
 
-        self.spectrumWidget.spectrum.clearPlots()
-        self.spectrumWidget.spectrum.update()
+        self.spectrum_widget.spectrum.clearPlots()
+        self.spectrum_widget.spectrum.update()
         self.show_visible_spectrums()
 
     def show_visible_spectrums(self):
-        for key, value in self.spectrumWidget.spectrum_data_dict.items():
-            if value is not None and key in self.spectrumWidget.roi_dict:
-                self.spectrumWidget.spectrum.plot(value, name=key, pen=self.spectrumWidget.roi_dict[key].colour)
+        for key, value in self.spectrum_widget.spectrum_data_dict.items():
+            if value is not None and key in self.spectrum_widget.roi_dict:
+                self.spectrum_widget.spectrum.plot(value, name=key, pen=self.spectrum_widget.roi_dict[key].colour)
 
     def add_roi_table_row(self, name: str, colour: tuple[int, int, int]):
         """
@@ -298,8 +298,8 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         if selected_row:
             self.roi_table_model.remove_row(self.selected_row)
             self.presenter.do_remove_roi(selected_row[0])
-            self.spectrumWidget.spectrum_data_dict.pop(selected_row[0])
-            self.spectrumWidget.spectrum.removeItem(selected_row[0])
+            self.spectrum_widget.spectrum_data_dict.pop(selected_row[0])
+            self.spectrum_widget.spectrum.removeItem(selected_row[0])
             self.presenter.handle_roi_moved()
             self.selected_row = 0
             self.tableView.selectRow(0)
@@ -312,8 +312,8 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         Clear all ROIs from the table view
         """
         self.roi_table_model.clear_table()
-        self.spectrumWidget.spectrum_data_dict = {}
-        self.spectrumWidget.spectrum.clearPlots()
+        self.spectrum_widget.spectrum_data_dict = {}
+        self.spectrum_widget.spectrum.clearPlots()
         self.removeBtn.setEnabled(False)
 
     @property

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -41,6 +41,8 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     bin_size_spinBox: QSpinBox
     bin_step_spinBox: QSpinBox
 
+    spectrumWidget: SpectrumWidget
+
     def __init__(self, main_window: 'MainWindowView'):
         super().__init__(None, 'gui/ui/spectrum_viewer.ui')
 
@@ -55,11 +57,13 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         self.presenter = SpectrumViewerWindowPresenter(self, main_window)
 
-        self.spectrum = SpectrumWidget()
-        self.imageLayout.addWidget(self.spectrum)
+        self.spectrumWidget = SpectrumWidget()
+        self.spectrum = self.spectrumWidget.spectrum_plot_widget
+
+        self.imageLayout.addWidget(self.spectrumWidget)
 
         self.spectrum.range_changed.connect(self.presenter.handle_range_slide_moved)
-        self.spectrum.roi_changed.connect(self.presenter.handle_roi_moved)
+        self.spectrumWidget.roi_changed.connect(self.presenter.handle_roi_moved)
 
         self._current_dataset_id = None
         self.sampleStackSelector.stack_selected_uuid.connect(self.presenter.handle_sample_change)
@@ -209,25 +213,25 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             return None
 
     def set_image(self, image_data: Optional['np.ndarray'], autoLevels: bool = True):
-        self.spectrum.image.setImage(image_data, autoLevels=autoLevels)
+        self.spectrumWidget.image.setImage(image_data, autoLevels=autoLevels)
 
     def set_spectrum(self, name: str, spectrum_data: 'np.ndarray'):
         """
         Try to set the spectrum data for a given ROI assuming the
         roi may not exist in the spectrum widget yet depending on when method is called
         """
-        self.spectrum.spectrum_data_dict[name] = spectrum_data
-        self.spectrum.spectrum.clearPlots()
+        self.spectrumWidget.spectrum_data_dict[name] = spectrum_data
+        self.spectrumWidget.spectrum.clearPlots()
 
         self.show_visible_spectrums()
 
     def clear(self) -> None:
-        self.spectrum.spectrum_data_dict = {}
-        self.spectrum.image.setImage(np.zeros((1, 1)))
-        self.spectrum.spectrum.clearPlots()
+        self.spectrumWidget.spectrum_data_dict = {}
+        self.spectrumWidget.image.setImage(np.zeros((1, 1)))
+        self.spectrumWidget.spectrum.clearPlots()
 
     def auto_range_image(self):
-        self.spectrum.image.vb.autoRange()
+        self.spectrumWidget.image.vb.autoRange()
 
     def set_normalise_error(self, norm_issue: str):
         self.normalise_error_issue = norm_issue
@@ -258,18 +262,18 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         @param alpha: The alpha value
         """
-        self.spectrum.set_roi_alpha(roi_name, alpha)
+        self.spectrumWidget.set_roi_alpha(roi_name, alpha)
         if alpha == 0:
-            self.spectrum.spectrum_data_dict[roi_name] = None
+            self.spectrumWidget.spectrum_data_dict[roi_name] = None
 
-        self.spectrum.spectrum.clearPlots()
-        self.spectrum.spectrum.update()
+        self.spectrumWidget.spectrum.clearPlots()
+        self.spectrumWidget.spectrum.update()
         self.show_visible_spectrums()
 
     def show_visible_spectrums(self):
-        for key, value in self.spectrum.spectrum_data_dict.items():
-            if value is not None and key in self.spectrum.roi_dict:
-                self.spectrum.spectrum.plot(value, name=key, pen=self.spectrum.roi_dict[key].colour)
+        for key, value in self.spectrumWidget.spectrum_data_dict.items():
+            if value is not None and key in self.spectrumWidget.roi_dict:
+                self.spectrumWidget.spectrum.plot(value, name=key, pen=self.spectrumWidget.roi_dict[key].colour)
 
     def add_roi_table_row(self, name: str, colour: tuple[int, int, int]):
         """
@@ -294,8 +298,8 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         if selected_row:
             self.roi_table_model.remove_row(self.selected_row)
             self.presenter.do_remove_roi(selected_row[0])
-            self.spectrum.spectrum_data_dict.pop(selected_row[0])
-            self.spectrum.spectrum.removeItem(selected_row[0])
+            self.spectrumWidget.spectrum_data_dict.pop(selected_row[0])
+            self.spectrumWidget.spectrum.removeItem(selected_row[0])
             self.presenter.handle_roi_moved()
             self.selected_row = 0
             self.tableView.selectRow(0)
@@ -308,8 +312,8 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         Clear all ROIs from the table view
         """
         self.roi_table_model.clear_table()
-        self.spectrum.spectrum_data_dict = {}
-        self.spectrum.spectrum.clearPlots()
+        self.spectrumWidget.spectrum_data_dict = {}
+        self.spectrumWidget.spectrum.clearPlots()
         self.removeBtn.setEnabled(False)
 
     @property


### PR DESCRIPTION
### Issue

Closes #2025.

### Description

In the `SpectrumWidget` for the Spectrum Viewer, the image view and the spectrum plot have been separated into two separate widgets as this allows us to use a QSplitter to resize them in a comfortable way. The splitter is configured so that initially the image takes up 70% of the window and the spectrum plot takes 30%, but this can be easily configured. The `SpectrumWidget` class now creates instances of the `SpectrumPlotWidget` and `SpectrumProjectionWidget`. This refactoring required the unit tests to be modified.

![image](https://github.com/mantidproject/mantidimaging/assets/30868085/be4af8ad-3f41-4c86-8e54-48f3b931a03f)

![image](https://github.com/mantidproject/mantidimaging/assets/30868085/073847ee-b861-415d-83f9-9d9ba153ff09)


### Testing 

Check `make check` still passes properly.

### Acceptance Criteria 

Open some data in the Spectrum Viewer and see if the ToF plot can be easily resized and viewed. Make sure that the rest of the Spectrum Viewer still works as intended.

### Documentation

Will be added to release notes.
