### PR TITLE
added --run-tests open in pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ test-verbose:
 	python -m pytest -vs -o log_cli=true
 
 test-system:
-	${XVFBRUN} python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov -o log_cli=true --run-system-tests
+	${XVFBRUN} python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov -o log_cli=true --run-system-tests mantidimaging/gui/test/
 
 test-screenshots:
 	-mkdir ${TEST_RESULT_DIR}

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,10 @@ install-dev-requirements:
 	python ./setup.py create_dev_env
 
 test:
-	python -m pytest -n auto --run-unit-tests
+	python -m pytest -n auto
 
 test-verbose:
-	python -m pytest -vs -o log_cli=true --run-unit-tests
+	python -m pytest -vs -o log_cli=true
 
 test-system:
 	${XVFBRUN} python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov -o log_cli=true --run-system-tests

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,10 @@ install-dev-requirements:
 	python ./setup.py create_dev_env
 
 test:
-	python -m pytest -n auto
+	python -m pytest -n auto --run-tests
 
 test-verbose:
-	python -m pytest -vs -o log_cli=true
+	python -m pytest -vs -o log_cli=true --run-tests
 
 test-system:
 	${XVFBRUN} python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov -o log_cli=true --run-system-tests

--- a/Makefile
+++ b/Makefile
@@ -43,22 +43,22 @@ install-dev-requirements:
 	python ./setup.py create_dev_env
 
 test:
-	python -m pytest -n auto --run-tests
+	python -m pytest -n auto --run-unit-tests
 
 test-verbose:
-	python -m pytest -vs -o log_cli=true --run-tests
+	python -m pytest -vs -o log_cli=true --run-unit-tests
 
 test-system:
 	${XVFBRUN} python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov -o log_cli=true --run-system-tests
 
 test-screenshots:
 	-mkdir ${TEST_RESULT_DIR}
-	APPLITOOLS_API_KEY=local APPLITOOLS_IMAGE_DIR=${TEST_RESULT_DIR} ${XVFBRUN} pytest -p no:xdist -p no:randomly -p no:cov mantidimaging/eyes_tests/ -vs
+	APPLITOOLS_API_KEY=local APPLITOOLS_IMAGE_DIR=${TEST_RESULT_DIR} ${XVFBRUN} pytest -p no:xdist -p no:randomly -p no:cov mantidimaging/eyes_tests/ -vs --run-eyes-tests
 	@echo "Screenshots writen to" ${TEST_RESULT_DIR}
 
 test-screenshots-win:
 	-mkdir ${TEST_RESULT_DIR}
-	${XVFBRUN} pytest -p no:xdist -p no:randomly -p no:cov mantidimaging/eyes_tests/ -vs
+	${XVFBRUN} pytest -p no:xdist -p no:randomly -p no:cov mantidimaging/eyes_tests/ -vs --run-eyes-tests
 	@echo "Screenshots writen to" ${TEST_RESULT_DIR}
 
 mypy:

--- a/conftest.py
+++ b/conftest.py
@@ -28,8 +28,6 @@ skipped_tests = []
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--run-system-tests"):
         allowed_markers.append(pytest.mark.system.mark)
-    if config.getoption("--run-unit-tests"):
-        allowed_markers.append(pytest.mark.unit.mark)
     if config.getoption("--run-eyes-tests"):
         allowed_markers.append(pytest.mark.eyes.mark)
     if config.getoption("--run-unit-tests") or len(allowed_markers) == 0:

--- a/conftest.py
+++ b/conftest.py
@@ -32,13 +32,15 @@ def pytest_collection_modifyitems(config, items):
         allowed_markers.append(pytest.mark.unit.mark)
     if config.getoption("--run-eyes-tests"):
         allowed_markers.append(pytest.mark.eyes.mark)
+    if config.getoption("--run-unit-tests") or len(allowed_markers) == 0:
+        allowed_markers.append(pytest.mark.unit.mark)
     for item in items:
-        if all(test not in item.nodeid for test in ["gui_system", "eyes_test"]):
-            item.add_marker(pytest.mark.unit)
         if "gui_system" in item.nodeid:
             item.add_marker(pytest.mark.system)
-        if "eyes_test" in item.nodeid:
+        elif "eyes_test" in item.nodeid:
             item.add_marker(pytest.mark.eyes)
+        else:
+            item.add_marker(pytest.mark.unit)
         if any(mark in allowed_markers for mark in item.own_markers):
             pass
         else:

--- a/conftest.py
+++ b/conftest.py
@@ -13,17 +13,25 @@ def _test_gui_system_filename_match(basename: str) -> bool:
     return "gui_system" in basename and "_test.py" in basename
 
 
+def _test_normal_filename_match(path) -> bool:
+    return "gui_system" not in path.basename and "eyes_tests" not in str(path) and "_test.py" in path.basename
+
+
 def pytest_addoption(parser):
     parser.addoption("--run-system-tests", action="store_true", default=False, help="Run GUI system tests")
+    parser.addoption("--run-tests", action="store_true", default=False, help="Run normal tests")
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "system: GUI system tests")
+    config.addinivalue_line("markers", "normal: normal tests")
 
 
 def pytest_ignore_collect(path, config):
     # When running GUI system tests, ignore all other files
     if config.getoption("--run-system-tests") and path.isfile() and not _test_gui_system_filename_match(path.basename):
+        return True
+    elif config.getoption("--run-tests") and path.isfile() and not _test_normal_filename_match(path):
         return True
     else:
         return False
@@ -34,6 +42,11 @@ def pytest_collection_modifyitems(config, items):
         skip_system = pytest.mark.skip(reason="use --run-system-tests option to run")
         for item in items:
             if "system" in item.keywords:
+                item.add_marker(skip_system)
+    elif not config.getoption("--run-tests"):
+        skip_system = pytest.mark.skip(reason="use --run-tests option to run")
+        for item in items:
+            if "system" not in item.keywords and "eyes_tests" not in item.path:
                 item.add_marker(skip_system)
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -9,45 +9,41 @@ import pytest
 from mantidimaging.core.utility.leak_tracker import leak_tracker
 
 
-def _test_gui_system_filename_match(basename: str) -> bool:
-    return "gui_system" in basename and "_test.py" in basename
-
-
-def _test_normal_filename_match(path) -> bool:
-    return "gui_system" not in path.basename and "eyes_tests" not in str(path) and "_test.py" in path.basename
-
-
 def pytest_addoption(parser):
     parser.addoption("--run-system-tests", action="store_true", default=False, help="Run GUI system tests")
-    parser.addoption("--run-tests", action="store_true", default=False, help="Run normal tests")
+    parser.addoption("--run-unit-tests", action="store_true", default=False, help="Run unit tests")
+    parser.addoption("--run-eyes-tests", action="store_true", default=False, help="Run eyes tests")
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "system: GUI system tests")
-    config.addinivalue_line("markers", "normal: normal tests")
+    config.addinivalue_line("markers", "unit: unit tests")
+    config.addinivalue_line("markers", "eyes: eyes tests")
 
 
-def pytest_ignore_collect(path, config):
-    # When running GUI system tests, ignore all other files
-    if config.getoption("--run-system-tests") and path.isfile() and not _test_gui_system_filename_match(path.basename):
-        return True
-    elif config.getoption("--run-tests") and path.isfile() and not _test_normal_filename_match(path):
-        return True
-    else:
-        return False
+allowed_markers = []
+skipped_tests = []
 
 
 def pytest_collection_modifyitems(config, items):
-    if not config.getoption("--run-system-tests"):
-        skip_system = pytest.mark.skip(reason="use --run-system-tests option to run")
-        for item in items:
-            if "system" in item.keywords:
-                item.add_marker(skip_system)
-    elif not config.getoption("--run-tests"):
-        skip_system = pytest.mark.skip(reason="use --run-tests option to run")
-        for item in items:
-            if "system" not in item.keywords and "eyes_tests" not in item.path:
-                item.add_marker(skip_system)
+    if config.getoption("--run-system-tests"):
+        allowed_markers.append(pytest.mark.system.mark)
+    if config.getoption("--run-unit-tests"):
+        allowed_markers.append(pytest.mark.unit.mark)
+    if config.getoption("--run-eyes-tests"):
+        allowed_markers.append(pytest.mark.eyes.mark)
+    for item in items:
+        if all(test not in item.nodeid for test in ["gui_system", "eyes_test"]):
+            item.add_marker(pytest.mark.unit)
+        if "gui_system" in item.nodeid:
+            item.add_marker(pytest.mark.system)
+        if "eyes_test" in item.nodeid:
+            item.add_marker(pytest.mark.eyes)
+        if any(mark in allowed_markers for mark in item.own_markers):
+            pass
+        else:
+            item.add_marker(pytest.mark.skip(reason="Test not selected"))
+            skipped_tests.append(item.nodeid)
 
 
 # Leak track for tests

--- a/docs/release_notes/next/dev-2082-pytest_separation
+++ b/docs/release_notes/next/dev-2082-pytest_separation
@@ -1,0 +1,1 @@
+#2082: Normal, System, and Screenshot test are now explicitly separated in the Makefile


### PR DESCRIPTION
### Issue

Closes #2082.
Closes #1906.

### Description

On Windows, running `python -m pytest -n auto` was running the system tests and the screenshot eyes tests instead of just the "normal" tests.

A `--run-unit-tests` option is now available with pytest to explicitly only run the unittests by not collecting the `eyes_tests` and the `system-tests`. This functionality should be robust against future added tests.
You can also exclude the unit tests from pytest by not using the  `--run-unit-tests` option.

` --run-unit-tests` has been included into the makefile such that running `make test` should only run the unittest and not the system tests or screenshot eyes tests. These can be run with `make test-system` and `make test-screenshots` (or on windows: `make test-screenshots-win`) respectively. The `--ignore=<Path>` can now be used along with custom flags to explicitly exclude certain paths or tests in the collection phase of `pytest`.

### Acceptance Criteria 

run the following and make sure that the appropriate tests ran as expected:

1. `make test`
2. `make test-verbose`
3. `make test-system`
4. `make test-screenshots` or `make test-screenshots-win`
5. `make check`
6. use the `--ignore=<path>` flag along with a custom flag to check it works as expected, e.g. `python -m pytest --run-unit-tests --ignore=mantidimaging/core`

NOTE: running `--run-eyes-tests` will only work if the API local key is correctly set up. This can be done via the command line on linux but is done via the environment variables in Windows. The environment variables are taken care of in the makefile so running `make test-screenshots-win` should run the eyes tests locally on windows.

### Documentation

Will add to Developer release notes
