### PR TITLE
Convert Class Method to Static Method in Stripe Operations 

### DIFF
--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -47,11 +47,11 @@ class RemoveDeadStripesFilter(BaseFilter):
             return images
         params = {"snr": snr, "size": size, "residual": False}
         if images.is_sinograms:
-            ps.run_compute_func(RemoveDeadStripesFilter.compute_function_sino, images.num_sinograms,
-                                images.shared_array, params, progress)
+            compute_func = RemoveDeadStripesFilter.compute_function_sino
         else:
-            ps.run_compute_func(RemoveDeadStripesFilter.compute_function, images.num_projections, images.shared_array,
-                                params, progress)
+            compute_func = RemoveDeadStripesFilter.compute_function
+
+        ps.run_compute_func(compute_func, images.num_projections, images.shared_array, params, progress)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -50,8 +50,7 @@ class RemoveDeadStripesFilter(BaseFilter):
             compute_func = RemoveDeadStripesFilter.compute_function_sino
         else:
             compute_func = RemoveDeadStripesFilter.compute_function
-
-        ps.run_compute_func(compute_func, images.num_projections, images.shared_array, params, progress)
+        ps.run_compute_func(compute_func, images.num_sinograms, images.shared_array, params, progress)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -35,8 +35,8 @@ class RemoveDeadStripesFilter(BaseFilter):
     link_histograms = True
     operate_on_sinograms = True
 
-    @classmethod
-    def filter_func(cls, images: ImageStack, snr=3, size=61, progress=None):
+    @staticmethod
+    def filter_func(images: ImageStack, snr=3, size=61, progress=None):
         """
         :param snr: The ratio value.
         :param size: The window size of the median filter to remove dead stripes.
@@ -47,10 +47,11 @@ class RemoveDeadStripesFilter(BaseFilter):
             return images
         params = {"snr": snr, "size": size, "residual": False}
         if images.is_sinograms:
-            compute_func = cls.compute_function_sino
+            ps.run_compute_func(RemoveDeadStripesFilter.compute_function_sino, images.num_sinograms,
+                                images.shared_array, params, progress)
         else:
-            compute_func = cls.compute_function
-        ps.run_compute_func(compute_func, images.num_sinograms, images.shared_array, params, progress)
+            ps.run_compute_func(RemoveDeadStripesFilter.compute_function, images.num_projections, images.shared_array,
+                                params, progress)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
+++ b/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
@@ -45,11 +45,11 @@ class RemoveLargeStripesFilter(BaseFilter):
         """
         params = {"snr": snr, "size": la_size}
         if images.is_sinograms:
-            ps.run_compute_func(RemoveLargeStripesFilter.compute_function_sino, images.num_sinograms,
-                                images.shared_array, params, progress)
+            compute_func = RemoveLargeStripesFilter.compute_function_sino
         else:
-            ps.run_compute_func(RemoveLargeStripesFilter.compute_function, images.num_projections, images.shared_array,
-                                params, progress)
+            compute_func = RemoveLargeStripesFilter.compute_function
+
+        ps.run_compute_func(compute_func, images.num_projections, images.shared_array, params, progress)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
+++ b/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
@@ -48,8 +48,7 @@ class RemoveLargeStripesFilter(BaseFilter):
             compute_func = RemoveLargeStripesFilter.compute_function_sino
         else:
             compute_func = RemoveLargeStripesFilter.compute_function
-
-        ps.run_compute_func(compute_func, images.num_projections, images.shared_array, params, progress)
+        ps.run_compute_func(compute_func, images.num_sinograms, images.shared_array, params, progress)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
+++ b/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
@@ -35,8 +35,8 @@ class RemoveLargeStripesFilter(BaseFilter):
     link_histograms = True
     operate_on_sinograms = True
 
-    @classmethod
-    def filter_func(cls, images: 'ImageStack', snr=3, la_size=61, progress=None):
+    @staticmethod
+    def filter_func(images: 'ImageStack', snr=3, la_size=61, progress=None):
         """
         :param snr: The ratio value.
         :param size: The window size of the median filter to remove large stripes.
@@ -45,10 +45,11 @@ class RemoveLargeStripesFilter(BaseFilter):
         """
         params = {"snr": snr, "size": la_size}
         if images.is_sinograms:
-            compute_func = cls.compute_function_sino
+            ps.run_compute_func(RemoveLargeStripesFilter.compute_function_sino, images.num_sinograms,
+                                images.shared_array, params, progress)
         else:
-            compute_func = cls.compute_function
-        ps.run_compute_func(compute_func, images.num_sinograms, images.shared_array, params, progress)
+            ps.run_compute_func(RemoveLargeStripesFilter.compute_function, images.num_projections, images.shared_array,
+                                params, progress)
         return images
 
     @staticmethod

--- a/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
@@ -35,8 +35,8 @@ class RemoveStripeFilteringFilter(BaseFilter):
     link_histograms = True
     operate_on_sinograms = True
 
-    @classmethod
-    def filter_func(cls, images: ImageStack, sigma=3, size=21, window_dim=1, filtering_dim=1, progress=None):
+    @staticmethod
+    def filter_func(images: ImageStack, sigma=3, size=21, window_dim=1, filtering_dim=1, progress=None):
         """
         :param sigma: The sigma of the Gaussian window used to separate the
                       low-pass and high-pass components of the intensity profile
@@ -55,15 +55,15 @@ class RemoveStripeFilteringFilter(BaseFilter):
         if images.is_sinograms:
             if filtering_dim == 1:
                 params["sort"] = True
-                compute_func = cls.compute_function_sino
+                compute_func = RemoveStripeFilteringFilter.compute_function_sino
             else:
-                compute_func = cls.compute_function_2d_sino
+                compute_func = RemoveStripeFilteringFilter.compute_function_2d_sino
         else:
             if filtering_dim == 1:
                 params["sort"] = True
-                compute_func = cls.compute_function
+                compute_func = RemoveStripeFilteringFilter.compute_function
             else:
-                compute_func = cls.compute_function_2d
+                compute_func = RemoveStripeFilteringFilter.compute_function_2d
 
         ps.run_compute_func(compute_func, images.num_sinograms, images.shared_array, params, progress)
         return images

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
@@ -35,8 +35,8 @@ class RemoveStripeSortingFittingFilter(BaseFilter):
     link_histograms = True
     operate_on_sinograms = True
 
-    @classmethod
-    def filter_func(cls, images: ImageStack, order=1, sigma=3, progress=None):
+    @staticmethod
+    def filter_func(images: ImageStack, order=1, sigma=3, progress=None):
         """
         :param order: The polynomial fit order. Check algotom docs for more
                       information.
@@ -49,9 +49,9 @@ class RemoveStripeSortingFittingFilter(BaseFilter):
             return images
         params = {'order': order, 'sigma': sigma, 'sort': True}
         if images.is_sinograms:
-            compute_func = cls.compute_function_sino
+            compute_func = RemoveStripeSortingFittingFilter.compute_function_sino
         else:
-            compute_func = cls.compute_function
+            compute_func = RemoveStripeSortingFittingFilter.compute_function
         ps.run_compute_func(compute_func, images.num_sinograms, images.shared_array, params, progress)
 
         return images


### PR DESCRIPTION
### Description

This pull request modifies the filter_func method in the Stripe Operations from a class method (@classmethod) to a static method (@staticmethod). This change is proposed to enhance the method's utility by making it callable without needing an instance of the class, which is more suitable for its current implementation that does not require access to the class state.

### Testing 

Needs to be tested 

