### PR TITLE
Avoid unneeded calculation of ROI in MIImageView

### DIFF
--- a/docs/release_notes/next/fix-2030-slow-imageview
+++ b/docs/release_notes/next/fix-2030-slow-imageview
@@ -1,0 +1,1 @@
+#2031 : Speed up imageview by avoiding unneeded calculation

--- a/mantidimaging/gui/widgets/mi_image_view/test/view_test.py
+++ b/mantidimaging/gui/widgets/mi_image_view/test/view_test.py
@@ -64,7 +64,7 @@ class MIImageViewTest(unittest.TestCase):
         self.view.roi.setSize.assert_called_once_with([right - left, bottom - top])
         self.view._update_roi_region_avg.assert_called_once()
         self.view.roi_changed_callback.assert_called_once()
-        self.view._update_message.assert_called_once()
+        self.view._update_message.assert_called()
 
     def test_default_roi(self):
         image = np.zeros((1, 50, 50))

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -197,23 +197,27 @@ class MIImageView(ImageView, BadDataOverlay, AutoColorMenu):
         self._refresh_message()
 
     def _update_roi_region_avg(self) -> Optional[SensibleROI]:
-        if not self.ui.roiBtn.isChecked():
-            return None
         if self.image.ndim != 3:
             return None
         roi_pos, roi_size = self.get_roi()
         # image indices are in order [Z, X, Y]
         left, right = roi_pos.x, roi_pos.x + roi_size.x
         top, bottom = roi_pos.y, roi_pos.y + roi_size.y
-        data = self.image[:, top:bottom, left:right]
 
-        data = data.mean(axis=(1, 2))
+        if self.roi.isVisible():
+            mean_val = self.image[self.timeLine.value(), top:bottom, left:right].mean()
+            self.roiString = f"({left}, {top}, {right}, {bottom}) | " \
+                             f"region avg={mean_val:.6f}"
+
+        if not self.ui.roiBtn.isChecked():
+            return None
+
+        data = self.image[:, top:bottom, left:right].mean(axis=(1, 2))
 
         if len(self.roiCurves) == 0:
             self.roiCurves.append(self.ui.roiPlot.plot())
         self.roiCurves[0].setData(y=data, x=self.tVals)
-        self.roiString = f"({left}, {top}, {right}, {bottom}) | " \
-                         f"region avg={data[int(self.timeLine.value())].mean():.6f}"
+
         return SensibleROI(left, top, right, bottom)
 
     def roiClicked(self):

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -205,7 +205,8 @@ class MIImageView(ImageView, BadDataOverlay, AutoColorMenu):
         top, bottom = roi_pos.y, roi_pos.y + roi_size.y
 
         if self.roi.isVisible():
-            mean_val = self.image[self.timeLine.value(), top:bottom, left:right].mean()
+            z_value = int(self.timeLine.value())
+            mean_val = self.image[z_value, top:bottom, left:right].mean()
             self.roiString = f"({left}, {top}, {right}, {bottom}) | " \
                              f"region avg={mean_val:.6f}"
 

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -206,12 +206,12 @@ class MIImageView(ImageView, BadDataOverlay, AutoColorMenu):
         left, right = roi_pos.x, roi_pos.x + roi_size.x
         top, bottom = roi_pos.y, roi_pos.y + roi_size.y
         data = self.image[:, top:bottom, left:right]
-        if data is not None:
-            while data.ndim > 1:
-                data = data.mean(axis=1)
-            if len(self.roiCurves) == 0:
-                self.roiCurves.append(self.ui.roiPlot.plot())
-            self.roiCurves[0].setData(y=data, x=self.tVals)
+
+        data = data.mean(axis=(1, 2))
+
+        if len(self.roiCurves) == 0:
+            self.roiCurves.append(self.ui.roiPlot.plot())
+        self.roiCurves[0].setData(y=data, x=self.tVals)
         self.roiString = f"({left}, {top}, {right}, {bottom}) | " \
                          f"region avg={data[int(self.timeLine.value())].mean():.6f}"
         return SensibleROI(left, top, right, bottom)

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -197,6 +197,8 @@ class MIImageView(ImageView, BadDataOverlay, AutoColorMenu):
         self._refresh_message()
 
     def _update_roi_region_avg(self) -> Optional[SensibleROI]:
+        if not self.ui.roiBtn.isChecked():
+            return None
         if self.image.ndim != 3:
             return None
         roi_pos, roi_size = self.get_roi()
@@ -213,6 +215,13 @@ class MIImageView(ImageView, BadDataOverlay, AutoColorMenu):
         self.roiString = f"({left}, {top}, {right}, {bottom}) | " \
                          f"region avg={data[int(self.timeLine.value())].mean():.6f}"
         return SensibleROI(left, top, right, bottom)
+
+    def roiClicked(self):
+        # When ROI area is hidden with the button, clear the message
+        if not self.ui.roiBtn.isChecked() and hasattr(self, "_last_mouse_hover_location"):
+            self.roiString = None
+            self._refresh_message()
+        super().roiClicked()
 
     def extend_roi_plot_mouse_press_handler(self):
         original_handler = self.ui.roiPlot.mousePressEvent

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -171,9 +171,7 @@ class MIImageView(ImageView, BadDataOverlay, AutoColorMenu):
             sleep(0.02)
             QApplication.processEvents()
 
-    def _refresh_message(self, recalculate_roi_avg: bool = True):
-        if recalculate_roi_avg:
-            self._update_roi_region_avg()
+    def _refresh_message(self):
         try:
             self._update_message(self._last_mouse_hover_location)
         except IndexError:
@@ -196,6 +194,7 @@ class MIImageView(ImageView, BadDataOverlay, AutoColorMenu):
         roi = self._update_roi_region_avg()
         if self.roi_changed_callback and roi is not None:
             self.roi_changed_callback(roi)
+        self._refresh_message()
 
     def _update_roi_region_avg(self) -> Optional[SensibleROI]:
         if self.image.ndim != 3:
@@ -281,7 +280,7 @@ class MIImageView(ImageView, BadDataOverlay, AutoColorMenu):
         # Keep default update=True for setSize otherwise the scale handle can become detached from the ROI box
         self.roi.setSize([roi.width, roi.height])
         self.roiChanged()
-        self._refresh_message(False)
+        self._refresh_message()
 
     def default_roi(self):
         # Recommend an ROI that covers the top left quadrant

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -210,16 +210,17 @@ class MIImageView(ImageView, BadDataOverlay, AutoColorMenu):
             self.roiString = f"({left}, {top}, {right}, {bottom}) | " \
                              f"region avg={mean_val:.6f}"
 
-        if not self.ui.roiBtn.isChecked():
+        if self.ui.roiBtn.isChecked():
+            data = self.image[:, top:bottom, left:right].mean(axis=(1, 2))
+
+            if len(self.roiCurves) == 0:
+                self.roiCurves.append(self.ui.roiPlot.plot())
+            self.roiCurves[0].setData(y=data, x=self.tVals)
+
+        if self.roi.isVisible() or self.ui.roiBtn.isChecked():
+            return SensibleROI(left, top, right, bottom)
+        else:
             return None
-
-        data = self.image[:, top:bottom, left:right].mean(axis=(1, 2))
-
-        if len(self.roiCurves) == 0:
-            self.roiCurves.append(self.ui.roiPlot.plot())
-        self.roiCurves[0].setData(y=data, x=self.tVals)
-
-        return SensibleROI(left, top, right, bottom)
 
     def roiClicked(self):
         # When ROI area is hidden with the button, clear the message

--- a/mantidimaging/gui/widgets/roi_selector/view.py
+++ b/mantidimaging/gui/widgets/roi_selector/view.py
@@ -62,6 +62,8 @@ class ROISelectorView(QMainWindow):
         button.clicked.connect(lambda: self.close())
         self.roi_view.ui.gridLayout.addWidget(button)
 
+        self.roi_view.roiChanged()
+
     def toggle_average_images(self) -> None:
         self.roi_view.setImage(self.main_image if self.roi_view_averaged else self.averaged_image)
         self.roi_view_averaged = not self.roi_view_averaged

--- a/mantidimaging/gui/windows/stack_choice/view.py
+++ b/mantidimaging/gui/windows/stack_choice/view.py
@@ -79,6 +79,8 @@ class StackChoiceView(BaseMainWindowView):
         self.new_stack.roi.sigRegionChanged.connect(self._sync_roi_plot_for_old_stack_with_new_stack)
         self.original_stack.roi.sigRegionChanged.connect(self.original_stack.roiChanged)
         self.new_stack.roi.sigRegionChanged.connect(self.new_stack.roiChanged)
+        self.original_stack.roi.sigRegionChanged.connect(self.original_stack.viewbox.update)
+        self.new_stack.roi.sigRegionChanged.connect(self.new_stack.viewbox.update)
 
         self._sync_both_image_axis()
         self._ensure_range_is_the_same()


### PR DESCRIPTION
### Issue

Closes #2030

### Description

Previously the ROI line plot was recalculated for every movement to a new slice, even though this does not change the plot and the plot may not be visible.

Now, this is only done on changes to the ROI and only if the ROI plot is visible.

There is a change to only show the ROI info in the message if the ROI is visible. This will need the screenshots updating.

There is also an optimisation to only call `mean()` once.

For me this takes the run time for `timeLineChanged()` with the 2k x 2k x 1k flower dataset from ~0.4 to ~0.01 seconds. 
```
Before:
INFO:         1    0.000    0.000    0.469    0.469 /.../ImageView.py:810(timeLineChanged)
INFO:         1    0.000    0.000    0.454    0.454 /.../ImageView.py:810(timeLineChanged)
INFO:         1    0.000    0.000    0.516    0.516 /.../ImageView.py:810(timeLineChanged)

After:
INFO:         1    0.000    0.000    0.010    0.010 /.../ImageView.py:810(timeLineChanged)
INFO:         1    0.000    0.000    0.006    0.006 /.../ImageView.py:810(timeLineChanged)
INFO:         1    0.000    0.000    0.008    0.008 /.../ImageView.py:810(timeLineChanged)
```

### Testing &  Acceptance Criteria 

Test the responsiveness of moving though a large dataset in the main window. Should be noticeable for a 1k x 1k or 2k x 2k image stack, or benchmarkable (see issue) for a smaller stack.

Check that ROI message and line plot show when clicking the ROI button, and go after unclicking it. Moving through the imagestack should still be fast even with the plot shown, as its only recalculated on ROI moves.

Also check that the ROI selector in the the crop operation works. And the image views in compare images and safe apply work.

### Documentation

Release notes
