### PR TITLE
Update Environment Versions to 2.7.0

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,7 +8,7 @@ channels:
   - algotom
   - intel
 dependencies:
-  - mantidimaging>=2.5.0
+  - mantidimaging>=2.7.0,<2.8.0
   - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774
   - pip
   - pip:
@@ -32,4 +32,3 @@ dependencies:
   - make==4.3
   - ruff=0.2.1
   - pre-commit==3.5.*
-

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,6 +1,6 @@
 name: mantidimaging-dev
 channels:
-  - mantidimaging/label/unstable
+  - mantidimaging/label/main
   - dtasev
   - astra-toolbox
   - conda-forge

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ channels:
   - intel
 # Dependencies that can be installed with conda should be in conda/meta.yaml
 dependencies:
-  - mantidimaging>=2.5.0
+  - mantidimaging>=2.7.0,<2.8.0
   - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: mantidimaging-nightly
+name: mantidimaging
 channels:
   - mantidimaging/label/main
   - astra-toolbox

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: mantidimaging-nightly
 channels:
-  - mantidimaging/label/unstable
+  - mantidimaging/label/main
   - astra-toolbox
   - conda-forge
   - ccpi


### PR DESCRIPTION
### Issue

Update Environment Versions as part of #2054 

### Description

Updates `environment.yml` and `environment-dev.yml`

### Testing 

Check versions are now 2.7.0

### Acceptance Criteria 

- Versions are now 2.7.0 in environment files
- Check that install succeeds with:  `mamba env create -f environment.yml`

### Documentation

N/A
