### PR TITLE
2062 Spectrum Viewer ROI Desync Fix

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -220,8 +220,12 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         if self.presenter.export_mode == ExportMode.ROI_MODE:
             if self.current_roi in self.old_table_names and self.last_clicked_roi in self.old_table_names:
                 pass
-            else:
+            elif self.current_roi == ROI_RITS and self.last_clicked_roi in self.old_table_names:
                 self.current_roi = self.last_clicked_roi
+            elif self.current_roi == ROI_RITS and self.last_clicked_roi not in self.old_table_names:
+                self.current_roi = self.roi_table_model.row_data(self.selected_row)[0]
+            else:
+                self.last_clicked_roi = self.current_roi
             if self.roi_table_model.rowCount() == 0:
                 self.disable_roi_properties()
             if not self.roi_table_model.rowCount() == 0:

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -421,6 +421,10 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         if self.roi_table_model.rowCount() == 0:
             self.removeBtn.setEnabled(False)
             self.disable_roi_properties()
+        else:
+            self.set_old_table_names()
+            self.current_roi = self.roi_table_model.row_data(self.selected_row)[0]
+            self.set_roi_properties()
 
     def clear_all_rois(self) -> None:
         """


### PR DESCRIPTION
### Issue

Closes #2062 

### Description

Upon removing an ROI, the current roi and the old_table_names are refreshed to the newer state of the ROI Table and then the Properties Table is refreshed. This prevents the view checking for ROIs that no longer exist in the table when `on_data_in_table_change` is triggered by changing the visibility on a different ROI.

### Testing 

make check

### Acceptance Criteria 

1. Load data and open Spectrum View
2. Create a few ROIs 
3. Delete the first ROI in the ROI Table
4. Change the visibility of the other ROIs in the table, they should no behave as expected
5. Check that the active ROI in the Properties Table is correct when deleting the current ROI.
6. Perform Usual checks of switching tabs, samples, etc.
