### PR TITLE
Implement Click Dialog for ROI Colour Changes in Table

### DIFF
--- a/docs/release_notes/next/feature-2046-ROI_Colors _table
+++ b/docs/release_notes/next/feature-2046-ROI_Colors _table
@@ -1,0 +1,1 @@
+#2046 : Enhancement: Implement Click Dialog for Changing ROI Colors in Table

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -241,7 +241,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         if roi_name in self.view.spectrum_widget.roi_dict:
             self.view.spectrum_widget.roi_dict[roi_name].colour = new_colour
-        self.view.update_roi_color_in_table(roi_name, new_colour)
+        self.view.update_roi_color(roi_name, new_colour)
 
     def add_rits_roi(self) -> None:
         roi_name = ROI_RITS

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -43,9 +43,9 @@ class SpectrumROI(ROI):
         self.roi.setAcceptedMouseButtons(Qt.MouseButton.LeftButton)
 
         self.menu = QMenu()
-        change_color_action = QAction("Change ROI Colour", self)
-        change_color_action.triggered.connect(self.onChangeColor)
-        self.menu.addAction(change_color_action)
+        self.change_color_action = QAction("Change ROI Colour", self)
+        self.change_color_action.triggered.connect(self.onChangeColor)
+        self.menu.addAction(self.change_color_action)
 
     def onChangeColor(self):
         current_color = QColor(*self._colour)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -108,6 +108,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.tableView.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.tableView.setSelectionMode(QAbstractItemView.SingleSelection)
         self.tableView.setAlternatingRowColors(True)
+        self.tableView.clicked.connect(self.handle_table_click)
 
         # Roi Prop table
         self.roi_table_properties = ["Top", "Bottom", "Left", "Right"]
@@ -340,10 +341,18 @@ class SpectrumViewerWindowView(BaseMainWindowView):
                 spinbox.setEnabled(True)
         self.set_roi_properties()
 
-    def update_roi_color_in_table(self, roi_name: str, new_color: tuple):
+    def handle_table_click(self, index):
+        if index.isValid() and index.column() == 1:
+            roi_name = self.roi_table_model.index(index.row(), 0).data()
+            self.set_spectum_roi_color(roi_name)
+
+    def set_spectum_roi_color(self, roi_name: str) -> None:
+        spectrum_roi = self.spectrum_widget.roi_dict[roi_name]
+        spectrum_roi.change_color_action.trigger()
+
+    def update_roi_color(self, roi_name: str, new_color: tuple) -> None:
         """
         Finds ROI by name in table and updates colour.
-
         @param roi_name: Name of the ROI to update.
         @param new_color: The new color for the ROI in (R, G, B) format.
         """
@@ -354,7 +363,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     def find_row_for_roi(self, roi_name: str) -> Optional[int]:
         """
         Returns row index for ROI name, or None if not found.
-
         @param roi_name: Name ROI find.
         @return: Row index ROI or None.
         """


### PR DESCRIPTION
### Issue

Closes #2046


### Description

This pull request introduces a feature allowing users to change the colour of Regions of Interest (ROIs) directly from the table representation in the Spectrum Viewer. By implementing a click dialogue, users can now select an ROI entry in the table, open a colour selection dialogue, and choose a new colour. This enhancement is aimed at providing a consistent and user-friendly interface across the Spectrum Viewer, improving overall usability

While the Spectrum Viewer currently supports changing ROI colours via a right-click context menu within the viewer, there has been no equivalent, intuitive method for altering ROI colours when interacting with the table representation of ROIs. This pull request addresses this gap by extending colour-changing functionality to the table, thereby streamlining the user experience and aligning it with the existing capabilities of the viewer component.


### Testing 

Single and multiple ROI colour changes through the table.
Synchronization of colour changes between the table, viewer, and data model.


### Documentation

Changes in docs/release_notes*
