### PR TITLE
2062 roi tracking - Quick fix RITS_ROI bug

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -137,9 +137,10 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                 self.view.set_spectrum(name, self.model.get_spectrum(name, self.spectrum_mode))
 
     def handle_roi_clicked(self, roi) -> None:
-        self.view.current_roi = roi.name
-        self.view.last_clicked_roi = roi.name
-        self.view.set_roi_properties()
+        if not roi.name == ROI_RITS:
+            self.view.current_roi = roi.name
+            self.view.last_clicked_roi = roi.name
+            self.view.set_roi_properties()
 
     def redraw_spectrum(self, name: str) -> None:
         """


### PR DESCRIPTION
Fixes a bug where if the Roi Table is empty and then the RITS ROI is explicitly clicked on, then the tab is switch back to the ROI Tab, it lead to an IndexError.

>   File "C:\Users\ddb29996\mantidimaging\mantidimaging\gui\windows\spectrum_viewer\presenter.py", line 292, in handle_export_tab_change
    self.view.on_visibility_change()
  File "C:\Users\ddb29996\mantidimaging\mantidimaging\gui\windows\spectrum_viewer\view.py", line 227, in on_visibility_change
    self.current_roi = self.roi_table_model.row_data(self.selected_row)[0]
  File "C:\Users\ddb29996\mantidimaging\mantidimaging\gui\windows\spectrum_viewer\roi_table_model.py", line 98, in row_data
    return self._data[row]
IndexError: list index out of range
2024-02-26 14:49:22,084 [mantidimaging.gui.mvp_base.view:L40] ERROR: show_error_dialog(): Uncaught exception IndexError: list index out of range

This is now fixed by never assigning `self.last_clicked_roi` as `rits_roi` as it makes no sense to do so.