### PR TITLE
Fix deprecated-import (UP035) issues

### DIFF
--- a/docs/ext/release_notes.py
+++ b/docs/ext/release_notes.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable
+from collections.abc import Iterable
 
 from docutils import nodes
 from docutils.statemachine import ViewList

--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 import re
-from typing import Iterator, Final
+from typing import Final
+from collections.abc import Iterator
 from logging import getLogger
 
 from mantidimaging.core.utility.data_containers import FILE_TYPES

--- a/mantidimaging/core/io/loader/img_loader.py
+++ b/mantidimaging/core/io/loader/img_loader.py
@@ -4,7 +4,8 @@
 This module handles the loading of FIT, FITS, TIF, TIFF
 """
 from __future__ import annotations
-from typing import Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING
+from collections.abc import Callable
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.parallel import utility as pu

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -5,7 +5,8 @@ import os
 from dataclasses import dataclass, field
 from logging import getLogger
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
+from collections.abc import Callable
 
 import numpy as np
 import astropy.io.fits as fits

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 import datetime
 import os
 from logging import getLogger
-from typing import Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING
+from collections.abc import Callable
 
 import h5py
 from pathlib import Path

--- a/mantidimaging/core/operation_history/operations.py
+++ b/mantidimaging/core/operation_history/operations.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from functools import partial
 from logging import getLogger
-from typing import Any, Callable, Iterable
+from typing import Any
+from collections.abc import Callable, Iterable
 
 import numpy as np
 

--- a/mantidimaging/core/operations/arithmetic/arithmetic.py
+++ b/mantidimaging/core/operations/arithmetic/arithmetic.py
@@ -2,7 +2,8 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from functools import partial
-from typing import Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING
+from collections.abc import Callable
 
 from mantidimaging.gui.utility.qt_helpers import add_property_to_form, MAX_SPIN_BOX, Type
 from mantidimaging.core.operations.base_filter import BaseFilter

--- a/mantidimaging/core/operations/base_filter.py
+++ b/mantidimaging/core/operations/base_filter.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
 from enum import Enum, auto
 
 import numpy as np

--- a/mantidimaging/core/operations/divide/divide.py
+++ b/mantidimaging/core/operations/divide/divide.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Callable, Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
+from collections.abc import Callable
 
 from mantidimaging import helper as h
 import numpy as np

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from functools import partial
 from logging import getLogger
-from typing import Callable, Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
+from collections.abc import Callable
 
 import numpy as np
 from PyQt5.QtGui import QValidator

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -2,7 +2,8 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from functools import partial
-from typing import Callable, Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
+from collections.abc import Callable
 
 import numpy as np
 

--- a/mantidimaging/core/parallel/shared.py
+++ b/mantidimaging/core/parallel/shared.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Callable, Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
+from collections.abc import Callable
 
 from mantidimaging.core.parallel import utility as pu
 

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import os
 from logging import getLogger
 from multiprocessing import shared_memory
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
+from collections.abc import Callable
 
 import numpy as np
 

--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 from logging import getLogger
 from threading import Lock
-from typing import Generator
+from collections.abc import Generator
 
 import astra
 import numpy as np

--- a/mantidimaging/core/rotation/data_model.py
+++ b/mantidimaging/core/rotation/data_model.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from logging import getLogger
-from typing import Iterator, NamedTuple
+from typing import NamedTuple
+from collections.abc import Iterator
 
 import numpy as np
 import scipy as sp

--- a/mantidimaging/core/utility/leak_tracker.py
+++ b/mantidimaging/core/utility/leak_tracker.py
@@ -6,7 +6,8 @@ import sys
 import traceback
 import weakref
 from types import FunctionType
-from typing import NamedTuple, Iterable
+from typing import NamedTuple
+from collections.abc import Iterable
 
 from numpy import ndarray
 

--- a/mantidimaging/core/utility/sensible_roi.py
+++ b/mantidimaging/core/utility/sensible_roi.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterator, TYPE_CHECKING
+from typing import TYPE_CHECKING
+from collections.abc import Iterator
 
 if TYPE_CHECKING:
     from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint

--- a/mantidimaging/core/utility/size_calculator.py
+++ b/mantidimaging/core/utility/size_calculator.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import math
 
 import numpy
-from typing import Iterable, TYPE_CHECKING
+from typing import TYPE_CHECKING
+from collections.abc import Iterable
 
 if TYPE_CHECKING:
     import numpy.typing as npt

--- a/mantidimaging/gui/dialogs/async_task/model.py
+++ b/mantidimaging/gui/dialogs/async_task/model.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from logging import getLogger
-from typing import Callable
+from collections.abc import Callable
 
 from PyQt5.QtCore import QObject, pyqtSignal
 

--- a/mantidimaging/gui/dialogs/async_task/presenter.py
+++ b/mantidimaging/gui/dialogs/async_task/presenter.py
@@ -6,7 +6,7 @@ import traceback
 from logging import getLogger
 from enum import Enum
 
-from typing import Callable
+from collections.abc import Callable
 
 from PyQt5.QtCore import QObject, pyqtSignal
 

--- a/mantidimaging/gui/dialogs/async_task/task.py
+++ b/mantidimaging/gui/dialogs/async_task/task.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from logging import getLogger
-from typing import Callable
+from collections.abc import Callable
 
 from PyQt5.QtCore import QThread
 

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -2,7 +2,8 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.mvp_base import BaseDialogView

--- a/mantidimaging/gui/utility/qt_helpers.py
+++ b/mantidimaging/gui/utility/qt_helpers.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 import os
 from enum import IntEnum, auto
 from logging import getLogger
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 
 from PyQt5 import uic  # type: ignore
 from PyQt5.QtCore import QObject, Qt

--- a/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
+++ b/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 from pyqtgraph import ColorMap, ImageItem, ViewBox

--- a/mantidimaging/gui/widgets/indicator_icon/view.py
+++ b/mantidimaging/gui/widgets/indicator_icon/view.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 from PIL import Image

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from math import degrees
 from time import sleep
-from typing import Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING
+from collections.abc import Callable
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QApplication, QHBoxLayout, QLabel, QPushButton, QSizePolicy

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
+from collections.abc import Callable
 from logging import getLogger
 import numpy as np
 

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -6,7 +6,8 @@ import uuid
 from enum import Enum, auto
 from logging import getLogger
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NamedTuple, Iterable
+from typing import TYPE_CHECKING, Any, NamedTuple
+from collections.abc import Iterable
 
 import numpy as np
 from PyQt5.QtWidgets import QTabBar, QApplication, QTreeWidgetItem

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Callable, TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
 
 from mantidimaging.core.operations.base_filter import FilterGroup
 from mantidimaging.core.operations.loader import load_filter_packages

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -6,7 +6,8 @@ import traceback
 from enum import Enum, auto
 from functools import partial
 from logging import getLogger
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
 
 import numpy as np
 from PyQt5.QtWidgets import QWidget

--- a/mantidimaging/gui/windows/wizard/model.py
+++ b/mantidimaging/gui/windows/wizard/model.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Iterable, Any
+from typing import Any
+from collections.abc import Iterable
 
 
 class EnablePredicate(ABC):

--- a/mantidimaging/test_helpers/qt_test_helpers.py
+++ b/mantidimaging/test_helpers/qt_test_helpers.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 from PyQt5.QtTest import QTest
 

--- a/scripts/operations_tests/operations_tests.py
+++ b/scripts/operations_tests/operations_tests.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from statistics import stdev
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
### Issue
Work on #2117

### Description
Fix deprecated imports. A few things have moved around in the python standard library

See https://docs.astral.sh/ruff/rules/deprecated-import/

Commit generated using Ruff's auto fix

### Testing & Acceptance Criteria 

`make ruff`
and
`make mypy`

Should pass

### Documentation

Not needed yet
