### PR TITLE
2027 adjustable ROI

### DIFF
--- a/mantidimaging/gui/ui/spectrum_viewer.ui
+++ b/mantidimaging/gui/ui/spectrum_viewer.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>921</width>
-    <height>739</height>
+    <width>913</width>
+    <height>710</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -351,7 +351,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QGroupBox" name="groupBox">
+         <widget class="QGroupBox" name="roiPropertiesGroupBox">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
             <horstretch>0</horstretch>

--- a/mantidimaging/gui/ui/spectrum_viewer.ui
+++ b/mantidimaging/gui/ui/spectrum_viewer.ui
@@ -351,20 +351,22 @@
          </widget>
         </item>
         <item>
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
+         <widget class="QGroupBox" name="groupBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::MinimumExpanding</enum>
+          <property name="title">
+           <string>ROI Properties</string>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
+          <layout class="QVBoxLayout" name="verticalLayout_7">
+           <item>
+            <widget class="QTableWidget" name="roiPropertiesTableWidget"/>
+           </item>
+          </layout>
+         </widget>
         </item>
        </layout>
       </widget>

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -63,6 +63,11 @@ class SpectrumROI(ROI):
     def selected_row(self) -> Optional[int]:
         return self._selected_row
 
+    def adjust_spec_roi(self, roi: SensibleROI) -> None:
+        self.setPos((roi.left, roi.top))
+        self.setSize((roi.width, roi.height))
+
+
 
 class SpectrumWidget(GraphicsLayoutWidget):
     """
@@ -182,6 +187,16 @@ class SpectrumWidget(GraphicsLayoutWidget):
         self.roi_dict[name].sigRegionChanged.connect(self.roi_changed.emit)
         self.image.vb.addItem(self.roi_dict[name])
         self.roi_dict[name].hoverPen = mkPen(self.roi_dict[name].colour, width=3)
+
+    def adjust_roi(self, new_roi: SensibleROI, roi_name: str):
+        """
+        Adjust the existing ROI with the given name.
+        @param spec_roi: The new SpectrumROI to replace the existing SpectrumROI
+        @param roi_name: The name of the existing ROI.
+        """
+        self.roi_dict[roi_name].adjust_spec_roi(new_roi)
+
+
 
     def get_roi(self, roi_name: str) -> SensibleROI:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -68,7 +68,6 @@ class SpectrumROI(ROI):
         self.setSize((roi.width, roi.height))
 
 
-
 class SpectrumWidget(GraphicsLayoutWidget):
     """
     The widget containing the spectrum plot and the image projection.
@@ -195,8 +194,6 @@ class SpectrumWidget(GraphicsLayoutWidget):
         @param roi_name: The name of the existing ROI.
         """
         self.roi_dict[roi_name].adjust_spec_roi(new_roi)
-
-
 
     def get_roi(self, roi_name: str) -> SensibleROI:
         """


### PR DESCRIPTION
### Issue

Closes #2027.

### Description

A table has been added under the ROI tabs in the Spectrum Viewer which displays the properties of the currently selected ROI (selected by clicking on the ROI Table). Currently the properties displayed are: Left, Top, Right, Bottom, Width, Height, Area.
The currently selected ROI can be adjusted by using spin boxes in the table allowing for more precise positioning.
This table also functions for the RITS ROI when that tab is activated.

More properties and details about the ROIs can be added as needed/required.

Unit Tests will be written in a future commit.

![image](https://github.com/mantidproject/mantidimaging/assets/30868085/edcf84e9-6ebd-48ef-97e2-46bca6ab9375)


### Testing 

make check

### Acceptance Criteria 

Check that the numbers in the table are correct and update accordingly (i.e. when the ROI is changed).
Check that changing the numbers in the Table update the ROI properly.
The rest of the Spectrum viewer should function the same as before.
