### PR TITLE
Unit Tests for UnitConversion Class

### DIFF
--- a/docs/release_notes/next/dev-2172-unit-conversion-tests
+++ b/docs/release_notes/next/dev-2172-unit-conversion-tests
@@ -1,0 +1,1 @@
+#2172: Unit tests for the UnitConversion class

--- a/mantidimaging/core/utility/test/unit_conversion_test.py
+++ b/mantidimaging/core/utility/test/unit_conversion_test.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+import numpy as np
+
+import unittest
+from numpy.testing import assert_array_almost_equal, assert_array_equal
+
+from mantidimaging.core.utility import unit_conversion
+
+
+class UnitConversionTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tof_data = np.array([1, 2, 3, 5, 8, 9])
+
+    def test_WHEN_no_data_THEN_error_on_check_data(self):
+        self.assertRaises(TypeError, unit_conversion.UnitConversion().check_data)
+
+    def test_WHEN_data_THEN_velocity_calculated(self):
+        assert_array_almost_equal(
+            unit_conversion.UnitConversion(self.tof_data).velocity,
+            np.array([56., 28., 18.66666667, 11.2, 7., 6.22222222]))
+
+    def test_WHEN_set_data_to_convert_THEN_data_set(self):
+        units = unit_conversion.UnitConversion()
+        units.set_data_to_convert(self.tof_data)
+        assert_array_equal(units.tof_data_to_convert, self.tof_data)
+
+    def test_WHEN_set_target_to_camera_dist_THEN_camera_dist_set(self):
+        units = unit_conversion.UnitConversion()
+        units.set_target_to_camera_dist(30)
+        self.assertEqual(units.target_to_camera_dist, 30)
+
+    def test_WHEN_set_data_offset_THEN_data_offset_set(self):
+        units = unit_conversion.UnitConversion()
+        units.set_data_offset(100)
+        self.assertEqual(units.data_offset, 100 * 1e-6)
+
+    def test_WHEN_tof_converted_to_wavelength_THEN_wavelength_data_returned(self):
+        wavelength_data = unit_conversion.UnitConversion(self.tof_data).tof_seconds_to_wavelength()
+        assert_array_almost_equal(
+            wavelength_data,
+            np.array([70.64346392, 141.28692784, 211.93039176, 353.2173196, 565.14771137, 635.79117529]))
+
+    def test_WHEN_tof_converted_to_energy_THEN_energy_data_returned(self):
+        energy_data = unit_conversion.UnitConversion(self.tof_data).tof_seconds_to_energy()
+        assert_array_almost_equal(energy_data,
+                                  np.array([0.29271406, 0.14635703, 0.09757135, 0.05854281, 0.03658926, 0.03252378]))
+
+    def test_WHEN_tof_converted_to_us_THEN_us_data_returned(self):
+        us_data = unit_conversion.UnitConversion(self.tof_data).tof_seconds_to_us()
+        assert_array_almost_equal(us_data, np.array([1000000., 2000000., 3000000., 5000000., 8000000., 9000000.]))

--- a/mantidimaging/core/utility/test/unit_conversion_test.py
+++ b/mantidimaging/core/utility/test/unit_conversion_test.py
@@ -30,7 +30,7 @@ class UnitConversionTest(unittest.TestCase):
 
     def test_WHEN_set_target_to_camera_dist_THEN_camera_dist_set(self):
         units = unit_conversion.UnitConversion()
-        units.set_target_to_camera_dist(30)
+        units.target_to_camera_dist = 30
         self.assertEqual(units.target_to_camera_dist, 30)
 
     def test_WHEN_set_data_offset_THEN_data_offset_set(self):
@@ -39,7 +39,7 @@ class UnitConversionTest(unittest.TestCase):
         self.assertEqual(units.data_offset, 100 * 1e-6)
 
     def test_WHEN_tof_converted_to_wavelength_THEN_wavelength_data_returned(self):
-        wavelength_data = unit_conversion.UnitConversion(self.tof_data).tof_seconds_to_wavelength()
+        wavelength_data = unit_conversion.UnitConversion(self.tof_data).tof_seconds_to_wavelength_in_angstroms()
         assert_array_almost_equal(
             wavelength_data,
             np.array([70.64346392, 141.28692784, 211.93039176, 353.2173196, 565.14771137, 635.79117529]))

--- a/mantidimaging/core/utility/unit_conversion.py
+++ b/mantidimaging/core/utility/unit_conversion.py
@@ -13,7 +13,7 @@ class UnitConversion:
     mega_electro_volt: float = 1.60217662e-19 / 1e6
     target_to_camera_dist: float = 56  # [m]
     data_offset: float = 0  # [s]
-    tof_data_to_convert: np.ndarray = None
+    tof_data_to_convert: np.ndarray
     velocity: np.ndarray
 
     def __init__(self, data_to_convert: np.ndarray | None = None) -> None:
@@ -43,7 +43,7 @@ class UnitConversion:
     def check_data(self) -> None:
         try:
             self.velocity = self.target_to_camera_dist / (self.tof_data_to_convert + self.data_offset)
-        except TypeError as exc:
+        except AttributeError as exc:
             raise TypeError("No data to convert") from exc
 
     def set_data_offset(self, data_offset: float) -> None:

--- a/mantidimaging/core/utility/unit_conversion.py
+++ b/mantidimaging/core/utility/unit_conversion.py
@@ -13,7 +13,7 @@ class UnitConversion:
     mega_electro_volt: float = 1.60217662e-19 / 1e6
     target_to_camera_dist: float = 56  # [m]
     data_offset: float = 0  # [s]
-    tof_data_to_convert: np.ndarray
+    tof_data_to_convert: np.ndarray = None
     velocity: np.ndarray
 
     def __init__(self, data_to_convert: np.ndarray | None = None) -> None:

--- a/mantidimaging/core/utility/unit_conversion.py
+++ b/mantidimaging/core/utility/unit_conversion.py
@@ -19,6 +19,7 @@ class UnitConversion:
     def __init__(self, data_to_convert: np.ndarray | None = None) -> None:
         if data_to_convert is not None:
             self.set_data_to_convert(data_to_convert)
+            self.check_data()
 
     def tof_seconds_to_wavelength_in_angstroms(self) -> np.ndarray:
         self.check_data()
@@ -40,7 +41,10 @@ class UnitConversion:
         self.tof_data_to_convert = data_to_convert
 
     def check_data(self) -> None:
-        if self.tof_data_to_convert is None:
-            raise TypeError("Data is not present")
-        else:
+        try:
             self.velocity = self.target_to_camera_dist / (self.tof_data_to_convert + self.data_offset)
+        except TypeError as exc:
+            raise TypeError("No data to convert") from exc
+
+    def set_data_offset(self, data_offset: float) -> None:
+        self.data_offset = data_offset * 1e-6


### PR DESCRIPTION
### Issue

Close #2172.

### Description

Added a set of unit tests for the `UnitConversion` which is currently used to calculate the Time of Flight data in the Spectrum Viewer.

### Testing 

make check

### Acceptance Criteria 

Ensure that all tests pass via `make test` or `make check`

### Documentation

Add release note