### PR TITLE
Disable no site packages

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -92,9 +92,8 @@ jobs:
 
       - name: mypy
         shell: bash -l {0}
-        # COMPAT: applitools has some bad signatures, so use --no-site-packages
         run: |
-          mypy --ignore-missing-imports --no-site-packages mantidimaging
+          mypy --ignore-missing-imports mantidimaging
 
       - name: pytest
         timeout-minutes: 10

--- a/.github/workflows/cos7_testing.yml
+++ b/.github/workflows/cos7_testing.yml
@@ -40,8 +40,7 @@ jobs:
     - name: mypy
       uses: ./.github/actions/test
       with:
-        # COMPAT: applitools has some bad signatures, so use --no-site-packages
-        command: mypy --ignore-missing-imports --no-site-packages mantidimaging
+        command: mypy --ignore-missing-imports mantidimaging
         label: centos7
 
     - name: pytest

--- a/.github/workflows/u18_testing.yml
+++ b/.github/workflows/u18_testing.yml
@@ -39,8 +39,7 @@ jobs:
     - name: mypy
       uses: ./.github/actions/test
       with:
-        # COMPAT: applitools has some bad signatures, so use --no-site-packages
-        command: mypy --ignore-missing-imports --no-site-packages mantidimaging
+        command: mypy --ignore-missing-imports mantidimaging
         label: ubuntu18
 
     - name: pytest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -79,9 +79,8 @@ jobs:
 
       - name: mypy
         shell: bash -l {0}
-        # COMPAT: applitools has some bad signatures, so use --no-site-packages
         run: |
-          mypy --ignore-missing-imports --no-site-packages mantidimaging
+          mypy --ignore-missing-imports mantidimaging
 
       - name: pytest
         timeout-minutes: 10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
     -   id: mypy
         files: ^mantidimaging/
         args: [--ignore-missing-imports]
+        additional_dependencies: [types-docutils, types-PyYAML, types-requests]
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.3.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     hooks:
     -   id: mypy
         files: ^mantidimaging/
-        args: [--ignore-missing-imports, --no-site-packages]
+        args: [--ignore-missing-imports]
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.3.2
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test-screenshots-win:
 	@echo "Screenshots writen to" ${TEST_RESULT_DIR}
 
 mypy:
-	python -m mypy --ignore-missing-imports --no-site-packages ${SOURCE_DIRS}
+	python -m mypy --ignore-missing-imports ${SOURCE_DIRS}
 
 yapf:
 	python -m yapf --parallel --diff --recursive ${SOURCE_DIRS}

--- a/docs/release_notes/next/dev-2008-mypy-site-packages
+++ b/docs/release_notes/next/dev-2008-mypy-site-packages
@@ -1,0 +1,1 @@
+#2008: Update mypy, remove --no-site-packages, fix issues

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -17,6 +17,9 @@ dependencies:
       - eyes-images==5.20.*
   - yapf==0.40.*
   - mypy==1.8
+  - types-requests
+  - types-PyYAML
+  - types-docutils
   - pytest==7.4.*
   - pytest-cov==4.1.*
   - pytest-randomly==3.15.*

--- a/mantidimaging/eyes_tests/eyes_manager.py
+++ b/mantidimaging/eyes_tests/eyes_manager.py
@@ -6,15 +6,22 @@ import inspect
 import os
 import sys
 from tempfile import mkdtemp
+from typing import TYPE_CHECKING, Any
 from unittest import mock
 from uuid import uuid4
 
 from PyQt5.QtWidgets import QWidget, QApplication
 from PyQt5.QtTest import QTest
-from applitools.common import BatchInfo, MatchLevel
-from applitools.images import Eyes
 
 from mantidimaging.gui.windows.main import MainWindowView
+
+# COMPAT: applitools has some bad signatures, so avoid importing it when type checking
+# See https://github.com/mantidproject/mantidimaging/issues/2008
+if not TYPE_CHECKING:
+    from applitools.common import BatchInfo, MatchLevel
+    from applitools.images import Eyes
+else:
+    MatchLevel = Any
 
 # Used to disabiguate tests on the Applitools platform. set explicitly to avoid depending on the window size
 VIEWPORT_WIDTH = 1920


### PR DESCRIPTION
### Issue

Closes #2008

~~Needs for #2100 and #2104 to be merged first~~

### Description
Final bits for removing the `--no-site-packages` option to mypy.

Add some type stub packages.

Includes a hack for applitools, which has some invalid types.

This reduces the imprecise typing from 42.41% to 41.89% (by my maths, 175 newly precise lines)

### Testing & Acceptance Criteria 

Test should pass.

If testing locally you may need to create a new environment

### Documentation

Release notes