### PR TITLE
FLASH PR: Update conf.py to set language and update intersphinx_mapping format

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,7 +86,7 @@ release = '2.8.0a1'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -170,7 +170,7 @@ texinfo_documents = [
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # Stop sphinx from being a smartypants and merging the -- into a single unicode dash
 html_use_smartypants = False


### PR DESCRIPTION
### Issue

FLASH PR

### Description

I noticed during reviewing #2170 during building docs, that a few warnings were logged. This flash PR resolves the following issues:
``` bash
WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).
WARNING: The pre-Sphinx 1.0 'intersphinx_mapping' format is deprecated and will be removed in Sphinx 8. Update to the current format as described in the documentation. Hint: "intersphinx_mapping = {'<name>': ('https://docs.python.org/', None)}".https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping
```
In `docs/conf.py`:
* Line 89, replace `language = None` with `language = 'en'`
* Line 173, replace 
```python
intersphinx_mapping = {'https://docs.python.org/': None}
``` 
with 
```python
intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
```

### Testing 

* Build docs and check warnings are no longer present.
* Check docs still build correctly.

### Acceptance Criteria 

Docs build correctly and with no warnings relating to language or intersphinx_mapping-mapping format

### Documentation

NA
