### PR TITLE
Spectrum Viewer stacks update after Operations

### DIFF
--- a/docs/release_notes/next/fix-2113-spectrum-viewer-sync-stacks
+++ b/docs/release_notes/next/fix-2113-spectrum-viewer-sync-stacks
@@ -1,0 +1,1 @@
+#2113: Spectrum Viewer stacks now update with Main Window after operation applied

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -48,6 +48,18 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.main_window = main_window
         self.model = SpectrumViewerWindowModel(self)
         self.export_mode = ExportMode.ROI_MODE
+        self.main_window.stack_changed.connect(self.handle_stack_changed)
+
+    def handle_stack_changed(self):
+        self.model.set_stack(self.main_window.get_stack(self.current_stack_uuid))
+        normalise_uuid = self.view.get_normalise_stack()
+        if normalise_uuid is not None:
+            try:
+                norm_stack: Optional['ImageStack'] = self.main_window.get_stack(normalise_uuid)
+            except RuntimeError:
+                norm_stack = None
+            self.model.set_normalise_stack(norm_stack)
+        self.redraw_all_rois()
 
     def handle_sample_change(self, uuid: Optional['UUID']) -> None:
         if uuid == self.current_stack_uuid:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -50,8 +50,11 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.export_mode = ExportMode.ROI_MODE
         self.main_window.stack_changed.connect(self.handle_stack_changed)
 
-    def handle_stack_changed(self):
-        self.model.set_stack(self.main_window.get_stack(self.current_stack_uuid))
+    def handle_stack_changed(self) -> None:
+        if self.current_stack_uuid:
+            self.model.set_stack(self.main_window.get_stack(self.current_stack_uuid))
+        else:
+            return
         normalise_uuid = self.view.get_normalise_stack()
         if normalise_uuid is not None:
             try:
@@ -59,6 +62,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             except RuntimeError:
                 norm_stack = None
             self.model.set_normalise_stack(norm_stack)
+        self.show_new_sample()
         self.redraw_all_rois()
 
     def handle_sample_change(self, uuid: Optional['UUID']) -> None:


### PR DESCRIPTION
### Issue

Closes #2096

### Description

The Spectrum Viewer now hijacks the `stack_changed` signal from the Main Window which is emitted when an operation is completed. On signal catch, the current stack and the normalised stack are reset and the ROIs and spectrum are redrawn. Using the same signal to update both the Main Window and the Spectrum Viewer will prevent them from going out of sync in the future.

### Testing
 
make check

### Acceptance Criteria 

Repeat the steps given in the issue and check that the Spectrum plot now updates as expected:

- Load sample stack and open-beam stack ToF data into Mantid Imaging
- Open Spectrum Viewer window
- **Spectrum Viewer:** Normalise sample to open beam
- Open Operations window
- Position Spectrum Viewer and Operations window side-by-side
- **Operations window:** Select the Arithmetic operation (can be any operation in theory)
- **Operations window:** Toggle safe apply off
- **Operations window:** Select open beam stack
- **Spectrum Viewer:** Take note of the normalised spectrum.
- **Operations window:** Apply the division operation by a factor of 2 to the open beam within.
- **Spectrum Viewer:** Check that the spectrum updates as expected.

### Documentation

fix added to release notes
