### PR TITLE
Liveview screenshot tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ CHANNELS=$(shell cat environment.yml | sed -ne '/channels:/,/dependencies:/{//!p
 ifeq ($(OS),Windows_NT)
     XVFBRUN=
 	TEST_RESULT_DIR:=$(TEMP)\mantidimaging_tests
+	export APPLITOOLS_API_KEY=local
+	export APPLITOOLS_IMAGE_DIR:=${TEST_RESULT_DIR}
 else
 	XVFBRUN=xvfb-run --auto-servernum
 	TEST_RESULT_DIR:=$(shell mktemp -d)
@@ -52,6 +54,11 @@ test-system:
 test-screenshots:
 	-mkdir ${TEST_RESULT_DIR}
 	APPLITOOLS_API_KEY=local APPLITOOLS_IMAGE_DIR=${TEST_RESULT_DIR} ${XVFBRUN} pytest -p no:xdist -p no:randomly -p no:cov mantidimaging/eyes_tests/ -vs
+	@echo "Screenshots writen to" ${TEST_RESULT_DIR}
+
+test-screenshots-win:
+	-mkdir ${TEST_RESULT_DIR}
+	${XVFBRUN} pytest -p no:xdist -p no:randomly -p no:cov mantidimaging/eyes_tests/ -vs
 	@echo "Screenshots writen to" ${TEST_RESULT_DIR}
 
 mypy:

--- a/mantidimaging/eyes_tests/live_viewer_window_test.py
+++ b/mantidimaging/eyes_tests/live_viewer_window_test.py
@@ -74,6 +74,6 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
         image_list = [Image_Data(path) for path in file_list]
         mock_load_image.return_value = self._generate_image()
         self.imaging.show_live_viewer(self.live_directory)
-        self.imaging.live_viewer.filter_params = {"Rotate Stack": {"params": {"angle": 90}}}
         self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list)
+        self.imaging.live_viewer.rotate_angles_group.actions()[1].trigger()
         self.check_target(widget=self.imaging.live_viewer)

--- a/mantidimaging/eyes_tests/live_viewer_window_test.py
+++ b/mantidimaging/eyes_tests/live_viewer_window_test.py
@@ -66,3 +66,14 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
         self.imaging.show_live_viewer(self.live_directory)
         self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list)
         self.check_target(widget=self.imaging.live_viewer)
+
+    @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image')
+    @mock.patch('mantidimaging.gui.windows.live_viewer.model.ImageWatcher')
+    def test_rotate_operation_rotates_image(self, _mock_image_watcher, mock_load_image):
+        file_list = self._make_simple_dir(self.live_directory)
+        image_list = [Image_Data(path) for path in file_list]
+        mock_load_image.return_value = self._generate_image()
+        self.imaging.show_live_viewer(self.live_directory)
+        self.imaging.live_viewer.filter_params = {"Rotate Stack": {"params": {"angle": 90}}}
+        self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list)
+        self.check_target(widget=self.imaging.live_viewer)

--- a/mantidimaging/eyes_tests/live_viewer_window_test.py
+++ b/mantidimaging/eyes_tests/live_viewer_window_test.py
@@ -42,7 +42,8 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
 
         return file_list
 
-    def test_live_view_opens_without_data(self):
+    @mock.patch('mantidimaging.gui.windows.live_viewer.model.ImageWatcher')
+    def test_live_view_opens_without_data(self, _mock_image_watcher):
         self.imaging.show_live_viewer(self.live_directory)
         self.check_target(widget=self.imaging.live_viewer)
 

--- a/mantidimaging/eyes_tests/live_viewer_window_test.py
+++ b/mantidimaging/eyes_tests/live_viewer_window_test.py
@@ -2,7 +2,12 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+from unittest import mock
+
+import numpy as np
+
 from mantidimaging.core.operations.loader import load_filter_packages
+from mantidimaging.gui.windows.live_viewer.model import Image_Data
 from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
 from pathlib import Path
 
@@ -17,7 +22,33 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
         super().setUp()
         self.fs.add_real_directory(Path(__file__).parent.parent)
 
+    def _generate_image(self):
+        image = np.zeros((10, 10))
+        image[5, :] = np.arange(10)
+        return image
+
+    def _make_simple_dir(self, directory: Path):
+        file_list = [directory / f"abc_{i:06d}.tif" for i in range(5)]
+        if not directory.exists():
+            self.fs.create_dir(directory)
+
+        for file in file_list:
+            self.fs.create_file(file)
+
+        return file_list
+
     def test_live_view_opens_without_data(self):
         self.fs.create_dir("/live_dir")
         self.imaging.show_live_viewer(Path("/live_dir"))
+        self.check_target(widget=self.imaging.live_viewer)
+
+    @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image')
+    @mock.patch('mantidimaging.gui.windows.live_viewer.model.ImageWatcher')
+    def test_live_view_opens_with_data(self, _mock_image_watcher, mock_load_image):
+        self.fs.create_dir("/live_dir")
+        file_list = self._make_simple_dir(Path("/live_dir"))
+        image_list = [Image_Data(path) for path in file_list]
+        mock_load_image.return_value = self._generate_image()
+        self.imaging.show_live_viewer(Path("/live_dir"))
+        self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list)
         self.check_target(widget=self.imaging.live_viewer)

--- a/mantidimaging/eyes_tests/live_viewer_window_test.py
+++ b/mantidimaging/eyes_tests/live_viewer_window_test.py
@@ -13,14 +13,17 @@ from pathlib import Path
 
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
 
-filters = {f.filter_name: f for f in load_filter_packages()}  # Needed for pyfakefs
-
 
 class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        load_filter_packages()  # Needs to be called before pyfakefs hides the filesystem
+
     def setUp(self) -> None:
         super().setUp()
-        self.fs.add_real_directory(Path(__file__).parent.parent)
+        self.fs.add_real_directory(Path(__file__).parent.parent)  # Allow ui file to be found
         self.live_directory = Path("/live_dir")
         self.fs.create_dir(self.live_directory)
 

--- a/mantidimaging/eyes_tests/live_viewer_window_test.py
+++ b/mantidimaging/eyes_tests/live_viewer_window_test.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from mantidimaging.core.operations.loader import load_filter_packages
+from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
+from pathlib import Path
+
+from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
+
+filters = {f.filter_name: f for f in load_filter_packages()}  # Needed for pyfakefs
+
+
+class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.fs.add_real_directory(Path(__file__).parent.parent)
+
+    def test_live_view_opens_without_data(self):
+        self.fs.create_dir("/live_dir")
+        self.imaging.show_live_viewer(Path("/live_dir"))
+        self.check_target(widget=self.imaging.live_viewer)

--- a/mantidimaging/eyes_tests/live_viewer_window_test.py
+++ b/mantidimaging/eyes_tests/live_viewer_window_test.py
@@ -52,3 +52,14 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
         self.imaging.show_live_viewer(Path("/live_dir"))
         self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list)
         self.check_target(widget=self.imaging.live_viewer)
+
+    @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image')
+    @mock.patch('mantidimaging.gui.windows.live_viewer.model.ImageWatcher')
+    def test_live_view_opens_with_bad_data(self, _mock_image_watcher, mock_load_image):
+        self.fs.create_dir("/live_dir")
+        file_list = self._make_simple_dir(Path("/live_dir"))
+        image_list = [Image_Data(path) for path in file_list]
+        mock_load_image.side_effect = ValueError
+        self.imaging.show_live_viewer(Path("/live_dir"))
+        self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list)
+        self.check_target(widget=self.imaging.live_viewer)

--- a/mantidimaging/eyes_tests/live_viewer_window_test.py
+++ b/mantidimaging/eyes_tests/live_viewer_window_test.py
@@ -21,6 +21,8 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
     def setUp(self) -> None:
         super().setUp()
         self.fs.add_real_directory(Path(__file__).parent.parent)
+        self.live_directory = Path("/live_dir")
+        self.fs.create_dir(self.live_directory)
 
     def _generate_image(self):
         image = np.zeros((10, 10))
@@ -38,28 +40,25 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
         return file_list
 
     def test_live_view_opens_without_data(self):
-        self.fs.create_dir("/live_dir")
-        self.imaging.show_live_viewer(Path("/live_dir"))
+        self.imaging.show_live_viewer(self.live_directory)
         self.check_target(widget=self.imaging.live_viewer)
 
     @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image')
     @mock.patch('mantidimaging.gui.windows.live_viewer.model.ImageWatcher')
     def test_live_view_opens_with_data(self, _mock_image_watcher, mock_load_image):
-        self.fs.create_dir("/live_dir")
-        file_list = self._make_simple_dir(Path("/live_dir"))
+        file_list = self._make_simple_dir(self.live_directory)
         image_list = [Image_Data(path) for path in file_list]
         mock_load_image.return_value = self._generate_image()
-        self.imaging.show_live_viewer(Path("/live_dir"))
+        self.imaging.show_live_viewer(self.live_directory)
         self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list)
         self.check_target(widget=self.imaging.live_viewer)
 
     @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image')
     @mock.patch('mantidimaging.gui.windows.live_viewer.model.ImageWatcher')
     def test_live_view_opens_with_bad_data(self, _mock_image_watcher, mock_load_image):
-        self.fs.create_dir("/live_dir")
-        file_list = self._make_simple_dir(Path("/live_dir"))
+        file_list = self._make_simple_dir(self.live_directory)
         image_list = [Image_Data(path) for path in file_list]
         mock_load_image.side_effect = ValueError
-        self.imaging.show_live_viewer(Path("/live_dir"))
+        self.imaging.show_live_viewer(self.live_directory)
         self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list)
         self.check_target(widget=self.imaging.live_viewer)

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -87,14 +87,13 @@ class LiveViewerWindowPresenter(BasePresenter):
         """
         try:
             image_data = self.load_image(image_path)
-
-            image_data = self.perform_operations(image_data)
         except (IOError, KeyError, ValueError, TiffFileError, DeflateError) as error:
             message = f"{type(error).__name__} reading image: {image_path}: {error}"
             logger.error(message)
             self.view.remove_image()
             self.view.live_viewer.show_error(message)
             return
+        image_data = self.perform_operations(image_data)
         if image_data.size == 0:
             message = "reading image: {image_path}: Image has zero size"
             logger.error("reading image: %s: Image has zero size", image_path)

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -165,6 +165,8 @@ class FakeFSTestCase(pyfakefs.fake_filesystem_unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.setUpPyfakefs()
+        if sys.platform == 'linux':
+            self.fs.add_real_file("/proc/meminfo", read_only=True)
 
     def _files_equal(self, file1, file2) -> None:
         self.assertIsNotNone(file1)


### PR DESCRIPTION
### Issue

Closes #2039 

### Description

Implemented during a ensemble session.

Adds 3 screenshot tests for the live viewer, plus a small refactor.

### Testing 

This adds screenshot tests to the live viewer

### Acceptance Criteria 

Check new screenshots show on applitools, and look as expected.

### Documentation

Not needed
