### PR TITLE
Startup performance logging

### DIFF
--- a/mantidimaging/__main__.py
+++ b/mantidimaging/__main__.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
+import time
+
+process_start_time = time.monotonic()
 
 if __name__ == '__main__':
     from multiprocessing import freeze_support

--- a/mantidimaging/core/parallel/manager.py
+++ b/mantidimaging/core/parallel/manager.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
+
+import time
 from multiprocessing import get_context
 import os
 import uuid
@@ -20,6 +22,7 @@ MEM_DIR_LINUX = '/dev/shm'
 CURRENT_PID = psutil.Process().pid
 
 LOG = getLogger(__name__)
+perf_logger = getLogger("perf." + __name__)
 
 cores: int = 1
 pool: Pool | None = None
@@ -27,11 +30,15 @@ pool: Pool | None = None
 
 def create_and_start_pool():
     LOG.info('Creating process pool')
+    t0 = time.monotonic()
     context = get_context('spawn')
     global cores
     cores = context.cpu_count()
     global pool
     pool = context.Pool(cores, initializer=worker_setup)
+
+    if perf_logger.isEnabledFor(1):
+        perf_logger.info(f"Process pool started in {time.monotonic() - t0}")
 
 
 def worker_setup():

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -6,6 +6,7 @@ import os
 import uuid
 from logging import getLogger
 from pathlib import Path
+import time
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -42,6 +43,7 @@ from mantidimaging.gui.windows.stack_choice.compare_presenter import StackCompar
 from mantidimaging.gui.windows.stack_visualiser import StackVisualiserView
 from mantidimaging.gui.windows.welcome_screen.presenter import WelcomeScreenPresenter
 from mantidimaging.gui.windows.wizard.presenter import WizardPresenter
+from mantidimaging.__main__ import process_start_time
 
 if TYPE_CHECKING:
     from mantidimaging.core.data.dataset import MixedDataset
@@ -50,6 +52,7 @@ RECON_GROUP_TEXT = "Recons"
 SINO_TEXT = "Sinograms"
 
 LOG = getLogger(__name__)
+perf_logger = getLogger("perf." + __name__)
 
 
 class QTreeDatasetWidgetItem(QTreeWidgetItem):
@@ -163,6 +166,11 @@ class MainWindowView(BaseMainWindowView):
         self.setCentralWidget(self.splitter)
 
         self.tabifiedDockWidgetActivated.connect(self._on_tab_bar_clicked)
+
+    def _window_ready(self) -> None:
+        if perf_logger.isEnabledFor(1):
+            perf_logger.info(f"Mantid Imaging ready in {time.monotonic() - process_start_time}")
+        super()._window_ready()
 
     def setup_shortcuts(self):
         self.actionLoadDataset.triggered.connect(self.show_image_load_dialog)

--- a/mantidimaging/helper.py
+++ b/mantidimaging/helper.py
@@ -54,7 +54,7 @@ def initialise_logging(arg_level: str) -> None:
     perf_logger = logging.getLogger('perf')
     perf_logger.setLevel(100)
     perf_logger.propagate = False
-    if settings.value("logging/performance_log", defaultValue=False):
+    if settings.value("logging/performance_log", defaultValue=False, type=bool):
         perf_logger.setLevel(1)
         perf_logger.addHandler(console_handler)
         if log_directory != Path(""):


### PR DESCRIPTION
### Issue
Part of #2035 

### Description

Add some performance logging around start up to see how much is due to creating the processing pool. Also try to record the time from the start of our python code, until the main window is displayed.

### Testing 

Enable performance logging, by setting the qsetting key logging/performance_log to "true".

### Acceptance Criteria 
Start mantid imaging look for log entries
```
>python -m mantidimaging
2024-03-20 16:48:25,718 [mantidimaging.core.parallel.manager:L32] INFO: Creating process pool
2024-03-20 16:48:26,325 [perf.mantidimaging.core.parallel.manager:L41] INFO: Process pool started in 0.6099999999996726
2024-03-20 16:48:28,734 [perf.mantidimaging.gui.windows.main.view:L172] INFO: Mantid Imaging ready in 3.0469999999995707
2024-03-20 16:48:28,734 [perf.mantidimaging.gui.mvp_base.view:L59] INFO: MainWindowView shown in 2.405999999999949
```

### Documentation

Not needed
