### PR TITLE
Add setting for number of processes to start

### DIFF
--- a/docs/release_notes/next/dev-2035-process-count
+++ b/docs/release_notes/next/dev-2035-process-count
@@ -1,0 +1,1 @@
+#2035: Add setting for number of processes to start in multiprocessing pool (default to 8)

--- a/mantidimaging/core/parallel/manager.py
+++ b/mantidimaging/core/parallel/manager.py
@@ -28,13 +28,16 @@ cores: int = 1
 pool: Pool | None = None
 
 
-def create_and_start_pool():
-    LOG.info('Creating process pool')
+def create_and_start_pool(process_count: int) -> None:
     t0 = time.monotonic()
     context = get_context('spawn')
     global cores
-    cores = context.cpu_count()
+    if process_count == 0:
+        cores = context.cpu_count()
+    else:
+        cores = process_count
     global pool
+    LOG.info(f'Creating process pool with {cores} processes')
     pool = context.Pool(cores, initializer=worker_setup)
 
     if perf_logger.isEnabledFor(1):

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -8,6 +8,7 @@ import sys
 import warnings
 import os
 
+from PyQt5.QtCore import QSettings
 from PyQt5.QtWidgets import QApplication
 from PyQt5 import QtCore
 from PyQt5.QtGui import QGuiApplication
@@ -90,9 +91,12 @@ def main() -> None:
 
     h.initialise_logging(args.log_level)
 
+    settings = QSettings()
+    process_count = settings.value("multiprocessing/process_count", 8, type=int)
+
     from mantidimaging import gui
     try:
-        pm.create_and_start_pool(0)
+        pm.create_and_start_pool(process_count)
         gui.execute()
         result = q_application.exec_()
     except BaseException as e:

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -92,7 +92,7 @@ def main() -> None:
 
     from mantidimaging import gui
     try:
-        pm.create_and_start_pool()
+        pm.create_and_start_pool(0)
         gui.execute()
         result = q_application.exec_()
     except BaseException as e:

--- a/mantidimaging/test_helpers/start_qapplication.py
+++ b/mantidimaging/test_helpers/start_qapplication.py
@@ -85,7 +85,7 @@ def start_qapplication(cls):
 def start_multiprocessing_pool(cls):
 
     def setUpClass():
-        create_and_start_pool()
+        create_and_start_pool(0)
 
     def tearDownClass():
         end_pool()


### PR DESCRIPTION
### Issue

Closes #2035 

### Description

Add a qsetting for number of processes to start in the multiprocessing pool. Lowering this can reduce startup time and memory usage. Previously MI would start a process of each CPU core detected, which can be too high in the case of hyper-threading and heterogeneous CPUs.

### Testing 

Make sure you have performance logging enabled in the qsettings. On linux in `.config/mantidproject/Mantid Imaging.conf` or in windows in the registry.
`logging/performance_log = true`

At startup you should see the number of processes started and the time to start the pool. In the qsetting set
`multiprocessing/process_count=4`
Start again an check there is a change

### Acceptance Criteria 

Startup should be slightly faster.
Operations should still work

### Documentation

Release notes
