### PR TITLE
Move Gaussian Operation to Use compute_function Style

### DIFF
--- a/docs/release_notes/next/feature-2051-operations
+++ b/docs/release_notes/next/feature-2051-operations
@@ -1,0 +1,1 @@
+#2051: Move operations to compute_function style


### PR DESCRIPTION
### Issue

Move operations to compute_function style #2051

### Description

The project aims to standardize how operations are executed, moving away from using the partial function style towards a more structured compute_function approach. A new static method compute_function has been introduced in gaussian.py. This method the core logic for applying the Gaussian filter directly on a per-slice basis. This modification ensures a clear separation between the setup and execution phases of the operation.

### Documentation

not done yet

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*
