### PR TITLE
Fix menu position

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - ccpi-regulariser
     - jenkspy=0.2.0
     - pyqt=5.15.*
-    - pyqtgraph=0.13.3
+    - pyqtgraph=0.13.7
     - qt-material=2.14
     - darkdetect=0.8.0
     - qt-gtk-platformtheme # [linux]

--- a/docs/release_notes/next/fix-2119-pyqt-menu
+++ b/docs/release_notes/next/fix-2119-pyqt-menu
@@ -1,0 +1,1 @@
+#2129 : fix menu position for new pyqtgraph

--- a/mantidimaging/gui/widgets/auto_colour_menu/auto_color_menu.py
+++ b/mantidimaging/gui/widgets/auto_colour_menu/auto_color_menu.py
@@ -12,8 +12,6 @@ if TYPE_CHECKING:
     import numpy as np
     from PyQt5.QtWidgets import QWidget
 
-DEFAULT_MENU_POSITION = 12
-
 
 class AutoColorMenu:
     """
@@ -38,12 +36,13 @@ class AutoColorMenu:
     def add_auto_color_menu_action(self,
                                    parent: QWidget | None,
                                    recon_mode: bool = False,
-                                   index: int = DEFAULT_MENU_POSITION,
                                    set_enabled: bool = True) -> QAction:
         self.auto_color_parent = parent
         self.auto_color_recon_mode = recon_mode
         self.auto_color_action = QAction("Auto")
-        place = self.histogram.gradient.menu.actions()[index]
+
+        index_of_rgb_item = [action.text() for action in self.histogram.gradient.menu.actions()].index("RGB")
+        place = self.histogram.gradient.menu.actions()[index_of_rgb_item - 1]
 
         self.histogram.gradient.menu.insertAction(place, self.auto_color_action)
         self.histogram.gradient.menu.insertSeparator(self.auto_color_action)


### PR DESCRIPTION
### Issue

Closes #2119 

~~Note, this is waiting on the pyqtgraph 0.13.5 release~~

### Description

Update pyqtgraph to 0.13.7
Set menu position of the `Auto` option relative to the `RGB` entry.
Removed `index` as an argument as it was never used.

### Testing & Acceptance Criteria 

Update your dev environment 

Open a dataset.
Right click on the colour bar by the histogram, and change choose auto.
Should give the auto colour dialog with no errors.

Also check that all the main gui windows (operations, recon, spectrum view) open, and behave normally

### Documentation

release notes
