### PR TITLE
Table ROI color change: backport to 2.7

### DIFF
--- a/docs/release_notes/2.7.rst
+++ b/docs/release_notes/2.7.rst
@@ -10,6 +10,7 @@ New Features
 - #2026: Time of flight graph in the Spectrum Viewer is now resizable
 - #2027: The Spectrum ROI details display in an adjustable table via spinboxes
 - #2048: Update spectrum documentation to reflect changes made to the Spectrum Viewer.
+- #2046 : Enhancement: Implement Click Dialog for Changing ROI Colors in Table
 
 Fixes
 -----

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -243,6 +243,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         if roi_name in self.view.spectrum_widget.roi_dict:
             self.view.spectrum_widget.roi_dict[roi_name].colour = new_colour
         self.view.update_roi_color(roi_name, new_colour)
+        self.view.on_visibility_change()
 
     def add_rits_roi(self) -> None:
         roi_name = ROI_RITS

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -242,7 +242,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         if roi_name in self.view.spectrum_widget.roi_dict:
             self.view.spectrum_widget.roi_dict[roi_name].colour = new_colour
-        self.view.update_roi_color_in_table(roi_name, new_colour)
+        self.view.update_roi_color(roi_name, new_colour)
 
     def add_rits_roi(self) -> None:
         roi_name = ROI_RITS

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -43,9 +43,9 @@ class SpectrumROI(ROI):
         self.roi.setAcceptedMouseButtons(Qt.MouseButton.LeftButton)
 
         self.menu = QMenu()
-        change_color_action = QAction("Change ROI Colour", self)
-        change_color_action.triggered.connect(self.onChangeColor)
-        self.menu.addAction(change_color_action)
+        self.change_color_action = QAction("Change ROI Colour", self)
+        self.change_color_action.triggered.connect(self.onChangeColor)
+        self.menu.addAction(self.change_color_action)
 
     def onChangeColor(self):
         current_color = QColor(*self._colour)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -111,6 +111,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.tableView.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.tableView.setSelectionMode(QAbstractItemView.SingleSelection)
         self.tableView.setAlternatingRowColors(True)
+        self.tableView.clicked.connect(self.handle_table_click)
 
         # Roi Prop table
         self.roi_table_properties = ["Top", "Bottom", "Left", "Right"]
@@ -351,10 +352,18 @@ class SpectrumViewerWindowView(BaseMainWindowView):
                 spinbox.setEnabled(True)
         self.set_roi_properties()
 
-    def update_roi_color_in_table(self, roi_name: str, new_color: tuple):
+    def handle_table_click(self, index):
+        if index.isValid() and index.column() == 1:
+            roi_name = self.roi_table_model.index(index.row(), 0).data()
+            self.set_spectum_roi_color(roi_name)
+
+    def set_spectum_roi_color(self, roi_name: str) -> None:
+        spectrum_roi = self.spectrum_widget.roi_dict[roi_name]
+        spectrum_roi.change_color_action.trigger()
+
+    def update_roi_color(self, roi_name: str, new_color: tuple) -> None:
         """
         Finds ROI by name in table and updates colour.
-
         @param roi_name: Name of the ROI to update.
         @param new_color: The new color for the ROI in (R, G, B) format.
         """
@@ -365,7 +374,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     def find_row_for_roi(self, roi_name: str) -> Optional[int]:
         """
         Returns row index for ROI name, or None if not found.
-
         @param roi_name: Name ROI find.
         @return: Row index ROI or None.
         """


### PR DESCRIPTION
Backport #2047 to release branch. Release notes tweaked.

This completes the recent colour changing work, but adding a additional route to trigger it.

This has a small foot print, so unlikely to introduce any bugs. Unlikely to cause any problems with ROI state consistency.