### PR TITLE
Added Settings menu to Main Window with Theme options

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - pyqt=5.15.*
     - pyqtgraph=0.13.3
     - qt-gtk-platformtheme # [linux]
+    - qt-material
 
 build:
   number: 1

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - pyqt=5.15.*
     - pyqtgraph=0.13.3
     - qt-material=2.14
+    - darkdetect=0.8.0
     - qt-gtk-platformtheme # [linux]
 
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -37,8 +37,9 @@ requirements:
     - jenkspy=0.2.0
     - pyqt=5.15.*
     - pyqtgraph=0.13.3
+    - qt-material=2.14
     - qt-gtk-platformtheme # [linux]
-    - qt-material
+
 
 build:
   number: 1

--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections import Counter
 
 import pytest
+from PyQt5 import QtCore
+from PyQt5.QtGui import QFont
 
 from mantidimaging.core.utility.leak_tracker import leak_tracker
 
@@ -63,3 +65,20 @@ def leak_test_stats():
 
     # leak_tracker.clear() # Uncomment to clear after each test
     # print(leak_tracker.pretty_print(debug_owners=True)) # uncomment to track leaks
+
+
+@pytest.fixture(autouse=True)
+def setup_QSettings():
+    settings = QtCore.QSettings('mantidproject', 'Mantid Imaging')
+    default_font = QFont()
+    extra_style_default = {
+
+        # Density Scale
+        'density_scale': '-5',
+
+        # font
+        'font_size': str(default_font.pointSize()) + 'px',
+    }
+    settings.setValue('extra_style_default', extra_style_default)
+    if settings.value('extra_style') is None:
+        settings.setValue('extra_style', extra_style_default)

--- a/docs/release_notes/next/feature-2144-UI-theme-settings
+++ b/docs/release_notes/next/feature-2144-UI-theme-settings
@@ -1,0 +1,1 @@
+#2144: MI UI theme can be changed in runtime via a settings menu

--- a/mantidimaging/gui/mvp_base/view.py
+++ b/mantidimaging/gui/mvp_base/view.py
@@ -28,8 +28,6 @@ class BaseMainWindowView(QMainWindow):
         if ui_file is not None:
             compile_ui(ui_file, self)
 
-        print(f"mvp_case: {settings.value('theme_selection')=}")
-
         if settings.value('theme_selection') == 'Fusion':
             self.setStyleSheet('Fusion')
         else:

--- a/mantidimaging/gui/mvp_base/view.py
+++ b/mantidimaging/gui/mvp_base/view.py
@@ -16,6 +16,9 @@ LOG = getLogger(__name__)
 perf_logger = getLogger("perf." + __name__)
 settings = QtCore.QSettings('mantidproject', 'Mantid Imaging')
 
+if not settings.contains("theme_selection") or settings.value("theme_selection") is None:
+    settings.setValue('theme_selection', 'Fusion')
+
 
 class BaseMainWindowView(QMainWindow):
 

--- a/mantidimaging/gui/mvp_base/view.py
+++ b/mantidimaging/gui/mvp_base/view.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 import time
 from logging import getLogger
 
+from PyQt5 import QtCore
 from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtWidgets import QMainWindow, QMessageBox, QDialog
+from qt_material import apply_stylesheet
 
 from mantidimaging.gui.utility import compile_ui
 
 LOG = getLogger(__name__)
 perf_logger = getLogger("perf." + __name__)
+settings = QtCore.QSettings('mantidproject', 'Mantid Imaging')
 
 
 class BaseMainWindowView(QMainWindow):
@@ -24,6 +27,13 @@ class BaseMainWindowView(QMainWindow):
 
         if ui_file is not None:
             compile_ui(ui_file, self)
+
+        print(f"mvp_case: {settings.value('theme_selection')=}")
+
+        if settings.value('theme_selection') == 'Fusion':
+            self.setStyleSheet('Fusion')
+        else:
+            apply_stylesheet(self, theme=settings.value('theme_selection'), invert_secondary=False)
 
     def closeEvent(self, e):
         LOG.debug('UI window closed')

--- a/mantidimaging/gui/mvp_base/view.py
+++ b/mantidimaging/gui/mvp_base/view.py
@@ -8,7 +8,6 @@ from logging import getLogger
 from PyQt5 import QtCore
 from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtWidgets import QMainWindow, QMessageBox, QDialog
-from qt_material import apply_stylesheet
 
 from mantidimaging.gui.utility import compile_ui
 
@@ -30,11 +29,6 @@ class BaseMainWindowView(QMainWindow):
 
         if ui_file is not None:
             compile_ui(ui_file, self)
-
-        if settings.value('theme_selection') == 'Fusion':
-            self.setStyleSheet('Fusion')
-        else:
-            apply_stylesheet(self, theme=settings.value('theme_selection'), invert_secondary=False)
 
     def closeEvent(self, e):
         LOG.debug('UI window closed')

--- a/mantidimaging/gui/mvp_base/view.py
+++ b/mantidimaging/gui/mvp_base/view.py
@@ -7,7 +7,7 @@ from logging import getLogger
 
 from PyQt5 import QtCore
 from PyQt5.QtCore import Qt, QTimer
-from PyQt5.QtWidgets import QMainWindow, QMessageBox, QDialog
+from PyQt5.QtWidgets import QMainWindow, QMessageBox, QDialog, QApplication
 
 from mantidimaging.gui.utility import compile_ui
 
@@ -29,6 +29,8 @@ class BaseMainWindowView(QMainWindow):
 
         if ui_file is not None:
             compile_ui(ui_file, self)
+
+        QApplication.instance().setStyle(settings.value('theme_selection'))
 
     def closeEvent(self, e):
         LOG.debug('UI window closed')

--- a/mantidimaging/gui/ui/main_window.ui
+++ b/mantidimaging/gui/ui/main_window.ui
@@ -27,7 +27,7 @@
      <x>0</x>
      <y>0</y>
      <width>1100</width>
-     <height>25</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -45,6 +45,8 @@
     <addaction name="actionSaveNeXusFile"/>
     <addaction name="separator"/>
     <addaction name="actionLiveViewer"/>
+    <addaction name="separator"/>
+    <addaction name="actionSettings"/>
     <addaction name="separator"/>
     <addaction name="actionExit"/>
    </widget>
@@ -237,6 +239,11 @@
    </property>
    <property name="toolTip">
     <string>Open Live Viewer</string>
+   </property>
+  </action>
+  <action name="actionSettings">
+   <property name="text">
+    <string>Settings</string>
    </property>
   </action>
  </widget>

--- a/mantidimaging/gui/ui/settings_window.ui
+++ b/mantidimaging/gui/ui/settings_window.ui
@@ -72,7 +72,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="2" column="1">
            <spacer name="verticalSpacer">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -84,6 +84,23 @@
              </size>
             </property>
            </spacer>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="menuFontSizeChoice">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="menuFontSizeLabel">
+            <property name="text">
+             <string>Menu font size:</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/mantidimaging/gui/ui/settings_window.ui
+++ b/mantidimaging/gui/ui/settings_window.ui
@@ -6,14 +6,26 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>418</width>
-    <height>348</height>
+    <width>454</width>
+    <height>444</height>
    </rect>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>456</width>
+    <height>449</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>MainWindow</string>
   </property>
   <widget class="QWidget" name="centralwidget">
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
    <widget class="QWidget" name="verticalWidget" native="true">
     <property name="geometry">
      <rect>
@@ -24,7 +36,7 @@
      </rect>
     </property>
     <property name="sizePolicy">
-     <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+     <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
       <horstretch>1</horstretch>
       <verstretch>1</verstretch>
      </sizepolicy>
@@ -50,8 +62,8 @@
           <rect>
            <x>10</x>
            <y>10</y>
-           <width>341</width>
-           <height>241</height>
+           <width>411</width>
+           <height>361</height>
           </rect>
          </property>
          <layout class="QFormLayout" name="formLayout">
@@ -72,6 +84,13 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="menuFontSizeLabel">
+            <property name="text">
+             <string>Menu font size:</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="1">
            <widget class="QComboBox" name="menuFontSizeChoice">
             <property name="sizePolicy">
@@ -81,26 +100,6 @@
              </sizepolicy>
             </property>
            </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="menuFontSizeLabel">
-            <property name="text">
-             <string>Menu font size:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="useOsThemeLabel">
@@ -115,6 +114,73 @@
              <string/>
             </property>
            </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Use OS defaults: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QCheckBox" name="osDefaultsCheckBox">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="2">
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+       <widget class="QWidget" name="performanceTab">
+        <attribute name="title">
+         <string>Performance</string>
+        </attribute>
+        <widget class="QWidget" name="formLayoutWidget_2">
+         <property name="geometry">
+          <rect>
+           <x>10</x>
+           <y>10</y>
+           <width>411</width>
+           <height>361</height>
+          </rect>
+         </property>
+         <layout class="QFormLayout" name="formLayout_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="processesLabel">
+            <property name="text">
+             <string>Processes (applies on restart): </string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="processesSpinBox"/>
+          </item>
+          <item row="1" column="1">
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>

--- a/mantidimaging/gui/ui/settings_window.ui
+++ b/mantidimaging/gui/ui/settings_window.ui
@@ -145,46 +145,6 @@
          </layout>
         </widget>
        </widget>
-       <widget class="QWidget" name="performanceTab">
-        <attribute name="title">
-         <string>Performance</string>
-        </attribute>
-        <widget class="QWidget" name="formLayoutWidget_2">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>10</y>
-           <width>411</width>
-           <height>361</height>
-          </rect>
-         </property>
-         <layout class="QFormLayout" name="formLayout_2">
-          <item row="0" column="0">
-           <widget class="QLabel" name="processesLabel">
-            <property name="text">
-             <string>Processes (applies on restart): </string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QSpinBox" name="processesSpinBox"/>
-          </item>
-          <item row="1" column="1">
-           <spacer name="verticalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
-       </widget>
       </widget>
      </item>
     </layout>

--- a/mantidimaging/gui/ui/settings_window.ui
+++ b/mantidimaging/gui/ui/settings_window.ui
@@ -72,19 +72,6 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
           <item row="1" column="1">
            <widget class="QComboBox" name="menuFontSizeChoice">
             <property name="sizePolicy">
@@ -99,6 +86,33 @@
            <widget class="QLabel" name="menuFontSizeLabel">
             <property name="text">
              <string>Menu font size:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="useOsThemeLabel">
+            <property name="text">
+             <string>Dark mode:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QCheckBox" name="useOsThemeCheckBox">
+            <property name="text">
+             <string/>
             </property>
            </widget>
           </item>

--- a/mantidimaging/gui/ui/settings_window.ui
+++ b/mantidimaging/gui/ui/settings_window.ui
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SettingsWindow</class>
+ <widget class="QMainWindow" name="SettingsWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>418</width>
+    <height>348</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>MainWindow</string>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <widget class="QWidget" name="verticalWidget" native="true">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>10</y>
+      <width>1921</width>
+      <height>951</height>
+     </rect>
+    </property>
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+      <horstretch>1</horstretch>
+      <verstretch>1</verstretch>
+     </sizepolicy>
+    </property>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <widget class="QTabWidget" name="settingsTabWidget">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>1</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="currentIndex">
+        <number>0</number>
+       </property>
+       <widget class="QWidget" name="appearanceTab">
+        <attribute name="title">
+         <string>Appearance</string>
+        </attribute>
+        <widget class="QWidget" name="formLayoutWidget">
+         <property name="geometry">
+          <rect>
+           <x>10</x>
+           <y>10</y>
+           <width>341</width>
+           <height>241</height>
+          </rect>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="themeLabel">
+            <property name="text">
+             <string>Theme:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="themeName">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QStatusBar" name="statusbar"/>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/mantidimaging/gui/ui/settings_window.ui
+++ b/mantidimaging/gui/ui/settings_window.ui
@@ -110,7 +110,7 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QCheckBox" name="useOsThemeCheckBox">
+           <widget class="QCheckBox" name="darkModeCheckBox">
             <property name="text">
              <string/>
             </property>

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -841,6 +841,7 @@ class MainWindowPresenter(BasePresenter):
         use_dark_mode = settings.value('use_dark_mode')
         override_os_theme = settings.value('override_os_theme')
         font = QFont(settings.value('default_font_family'), int(extra_style['font_size'].replace('px', '')))
+        print(f"extra_style: {extra_style}")
         for window in [
                 self.view, self.view.recon, self.view.live_viewer, self.view.spectrum_viewer, self.view.filters,
                 self.view.settings_window

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 from collections.abc import Iterable
 
-import darkdetect
 import numpy as np
 from PyQt5.QtCore import QSettings, Qt
 from PyQt5.QtGui import QFont, QPalette, QColor
@@ -34,22 +33,6 @@ if TYPE_CHECKING:
 RECON_TEXT = "Recon"
 
 settings = QSettings('mantidproject', 'Mantid Imaging')
-
-extra_style_default = {
-
-    # Density Scale
-    'density_scale': '-5',
-
-    # font
-    'font_size': settings.value('default_font_size', defaultValue='12') + 'px',
-}
-
-if settings.contains("extra_style") and settings.value('extra_style') is not None:
-    extra_style = settings.value('extra_style')
-else:
-    settings.setValue('extra_style', extra_style_default)
-    extra_style = extra_style_default
-settings.setValue('os_theme', darkdetect.theme())
 
 
 class StackId(NamedTuple):
@@ -881,7 +864,8 @@ class MainWindowPresenter(BasePresenter):
                 else:
                     apply_stylesheet(window, theme=theme, invert_secondary=False, extra=extra_style)
 
-    def use_fusion_dark_mode(self) -> None:
+    @staticmethod
+    def use_fusion_dark_mode() -> None:
         palette = QPalette()
         palette.setColor(QPalette.Window, QColor(53, 53, 53))
         palette.setColor(QPalette.WindowText, Qt.white)
@@ -898,6 +882,7 @@ class MainWindowPresenter(BasePresenter):
         palette.setColor(QPalette.HighlightedText, Qt.black)
         QApplication.instance().setPalette(palette)
 
-    def use_fusion_light_mode(self) -> None:
+    @staticmethod
+    def use_fusion_light_mode() -> None:
         palette = QPalette()
         QApplication.instance().setPalette(palette)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -865,13 +865,13 @@ class MainWindowPresenter(BasePresenter):
                 QApplication.instance().setFont(font)
                 window.setStyleSheet(theme)
                 if theme == 'Fusion':
-                    if not override_os_theme:
+                    if override_os_theme == 'False':
                         if os_theme == 'Light':
                             self.use_fusion_light_mode()
                         elif os_theme == 'Dark':
                             self.use_fusion_dark_mode()
                     else:
-                        if use_dark_mode:
+                        if use_dark_mode == 'True':
                             self.use_fusion_dark_mode()
                         else:
                             self.use_fusion_light_mode()

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -41,13 +41,14 @@ extra_style_default = {
     'density_scale': '-5',
 
     # font
-    'font_size': '10px',
+    'font_size': settings.value('default_font_size', defaultValue='12') + 'px',
 }
 
-if settings.contains("extra_style") and settings.value('extra_style'):
+if settings.contains("extra_style") and settings.value('extra_style') is not None:
     extra_style = settings.value('extra_style')
 else:
     settings.setValue('extra_style', extra_style_default)
+    extra_style = extra_style_default
 settings.setValue('os_theme', darkdetect.theme())
 
 
@@ -856,7 +857,7 @@ class MainWindowPresenter(BasePresenter):
         os_theme = settings.value('os_theme')
         use_dark_mode = settings.value('use_dark_mode')
         override_os_theme = settings.value('override_os_theme')
-        font = QFont("Arial", int(extra_style['font_size'].replace('px', '')))
+        font = QFont(settings.value('default_font_family'), int(extra_style['font_size'].replace('px', '')))
         for window in [
                 self.view, self.view.recon, self.view.live_viewer, self.view.spectrum_viewer, self.view.filters,
                 self.view.settings_window

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -49,11 +49,6 @@ if settings.contains("extra_style") and settings.value('extra_style'):
 else:
     settings.setValue('extra_style', extra_style_default)
 settings.setValue('os_theme', darkdetect.theme())
-#settings.clear()
-print(f"{settings.value('use_dark_mode')=}")
-print(f"{settings.value('os_theme')=}")
-print(f"{settings.value('override_os_theme')=}")
-print(f"{not settings.value('override_os_theme')=}")
 
 
 class StackId(NamedTuple):
@@ -870,7 +865,6 @@ class MainWindowPresenter(BasePresenter):
                 QApplication.instance().setFont(font)
                 window.setStyleSheet(theme)
                 if theme == 'Fusion':
-                    print(f"Using Fusion theme\n {use_dark_mode=}")
                     if not override_os_theme:
                         if os_theme == 'Light':
                             self.use_fusion_light_mode()
@@ -878,15 +872,12 @@ class MainWindowPresenter(BasePresenter):
                             self.use_fusion_dark_mode()
                     else:
                         if use_dark_mode:
-                            print("using dark mode")
                             self.use_fusion_dark_mode()
                         else:
-                            print("using light mode")
                             self.use_fusion_light_mode()
                     QApplication.instance().setFont(font)
                     window.setStyleSheet(theme)
                 else:
-                    print(f"using apply_stylesheet: {theme=}")
                     apply_stylesheet(window, theme=theme, invert_secondary=False, extra=extra_style)
 
     def use_fusion_dark_mode(self) -> None:

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -835,13 +835,17 @@ class MainWindowPresenter(BasePresenter):
         return self.model.is_dataset_strict(ds_id)
 
     def do_update_UI(self) -> None:
-        theme = settings.value('theme_selection')
-        extra_style = settings.value('extra_style')
+        if settings.value('use_os_defaults', defaultValue='True') == 'True':
+            extra_style = settings.value('extra_style_default')
+            theme = 'Fusion'
+            override_os_theme = 'False'
+        else:
+            extra_style = settings.value('extra_style')
+            use_dark_mode = settings.value('use_dark_mode')
+            theme = settings.value('theme_selection')
+            override_os_theme = settings.value('override_os_theme')
         os_theme = settings.value('os_theme')
-        use_dark_mode = settings.value('use_dark_mode')
-        override_os_theme = settings.value('override_os_theme')
         font = QFont(settings.value('default_font_family'), int(extra_style['font_size'].replace('px', '')))
-        print(f"extra_style: {extra_style}")
         for window in [
                 self.view, self.view.recon, self.view.live_viewer, self.view.spectrum_viewer, self.view.filters,
                 self.view.settings_window

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -12,7 +12,7 @@ from collections.abc import Iterable
 import numpy as np
 from PyQt5.QtCore import QSettings
 from PyQt5.QtGui import QFont
-from PyQt5.QtWidgets import QTabBar, QApplication, QTreeWidgetItem, QSpinBox
+from PyQt5.QtWidgets import QTabBar, QApplication, QTreeWidgetItem
 from qt_material import apply_stylesheet
 
 from mantidimaging.core.data import ImageStack
@@ -36,12 +36,12 @@ settings = QSettings('mantidproject', 'Mantid Imaging')
 
 extra_style_default = {
 
-        # Density Scale
-        'density_scale': '-5',
+    # Density Scale
+    'density_scale': '-5',
 
-        # font
-        'font_size': '10px',
-    }
+    # font
+    'font_size': '10px',
+}
 
 if settings.contains("extra_style") and settings.value('extra_style'):
     extra_style = settings.value('extra_style')
@@ -852,11 +852,12 @@ class MainWindowPresenter(BasePresenter):
         theme = settings.value('theme_selection')
         extra_style = settings.value('extra_style')
         font = QFont("Arial", int(extra_style['font_size'].replace('px', '')))
-        for window in [self.view, self.view.recon, self.view.live_viewer, self.view.spectrum_viewer, self.view.filters,
-                       self.view.settings_window]:
+        for window in [
+                self.view, self.view.recon, self.view.live_viewer, self.view.spectrum_viewer, self.view.filters,
+                self.view.settings_window
+        ]:
             if window:
                 QApplication.instance().setFont(font)
                 window.setStyleSheet(theme)
                 if theme != 'Fusion':
                     apply_stylesheet(window, theme=theme, invert_secondary=False, extra=extra_style)
-

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 import numpy as np
-from PyQt5.QtCore import Qt, pyqtSignal, QUrl, QPoint, QSettings
+from PyQt5.QtCore import Qt, pyqtSignal, QUrl, QPoint
 from PyQt5.QtGui import QIcon, QDragEnterEvent, QDropEvent, QDesktopServices
 from PyQt5.QtWidgets import QAction, QDialog, QLabel, QMessageBox, QMenu, QFileDialog, QSplitter, \
     QTreeWidgetItem, QTreeWidget
@@ -54,8 +54,6 @@ SINO_TEXT = "Sinograms"
 
 LOG = getLogger(__name__)
 perf_logger = getLogger("perf." + __name__)
-
-settings = QSettings('mantidproject', 'Mantid Imaging')
 
 
 class QTreeDatasetWidgetItem(QTreeWidgetItem):

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -181,7 +181,6 @@ class MainWindowView(BaseMainWindowView):
             perf_logger.info(f"Mantid Imaging ready in {time.monotonic() - process_start_time}")
         super()._window_ready()
 
-
     def setup_shortcuts(self):
         self.actionLoadDataset.triggered.connect(self.show_image_load_dialog)
         self.actionLoadImages.triggered.connect(self.load_image_stack)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -15,7 +15,7 @@ from PyQt5.QtCore import Qt, pyqtSignal, QUrl, QPoint, QSettings
 from PyQt5.QtGui import QIcon, QDragEnterEvent, QDropEvent, QDesktopServices
 from PyQt5.QtWidgets import QAction, QDialog, QLabel, QMessageBox, QMenu, QFileDialog, QSplitter, \
     QTreeWidgetItem, QTreeWidget
-from qt_material import apply_stylesheet
+
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset
@@ -175,10 +175,13 @@ class MainWindowView(BaseMainWindowView):
 
         self.tabifiedDockWidgetActivated.connect(self._on_tab_bar_clicked)
 
+        self.presenter.do_update_UI()
+
     def _window_ready(self) -> None:
         if perf_logger.isEnabledFor(1):
             perf_logger.info(f"Mantid Imaging ready in {time.monotonic() - process_start_time}")
         super()._window_ready()
+
 
     def setup_shortcuts(self):
         self.actionLoadDataset.triggered.connect(self.show_image_load_dialog)
@@ -389,14 +392,6 @@ class MainWindowView(BaseMainWindowView):
             self.settings_window.activateWindow()
             self.settings_window.raise_()
             self.settings_window.show()
-
-    def set_theme(self, theme: str) -> None:
-        for window in [self, self.recon, self.live_viewer, self.spectrum_viewer, self.filters, self.settings_window]:
-            if window:
-                if theme == 'Fusion':
-                    window.setStyleSheet(theme)
-                else:
-                    apply_stylesheet(window, theme=theme, invert_secondary=False)
 
     def show_recon_window(self):
         if not self.recon:

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -16,7 +16,6 @@ from PyQt5.QtGui import QIcon, QDragEnterEvent, QDropEvent, QDesktopServices
 from PyQt5.QtWidgets import QAction, QDialog, QLabel, QMessageBox, QMenu, QFileDialog, QSplitter, \
     QTreeWidgetItem, QTreeWidget
 
-
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.core.io.utility import find_first_file_that_is_possibly_a_sample

--- a/mantidimaging/gui/windows/settings/__init__.py
+++ b/mantidimaging/gui/windows/settings/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/settings/presenter.py
+++ b/mantidimaging/gui/windows/settings/presenter.py
@@ -26,7 +26,10 @@ class SettingsWindowPresenter(BasePresenter):
         self.view = view
         self.main_window = main_window
         self.current_theme = settings.value('theme_selection')
-        self.current_menu_font_size = settings.value('extra_style')['font_size']
+        if settings.value('selected_font_size') is None:
+            self.current_menu_font_size = settings.value('default_font_size')
+        else:
+            self.current_menu_font_size = settings.value('selected_font_size')
 
     def set_theme(self):
         self.current_theme = self.view.current_theme
@@ -39,6 +42,7 @@ class SettingsWindowPresenter(BasePresenter):
 
     def set_extra_style(self):
         extra_style = settings.value('extra_style')
+        settings.setValue('selected_font_size', self.view.current_menu_font_size)
         extra_style.update({'font_size': self.view.current_menu_font_size + 'px'})
         settings.setValue('extra_style', extra_style)
         self.main_window.presenter.do_update_UI()

--- a/mantidimaging/gui/windows/settings/presenter.py
+++ b/mantidimaging/gui/windows/settings/presenter.py
@@ -38,4 +38,3 @@ class SettingsWindowPresenter(BasePresenter):
         extra_style.update({'font_size': self.view.current_menu_font_size + 'px'})
         settings.setValue('extra_style', extra_style)
         self.main_window.presenter.do_update_UI()
-

--- a/mantidimaging/gui/windows/settings/presenter.py
+++ b/mantidimaging/gui/windows/settings/presenter.py
@@ -31,10 +31,26 @@ class SettingsWindowPresenter(BasePresenter):
     def set_theme(self):
         self.current_theme = self.view.current_theme
         settings.setValue('theme_selection', self.current_theme)
+        if self.current_theme == 'Fusion':
+            self.view.useOsThemeCheckBox.setEnabled(True)
+        else:
+            self.view.useOsThemeCheckBox.setEnabled(False)
         self.main_window.presenter.do_update_UI()
 
     def set_extra_style(self):
         extra_style = settings.value('extra_style')
         extra_style.update({'font_size': self.view.current_menu_font_size + 'px'})
         settings.setValue('extra_style', extra_style)
+        self.main_window.presenter.do_update_UI()
+
+    def set_dark_mode(self):
+        print(f"{self.view.useOsThemeCheckBox.isChecked()=}")
+        if self.view.useOsThemeCheckBox.isChecked():
+            use_dark_mode = 1
+        else:
+            use_dark_mode = 0
+        print(f"{use_dark_mode=}")
+
+        settings.setValue('use_dark_mode', use_dark_mode)
+        settings.setValue('override_os_theme', True)
         self.main_window.presenter.do_update_UI()

--- a/mantidimaging/gui/windows/settings/presenter.py
+++ b/mantidimaging/gui/windows/settings/presenter.py
@@ -26,8 +26,16 @@ class SettingsWindowPresenter(BasePresenter):
         self.view = view
         self.main_window = main_window
         self.current_theme = settings.value('theme_selection')
+        self.current_menu_font_size = settings.value('extra_style')['font_size']
 
     def set_theme(self):
         self.current_theme = self.view.current_theme
         settings.setValue('theme_selection', self.current_theme)
-        self.main_window.set_theme(self.current_theme)
+        self.main_window.presenter.do_update_UI()
+
+    def set_extra_style(self):
+        extra_style = settings.value('extra_style')
+        extra_style.update({'font_size': self.view.current_menu_font_size + 'px'})
+        settings.setValue('extra_style', extra_style)
+        self.main_window.presenter.do_update_UI()
+

--- a/mantidimaging/gui/windows/settings/presenter.py
+++ b/mantidimaging/gui/windows/settings/presenter.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from logging import getLogger
+from typing import TYPE_CHECKING
+
+from PyQt5.QtCore import QSettings
+
+from mantidimaging.gui.mvp_base import BasePresenter
+
+LOG = getLogger(__name__)
+
+if TYPE_CHECKING:
+    from mantidimaging.gui.windows.settings.view import SettingsWindowView  # pragma: no cover
+    from mantidimaging.gui.windows.main import MainWindowView
+
+settings = QSettings('mantidproject', 'Mantid Imaging')
+
+
+class SettingsWindowPresenter(BasePresenter):
+    view: 'SettingsWindowView'
+
+    def __init__(self, view: 'SettingsWindowView', main_window: 'MainWindowView'):
+        super().__init__(view)
+        self.view = view
+        self.main_window = main_window
+        self.current_theme = settings.value('theme_selection')
+
+    def set_theme(self):
+        self.current_theme = self.view.current_theme
+        settings.setValue('theme_selection', self.current_theme)
+        self.main_window.set_theme(self.current_theme)

--- a/mantidimaging/gui/windows/settings/presenter.py
+++ b/mantidimaging/gui/windows/settings/presenter.py
@@ -32,9 +32,9 @@ class SettingsWindowPresenter(BasePresenter):
         self.current_theme = self.view.current_theme
         settings.setValue('theme_selection', self.current_theme)
         if self.current_theme == 'Fusion':
-            self.view.useOsThemeCheckBox.setEnabled(True)
+            self.view.darkModeCheckBox.setEnabled(True)
         else:
-            self.view.useOsThemeCheckBox.setEnabled(False)
+            self.view.darkModeCheckBox.setEnabled(False)
         self.main_window.presenter.do_update_UI()
 
     def set_extra_style(self):
@@ -44,7 +44,7 @@ class SettingsWindowPresenter(BasePresenter):
         self.main_window.presenter.do_update_UI()
 
     def set_dark_mode(self):
-        if self.view.useOsThemeCheckBox.isChecked():
+        if self.view.darkModeCheckBox.isChecked():
             use_dark_mode = 1
         else:
             use_dark_mode = 0

--- a/mantidimaging/gui/windows/settings/presenter.py
+++ b/mantidimaging/gui/windows/settings/presenter.py
@@ -45,10 +45,10 @@ class SettingsWindowPresenter(BasePresenter):
 
     def set_dark_mode(self):
         if self.view.darkModeCheckBox.isChecked():
-            use_dark_mode = 1
+            use_dark_mode = 'True'
         else:
-            use_dark_mode = 0
+            use_dark_mode = 'False'
 
         settings.setValue('use_dark_mode', use_dark_mode)
-        settings.setValue('override_os_theme', True)
+        settings.setValue('override_os_theme', 'True')
         self.main_window.presenter.do_update_UI()

--- a/mantidimaging/gui/windows/settings/presenter.py
+++ b/mantidimaging/gui/windows/settings/presenter.py
@@ -19,9 +19,9 @@ settings = QSettings('mantidproject', 'Mantid Imaging')
 
 
 class SettingsWindowPresenter(BasePresenter):
-    view: 'SettingsWindowView'
+    view: SettingsWindowView
 
-    def __init__(self, view: 'SettingsWindowView', main_window: 'MainWindowView'):
+    def __init__(self, view: SettingsWindowView, main_window: MainWindowView):
         super().__init__(view)
         self.view = view
         self.main_window = main_window

--- a/mantidimaging/gui/windows/settings/presenter.py
+++ b/mantidimaging/gui/windows/settings/presenter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from logging import getLogger
 from typing import TYPE_CHECKING
 
-from PyQt5.QtCore import QSettings
+from PyQt5.QtCore import QSettings, QSignalBlocker
 
 from mantidimaging.gui.mvp_base import BasePresenter
 
@@ -55,4 +55,38 @@ class SettingsWindowPresenter(BasePresenter):
 
         settings.setValue('use_dark_mode', use_dark_mode)
         settings.setValue('override_os_theme', 'True')
+        self.main_window.presenter.do_update_UI()
+
+    def set_to_os_defaults(self):
+        if self.view.osDefaultsCheckBox.isChecked():
+            settings.setValue('use_os_defaults', 'True')
+            theme_text = 'Fusion'
+            theme_enabled = False
+            font_text = settings.value('default_font_size')
+            font_enabled = False
+            if settings.value('os_theme') == 'Dark':
+                dark_mode_checked = True
+            else:
+                dark_mode_checked = False
+            dark_mode_enabled = False
+        else:
+            settings.setValue('use_os_defaults', 'False')
+            theme_text = settings.value('theme_selection')
+            theme_enabled = True
+            font_text = settings.value('selected_font_size')
+            font_enabled = True
+            if settings.value('use_dark_mode') == 'True':
+                dark_mode_checked = True
+            else:
+                dark_mode_checked = False
+            dark_mode_enabled = True
+        with QSignalBlocker(self.view.themeName):
+            self.view.themeName.setCurrentText(theme_text)
+            self.view.themeName.setEnabled(theme_enabled)
+        with QSignalBlocker(self.view.menuFontSizeChoice):
+            self.view.menuFontSizeChoice.setCurrentText(font_text)
+            self.view.menuFontSizeChoice.setEnabled(font_enabled)
+        with QSignalBlocker(self.view.darkModeCheckBox):
+            self.view.darkModeCheckBox.setChecked(dark_mode_checked)
+            self.view.darkModeCheckBox.setEnabled(dark_mode_enabled)
         self.main_window.presenter.do_update_UI()

--- a/mantidimaging/gui/windows/settings/presenter.py
+++ b/mantidimaging/gui/windows/settings/presenter.py
@@ -44,12 +44,10 @@ class SettingsWindowPresenter(BasePresenter):
         self.main_window.presenter.do_update_UI()
 
     def set_dark_mode(self):
-        print(f"{self.view.useOsThemeCheckBox.isChecked()=}")
         if self.view.useOsThemeCheckBox.isChecked():
             use_dark_mode = 1
         else:
             use_dark_mode = 0
-        print(f"{use_dark_mode=}")
 
         settings.setValue('use_dark_mode', use_dark_mode)
         settings.setValue('override_os_theme', True)

--- a/mantidimaging/gui/windows/settings/view.py
+++ b/mantidimaging/gui/windows/settings/view.py
@@ -41,7 +41,6 @@ class SettingsWindowView(BaseMainWindowView, QtStyleTools):
         self.themeName.setCurrentText(self.presenter.current_theme)
 
         self.menuFontSizeChoice.addItems(['8', '10', '12', '14', '16'])
-        print(f"{self.presenter.current_menu_font_size=}")
         self.menuFontSizeChoice.setCurrentText(self.presenter.current_menu_font_size.replace('px', ''))
 
         self.themeName.currentTextChanged.connect(self.presenter.set_theme)

--- a/mantidimaging/gui/windows/settings/view.py
+++ b/mantidimaging/gui/windows/settings/view.py
@@ -28,7 +28,7 @@ class SettingsWindowView(BaseMainWindowView, QtStyleTools):
     themeLabel: QLabel
     menuFontSizeLabel: QLabel
     menuFontSizeChoice: QComboBox
-    useOsThemeCheckBox: QCheckBox
+    darkModeCheckBox: QCheckBox
 
     def __init__(self, main_window: 'MainWindowView'):
         super().__init__(None, 'gui/ui/settings_window.ui')
@@ -45,16 +45,16 @@ class SettingsWindowView(BaseMainWindowView, QtStyleTools):
 
         self.themeName.currentTextChanged.connect(self.presenter.set_theme)
         self.menuFontSizeChoice.currentTextChanged.connect(self.presenter.set_extra_style)
-        self.useOsThemeCheckBox.stateChanged.connect(self.presenter.set_dark_mode)
+        self.darkModeCheckBox.stateChanged.connect(self.presenter.set_dark_mode)
 
         if self.current_theme != 'Fusion':
-            self.useOsThemeCheckBox.setEnabled(False)
-        with (QSignalBlocker(self.useOsThemeCheckBox)):
+            self.darkModeCheckBox.setEnabled(False)
+        with (QSignalBlocker(self.darkModeCheckBox)):
             if settings.value('use_dark_mode') or (settings.value('os_theme') == 'Dark'
                                                    and not settings.value('override_os_theme')):
-                self.useOsThemeCheckBox.setChecked(True)
+                self.darkModeCheckBox.setChecked(True)
             else:
-                self.useOsThemeCheckBox.setChecked(False)
+                self.darkModeCheckBox.setChecked(False)
 
     @property
     def current_theme(self) -> str:

--- a/mantidimaging/gui/windows/settings/view.py
+++ b/mantidimaging/gui/windows/settings/view.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+from logging import getLogger
+from typing import TYPE_CHECKING
+
+from PyQt5.QtCore import QSettings
+from PyQt5.QtWidgets import QTabWidget, QWidget, QComboBox, QLabel
+
+from mantidimaging.gui.mvp_base import BaseMainWindowView
+
+from qt_material import list_themes
+
+from mantidimaging.gui.windows.settings.presenter import SettingsWindowPresenter
+
+if TYPE_CHECKING:
+    from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
+
+LOG = getLogger(__name__)
+
+settings = QSettings('mantidproject', 'Mantid Imaging')
+
+
+class SettingsWindowView(BaseMainWindowView):
+    settingsTabWidget: QTabWidget
+    appearanceTab: QWidget
+    themeName: QComboBox
+    themeLabel: QLabel
+
+    def __init__(self, main_window: 'MainWindowView'):
+        super().__init__(None, 'gui/ui/settings_window.ui')
+        self.setWindowTitle('Settings')
+        self.main_window = main_window
+        self.presenter = SettingsWindowPresenter(self, main_window)
+
+        self.themeName.addItem('Fusion')
+        self.themeName.addItems(list_themes())
+        self.themeName.setCurrentText(self.presenter.current_theme)
+
+        self.themeName.currentTextChanged.connect(self.presenter.set_theme)
+
+    @property
+    def current_theme(self) -> str:
+        return self.themeName.currentText()

--- a/mantidimaging/gui/windows/settings/view.py
+++ b/mantidimaging/gui/windows/settings/view.py
@@ -30,7 +30,7 @@ class SettingsWindowView(BaseMainWindowView, QtStyleTools):
     menuFontSizeChoice: QComboBox
     darkModeCheckBox: QCheckBox
 
-    def __init__(self, main_window: 'MainWindowView'):
+    def __init__(self, main_window: MainWindowView):
         super().__init__(None, 'gui/ui/settings_window.ui')
         self.setWindowTitle('Settings')
         self.main_window = main_window

--- a/mantidimaging/gui/windows/settings/view.py
+++ b/mantidimaging/gui/windows/settings/view.py
@@ -29,6 +29,7 @@ class SettingsWindowView(BaseMainWindowView, QtStyleTools):
     menuFontSizeLabel: QLabel
     menuFontSizeChoice: QComboBox
     darkModeCheckBox: QCheckBox
+    osDefaultsCheckBox: QCheckBox
 
     def __init__(self, main_window: MainWindowView):
         super().__init__(None, 'gui/ui/settings_window.ui')
@@ -46,6 +47,7 @@ class SettingsWindowView(BaseMainWindowView, QtStyleTools):
         self.themeName.currentTextChanged.connect(self.presenter.set_theme)
         self.menuFontSizeChoice.currentTextChanged.connect(self.presenter.set_extra_style)
         self.darkModeCheckBox.stateChanged.connect(self.presenter.set_dark_mode)
+        self.osDefaultsCheckBox.stateChanged.connect(self.presenter.set_to_os_defaults)
 
         if self.current_theme != 'Fusion':
             self.darkModeCheckBox.setEnabled(False)
@@ -55,6 +57,9 @@ class SettingsWindowView(BaseMainWindowView, QtStyleTools):
                 self.darkModeCheckBox.setChecked(True)
             else:
                 self.darkModeCheckBox.setChecked(False)
+
+        if settings.value('use_os_defaults') == 'True' or settings.value('use_os_defaults') is None:
+            self.osDefaultsCheckBox.setChecked(True)
 
     @property
     def current_theme(self) -> str:

--- a/mantidimaging/gui/windows/settings/view.py
+++ b/mantidimaging/gui/windows/settings/view.py
@@ -9,7 +9,7 @@ from PyQt5.QtWidgets import QTabWidget, QWidget, QComboBox, QLabel
 
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 
-from qt_material import list_themes
+from qt_material import list_themes, QtStyleTools
 
 from mantidimaging.gui.windows.settings.presenter import SettingsWindowPresenter
 
@@ -21,11 +21,13 @@ LOG = getLogger(__name__)
 settings = QSettings('mantidproject', 'Mantid Imaging')
 
 
-class SettingsWindowView(BaseMainWindowView):
+class SettingsWindowView(BaseMainWindowView, QtStyleTools):
     settingsTabWidget: QTabWidget
     appearanceTab: QWidget
     themeName: QComboBox
     themeLabel: QLabel
+    menuFontSizeLabel: QLabel
+    menuFontSizeChoice: QComboBox
 
     def __init__(self, main_window: 'MainWindowView'):
         super().__init__(None, 'gui/ui/settings_window.ui')
@@ -37,8 +39,17 @@ class SettingsWindowView(BaseMainWindowView):
         self.themeName.addItems(list_themes())
         self.themeName.setCurrentText(self.presenter.current_theme)
 
+        self.menuFontSizeChoice.addItems(['8', '10', '12', '14', '16'])
+        print(f"{self.presenter.current_menu_font_size=}")
+        self.menuFontSizeChoice.setCurrentText(self.presenter.current_menu_font_size.replace('px',''))
+
         self.themeName.currentTextChanged.connect(self.presenter.set_theme)
+        self.menuFontSizeChoice.currentTextChanged.connect(self.presenter.set_extra_style)
 
     @property
     def current_theme(self) -> str:
         return self.themeName.currentText()
+
+    @property
+    def current_menu_font_size(self) -> str:
+        return self.menuFontSizeChoice.currentText()

--- a/mantidimaging/gui/windows/settings/view.py
+++ b/mantidimaging/gui/windows/settings/view.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from logging import getLogger
 from typing import TYPE_CHECKING
 
-from PyQt5.QtCore import QSettings
-from PyQt5.QtWidgets import QTabWidget, QWidget, QComboBox, QLabel
+from PyQt5.QtCore import QSettings, QSignalBlocker
+from PyQt5.QtWidgets import QTabWidget, QWidget, QComboBox, QLabel, QCheckBox
 
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 
@@ -28,6 +28,7 @@ class SettingsWindowView(BaseMainWindowView, QtStyleTools):
     themeLabel: QLabel
     menuFontSizeLabel: QLabel
     menuFontSizeChoice: QComboBox
+    useOsThemeCheckBox: QCheckBox
 
     def __init__(self, main_window: 'MainWindowView'):
         super().__init__(None, 'gui/ui/settings_window.ui')
@@ -45,6 +46,16 @@ class SettingsWindowView(BaseMainWindowView, QtStyleTools):
 
         self.themeName.currentTextChanged.connect(self.presenter.set_theme)
         self.menuFontSizeChoice.currentTextChanged.connect(self.presenter.set_extra_style)
+        self.useOsThemeCheckBox.stateChanged.connect(self.presenter.set_dark_mode)
+
+        if self.current_theme != 'Fusion':
+            self.useOsThemeCheckBox.setEnabled(False)
+        with (QSignalBlocker(self.useOsThemeCheckBox)):
+            if settings.value('use_dark_mode') or (settings.value('os_theme') == 'Dark'
+                                                   and not settings.value('override_os_theme')):
+                self.useOsThemeCheckBox.setChecked(True)
+            else:
+                self.useOsThemeCheckBox.setChecked(False)
 
     @property
     def current_theme(self) -> str:

--- a/mantidimaging/gui/windows/settings/view.py
+++ b/mantidimaging/gui/windows/settings/view.py
@@ -40,7 +40,7 @@ class SettingsWindowView(BaseMainWindowView, QtStyleTools):
         self.themeName.addItems(list_themes())
         self.themeName.setCurrentText(self.presenter.current_theme)
 
-        self.menuFontSizeChoice.addItems(['8', '10', '12', '14', '16'])
+        self.menuFontSizeChoice.addItems([str(font_size) for font_size in range(4, 21)])
         self.menuFontSizeChoice.setCurrentText(self.presenter.current_menu_font_size.replace('px', ''))
 
         self.themeName.currentTextChanged.connect(self.presenter.set_theme)

--- a/mantidimaging/gui/windows/settings/view.py
+++ b/mantidimaging/gui/windows/settings/view.py
@@ -41,7 +41,7 @@ class SettingsWindowView(BaseMainWindowView, QtStyleTools):
 
         self.menuFontSizeChoice.addItems(['8', '10', '12', '14', '16'])
         print(f"{self.presenter.current_menu_font_size=}")
-        self.menuFontSizeChoice.setCurrentText(self.presenter.current_menu_font_size.replace('px',''))
+        self.menuFontSizeChoice.setCurrentText(self.presenter.current_menu_font_size.replace('px', ''))
 
         self.themeName.currentTextChanged.connect(self.presenter.set_theme)
         self.menuFontSizeChoice.currentTextChanged.connect(self.presenter.set_extra_style)

--- a/mantidimaging/gui/windows/settings/view.py
+++ b/mantidimaging/gui/windows/settings/view.py
@@ -50,8 +50,8 @@ class SettingsWindowView(BaseMainWindowView, QtStyleTools):
         if self.current_theme != 'Fusion':
             self.darkModeCheckBox.setEnabled(False)
         with (QSignalBlocker(self.darkModeCheckBox)):
-            if settings.value('use_dark_mode') or (settings.value('os_theme') == 'Dark'
-                                                   and not settings.value('override_os_theme')):
+            if settings.value('use_dark_mode') == 'True' or (settings.value('os_theme') == 'Dark'
+                                                             and settings.value('override_os_theme') == 'False'):
                 self.darkModeCheckBox.setChecked(True)
             else:
                 self.darkModeCheckBox.setChecked(False)

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -17,11 +17,20 @@ import mantidimaging.core.parallel.manager as pm
 from mantidimaging import helper as h
 from mantidimaging.core.utility.command_line_arguments import CommandLineArguments
 
-from qt_material import apply_stylesheet
-
 formatwarning_orig = warnings.formatwarning
 warnings.formatwarning = lambda message, category, filename, lineno, line=None: formatwarning_orig(
     message, category, filename, lineno, line="")
+
+settings = QtCore.QSettings('mantidproject', 'Mantid Imaging')
+
+if settings.contains("theme_selection"):
+    # there is the key in QSettings
+    print('Checking for theme preference in config')
+    theme_selection = settings.value('theme_selection')
+    print('Found theme_selection in config:' + theme_selection)
+else:
+    print('theme_selection not found in config. Using default Fusion')
+    settings.setValue('theme_selection', 'Fusion')
 
 
 def parse_args() -> argparse.Namespace:
@@ -59,9 +68,9 @@ def parse_args() -> argparse.Namespace:
 def setup_application() -> QApplication:
     QGuiApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
     q_application = QApplication(sys.argv)
-    #q_application.setStyle('Fusion')
+    q_application.setStyle(settings.value('theme_selection'))
 
-    apply_stylesheet(q_application, theme='light_blue.xml', invert_secondary=True)
+    #apply_stylesheet(q_application, theme='light_blue.xml', invert_secondary=True)
     q_application.setApplicationName("Mantid Imaging")
     q_application.setOrganizationName("mantidproject")
     q_application.setOrganizationDomain("mantidproject.org")

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -80,6 +80,7 @@ def setup_application() -> QApplication:
         # font
         'font_size': str(default_font.pointSize()) + 'px',
     }
+    settings.setValue('extra_style_default', extra_style_default)
     if settings.value('extra_style') is None:
         settings.setValue('extra_style', extra_style_default)
     settings.setValue('os_theme', darkdetect.theme())

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -25,12 +25,10 @@ settings = QtCore.QSettings('mantidproject', 'Mantid Imaging')
 
 if settings.contains("theme_selection"):
     # there is the key in QSettings
-    print('Checking for theme preference in config')
     theme_selection = settings.value('theme_selection')
-    print('Found theme_selection in config:' + theme_selection)
 else:
-    print('theme_selection not found in config. Using default Fusion')
     settings.setValue('theme_selection', 'Fusion')
+    theme_selection = None
 
 
 def parse_args() -> argparse.Namespace:
@@ -68,9 +66,9 @@ def parse_args() -> argparse.Namespace:
 def setup_application() -> QApplication:
     QGuiApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
     q_application = QApplication(sys.argv)
-    q_application.setStyle(settings.value('theme_selection'))
+    if theme_selection:
+        q_application.setStyle(settings.value('theme_selection'))
 
-    #apply_stylesheet(q_application, theme='light_blue.xml', invert_secondary=True)
     q_application.setApplicationName("Mantid Imaging")
     q_application.setOrganizationName("mantidproject")
     q_application.setOrganizationDomain("mantidproject.org")

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -17,6 +17,8 @@ import mantidimaging.core.parallel.manager as pm
 from mantidimaging import helper as h
 from mantidimaging.core.utility.command_line_arguments import CommandLineArguments
 
+from qt_material import apply_stylesheet
+
 formatwarning_orig = warnings.formatwarning
 warnings.formatwarning = lambda message, category, filename, lineno, line=None: formatwarning_orig(
     message, category, filename, lineno, line="")
@@ -57,7 +59,9 @@ def parse_args() -> argparse.Namespace:
 def setup_application() -> QApplication:
     QGuiApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
     q_application = QApplication(sys.argv)
-    q_application.setStyle('Fusion')
+    #q_application.setStyle('Fusion')
+
+    apply_stylesheet(q_application, theme='light_blue.xml', invert_secondary=True)
     q_application.setApplicationName("Mantid Imaging")
     q_application.setOrganizationName("mantidproject")
     q_application.setOrganizationDomain("mantidproject.org")

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -8,6 +8,7 @@ import sys
 import warnings
 import os
 
+import darkdetect
 from PyQt5.QtWidgets import QApplication
 from PyQt5 import QtCore
 from PyQt5.QtGui import QGuiApplication, QFont, QFontInfo
@@ -69,10 +70,21 @@ def setup_application() -> QApplication:
     if theme_selection:
         q_application.setStyle(settings.value('theme_selection'))
 
-    default_font = QFont('-1')
+    default_font = QFont()
     default_font_info = QFontInfo(default_font)
+    extra_style_default = {
+
+        # Density Scale
+        'density_scale': '-5',
+
+        # font
+        'font_size': str(default_font.pointSize()) + 'px',
+    }
+    settings.setValue('extra_style', extra_style_default)
+    settings.setValue('os_theme', darkdetect.theme())
     settings.setValue('default_font_size', str(default_font.pointSize()))
     settings.setValue('default_font_family', str(default_font_info.family()))
+
     q_application.setApplicationName("Mantid Imaging")
     q_application.setOrganizationName("mantidproject")
     q_application.setOrganizationDomain("mantidproject.org")

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -10,7 +10,7 @@ import os
 
 from PyQt5.QtWidgets import QApplication
 from PyQt5 import QtCore
-from PyQt5.QtGui import QGuiApplication
+from PyQt5.QtGui import QGuiApplication, QFont, QFontInfo
 
 import mantidimaging.core.parallel.manager as pm
 
@@ -69,6 +69,10 @@ def setup_application() -> QApplication:
     if theme_selection:
         q_application.setStyle(settings.value('theme_selection'))
 
+    default_font = QFont('-1')
+    default_font_info = QFontInfo(default_font)
+    settings.setValue('default_font_size', str(default_font.pointSize()))
+    settings.setValue('default_font_family', str(default_font_info.family()))
     q_application.setApplicationName("Mantid Imaging")
     q_application.setOrganizationName("mantidproject")
     q_application.setOrganizationDomain("mantidproject.org")

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -80,7 +80,8 @@ def setup_application() -> QApplication:
         # font
         'font_size': str(default_font.pointSize()) + 'px',
     }
-    settings.setValue('extra_style', extra_style_default)
+    if settings.value('extra_style') is None:
+        settings.setValue('extra_style', extra_style_default)
     settings.setValue('os_theme', darkdetect.theme())
     settings.setValue('default_font_size', str(default_font.pointSize()))
     settings.setValue('default_font_family', str(default_font_info.family()))

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -24,13 +24,6 @@ warnings.formatwarning = lambda message, category, filename, lineno, line=None: 
 
 settings = QtCore.QSettings('mantidproject', 'Mantid Imaging')
 
-if settings.contains("theme_selection"):
-    # there is the key in QSettings
-    theme_selection = settings.value('theme_selection')
-else:
-    settings.setValue('theme_selection', 'Fusion')
-    theme_selection = None
-
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Mantid Imaging GUI")
@@ -67,11 +60,10 @@ def parse_args() -> argparse.Namespace:
 def setup_application() -> QApplication:
     QGuiApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
     q_application = QApplication(sys.argv)
-    if theme_selection:
-        q_application.setStyle(settings.value('theme_selection'))
 
     default_font = QFont()
     default_font_info = QFontInfo(default_font)
+
     extra_style_default = {
 
         # Density Scale
@@ -83,6 +75,7 @@ def setup_application() -> QApplication:
     settings.setValue('extra_style_default', extra_style_default)
     if settings.value('extra_style') is None:
         settings.setValue('extra_style', extra_style_default)
+
     settings.setValue('os_theme', darkdetect.theme())
     settings.setValue('default_font_size', str(default_font.pointSize()))
     settings.setValue('default_font_family', str(default_font_info.family()))


### PR DESCRIPTION
### Issue

closes #2143 and #2099.

### Description

A Settings menu has been added via File -> Settings in the Main Window. Clicking on the Settings option opens up a new window where more settings can be added in the future. There is an option to change the current theme of the program to the standard "Fusion" theme or one of the many `qt-material` themes. By changing the theme, all windows of MI will be updated to the new theme during Runtime so the user can see them in real time. The new settings are saved via `QSettings` and are checked on startup so once changed to the users liking, it does not need to be changed again! 

If "Fusion" is the chosen theme, then a dark mode can be activated by clicking on the "dark mode" checkbox. This checkbox is disabled if any of the `qt-material` themes are chosen as light/dark is specified in the names of the `qt-material` themes.

Future work can be done via `qt-material` to make more custom themes chosen be the user.

### Testing 

make check

### Acceptance Criteria 

### Theme Testing

- Open MI and load data in.
- In the Main Window, go to File -> Settings
- Change the theme to and check that all open windows update to the new theme during Runtime.
- With the theme changed, open new windows (recon, spectrum, live viewer, etc) and check that opens in the new theme.
- Repeat with a few different themes to check that it functions as expected.
- With the selected theme not being the default "Fusion", exit out of MI and reopen again, the selected theme should remain.
- All other aspects of MI should function the same as previously.

To simulate a "first time start-up", you need to run `QSettings.clear()` with the appropriate arguments before starting MI. For example you could add `settings.clear()` on line 51 of `mantidimaging/gui/windows/main/presenter.py`, then start MI. This will cause MI to crash on startup but this is good enough to just clear all QSettings for MI. You can then remove the `settings.clear()` line and start MI as usual.

- With a first start-up, check that MI starts up with the same theme as you OS.
- Clear QSettings, change your OS theme and then open a "first startup" MI and check that it now opens with the new theme of your OS.
- You should be able to now change the theme from within MI, and restart MI where the previously chosen MI theme should remain.

### Font Testing

- The fonts used in MI can now be dynamically changed from the settings menu.
- Open the settings menu and another window (i.e. operations, SV, etc), change the font size via the settings and check that the fonts are updated across all windows.
- with the font changed, open a new window and check that the fonts are correct in that window.
- with the font size changed, close MI and reopen. Check that the font size previously chosen is still active.

### OS Theme check

- on first startup, MI will use OS defaults for font size and dark mode
- This can be disabled by unchecking the "use OS defaults" checkbox in the Settings Window.
- After a custom theme or font size has been used, the OS defaults can be toggled on or off via the checkbox


### Documentation

Will add release note!