### PR TITLE
Spectrum Viewer ROI visibility fix

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -138,6 +138,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def handle_roi_clicked(self, roi) -> None:
         self.view.current_roi = roi.name
+        self.view.last_clicked_roi = roi.name
         self.view.set_roi_properties()
 
     def redraw_spectrum(self, name: str) -> None:

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -87,6 +87,9 @@ class SpectrumROI(ROI):
         self.setPos((roi.left, roi.top))
         self.setSize((roi.width, roi.height))
 
+    def rename_roi(self, new_name: str) -> None:
+        self._name = new_name
+
 
 class SpectrumWidget(QWidget):
     """
@@ -256,6 +259,7 @@ class SpectrumWidget(QWidget):
         if old_name in self.roi_dict.keys() and new_name not in self.roi_dict.keys():
             self.roi_dict[new_name] = self.roi_dict.pop(old_name)
             self.spectrum_data_dict[new_name] = self.spectrum_data_dict.pop(old_name)
+            self.roi_dict[new_name].rename_roi(new_name)
 
 
 class SpectrumPlotWidget(GraphicsLayoutWidget):
@@ -263,7 +267,6 @@ class SpectrumPlotWidget(GraphicsLayoutWidget):
     spectrum: PlotItem
 
     range_control: LinearRegionItem
-    roi_dict: dict[Optional[str], ROI]
 
     range_changed = pyqtSignal(object)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -51,6 +51,8 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
     spectrum_widget: SpectrumWidget
 
+    number_roi_properties_procced: int = 0
+
     def __init__(self, main_window: 'MainWindowView'):
         super().__init__(None, 'gui/ui/spectrum_viewer.ui')
 
@@ -64,6 +66,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.selected_row_data: Optional[list] = None
         self.roiPropertiesSpinBoxes: dict[str, QSpinBox] = {}
         self.roiPropertiesLabels: dict[str, QLabel] = {}
+        self.old_table_names: list = []
 
         self.presenter = SpectrumViewerWindowPresenter(self, main_window)
 
@@ -178,19 +181,20 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             If the visibility of an ROI has changed, update the visibility of the ROI in the spectrum widget.
             """
             selected_row_data = self.roi_table_model.row_data(self.selected_row)
-
             if selected_row_data[0].lower() not in ["", " ", "all"] and selected_row_data[0] != self.current_roi:
                 if selected_row_data[0] in self.presenter.get_roi_names():
-                    selected_row_data[0] = self.current_roi
-                    return
+                    selected_row_data[0] = self.old_table_names[self.selected_row]
+                    self.current_roi = selected_row_data[0]
+                    self.last_clicked_roi = self.current_roi
                 else:
                     self.presenter.rename_roi(self.current_roi, selected_row_data[0])
                     self.current_roi = selected_row_data[0]
-                    return
+                    self.last_clicked_roi = self.current_roi
+                    self.set_roi_properties()
             else:
-                selected_row_data[0] = self.current_roi
+                selected_row_data[0] = self.old_table_names[self.selected_row]
 
-            selected_row_data[0] = self.current_roi
+            self.set_old_table_names()
             self.on_visibility_change()
             return
 
@@ -214,7 +218,10 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         When the visibility of an ROI is changed, update the visibility of the ROI in the spectrum widget
         """
         if self.presenter.export_mode == ExportMode.ROI_MODE:
-            self.current_roi = self.last_clicked_roi
+            if self.current_roi in self.old_table_names and self.last_clicked_roi in self.old_table_names:
+                pass
+            else:
+                self.current_roi = self.last_clicked_roi
             if self.roi_table_model.rowCount() == 0:
                 self.disable_roi_properties()
             if not self.roi_table_model.rowCount() == 0:
@@ -395,6 +402,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.tableView.selectRow(self.selected_row)
         self.current_roi = name
         self.removeBtn.setEnabled(True)
+        self.set_old_table_names()
 
     def remove_roi(self) -> None:
         """
@@ -492,3 +500,10 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
     def get_roi_properties_spinboxes(self):
         return self.roiPropertiesSpinBoxes
+
+    def set_old_table_names(self):
+        self.old_table_names = self.presenter.get_roi_names()
+        if 'all' in self.old_table_names:
+            self.old_table_names.remove('all')
+        if 'rits_roi' in self.old_table_names:
+            self.old_table_names.remove('rits_roi')


### PR DESCRIPTION
### Description

Fixes an issue where having two ROIs e.g. "roi" and "roi_1" and upon switching the visibility of "roi_1" off and on and resizing leads to roi_1 being renamed to roi and causing a keyError.

Example: 

> 2024-02-21 14:16:50,532 [mantidimaging.gui.windows.main.view:L513] ERROR: Traceback (most recent call last):
  File "mantidimaging\gui\windows\spectrum_viewer\view.py", line 194, in on_data_in_table_change
  File "mantidimaging\gui\windows\spectrum_viewer\view.py", line 226, in on_visibility_change
  File "mantidimaging\gui\windows\spectrum_viewer\view.py", line 373, in set_roi_alpha
  File "mantidimaging\gui\windows\spectrum_viewer\spectrum_widget.py", line 187, in set_roi_alpha
KeyError: 'roi_3'

Bug was located here:

> `on_data_in_table_change` , when the new roi visibility is turned off, the other roi is made the current_roi, and then when it is turned back on it  hits if `selected_row_data[0].lower() not in ["", " ", "all"] and selected_row_data[0] != self.current_roi`:  which then renames the new roi with the current_roi, hence why roi_1 gets renamed to roi

Changes have been made to better log the last clicked and the current roi to prevent erroneous unintentional renamings of ROIs. Upon making changes to the ROI Table, a snapshot of the Roi names are stored in `self.old_table_names` to compare against when a ROI is renamed in the future.

Various other fixes have been made when a new roi was added and renamed, it would no longer be tracked by the ROI Properties Table unless it was clicked off and on again in the table.

In a future piece of work, I would recommend splitting `on_data_in_table_change` into two functions e.g. `on_name_change` and 
`on_visibilty_change` to simplify the logic flows.

### Testing 

make check

### Acceptance Criteria 

- Load some data in, open the Spectrum Viewer.
- Create multiple ROIs, resize them and test combinations of their visibilities and renaming them.
- Make sure that upon renaming the ROIs and turning the visibilites back on that they are renamed in the ROI Properties Table correctly and continue to be tracked as expected.
- Check that switching between the RITS and Image tabs behaves as expected.
- Check that creating various ROIs and then changing the Sample behaves as expected

