### PR TITLE
Pin pyqtgraph to avoid #2120

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - ccpi-regulariser
     - jenkspy=0.2.0
     - pyqt=5.15.*
-    - pyqtgraph=0.13.*
+    - pyqtgraph=0.13.3
     - qt-gtk-platformtheme # [linux]
 
 build:


### PR DESCRIPTION
### Issue

Quick workaround for #2120 

### Description
Pin PyQtGraph to 0.13.4 to avoid change that effects put a custom menu item into the colour bar

### Testing & Acceptance Criteria 

Install the new pyqtgraph version and observe the issue by opening a dataset

`mamba install pyqtgraph=0.13.3`
switch back with
`mamba install pyqtgraph=0.13.3`

### Documentation

Not needed
