### PR TITLE
Optimize ROI Adjustments in Spectrum Viewer by delaying redraw

### DIFF
--- a/docs/release_notes/next/fix-2076-ROI-speed
+++ b/docs/release_notes/next/fix-2076-ROI-speed
@@ -1,0 +1,1 @@
+#2076: ROI speed up

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -205,7 +205,7 @@ class SpectrumWidget(QWidget):
 
         self.roi_dict[name] = roi_object.roi
         self.max_roi_size = roi_object.size()
-        self.roi_dict[name].sigRegionChanged.connect(self.roi_changed.emit)
+        self.roi_dict[name].sigRegionChangeFinished.connect(self.roi_changed.emit)
         self.roi_dict[name].sigClicked.connect(self.roi_clicked.emit)
         self.image.vb.addItem(self.roi_dict[name])
         self.roi_dict[name].hoverPen = mkPen(self.roi_dict[name].colour, width=3)

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -175,9 +175,6 @@ class SpectrumWidget(QWidget):
         for handle in handles:
             handle.setVisible(visible)
         self.roi_dict[name].setVisible(visible)
-        self.roi_dict[name].setAcceptedMouseButtons(Qt.MouseButton.LeftButton)
-        self.roi_dict[name].sigRegionChanged.connect(self.roi_changed.emit)
-        self.roi_dict[name].sigClicked.connect(self.roi_clicked.emit)
 
     def set_roi_alpha(self, name: str, alpha: float) -> None:
         """
@@ -276,7 +273,7 @@ class SpectrumPlotWidget(GraphicsLayoutWidget):
         self.nextRow()
         self._tof_range_label = self.addLabel()
         self.range_control = LinearRegionItem()
-        self.range_control.sigRegionChanged.connect(self._handle_tof_range_changed)
+        self.range_control.sigRegionChangeFinished.connect(self._handle_tof_range_changed)
         self.ci.layout.setRowStretchFactor(0, 1)
 
     def get_tof_range(self) -> tuple[int, int]:


### PR DESCRIPTION
### Issue 

Progress on #2076 

### Description

This pull request introduces significant performance optimizations to the spectrum viewer, specifically targeting the handling of Regions of Interest (ROIs) within large datasets. The core of this optimization involves a strategic shift from using the sigRegionChanged signal to the sigRegionChangeFinished signal in PyQtGraph's ROI management. This change is aimed at reducing unnecessary computations during the interactive adjustment of ROIs, thus enhancing the responsiveness and efficiency of the spectrum viewer.

### Testing 

The optimizations introduced have been thoroughly tested on a variety of datasets, with a particular focus on large datasets that previously exhibited performance issues during ROI adjustments in the spectrum viewer. The testing process involved the following key steps to ensure comprehensive coverage and validation of the changes:

### Acceptance Criteria 

use datasets, especially those that are large or have previously highlighted performance issues. Adjusting ROIs on these datasets should now result in a noticeably smoother experience, with reduced lag or delay.

### Documentation

All changes should be noted in the appropriate file in docs/release_notes*
