### PR TITLE
Enable Ruff pyupgrade (UP) rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,6 @@ repos:
         args: [--ignore-missing-imports]
         additional_dependencies: [types-docutils, types-PyYAML, types-requests]
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.2
+    rev: v0.3.3
     hooks:
     -   id: ruff

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -33,6 +33,6 @@ dependencies:
   - pyinstaller==6.1.*
   - sarepy=2020.07 # For building old docs
   - make==4.3
-  - ruff=0.3.2
+  - ruff=0.3.3
   - pre-commit==3.5.*
 

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 import numpy as np
 from skimage.transform import resize
@@ -45,7 +45,7 @@ class RebinFilter(BaseFilter):
         """
         if isinstance(rebin_param, tuple):
             new_shape = rebin_param
-        elif isinstance(rebin_param, (int, float)):
+        elif isinstance(rebin_param, (int | float)):
             current_shape = images.data.shape[1:]
             new_shape = (int(current_shape[0] * rebin_param), int(current_shape[1] * rebin_param))
         else:
@@ -60,7 +60,7 @@ class RebinFilter(BaseFilter):
         return images
 
     @staticmethod
-    def compute_function(i: int, arrays: List[np.ndarray], params: dict):
+    def compute_function(i: int, arrays: list[np.ndarray], params: dict):
         array = arrays[0]
         output = arrays[1]
         new_shape = params['new_shape']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,6 @@ line-length = 120
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "B", "FA", "C4", "NPY"]
-fixable = []
+select = ["F", "E", "W", "UP", "B", "C4", "FA", "NPY"]
+fixable = ["UP"]
+ignore = ["UP014"]


### PR DESCRIPTION
### Issue
closes #2117 

### Description

Final part for enabling the ruff pyupgrade (UP).

Exclude UP014 convert-named-tuple-functional-to-class, because its a nice compact format that we use in a couple of places.

Also bump ruff to 0.3.3 while we are here.

### Testing 

`make check`

### Acceptance Criteria 

Tests should pass

### Documentation
Not needed