### PR TITLE
Update various places to new conda repo

### DIFF
--- a/docker/centos7.Dockerfile
+++ b/docker/centos7.Dockerfile
@@ -13,10 +13,10 @@ RUN yum install -y make wget git which xorg-x11-server-Xvfb libxkbcommon-x11 fon
 # Fixes "D-Bus library appears to be incorrectly set up;" error
 RUN dbus-uuidgen > /var/lib/dbus/machine-id
 
-RUN wget -nv -O Mambaforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh &&\
-    chmod +x Mambaforge.sh &&\
-    bash Mambaforge.sh -b -p /opt/miniconda &&\
-    rm Mambaforge.sh
+RUN wget -nv -O Miniforge3.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh &&\
+    chmod +x Miniforge3.sh &&\
+    bash Miniforge3.sh -b -p /opt/miniconda &&\
+    rm Miniforge3.sh
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/ubuntu18.Dockerfile
+++ b/docker/ubuntu18.Dockerfile
@@ -22,10 +22,10 @@ RUN apt-get update && apt-get install -y make wget curl git fontconfig \
     apt-get clean
 
 
-RUN wget -nv -O Mambaforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh &&\
-    chmod +x Mambaforge.sh &&\
-    bash Mambaforge.sh -b -p /opt/miniconda &&\
-    rm Mambaforge.sh
+RUN wget -nv -O Miniforge3.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh &&\
+    chmod +x Miniforge3.sh &&\
+    bash Miniforge3.sh -b -p /opt/miniconda &&\
+    rm Miniforge3.sh
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ Mantid Imaging is a graphical toolkit for performing 3D reconstruction of neutro
    :caption: Links:
 
    Code Repository <https://github.com/mantidproject/mantidimaging>
-   Anaconda Package <https://anaconda.org/mantid/mantidimaging>
+   Anaconda Package <https://anaconda.org/mantidimaging/mantidimaging>
 
 
 Please cite as:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -56,7 +56,7 @@ Mantid Imaging can be installed using the packages_ published to Anaconda Cloud,
 or Mamba distribution if you already have one on your machine. However if you have issues you may find it worth installing
 a fresh Miniforge3.
 
-.. _packages: https://anaconda.org/mantid/mantidimaging/
+.. _packages: https://anaconda.org/mantidimaging/mantidimaging/
 
 1. Download and install CUDA Runtime version 10.2 - https://developer.nvidia.com/cuda-10.2-download-archive before installing the Mantid Imaging environment.
 2. Download and install `Miniforge3 <https://github.com/conda-forge/miniforge#download>`_ (this is the conda distribution that we recommend).

--- a/docs/release_notes/next/dev-2011-new-conda-repo
+++ b/docs/release_notes/next/dev-2011-new-conda-repo
@@ -1,0 +1,1 @@
+#2011 : Move to a new conda repo https://anaconda.org/mantidimaging/mantidimaging

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,6 +1,6 @@
 name: mantidimaging-dev
 channels:
-  - mantid/label/unstable
+  - mantidimaging/label/unstable
   - dtasev
   - astra-toolbox
   - conda-forge

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: mantidimaging-nightly
 channels:
-  - mantid/label/unstable
+  - mantidimaging/label/unstable
   - astra-toolbox
   - conda-forge
   - ccpi

--- a/setup.py
+++ b/setup.py
@@ -162,9 +162,13 @@ class CreateDeveloperEnvironment(Command):
     def make_environment_file(self, extra_deps):
         dev_env_file = Path(__file__).parent / "environment-dev.yml"
         output_env_file = tempfile.NamedTemporaryFile("wt", delete=False, suffix=".yaml")
+        in_dependencies_section = False
         with dev_env_file.open() as dev_env_file_fh:
             for line in dev_env_file_fh:
-                if line.strip().startswith("- mantidimaging"):
+                if line.startswith("dependencies:"):
+                    in_dependencies_section = True
+
+                if in_dependencies_section and line.strip().startswith("- mantidimaging"):
                     for extra_dep in extra_deps:
                         output_env_file.write(f"  - {extra_dep}\n")
                 else:


### PR DESCRIPTION
### Issue
Closes #2011 

### Description
Updates the docs
Updates the environment files, which are used by IDAaaS

### Testing & Acceptance Criteria 

Check that mantidimaging can be installed with
`mamba env create -f environment.yml`
and that in that environment
`mamba list mantidimaging`
shows the channel as
`mantidimaging/label/unstable`

### Documentation

Release notes
