### PR TITLE
Yapf Diff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,29 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
-    hooks:
-    -   id: end-of-file-fixer
-        types: [python]
--   repo: https://github.com/google/yapf
-    rev: v0.40.2
-    hooks:
-    -   id: yapf
--   repo: local
-    hooks:
-    -   id: check-licenses
-        name: Check Licenses
-        description: Checks that all files have correct copyright licenses
-        entry: python -m CheckLicensesInFiles
-        language: python
-        types: [python]
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.3.0'
-    hooks:
-    -   id: mypy
-        files: ^mantidimaging/
-        args: [--ignore-missing-imports, --no-site-packages]
--   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.1
-    hooks:
-    -   id: ruff
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v3.4.0
+      hooks:
+          - id: end-of-file-fixer
+            types: [python]
+    - repo: https://github.com/google/yapf
+      rev: v0.40.2
+      hooks:
+          - id: yapf
+            args: [--diff]
+    - repo: local
+      hooks:
+          - id: check-licenses
+            name: Check Licenses
+            description: Checks that all files have correct copyright licenses
+            entry: python -m CheckLicensesInFiles
+            language: python
+            types: [python]
+    - repo: https://github.com/pre-commit/mirrors-mypy
+      rev: "v1.3.0"
+      hooks:
+          - id: mypy
+            files: ^mantidimaging/
+            args: [--ignore-missing-imports, --no-site-packages]
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.2.1
+      hooks:
+          - id: ruff


### PR DESCRIPTION
Add diff argument to yapf pre-commit to check diff to prevent applying doulbe quotes

### Issue

I have experience yapf changing my single quotes to doulbe quotes on multiple occasions. this PR proses adding a diff argument to check the diff rather than auto applying, relying on the user to use the command ` make yapf_apply ` if they wish to apply.

### Acceptance Criteria 

- yapf doesn't apply suggested changes automatically
- yapf displays changes

### Documentation

N/A
