### PR TITLE
Zoomable spectrum plot in the Spectrum Viewer

### DIFF
--- a/docs/release_notes/next/feature-2133-zoomable-spectrum-plot
+++ b/docs/release_notes/next/feature-2133-zoomable-spectrum-plot
@@ -1,0 +1,1 @@
+#2133: The Spectrum plot in the Spectrum Viewer can be zoomed via a click and drag zoom-box

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -40,18 +40,12 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
                  name: str = "MIMiniImageView",
                  parent: QWidget | None = None,
                  recon_mode: bool = False,
-                 view_box: ViewBox | None = None):
+                 view_box_type: type[ViewBox] = ViewBox):
         super().__init__()
 
         self.name = name.title()
         self.im = ImageItem()
-        if view_box is None:
-            self.vb = ViewBox(invertY=True, lockAspect=True, name=name)
-        else:
-            self.vb = view_box
-            self.vb.invertY(True)
-            self.vb.setAspectLocked(True)
-            self.vb.register(name)
+        self.vb = view_box_type(invertY=True, lockAspect=True, name=name)
         self.vb.addItem(self.im)
         self.hist = HistogramLUTItem(self.im)
         graveyard.append(self.vb)

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -38,9 +38,9 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
 
     def __init__(self,
                  name: str = "MIMiniImageView",
-                 parent: 'Optional[QWidget]' = None,
+                 parent: QWidget | None = None,
                  recon_mode: bool = False,
-                 view_box: 'Optional[ViewBox]' = None):
+                 view_box: ViewBox | None = None):
         super().__init__()
 
         self.name = name.title()

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -36,12 +36,22 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
     bright_levels: None | list[int] = None
     levels: list[float]
 
-    def __init__(self, name: str = "MIMiniImageView", parent: QWidget | None = None, recon_mode: bool = False):
+    def __init__(self,
+                 name: str = "MIMiniImageView",
+                 parent: 'Optional[QWidget]' = None,
+                 recon_mode: bool = False,
+                 view_box: 'Optional[ViewBox]' = None):
         super().__init__()
 
         self.name = name.title()
         self.im = ImageItem()
-        self.vb = ViewBox(invertY=True, lockAspect=True, name=name)
+        if view_box is None:
+            self.vb = ViewBox(invertY=True, lockAspect=True, name=name)
+        else:
+            self.vb = view_box
+            self.vb.invertY(True)
+            self.vb.setAspectLocked(True)
+            self.vb.register(name)
         self.vb.addItem(self.im)
         self.hist = HistogramLUTItem(self.im)
         graveyard.append(self.vb)

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -263,7 +263,16 @@ class CustomViewBox(ViewBox):
     def __init__(self, *args, **kwds):
         kwds['enableMenu'] = False
         ViewBox.__init__(self, *args, **kwds)
-        self.setMouseMode(self.RectMode)
+        self.setMouseMode(self.PanMode)
+
+    def keyPressEvent(self, event):
+        if event.key() == Qt.Key_Control:
+            self.setMouseMode(self.RectMode)
+
+    def keyReleaseEvent(self, event):
+        if event.key() == Qt.Key_Control:
+            self.rbScaleBox.hide()
+            self.setMouseMode(self.PanMode)
 
     ## reimplement right-click to zoom out
     def mouseClickEvent(self, ev):
@@ -274,10 +283,8 @@ class CustomViewBox(ViewBox):
     def mouseDragEvent(self, ev, axis=None):
         if axis is not None and ev.button() == Qt.MouseButton.RightButton:
             ev.ignore()
-        elif ev.button() == Qt.MouseButton.MiddleButton:
-            self.setMouseMode(self.PanMode)
+        elif ev.button() == Qt.MouseButton.LeftButton:
             ViewBox.mouseDragEvent(self, ev)
-            self.setMouseMode(self.RectMode)
         else:
             ViewBox.mouseDragEvent(self, ev, axis=axis)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -261,7 +261,7 @@ class SpectrumWidget(QWidget):
 class CustomViewBox(ViewBox):
 
     def __init__(self, *args, **kwds):
-        kwds['enableMenu'] = False
+        #kwds['enableMenu'] = False
         ViewBox.__init__(self, *args, **kwds)
         self.setMouseMode(self.PanMode)
 
@@ -276,8 +276,10 @@ class CustomViewBox(ViewBox):
 
     ## reimplement right-click to zoom out
     def mouseClickEvent(self, ev):
-        if ev.button() == Qt.MouseButton.RightButton:
+        if ev.button() == Qt.MouseButton.RightButton and not self.menuEnabled():
             self.autoRange()
+        else:
+            ViewBox.mouseClickEvent(self, ev)
 
     ## reimplement mouseDragEvent to disable continuous axis zoom
     def mouseDragEvent(self, ev, axis=None):
@@ -300,7 +302,7 @@ class SpectrumPlotWidget(GraphicsLayoutWidget):
     def __init__(self) -> None:
         super().__init__()
 
-        self.spectrum_viewbox = CustomViewBox()
+        self.spectrum_viewbox = CustomViewBox(enableMenu=False)
         self.spectrum = self.addPlot(viewBox=self.spectrum_viewbox)
         self.nextRow()
         self._tof_range_label = self.addLabel()
@@ -341,7 +343,7 @@ class SpectrumProjectionWidget(GraphicsLayoutWidget):
 
     def __init__(self) -> None:
         super().__init__()
-
-        self.image = MIMiniImageView(name="Projection")
+        self.spectrum_projection_viewbox = CustomViewBox(enableMenu=True)
+        self.image = MIMiniImageView(name="Projection", view_box=self.spectrum_projection_viewbox)
         self.addItem(self.image, 0, 0)
         self.ci.layout.setRowStretchFactor(0, 3)

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -271,6 +271,8 @@ class CustomViewBox(ViewBox):
             for child in self.allChildren():
                 if isinstance(child, LinearRegionItem):
                     child.setMovable(False)
+                elif isinstance(child, SpectrumROI):
+                    child.translatable = False
 
     def keyReleaseEvent(self, event):
         if event.key() == Qt.Key_Control:
@@ -279,6 +281,8 @@ class CustomViewBox(ViewBox):
             for child in self.allChildren():
                 if isinstance(child, LinearRegionItem):
                     child.setMovable(True)
+                elif isinstance(child, SpectrumROI):
+                    child.translatable = True
 
     ## reimplement right-click to zoom out
     def mouseClickEvent(self, ev):
@@ -315,7 +319,6 @@ class SpectrumPlotWidget(GraphicsLayoutWidget):
         self.nextRow()
         self._image_index_range_label = self.addLabel()
         self.range_control = LinearRegionItem()
-        self.range_control.setMovable(False)
         self.range_control.sigRegionChangeFinished.connect(self._handle_tof_range_changed)
         self.ci.layout.setRowStretchFactor(0, 1)
 
@@ -350,7 +353,6 @@ class SpectrumProjectionWidget(GraphicsLayoutWidget):
 
     def __init__(self) -> None:
         super().__init__()
-        self.spectrum_projection_viewbox = CustomViewBox(enableMenu=True)
-        self.image = MIMiniImageView(name="Projection", view_box=self.spectrum_projection_viewbox)
+        self.image = MIMiniImageView(name="Projection", view_box_type=CustomViewBox)
         self.addItem(self.image, 0, 0)
         self.ci.layout.setRowStretchFactor(0, 3)

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -268,11 +268,17 @@ class CustomViewBox(ViewBox):
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_Control:
             self.setMouseMode(self.RectMode)
+            for child in self.allChildren():
+                if isinstance(child, LinearRegionItem):
+                    child.setMovable(False)
 
     def keyReleaseEvent(self, event):
         if event.key() == Qt.Key_Control:
             self.rbScaleBox.hide()
             self.setMouseMode(self.PanMode)
+            for child in self.allChildren():
+                if isinstance(child, LinearRegionItem):
+                    child.setMovable(True)
 
     ## reimplement right-click to zoom out
     def mouseClickEvent(self, ev):
@@ -302,13 +308,14 @@ class SpectrumPlotWidget(GraphicsLayoutWidget):
     def __init__(self) -> None:
         super().__init__()
 
-        self.spectrum_viewbox = CustomViewBox(enableMenu=False)
+        self.spectrum_viewbox = CustomViewBox(enableMenu=True)
         self.spectrum = self.addPlot(viewBox=self.spectrum_viewbox)
         self.nextRow()
         self._tof_range_label = self.addLabel()
         self.nextRow()
         self._image_index_range_label = self.addLabel()
         self.range_control = LinearRegionItem()
+        self.range_control.setMovable(False)
         self.range_control.sigRegionChangeFinished.connect(self._handle_tof_range_changed)
         self.ci.layout.setRowStretchFactor(0, 1)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from PyQt5.QtCore import pyqtSignal, Qt, QSignalBlocker
-from PyQt5.QtGui import QColor, QFont
+from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import QColorDialog, QAction, QMenu, QSplitter, QWidget, QVBoxLayout
 
-from pyqtgraph import ROI, GraphicsLayoutWidget, LinearRegionItem, PlotItem, mkPen, PlotWidget, ViewBox
+from pyqtgraph import ROI, GraphicsLayoutWidget, LinearRegionItem, PlotItem, mkPen, ViewBox
 
 from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint
 from mantidimaging.core.utility.sensible_roi import SensibleROI
@@ -259,6 +259,7 @@ class SpectrumWidget(QWidget):
 
 
 class CustomViewBox(ViewBox):
+
     def __init__(self, *args, **kwds):
         kwds['enableMenu'] = False
         ViewBox.__init__(self, *args, **kwds)
@@ -279,6 +280,7 @@ class CustomViewBox(ViewBox):
             self.setMouseMode(self.RectMode)
         else:
             ViewBox.mouseDragEvent(self, ev, axis=axis)
+
 
 class SpectrumPlotWidget(GraphicsLayoutWidget):
 

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -90,7 +90,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.spectrum_widget.roi_changed.connect(self.presenter.handle_roi_moved)
         self.spectrum_widget.roiColorChangeRequested.connect(self.presenter.change_roi_colour)
 
-        self.spectrum_right_click_menu = self.spectrum_widget.spectrum_plot_widget.spectrum.vb.menu
+        self.spectrum_right_click_menu = self.spectrum.spectrum_viewbox.menu
         self.units_menu = self.spectrum_right_click_menu.addMenu("Units")
         self.tof_mode_select_group = QActionGroup(self)
 


### PR DESCRIPTION
### Issue

Closes #2132 

### Description

The `SpectrumPlotWidget` in `spectrum_widget.py` now uses a custom viewbox which overrides the mouse events of the standard ViewBox class. The custom viewbox uses the `RectMode` mouse mode which uses a built-in zoom drag box. Now to pan the data, the middle mouse button can be used (by temporary using the `PanMode` mouse mode). The right mouse button can be clicked to reset the zoom to its default. The right click menu for this plot has been disabled as it is not useful for this plot.

### Testing 

make check

### Acceptance Criteria 

- Load data into MI and use the Spectrum Viewer.
- Click and drag a zoom box over the data to check the data is zoomed in as expected.
- NOTE: the ToF range box has to be moved to zoom as clicking and dragging this box will move the box instead of creating a zoom box, e.g. below:
![image](https://github.com/mantidproject/mantidimaging/assets/30868085/051e69df-f9d1-47af-ae0f-43360d44ca55)

- Use the middle and right mouse buttons to check they have the behaviour as mentioned above.

### Documentation

will add release note