### PR TITLE
Set style in before compiling ui file for consistent sizing

### DIFF
--- a/mantidimaging/gui/mvp_base/view.py
+++ b/mantidimaging/gui/mvp_base/view.py
@@ -26,11 +26,10 @@ class BaseMainWindowView(QMainWindow):
         super().__init__(parent)
 
         self._has_shown = False
+        QApplication.instance().setStyle(settings.value('theme_selection'))
 
         if ui_file is not None:
             compile_ui(ui_file, self)
-
-        QApplication.instance().setStyle(settings.value('theme_selection'))
 
     def closeEvent(self, e):
         LOG.debug('UI window closed')


### PR DESCRIPTION
### Issue

Close #2167.

### Description

In `gui/mvp_base/view.py` the Qapplication instance style is now set before the .ui file is compiled, which avoids the Spectrum Viewer from unreliably showing in differing sizes, which caused issues with reliable eyes tests.

### Acceptance Criteria 

As in the issue #2167, check open MI with data and open and close the spectrum viewer a large number of times to check that it is consistently being produced at the same size which should be around QSize(914, 978) but may differ depending on your resolution. You can use `python -m mantidimaging --path '/data/imaging/IMAT00010675_128/Tomo' -sv`

Alternatively, you can run the screenshot tests with the added option `-k test_spectrum_viewer_add_new_roi`

You may want to use a print statements like 
```
class BaseMainWindowView(QMainWindow):

    def __init__(self, parent, ui_file=None):
        self._t0 = time.monotonic()
        super().__init__(parent)

        self._has_shown = False

        print(f"{ui_file}: self.size() = {self.size()}")
        QApplication.instance().setStyle(settings.value('theme_selection'))
        print(f"{ui_file}: self.size() = {self.size()}")

        if ui_file is not None:
            compile_ui(ui_file, self)
```
and in `spectrum_viewer\view.py`:
```
    def show(self):
        print(f"SVWV show start    {self.size()=}")
        super().show()
        self.activateWindow()
        print(f"SVWV show end      {self.size()=}")
```

to see the sizing in the command line.


to check the sizing

