### PR TITLE
Fix TypeError: qWait(ms: int): unexpected type 'float' to 'int'

### DIFF
--- a/docs/release_notes/next/fix-1873-unexpected-float
+++ b/docs/release_notes/next/fix-1873-unexpected-float
@@ -1,0 +1,1 @@
+#1873 : fix typeError: qWait(ms: int): argument 1 has unexpected type 'float'

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -95,7 +95,7 @@ class GuiSystemBase(unittest.TestCase):
             for widget in cls.app.topLevelWidgets():
                 if isinstance(widget, widget_type) and widget.isVisible():
                     return True
-            QTest.qWait(delay * 1000)
+        QTest.qWait(int(delay * 1000))
         raise RuntimeError("_wait_for_stack_selector reach max retries")
 
     @mock.patch("mantidimaging.gui.windows.image_load_dialog.view.ImageLoadDialog.select_file")


### PR DESCRIPTION
### Issue

Given the context and specifics of the error, the resolution involves ensuring that all calls to QTest.qWait() are made with integer arguments, as the function expects. This change directly addresses the TypeError encountered during tests.

Closes #1873

### Description

This update modifies instances in the test suite where QTest.qWait() is called with a float argument instead of an integer. This is achieved by wrapping the multiplication of delay * 1000 with an int() conversion, ensuring compatibility with the QTest.qWait() argument specifications.

### Testing 

Ran the modified test suite using make test-system to ensure that the TypeError no longer occurs.

### Documentation

All changes should be noted in the appropriate file in docs/release_notes*
