### PR TITLE
Update mypy to 1.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         language: python
         types: [python]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.3.0'
+    rev: 'v1.8.0'
     hooks:
     -   id: mypy
         files: ^mantidimaging/

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -16,7 +16,7 @@ dependencies:
       - git+https://github.com/samtygier-stfc/sphinx-multiversion.git@prebuild_command
       - eyes-images==5.20.*
   - yapf==0.40.*
-  - mypy==1.3
+  - mypy==1.8
   - pytest==7.4.*
   - pytest-cov==4.1.*
   - pytest-randomly==3.15.*


### PR DESCRIPTION
### Issue

Step before #2008 

### Description

Update mypy package before doing type annotation work for #2008

### Testing & Acceptance Criteria 

Automated tests should pass

Create a fresh `mantidimaging-dev` environment and run `make mypy`
```
mamba activate base
python ./setup.py create_dev_env
mamba activate mantidimaging-dev
```


### Documentation

Will put release notes when #2008 is complete
