### PR TITLE
Enter Time of Flight user properties in Spectrum Viewer

### DIFF
--- a/mantidimaging/core/utility/unit_conversion.py
+++ b/mantidimaging/core/utility/unit_conversion.py
@@ -13,11 +13,12 @@ class UnitConversion:
     mega_electro_volt: float = 1.60217662e-19 / 1e6
     target_to_camera_dist: float = 56  # [m]
     data_offset: float = 0  # [us]
+    tof_data_to_convert: np.ndarray
+    velocity: np.ndarray
 
     def __init__(self, data_to_convert: np.ndarray | None = None) -> None:
-        self.tof_data_to_convert = data_to_convert
         if data_to_convert is not None:
-            self.velocity = self.target_to_camera_dist / (self.tof_data_to_convert + self.data_offset)
+            self.set_data_to_convert(data_to_convert)
 
     def tof_seconds_to_wavelength(self) -> np.ndarray:
         self.check_data()

--- a/mantidimaging/core/utility/unit_conversion.py
+++ b/mantidimaging/core/utility/unit_conversion.py
@@ -32,17 +32,21 @@ class UnitConversion:
         energy_evs = energy / self.mega_electro_volt
         return energy_evs
 
+    def tof_seconds_to_us(self) -> np.ndarray:
+        self.check_data()
+        return (self.tof_data_to_convert + self.data_offset) * 1e6
+
     def set_target_to_camera_dist(self, target_to_camera_dist: float) -> None:
         self.target_to_camera_dist = target_to_camera_dist
 
     def set_data_to_convert(self, data_to_convert: np.ndarray) -> None:
         self.tof_data_to_convert = data_to_convert
-        self.velocity = self.target_to_camera_dist / (self.tof_data_to_convert + self.data_offset)
 
     def check_data(self) -> None:
         if self.tof_data_to_convert is None:
             raise TypeError("Data is not present")
+        else:
+            self.velocity = self.target_to_camera_dist / (self.tof_data_to_convert + self.data_offset)
 
     def set_data_offset(self, data_offset: float) -> None:
         self.data_offset = data_offset * 1e-6
-        self.velocity = self.target_to_camera_dist / (self.tof_data_to_convert + self.data_offset)

--- a/mantidimaging/core/utility/unit_conversion.py
+++ b/mantidimaging/core/utility/unit_conversion.py
@@ -20,7 +20,7 @@ class UnitConversion:
         if data_to_convert is not None:
             self.set_data_to_convert(data_to_convert)
 
-    def tof_seconds_to_wavelength(self) -> np.ndarray:
+    def tof_seconds_to_wavelength_in_angstroms(self) -> np.ndarray:
         self.check_data()
         wavelength = self.planck_h / (self.neutron_mass * self.velocity)
         wavelength_angstroms = wavelength / self.angstrom
@@ -36,9 +36,6 @@ class UnitConversion:
         self.check_data()
         return (self.tof_data_to_convert + self.data_offset) * 1e6
 
-    def set_target_to_camera_dist(self, target_to_camera_dist: float) -> None:
-        self.target_to_camera_dist = target_to_camera_dist
-
     def set_data_to_convert(self, data_to_convert: np.ndarray) -> None:
         self.tof_data_to_convert = data_to_convert
 
@@ -47,6 +44,3 @@ class UnitConversion:
             raise TypeError("Data is not present")
         else:
             self.velocity = self.target_to_camera_dist / (self.tof_data_to_convert + self.data_offset)
-
-    def set_data_offset(self, data_offset: float) -> None:
-        self.data_offset = data_offset * 1e-6

--- a/mantidimaging/core/utility/unit_conversion.py
+++ b/mantidimaging/core/utility/unit_conversion.py
@@ -12,7 +12,7 @@ class UnitConversion:
     angstrom: float = 1e-10  # [m]
     mega_electro_volt: float = 1.60217662e-19 / 1e6
     target_to_camera_dist: float = 56  # [m]
-    data_offset: float = 0  # [us]
+    data_offset: float = 0  # [s]
     tof_data_to_convert: np.ndarray
     velocity: np.ndarray
 

--- a/mantidimaging/core/utility/unit_conversion.py
+++ b/mantidimaging/core/utility/unit_conversion.py
@@ -11,18 +11,37 @@ class UnitConversion:
     planck_h: float = 6.62606896e-34  # [JHz-1]
     angstrom: float = 1e-10  # [m]
     mega_electro_volt: float = 1.60217662e-19 / 1e6
+    target_to_camera_dist: float = 56  # [m]
+    data_offset: float = 0  # [us]
 
-    def __init__(self, data_to_convert: np.ndarray, target_to_camera_dist: float = 56) -> None:
+    def __init__(self, data_to_convert: np.ndarray | None = None) -> None:
         self.tof_data_to_convert = data_to_convert
-        self.target_to_camera_dist = target_to_camera_dist
-        self.velocity = self.target_to_camera_dist / self.tof_data_to_convert
+        if data_to_convert is not None:
+            self.velocity = self.target_to_camera_dist / (self.tof_data_to_convert + self.data_offset)
 
     def tof_seconds_to_wavelength(self) -> np.ndarray:
+        self.check_data()
         wavelength = self.planck_h / (self.neutron_mass * self.velocity)
         wavelength_angstroms = wavelength / self.angstrom
         return wavelength_angstroms
 
     def tof_seconds_to_energy(self) -> np.ndarray:
+        self.check_data()
         energy = self.neutron_mass * self.velocity / 2
         energy_evs = energy / self.mega_electro_volt
         return energy_evs
+
+    def set_target_to_camera_dist(self, target_to_camera_dist: float) -> None:
+        self.target_to_camera_dist = target_to_camera_dist
+
+    def set_data_to_convert(self, data_to_convert: np.ndarray) -> None:
+        self.tof_data_to_convert = data_to_convert
+        self.velocity = self.target_to_camera_dist / (self.tof_data_to_convert + self.data_offset)
+
+    def check_data(self) -> None:
+        if self.tof_data_to_convert is None:
+            raise TypeError("Data is not present")
+
+    def set_data_offset(self, data_offset: float) -> None:
+        self.data_offset = data_offset * 1e-6
+        self.velocity = self.target_to_camera_dist / (self.tof_data_to_convert + self.data_offset)

--- a/mantidimaging/gui/ui/spectrum_viewer.ui
+++ b/mantidimaging/gui/ui/spectrum_viewer.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>905</width>
-    <height>752</height>
+    <width>1009</width>
+    <height>795</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -391,7 +391,78 @@
          </widget>
         </item>
         <item>
-         <spacer name="PropertiesSpacer">
+         <widget class="QGroupBox" name="groupBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>300</width>
+            <height>84</height>
+           </size>
+          </property>
+          <property name="title">
+           <string>Time of Flight Properties</string>
+          </property>
+          <widget class="QLabel" name="label_3">
+           <property name="geometry">
+            <rect>
+             <x>10</x>
+             <y>31</y>
+             <width>101</width>
+             <height>16</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string>Flight path:</string>
+           </property>
+          </widget>
+          <widget class="QLabel" name="label_4">
+           <property name="geometry">
+            <rect>
+             <x>10</x>
+             <y>50</y>
+             <width>91</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string>Time delay: </string>
+           </property>
+          </widget>
+          <widget class="QDoubleSpinBox" name="flightPathSpinBox">
+           <property name="geometry">
+            <rect>
+             <x>80</x>
+             <y>30</y>
+             <width>211</width>
+             <height>19</height>
+            </rect>
+           </property>
+           <property name="suffix">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QDoubleSpinBox" name="timeDelaySpinBox">
+           <property name="geometry">
+            <rect>
+             <x>80</x>
+             <y>50</y>
+             <width>211</width>
+             <height>19</height>
+            </rect>
+           </property>
+           <property name="suffix">
+            <string/>
+           </property>
+          </widget>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>

--- a/mantidimaging/gui/ui/spectrum_viewer.ui
+++ b/mantidimaging/gui/ui/spectrum_viewer.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1009</width>
-    <height>795</height>
+    <width>1001</width>
+    <height>766</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -391,7 +391,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QGroupBox" name="groupBox">
+         <widget class="QGroupBox" name="tofPropertiesGroupBox">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
             <horstretch>0</horstretch>

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -81,6 +81,8 @@ class SpectrumViewerWindowModel:
         else:
             self.tof_mode = ToFUnitMode.WAVELENGTH
 
+        self.units = UnitConversion()
+
     def roi_name_generator(self) -> str:
         """
         Returns a new Unique ID for newly created ROIs
@@ -470,12 +472,12 @@ class SpectrumViewerWindowModel:
                 self.tof_range = (0, self._stack.data.shape[0] - 1)
                 self.tof_data = np.arange(self.tof_range[0], self.tof_range[1] + 1)
             else:
-                units = UnitConversion(self.tof_data)
+                self.units.set_data_to_convert(self.tof_data)
                 if self.tof_mode == ToFUnitMode.TOF_US:
                     self.tof_data = self.tof_data * 1e6
                 elif self.tof_mode == ToFUnitMode.WAVELENGTH:
-                    self.tof_data = units.tof_seconds_to_wavelength()
+                    self.tof_data = self.units.tof_seconds_to_wavelength()
                 elif self.tof_mode == ToFUnitMode.ENERGY:
-                    self.tof_data = units.tof_seconds_to_energy()
+                    self.tof_data = self.units.tof_seconds_to_energy()
                 self.tof_plot_range = (self.tof_data.min(), self.tof_data.max())
                 self.tof_range = (0, self.tof_data.size)

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -474,7 +474,7 @@ class SpectrumViewerWindowModel:
             else:
                 self.units.set_data_to_convert(self.tof_data)
                 if self.tof_mode == ToFUnitMode.TOF_US:
-                    self.tof_data = self.tof_data * 1e6
+                    self.tof_data = self.units.tof_seconds_to_us()
                 elif self.tof_mode == ToFUnitMode.WAVELENGTH:
                     self.tof_data = self.units.tof_seconds_to_wavelength()
                 elif self.tof_mode == ToFUnitMode.ENERGY:

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -476,7 +476,7 @@ class SpectrumViewerWindowModel:
                 if self.tof_mode == ToFUnitMode.TOF_US:
                     self.tof_data = self.units.tof_seconds_to_us()
                 elif self.tof_mode == ToFUnitMode.WAVELENGTH:
-                    self.tof_data = self.units.tof_seconds_to_wavelength()
+                    self.tof_data = self.units.tof_seconds_to_wavelength_in_angstroms()
                 elif self.tof_mode == ToFUnitMode.ENERGY:
                     self.tof_data = self.units.tof_seconds_to_energy()
                 self.tof_plot_range = (self.tof_data.min(), self.tof_data.max())

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -109,6 +109,12 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.on_visibility_change()
 
     def reset_units_menu(self):
+        if self.model.tof_data is None:
+            self.view.tof_mode_select_group.setEnabled(False)
+            self.view.tofPropertiesGroupBox.setEnabled(False)
+        else:
+            self.view.tof_mode_select_group.setEnabled(True)
+            self.view.tofPropertiesGroupBox.setEnabled(True)
         self.model.tof_mode = ToFUnitMode.IMAGE_NUMBER
         for action in self.view.tof_mode_select_group.actions():
             with QSignalBlocker(action):
@@ -362,8 +368,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.spectrum_widget.spectrum_plot_widget.set_tof_axis_label(tof_axis_label)
         self.refresh_spectrum_plot()
 
-    def refresh_spectrum_plot(self):
 
+    def refresh_spectrum_plot(self) -> None:
         self.view.spectrum_widget.spectrum.clearPlots()
         self.view.spectrum_widget.spectrum.update()
         self.view.show_visible_spectrums()
@@ -378,12 +384,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def handle_time_delay_change(self) -> None:
         self.model.tof_data = self.model.get_stack_time_of_flight()
-        print(f"self.model.tof_data: {self.model.tof_data}")
-        #self.model.tof_data = np.add(self.model.tof_data,
-        #                             np.full_like(self.model.tof_data, self.view.timeDelaySpinBox.value()))
         self.model.units.set_data_offset(self.view.timeDelaySpinBox.value())
-        print(f"self.model.units.data_offset: {self.model.units.data_offset}")
-        print(f"self.model.tof_data: {self.model.tof_data}")
         self.model.set_relevant_tof_units()
-        print(f"self.model.tof_data: {self.model.tof_data}\n")
         self.refresh_spectrum_plot()

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -382,6 +382,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         #self.model.tof_data = np.add(self.model.tof_data,
         #                             np.full_like(self.model.tof_data, self.view.timeDelaySpinBox.value()))
         self.model.units.set_data_offset(self.view.timeDelaySpinBox.value())
+        print(f"self.model.units.data_offset: {self.model.units.data_offset}")
         print(f"self.model.tof_data: {self.model.tof_data}")
         self.model.set_relevant_tof_units()
         print(f"self.model.tof_data: {self.model.tof_data}\n")

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -368,7 +368,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.spectrum_widget.spectrum_plot_widget.set_tof_axis_label(tof_axis_label)
         self.refresh_spectrum_plot()
 
-
     def refresh_spectrum_plot(self) -> None:
         self.view.spectrum_widget.spectrum.clearPlots()
         self.view.spectrum_widget.spectrum.update()

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -368,12 +368,12 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.auto_range_image()
 
     def handle_flight_path_change(self) -> None:
-        self.model.units.set_target_to_camera_dist(self.view.flightPathSpinBox.value())
+        self.model.units.target_to_camera_dist = self.view.flightPathSpinBox.value()
         self.model.set_relevant_tof_units()
         self.refresh_spectrum_plot()
 
     def handle_time_delay_change(self) -> None:
         self.model.tof_data = self.model.get_stack_time_of_flight()
-        self.model.units.set_data_offset(self.view.timeDelaySpinBox.value())
+        self.model.units.data_offset = self.view.timeDelaySpinBox.value() * 1e-6
         self.model.set_relevant_tof_units()
         self.refresh_spectrum_plot()

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -355,16 +355,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         selected_mode = self.view.tof_mode_select_group.checkedAction().text()
         self.model.tof_mode = self.view.allowed_modes[selected_mode]["mode"]
         self.model.set_relevant_tof_units()
-        tof_mode = self.model.tof_mode
-        tof_axis_label = ""
-        if tof_mode == ToFUnitMode.IMAGE_NUMBER:
-            tof_axis_label = "Image index"
-        if tof_mode == ToFUnitMode.TOF_US:
-            tof_axis_label = "Time of Flight (\u03BC s)"
-        if tof_mode == ToFUnitMode.WAVELENGTH:
-            tof_axis_label = "Neutron Wavelength (\u212B)"
-        if tof_mode == ToFUnitMode.ENERGY:
-            tof_axis_label = "Neutron Energy (MeV)"
+        tof_axis_label = self.view.allowed_modes[selected_mode]["label"]
         self.view.spectrum_widget.spectrum_plot_widget.set_tof_axis_label(tof_axis_label)
         self.refresh_spectrum_plot()
 

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -6,7 +6,7 @@ import uuid
 from pathlib import Path
 from unittest import mock
 
-from PyQt5.QtWidgets import QPushButton, QActionGroup
+from PyQt5.QtWidgets import QPushButton, QActionGroup, QGroupBox
 from parameterized import parameterized
 
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
@@ -35,7 +35,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view.exportButtonRITS = mock.create_autospec(QPushButton)
         self.view.addBtn = mock.create_autospec(QPushButton)
         self.view.tof_mode_select_group = mock.create_autospec(QActionGroup)
-        self.view.allowed_modes = mock.create_autospec(dict)
+        self.view.tofPropertiesGroupBox = mock.create_autospec(QGroupBox)
         self.presenter = SpectrumViewerWindowPresenter(self.view, self.main_window)
 
     def test_get_dataset_id_for_stack_no_stack_id(self):

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, TypedDict
 
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import QCheckBox, QVBoxLayout, QFileDialog, QPushButton, QLabel, QAbstractItemView, QHeaderView, \
-    QTabWidget, QComboBox, QSpinBox, QTableWidget, QTableWidgetItem, QGroupBox, QActionGroup, QAction
+    QTabWidget, QComboBox, QSpinBox, QTableWidget, QTableWidgetItem, QGroupBox, QActionGroup, QAction, QDoubleSpinBox
 from PyQt5.QtCore import QSignalBlocker, Qt
 
 from mantidimaging.core.utility import finder
@@ -57,6 +57,9 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     spectrum_widget: SpectrumWidget
 
     number_roi_properties_procced: int = 0
+
+    flightPathSpinBox: QDoubleSpinBox
+    timeDelaySpinBox: QDoubleSpinBox
 
     def __init__(self, main_window: MainWindowView):
         super().__init__(None, 'gui/ui/spectrum_viewer.ui')
@@ -199,6 +202,13 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         _ = self.roi_table_model  # Initialise model
         self.current_roi = self.last_clicked_roi = self.roi_table_model.roi_names()[0]
         self.set_roi_properties()
+
+        self.flightPathSpinBox.setMinimum(0)
+        self.flightPathSpinBox.setMaximum(1e10)
+        self.flightPathSpinBox.setValue(56)
+        self.timeDelaySpinBox.setMaximum(1e10)
+        self.flightPathSpinBox.valueChanged.connect(self.presenter.handle_flight_path_change)
+        self.timeDelaySpinBox.valueChanged.connect(self.presenter.handle_time_delay_change)
 
         def on_row_change(item, _) -> None:
             """

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -206,7 +206,10 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.flightPathSpinBox.setMinimum(0)
         self.flightPathSpinBox.setMaximum(1e10)
         self.flightPathSpinBox.setValue(56)
+        self.flightPathSpinBox.setSuffix(" m")
         self.timeDelaySpinBox.setMaximum(1e10)
+        self.timeDelaySpinBox.setSuffix(" \u03BCs")
+
         self.flightPathSpinBox.valueChanged.connect(self.presenter.handle_flight_path_change)
         self.timeDelaySpinBox.valueChanged.connect(self.presenter.handle_time_delay_change)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -58,6 +58,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
     number_roi_properties_procced: int = 0
 
+    tofPropertiesGroupBox: QGroupBox
     flightPathSpinBox: QDoubleSpinBox
     timeDelaySpinBox: QDoubleSpinBox
 


### PR DESCRIPTION
### Issue

Closes #2151.

### Description

A section has been added to the left hand side of the spectrum viewer which allows users to enter the Flight Path (meters) and the Time Delay (microseconds) used as these can change from experiment to experiment. The time delay can be used to artificially alter the neutron wavelength range. It was requested by IMAT that these option be "on show" rather than hidden away in a right click menu for example.

When the values in the spinboxes are changed, the associated attribute is altered in the `unit_conversion` object in the spectrum viewer model. This ensures that the converted data is recalculated properly when the ToF properties are changed and any alterations are contained in the `UnitConversion` class.

### Testing 

make check

### Acceptance Criteria 

- Open MI and load data with no spectrum.txt data
- In the SV, the Right Click `Units` option should be disabled and the ToF properties options on the left should be greyed out
- Load in data with a spectrum.txt file, e.g. the Brass dataset.
- The ToF properties box will be enabled and you can alter the Flight Path (FP) and Time Delay (TD).
- The defaults should be FP = 56m and TD = 0.
- For the Image Index mode, the FP and TD should not alter the data.
- For the Wavelength mode, the increasing the FP implies faster neutrons (with a fixed time of flight) so the wavelength should shift to a smaller number.
- For the Energy mode, the increasing the FP implies faster neutrons (with a fixed time of flight) so the wavelength should shift to a higher number.
- For the ToF us mode, changing the FP should not change the data but the TD will shift the data to the left or right by the value of the TD.
- For the Corrected Brass Dataset (`\\isis\shares\IMAT\ExampleData\Brass\Corrected_Sample_PH20`), there should be a Bragg Edge around 4.3 angstroms.

### Documentation

Will add Release Note
