### PR TITLE
fix eyes_test GitHub actions

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -123,7 +123,7 @@ jobs:
           APPLITOOLS_BATCH_ID: ${{ github.sha }}
           GITHUB_BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          xvfb-run --auto-servernum /bin/time -v python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov -o log_cli=true mantidimaging/eyes_tests --durations=10
+          xvfb-run --auto-servernum /bin/time -v python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov -o log_cli=true mantidimaging/eyes_tests --run-eyes-tests --durations=10
         timeout-minutes: 15
 
       - name: Coveralls

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -115,7 +115,7 @@ jobs:
           APPLITOOLS_BATCH_ID: ${{ github.sha }}
           GITHUB_BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov -o log_cli=true mantidimaging/eyes_tests --durations=10
+          python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov -o log_cli=true mantidimaging/eyes_tests --run-eyes-tests --durations=10
         timeout-minutes: 15
 
       # Label as 'windows-build-test' for testing purposes.


### PR DESCRIPTION
### Description

The eyes tests have not been running on GitHub Actions as the `--run-eyes-tests` flag was not added to the Windows and Conda work flows. This PR adds those flags so the applitools tests will now run!
