### PR TITLE
Pin pyqtgraph to avoid #2119

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - ccpi-regulariser
     - jenkspy=0.2.0
     - pyqt=5.15.*
-    - pyqtgraph=0.13.*
+    - pyqtgraph=0.13.3
     - qt-gtk-platformtheme # [linux]
 
 build:


### PR DESCRIPTION
### Issue
Backport #2121 to release branch

### Description

Pin PyQtGraph to 0.13.3 to avoid #2119 

### Testing & Acceptance Criteria 

Tests should pass.

### Documentation

Not needed
