### PR TITLE
Don't run tests when push only has documentation changes

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -6,6 +6,8 @@ on:
     - 'main'
     - 'release-*'
   pull_request:
+    paths:
+      - '!docs/**'
   release:
   merge_group:
 

--- a/.github/workflows/cos7_testing.yml
+++ b/.github/workflows/cos7_testing.yml
@@ -6,6 +6,8 @@ on:
     - 'main'
     - 'release-*'
   pull_request:
+    paths:
+      - '!docs/**'
   merge_group:
 
 jobs:

--- a/.github/workflows/u18_testing.yml
+++ b/.github/workflows/u18_testing.yml
@@ -6,6 +6,8 @@ on:
     - 'main'
     - 'release-*'
   pull_request:
+    paths:
+      - '!docs/**'
   merge_group:
 
 jobs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,6 +6,8 @@ on:
     - 'main'
     - 'release-*'
   pull_request:
+    paths:
+      - '!docs/**'
   release:
   merge_group:
 

--- a/docs/release_notes/next/dev-2116-tests-not-docs
+++ b/docs/release_notes/next/dev-2116-tests-not-docs
@@ -1,0 +1,1 @@
+#2116 : Don't run test suite when only doc changes


### PR DESCRIPTION
We don't need to run unit, system or screenshot tests

### Issue

Closes #2116 (as best as we can)

### Description
Add a `paths` with negated path, to avoid running main tests suite when there are only documentation changes.

### Testing 

I have tested lots of combinations. See screenshot below, showing that when also excluding the .workflows directory the tests did not run on this PR.

### Documentation

Release notes
