### PR TITLE
Fix params in operation test case

### DIFF
--- a/docs/release_notes/next/dev-2107-operation-test-params
+++ b/docs/release_notes/next/dev-2107-operation-test-params
@@ -1,0 +1,1 @@
+#2107: Fix operation test param defaults

--- a/scripts/operations_tests/operations_tests.py
+++ b/scripts/operations_tests/operations_tests.py
@@ -76,7 +76,7 @@ def compare_mode():
             test_name = f"{operation.lower()}_{sub_test_name}"
             if args.match and args.match not in test_name:
                 continue
-            params = case["params"] | test_case_info["params"]
+            params = test_case_info["params"] | case["params"]
             op_class = FILTERS[operation]
             op_func = op_class.filter_func
             test_case = TestCase(operation, test_name, sub_test_name, test_number, params, op_func)

--- a/scripts/operations_tests/test_cases.json
+++ b/scripts/operations_tests/test_cases.json
@@ -524,15 +524,6 @@
                 "params": {
                     "rebin_param": 0.5
                 }
-            },
-            {
-                "test_name": "rebin_to_dimensions_100x100",
-                "params": {
-                    "rebin_param": [
-                        100,
-                        100
-                    ]
-                }
             }
         ]
     },


### PR DESCRIPTION
### Issue
Closes #2107

### Description
Fix how case params are combined with defaults

Also disable the rebin_to_dimensions_100x100 case, because we need to pass a tuple to the function, but can't read a tuple from json.

### Testing & Acceptance Criteria 

Use a print statement as in the bug report to check the cases are being made properly

### Documentation

Release notes
