### PR TITLE
Improve reliability of ExecutionTimerTest on Windows

### DIFF
--- a/docs/release_notes/next/fix-1966-ExecutionTimer
+++ b/docs/release_notes/next/fix-1966-ExecutionTimer
@@ -1,0 +1,1 @@
+#1966: ExecutionTimer unit test fails intermittently for Windows GitHub Action

--- a/mantidimaging/core/utility/test/execution_timer_test.py
+++ b/mantidimaging/core/utility/test/execution_timer_test.py
@@ -20,7 +20,7 @@ class ExecutionTimerTest(unittest.TestCase):
 
             time.sleep(0.1)
 
-        self.assertGreaterEqual(t.total_seconds, 0.1)
+        self.assertGreaterEqual(t.total_seconds, 0.09)
 
     def test_custom_message(self):
         t = ExecutionTimer(msg='Task')


### PR DESCRIPTION
### Issue

Closes 1966

This pull request addresses an intermittent failure in the ExecutionTimerTest.test_execute method observed in Windows GitHub Action workflows. The failure is due to slight timing discrepancies that can occur in virtualised environments. By adjusting the assertion to allow a small margin of error, we aim to make the test more robust across different execution environments.

### Description

The adjustment from 0.1 to 0.09 seconds is a suggested value that should account for most of the observed discrepancies. However, this value may need further adjustment based on empirical data from multiple test runs across different environments

### Testing 

Running the test multiple times in a Windows environment to ensure the failure no longer occurs.

Checking that the test still effectively validates the functionality of the ExecutionTimer by ensuring that it does not introduce too much leniency

### Documentation

noted in the appropriate file in docs/release_notes
