### PR TITLE
Update ruff to 0.3.2

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Ruff
         shell: bash -l {0}
         run: |
-          ruff .
+          ruff check .
 
       - name: mypy
         shell: bash -l {0}

--- a/.github/workflows/cos7_testing.yml
+++ b/.github/workflows/cos7_testing.yml
@@ -34,7 +34,7 @@ jobs:
     - name: ruff
       uses: ./.github/actions/test
       with:
-        command: ruff .
+        command: ruff check .
         label: centos7
 
     - name: mypy

--- a/.github/workflows/u18_testing.yml
+++ b/.github/workflows/u18_testing.yml
@@ -33,7 +33,7 @@ jobs:
     - name: ruff
       uses: ./.github/actions/test
       with:
-        command: ruff .
+        command: ruff check .
         label: ubuntu18
 
     - name: mypy

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Ruff
         shell: bash -l {0}
         run: |
-          ruff .
+          ruff check .
 
       - name: mypy
         shell: bash -l {0}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
         files: ^mantidimaging/
         args: [--ignore-missing-imports, --no-site-packages]
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.1
+    rev: v0.3.2
     hooks:
     -   id: ruff

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ yapf_apply:
 	python -m yapf -i --parallel --recursive ${SOURCE_DIRS}
 
 ruff:
-	ruff ${SOURCE_DIRS}
+	ruff check ${SOURCE_DIRS}
 
 check: ruff yapf mypy test
 

--- a/docs/release_notes/next/dev-2114-update-ruff
+++ b/docs/release_notes/next/dev-2114-update-ruff
@@ -1,0 +1,1 @@
+#2114: Update ruff and fix some new warnings

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -30,6 +30,6 @@ dependencies:
   - pyinstaller==6.1.*
   - sarepy=2020.07 # For building old docs
   - make==4.3
-  - ruff=0.2.1
+  - ruff=0.3.2
   - pre-commit==3.5.*
 

--- a/mantidimaging/gui/widgets/palette_changer/test/presenter_test.py
+++ b/mantidimaging/gui/widgets/palette_changer/test/presenter_test.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 import numpy as np
 
 from mantidimaging.gui.widgets.palette_changer.presenter import PaletteChangerPresenter, SAMPLE_SIZE
+from mantidimaging.test_helpers.unit_test_helper import gen_img_numpy_rand
 
 
 def _normalise_break_value(break_value, min_value, max_value):
@@ -25,7 +26,7 @@ class PaletteChangerPresenterTest(unittest.TestCase):
         self.view = mock.MagicMock()
         self.histograms = [mock.Mock() for _ in range(2)]
         self.recon_histogram = mock.Mock()
-        self.recon_image = np.random.random((200, 200))
+        self.recon_image = gen_img_numpy_rand((200, 200), 2024)
         self.recon_gradient = self.recon_histogram.gradient
         self.presenter = PaletteChangerPresenter(self.view, self.histograms, self.recon_histogram, self.recon_image,
                                                  True)
@@ -39,8 +40,8 @@ class PaletteChangerPresenterTest(unittest.TestCase):
         assert self.presenter.flattened_image.ndim == 1
 
     def test_flattened_image_creation_for_small_image(self):
-        presenter = PaletteChangerPresenter(self.view, self.histograms, self.recon_histogram, np.random.random(
-            (20, 20)), True)
+        presenter = PaletteChangerPresenter(self.view, self.histograms, self.recon_histogram,
+                                            gen_img_numpy_rand((20, 20), 2024), True)
         assert presenter.flattened_image.size == 400
         assert presenter.flattened_image.ndim == 1
 
@@ -137,7 +138,7 @@ class PaletteChangerPresenterTest(unittest.TestCase):
 
     def test_get_sample_pixels(self):
         COUNT = 50
-        recon_image = np.random.random((50, 50))
+        recon_image = gen_img_numpy_rand((50, 50), 2024)
         sampled = self.presenter._get_sample_pixels(recon_image, COUNT, 0.9)
 
         self.assertEqual(len(sampled), COUNT)
@@ -148,14 +149,16 @@ class PaletteChangerPresenterTest(unittest.TestCase):
     def test_not_recon_mode_calls_choice(self, default_rng_mock):
         rng_mock = MagicMock()
         default_rng_mock.return_value = rng_mock
-        PaletteChangerPresenter(self.view, self.histograms, self.recon_histogram, np.random.random((20, 20)), False)
+        PaletteChangerPresenter(self.view, self.histograms, self.recon_histogram, gen_img_numpy_rand((20, 20), 2024),
+                                False)
         rng_mock.choice.assert_called_once()
 
     @mock.patch("mantidimaging.gui.widgets.palette_changer.presenter.np.random.default_rng")
     def test_recon_mode_doesnt_call_choice(self, default_rng_mock):
         rng_mock = MagicMock()
         default_rng_mock.return_value = rng_mock
-        PaletteChangerPresenter(self.view, self.histograms, self.recon_histogram, np.random.random((20, 20)), True)
+        PaletteChangerPresenter(self.view, self.histograms, self.recon_histogram, gen_img_numpy_rand((20, 20), 2024),
+                                True)
         rng_mock.choice.assert_not_called()
 
     def test_jenks_break_values(self):

--- a/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
@@ -10,7 +10,7 @@ import numpy
 import numpy as np
 
 from mantidimaging.core.io.saver import NEXUS_PROCESSED_DATA_PATH
-from mantidimaging.test_helpers.unit_test_helper import generate_images
+from mantidimaging.test_helpers.unit_test_helper import generate_images, gen_img_numpy_rand
 
 from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.gui.windows.nexus_load_dialog.presenter import _missing_data_message, TOMO_ENTRY, DATA_PATH, \
@@ -32,7 +32,7 @@ class NexusLoaderTest(unittest.TestCase):
         self.tomo_entry = self.nexus.create_group(self.full_tomo_path)
 
         self.n_images = 10
-        self.data_array = np.random.random((self.n_images, 10, 10))
+        self.data_array = gen_img_numpy_rand((self.n_images, 10, 10), 2024)
         self.tomo_entry.create_dataset(DATA_PATH, data=self.data_array, dtype="float64")
 
         self.flat_before = self.data_array[:2]


### PR DESCRIPTION
### Issue

Close #2114 

### Description

Update to ruff ~~0.3.1~~ 0.3.2

Use `ruff check` to avoid deprecation warning

Remove deprecated numpy random calls. Note this was not picked up in #2038 because of a ruff bug

### Testing 

Update dev environment and run `make mypy`

### Documentation
Release notes
