### PR TITLE
2094 ShutterCounts Backend

### DIFF
--- a/docs/release_notes/next/feature-2094-load_shuttercounts
+++ b/docs/release_notes/next/feature-2094-load_shuttercounts
@@ -1,0 +1,1 @@
+#2094: Add ShutterCount File type.

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -19,7 +19,7 @@ from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.core.utility.leak_tracker import leak_tracker
 
 if TYPE_CHECKING:
-    from mantidimaging.core.io.instrument_log import InstrumentLog
+    from mantidimaging.core.io.instrument_log import InstrumentLog, ShutterCount
     import numpy.typing as npt
 
 
@@ -58,6 +58,7 @@ class ImageStack:
 
         self._proj180deg: ImageStack | None = None
         self._log_file: InstrumentLog | None = None
+        self._shutter_count_file: ShutterCount | None = None
         self._projection_angles: ProjectionAngles | None = None
 
         if name is None:
@@ -298,6 +299,18 @@ class ImageStack:
         elif value is None:
             del self.metadata[const.LOG_FILE]
         self._log_file = value
+
+    @property
+    def shutter_count_file(self) -> ShutterCount | None:
+        return self._shutter_count_file
+
+    @shutter_count_file.setter
+    def shutter_count_file(self, value: ShutterCount | None) -> None:
+        if value is not None:
+            self.metadata[const.SHUTTER_COUNT_FILE] = str(value.source_file)
+        elif value is None:
+            del self.metadata[const.SHUTTER_COUNT_FILE]
+        self._shutter_count_file = value
 
     def set_projection_angles(self, angles: ProjectionAngles) -> None:
         if len(angles.value) != self.num_images:

--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -131,6 +131,7 @@ class FilenameGroup:
         self.all_indexes = all_indexes
         self.metadata_path: Path | None = None
         self.log_path: Path | None = None
+        self.shutter_count_path: Path | None = None
 
     @classmethod
     def from_file(cls, path: Path | str) -> FilenameGroup:
@@ -205,6 +206,16 @@ class FilenameGroup:
             # choose shortest match
             shortest = min(log_paths, key=lambda p: len(p.name))
             self.log_path = self.directory / shortest
+
+    def find_shutter_count_file(self) -> None:
+        """
+        Find the shutter count file in directory if it exists. The file must be in the parent directory.
+        """
+        shutter_count_pattern = self.directory.name + "*" + "ShutterCount" + ".txt"
+        shutter_count_paths = list(self.directory.parent.glob(shutter_count_pattern))
+        if shutter_count_paths:
+            shortest = min(shutter_count_paths, key=lambda p: len(p.name))
+            self.shutter_count_path = self.directory / shortest
 
     def find_related(self, file_type: FILE_TYPES) -> FilenameGroup | None:
         if self.directory.name not in ["Tomo", "tomo"]:

--- a/mantidimaging/core/io/loader/__init__.py
+++ b/mantidimaging/core/io/loader/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import annotations
 
 from .loader import (  # noqa: F401
-    load, load_log, load_stack_from_group, load_stack_from_image_params)
+    load, load_log, load_shutter_counts, load_stack_from_group, load_stack_from_image_params)

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -152,8 +152,6 @@ def load(filename_group: FilenameGroup,
             angle_order = np.argsort(angles)
             angles = angles[angle_order]
             file_names = [file_names[i] for i in angle_order]
-    # if shutter_count_file is not None:
-    #     load_shutter_counts(shutter_count_file)
 
     image_stack = img_loader.execute(load_func, file_names, in_format, dtype, indices, progress)
 

--- a/mantidimaging/core/operation_history/const.py
+++ b/mantidimaging/core/operation_history/const.py
@@ -9,6 +9,7 @@ OPERATION_KEYWORD_ARGS = 'kwargs'
 OPERATION_DISPLAY_NAME = 'display_name'
 PIXEL_SIZE = 'pixel_size'
 LOG_FILE = 'log_file'
+SHUTTER_COUNT_FILE = 'shutter_count_file'
 
 OPERATION_NAME_COR_TILT_FINDING = 'cor_tilt_finding'
 COR_TILT_ROTATION_CENTRE = 'rotation_centre'

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -129,6 +129,9 @@ Indices = NamedTuple("Indices", [("start", int), ("end", int), ("step", int)])
 
 
 class FILE_TYPES(Enum):
+    """
+    Order must match order of files in load dialog menu
+    """
     SAMPLE = ("Sample", "", "sample")
     FLAT_BEFORE = ("Flat", "Before", "images")
     FLAT_AFTER = ("Flat", "After", "images")
@@ -138,6 +141,9 @@ class FILE_TYPES(Enum):
     SAMPLE_LOG = ("Sample Log", "", "log")
     FLAT_BEFORE_LOG = ("Flat Before Log", "", "log")
     FLAT_AFTER_LOG = ("Flat After Log", "", "log")
+    SHUTTER_COUNTS = ("Sample Shutter Counts", "", "ShutterCount")
+    FLAT_BEFORE_SHUTTER_COUNTS = ("Flat Before Shutter Counts", "", "ShutterCount")
+    FLAT_AFTER_SHUTTER_COUNTS = ("Flat After Shutter Counts", "", "ShutterCount")
 
     def __init__(self, tname: str, suffix: str, mode: str) -> None:
         self.tname = tname
@@ -153,4 +159,10 @@ log_for_file_type = {
     FILE_TYPES.SAMPLE: FILE_TYPES.SAMPLE_LOG,
     FILE_TYPES.FLAT_BEFORE: FILE_TYPES.FLAT_BEFORE_LOG,
     FILE_TYPES.FLAT_AFTER: FILE_TYPES.FLAT_AFTER_LOG,
+}
+
+shuttercounts_for_file_type = {
+    FILE_TYPES.SAMPLE: FILE_TYPES.SHUTTER_COUNTS,
+    FILE_TYPES.FLAT_BEFORE: FILE_TYPES.FLAT_BEFORE_SHUTTER_COUNTS,
+    FILE_TYPES.FLAT_AFTER: FILE_TYPES.FLAT_AFTER_SHUTTER_COUNTS,
 }

--- a/mantidimaging/gui/windows/image_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/image_load_dialog/presenter.py
@@ -35,7 +35,7 @@ class LoadPresenter:
         Does nothing if the select file dialog is canceled.
         """
         name = field.file_info.fname
-        is_image_file = field.file_info.mode != "log" and field.file_info.mode != "ShutterCount"
+        is_image_file = field.file_info.mode not in ["log", "ShutterCount"]
         selected_file = self.view.select_file(name, is_image_file)
         if selected_file is None:  # When select file is canceled
             return
@@ -143,11 +143,11 @@ class LoadPresenter:
         loading_param.sinograms = self.view.images_are_sinograms.isChecked()
         return loading_param
 
-    def _update_loading_param(self, file_type, loading_param):
+    def _update_loading_param(self, file_type: FILE_TYPES, loading_param: LoadingParameters):
         """
         Update the loading parameters for a specific file type.
-        :param  file_type (str): The type of the file being loaded.
-        :param  loading_param (LoadingParameters): The loading parameters object.
+        :param  file_type: The type of the file being loaded.
+        :param  loading_param: The loading parameters object.
         :return None
         """
         if file_type.mode in ["log", "ShutterCount"]:
@@ -164,20 +164,22 @@ class LoadPresenter:
         if file_type in log_for_file_type:
             self._update_image_param(file_type, image_param, log_for_file_type, 'log_file')
         if file_type in shuttercounts_for_file_type:
-            self._update_image_param(file_type, image_param, shuttercounts_for_file_type, 'shutter_count_file')
+            # self._update_image_param(file_type, image_param, shuttercounts_for_file_type, 'shutter_count_file')
+            pass
 
         if file_type == FILE_TYPES.SAMPLE:
             image_param.indices = field.indices
 
         loading_param.image_stacks[file_type] = image_param
 
-    def _update_image_param(self, file_type, image_param, file_type_dict, attr_name):
+    def _update_image_param(self, file_type: FILE_TYPES, image_param: ImageParameters, file_type_dict: dict,
+                            attr_name: str) -> None:
         """
         Update the image parameter based on the selected file type.
-        :param  file_type (str): The selected file type.
+        :param  file_type: The selected file type.
         :param  image_param (ImageParam): The image parameter object to update.
-        :param  file_type_dict (dict): A dictionary mapping file types to their corresponding attributes.
-        :param  attr_name (str): The name of the attribute to update in the image parameter.
+        :param  file_type_dict: A dictionary mapping file types to their corresponding attributes.
+        :param  attr_name: The name of the attribute to update in the image parameter.
         :return None
         """
         field = self.view.fields[file_type_dict[file_type].fname]

--- a/mantidimaging/gui/windows/image_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/image_load_dialog/presenter.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from mantidimaging.core.io.filenames import FilenameGroup
 from mantidimaging.core.io.loader import load_log
 from mantidimaging.core.io.loader.loader import LoadingParameters, ImageParameters, read_image_dimensions
-from mantidimaging.core.utility.data_containers import FILE_TYPES, log_for_file_type
+from mantidimaging.core.utility.data_containers import FILE_TYPES, log_for_file_type, shuttercounts_for_file_type
 from mantidimaging.gui.windows.image_load_dialog.field import Field
 
 if TYPE_CHECKING:
@@ -35,7 +35,7 @@ class LoadPresenter:
         Does nothing if the select file dialog is canceled.
         """
         name = field.file_info.fname
-        is_image_file = field.file_info.mode != "log"
+        is_image_file = field.file_info.mode != "log" and field.file_info.mode != "ShutterCount"
         selected_file = self.view.select_file(name, is_image_file)
         if selected_file is None:  # When select file is canceled
             return
@@ -46,8 +46,10 @@ class LoadPresenter:
             self.do_update_flat_or_dark(field, selected_file)
         elif field.file_info.fname == "Sample Log":
             self.do_update_sample_log(field, selected_file)
+        elif field.file_info.mode in ["Sample Shutter Counts", "ShutterCount"]:
+            self.do_update_shutter_counts(field, selected_file)
         elif field.file_info.mode in ["log", "180"]:
-            self.do_update_single_file(field, selected_file)
+            self._update_field_action(field, selected_file)
 
     def do_update_sample(self, selected_file: str) -> None:
         """
@@ -73,26 +75,59 @@ class LoadPresenter:
                     self.update_field_with_filegroup(file_info, related_group)
 
     def update_field_with_filegroup(self, file_info: FILE_TYPES, file_group: FilenameGroup):
-        file_group.find_all_files()
-        file_list = list(file_group.all_files())
-        self.view.fields[file_info.fname].set_images(file_list)
+        """
+        Update the field with the given file group by finding all files in the group and setting them in the field.
 
-        if file_info in log_for_file_type:
-            file_group.find_log_file()
+        :param file_info (FILE_TYPES): The file information.
+        :param file_group (FilenameGroup): The file group containing the files.
 
-            if file_group.log_path:
-                log_field = self.view.fields[log_for_file_type[file_info].fname]
-                log_field.path = file_group.log_path
-                log_field.use = True
+        :return None
+        """
+        file_group.find_all_files()  # find all files in the group to register related file parsers
+        self.view.fields[file_info.fname].set_images(list(file_group.all_files()))
+        self._update_field(file_info, file_group, log_for_file_type, 'find_log_file', 'log_path')
+
+        self._update_field(file_info, file_group, shuttercounts_for_file_type, 'find_shutter_count_file',
+                           'shutter_count_path')
+
+    def _update_field(self, file_info, file_group, file_type_dict, find_file_method, file_path_attr):
+        if file_info in file_type_dict:
+            getattr(file_group, find_file_method)()
+            if getattr(file_group, file_path_attr):
+                field = self.view.fields[file_type_dict[file_info].fname]
+                field.path = getattr(file_group, file_path_attr)
+                field.use = True
+
+    def do_update_shutter_counts(self, field: Field, selected_file: str) -> None:
+        """
+        Updates the shutter counts for the selected file.
+
+        :param  field (Field): The field to update with the shutter counts.
+        :param  selected_file (str): The path of the selected file.
+
+        :return None
+        """
+        filename_group = FilenameGroup.from_file(Path(selected_file))
+        filename_group.find_shutter_count_file()
+        field.set_images(list(filename_group.all_files()))
+        self._update_field_action(field, selected_file)
 
     def do_update_flat_or_dark(self, field: Field, selected_file: str) -> None:
-        fg = FilenameGroup.from_file(Path(selected_file))
-        fg.find_all_files()
-        field.set_images(list(fg.all_files()))
+        """
+        Update the field with the images from the selected file.
+        :param  field (Field): The field to update.
+        :param  selected_file (str): The path of the selected file.
+        :return None
+        """
+        filename_group = FilenameGroup.from_file(Path(selected_file))
+        filename_group.find_all_files()
+        field.set_images(list(filename_group.all_files()))
 
     def get_parameters(self) -> LoadingParameters:
         """
-        Gather information from the dialog into a LoadingParameters
+        Get the loading parameters for the selected sample.
+        :return LoadingParameters: The loading parameters for the selected sample.
+        :raises  RuntimeError: If no sample is selected.
         """
         sample_field = self.view.fields[FILE_TYPES.SAMPLE.fname]
         if sample_field.path is None:
@@ -100,24 +135,7 @@ class LoadPresenter:
 
         loading_param = LoadingParameters()
         for file_type in FILE_TYPES:
-            if file_type.mode == "log":
-                continue
-            field = self.view.fields[file_type.fname]
-            if not field.use.isChecked() or field.path is None:
-                continue
-            file_group = FilenameGroup.from_file(field.path)
-            file_group.find_all_files()
-            image_param = ImageParameters(file_group)
-
-            if file_type in log_for_file_type:
-                log_field = self.view.fields[log_for_file_type[file_type].fname]
-                if log_field.use.isChecked():
-                    image_param.log_file = log_field.path
-
-            if file_type == FILE_TYPES.SAMPLE:
-                image_param.indices = field.indices
-
-            loading_param.image_stacks[file_type] = image_param
+            self._update_loading_param(file_type, loading_param)
 
         loading_param.name = sample_field.path.name
         loading_param.pixel_size = self.view.pixelSize.value()
@@ -125,13 +143,51 @@ class LoadPresenter:
         loading_param.sinograms = self.view.images_are_sinograms.isChecked()
         return loading_param
 
+    def _update_loading_param(self, file_type, loading_param):
+        """
+        Update the loading parameters for a specific file type.
+        :param  file_type (str): The type of the file being loaded.
+        :param  loading_param (LoadingParameters): The loading parameters object.
+        :return None
+        """
+        if file_type.mode in ["log", "ShutterCount"]:
+            return
+
+        field = self.view.fields[file_type.fname]
+        if not field.use.isChecked() or field.path is None:
+            return
+
+        file_group = FilenameGroup.from_file(field.path)
+        file_group.find_all_files()
+        image_param = ImageParameters(file_group)
+
+        if file_type in log_for_file_type:
+            self._update_image_param(file_type, image_param, log_for_file_type, 'log_file')
+        if file_type in shuttercounts_for_file_type:
+            self._update_image_param(file_type, image_param, shuttercounts_for_file_type, 'shutter_count_file')
+
+        if file_type == FILE_TYPES.SAMPLE:
+            image_param.indices = field.indices
+
+        loading_param.image_stacks[file_type] = image_param
+
+    def _update_image_param(self, file_type, image_param, file_type_dict, attr_name):
+        """
+        Update the image parameter based on the selected file type.
+        :param  file_type (str): The selected file type.
+        :param  image_param (ImageParam): The image parameter object to update.
+        :param  file_type_dict (dict): A dictionary mapping file types to their corresponding attributes.
+        :param  attr_name (str): The name of the attribute to update in the image parameter.
+        :return None
+        """
+        field = self.view.fields[file_type_dict[file_type].fname]
+        if field.use.isChecked():
+            setattr(image_param, attr_name, field.path)
+
     def _update_field_action(self, field: Field, file_name) -> None:
         if file_name is not None:
             field.path = Path(file_name)
             field.use = True  # type: ignore
-
-    def do_update_single_file(self, field: Field, file_name: str) -> None:
-        self._update_field_action(field, file_name)
 
     def do_update_sample_log(self, field: Field, file_name: str) -> None:
         """

--- a/mantidimaging/gui/windows/image_load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/image_load_dialog/test/presenter_test.py
@@ -53,6 +53,7 @@ class ImageLoadDialogPresenterTest(unittest.TestCase):
         file_log_path = mock.Mock()
         mock_file_group.all_files.return_value = file_list
         mock_file_group.log_path = file_log_path
+        mock_file_group.shutter_count_path = file_log_path
 
         mock_field_path = mock.PropertyMock()
         type(self.fields["Sample Log"]).path = mock_field_path
@@ -132,7 +133,7 @@ class ImageLoadDialogPresenterTest(unittest.TestCase):
         file_name = "file_name"
         field = mock.MagicMock(file_info=FILE_TYPES.PROJ_180)
 
-        self.p.do_update_single_file(field, file_name)
+        self.p._update_field_action(field, file_name)
 
         self.assertEqual(field.path, Path(file_name))
 
@@ -140,7 +141,7 @@ class ImageLoadDialogPresenterTest(unittest.TestCase):
         file_name = "file_name"
         field = mock.MagicMock(file_info=FILE_TYPES.PROJ_180)
 
-        self.p.do_update_single_file(field, None)
+        self.p._update_field_action(field, None)
 
         self.assertNotEqual(field.path, file_name)
 

--- a/mantidimaging/gui/windows/image_load_dialog/view.py
+++ b/mantidimaging/gui/windows/image_load_dialog/view.py
@@ -39,6 +39,8 @@ class ImageLoadDialog(BaseDialogView):
         self.tree.setTabKeyNavigation(True)
 
         for n, file_info in enumerate(FILE_TYPES):
+            if file_info.fname in ["Sample Shutter Counts", "Flat Before Shutter Counts", "Flat After Shutter Counts"]:
+                continue
             self.fields[file_info.fname] = self.create_file_input(n, file_info)
 
         self.sample = self.fields["Sample"]

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -147,6 +147,19 @@ class MainWindowModel:
             log.raise_if_angle_missing(images.filenames)
         images.log_file = log
 
+    def add_shutter_counts_to_sample(self, images_id: uuid.UUID, shutter_counts_file: Path) -> None:
+        """
+        Adds the shutter counts file to the sample associated with the given images ID.
+        :param images_id (uuid.UUID): The ID of the images.
+        :param shutter_counts_file (Path): The path to the shutter counts file.
+        :raises RuntimeError: If the images with the given ID cannot be found.
+        :returns None
+        """
+        images = self.get_images_by_uuid(images_id)
+        if images is None:
+            raise RuntimeError
+        images.shutter_count_file = loader.load_shutter_counts(shutter_counts_file)
+
     def _remove_dataset(self, dataset_id: uuid.UUID):
         """
         Removes a dataset and the image stacks it contains from the model.

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -128,6 +128,9 @@ class MainWindowPresenter(BasePresenter):
     def add_log_to_sample(self, stack_id: uuid.UUID, log_file: Path) -> None:
         self.model.add_log_to_sample(stack_id, log_file)
 
+    def add_shuttercounts_to_sample(self, stack_id: uuid.UUID, shuttercount_file: Path) -> None:
+        self.model.add_shutter_counts_to_sample(stack_id, shuttercount_file)
+
     def _do_rename_stack(self, current_name: str, new_name: str) -> None:
         dock = self._get_stack_visualiser_by_name(current_name)
         if dock is not None:

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -6,6 +6,7 @@ import unittest
 import uuid
 
 from unittest import mock
+from parameterized import parameterized
 import numpy as np
 
 from mantidimaging.core.data import ImageStack
@@ -54,12 +55,17 @@ class MainWindowModelTest(unittest.TestCase):
         load_mock.assert_called_once_with(sample_mock, progress_mock, dtype=lp.dtype)
         load_log_mock.assert_not_called()
 
+    @parameterized.expand([("log_file", mock.Mock(), None), ("shutter_count_file", None, mock.Mock()),
+                           ("log_file_and_shutter_count_file", mock.Mock(), mock.Mock()),
+                           ("no_log_file_or_shutter_count_file", None, None)])
     @mock.patch('mantidimaging.core.io.loader.loader.load')
-    def test_do_load_stack_sample_and_sample_log(self, load_mock: mock.Mock):
+    def test_do_load_stack_sample_and_(self, _, log_mock, shutter_mock, load_mock):
+        """
+        Test loading a stack with sample, log, and shutter count files.
+        """
         lp = LoadingParameters()
-        log_file_mock = mock.Mock()
         mock_filename_group = mock.Mock()
-        sample_mock = ImageParameters(mock_filename_group, log_file_mock)
+        sample_mock = ImageParameters(mock_filename_group, log_mock, shutter_mock)
         lp.image_stacks[FILE_TYPES.SAMPLE] = sample_mock
         lp.dtype = "dtype_test"
         lp.sinograms = False
@@ -72,7 +78,8 @@ class MainWindowModelTest(unittest.TestCase):
                                           progress=progress_mock,
                                           dtype=lp.dtype,
                                           indices=None,
-                                          log_file=log_file_mock)
+                                          log_file=log_mock,
+                                          shutter_count_file=shutter_mock)
 
     @mock.patch('mantidimaging.core.io.loader.loader.load')
     def test_do_load_stack_sample_indicies(self, load_mock: mock.Mock):
@@ -93,7 +100,8 @@ class MainWindowModelTest(unittest.TestCase):
                                           progress=progress_mock,
                                           dtype=lp.dtype,
                                           indices=indices,
-                                          log_file=None)
+                                          log_file=None,
+                                          shutter_count_file=None)
 
     @mock.patch('mantidimaging.gui.windows.main.model.loader.load_stack_from_image_params')
     @mock.patch('mantidimaging.gui.windows.main.model.StrictDataset')

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -306,6 +306,29 @@ class MainWindowView(BaseMainWindowView):
         QMessageBox.information(self, "Load complete", f"{selected_file} was loaded as a log into "
                                 f"{stack_to_add_log_to}.")
 
+    def load_shuttercounts_dialog(self):
+        stack_selector = DatasetSelectorDialog(main_window=self,
+                                               title="Stack Selector",
+                                               message="Which stack is the shutter count file being loaded for?",
+                                               show_stacks=True)
+        # Was closed without accepting (e.g. via x button or ESC)
+        if QDialog.DialogCode.Accepted != stack_selector.exec():
+            return
+        stack_to_add_shuttercounts_to = stack_selector.selected_id
+
+        # Open file dialog
+        selected_file = self._get_file_name("Shutter count file to be loaded", "Shutter count File (*.txt *.csv)")
+
+        # Cancel/Close was clicked
+        if selected_file == "":
+            return
+
+        self.presenter.add_shuttercounts_to_sample(stack_id=stack_to_add_shuttercounts_to,
+                                                   shuttercount_file=Path(selected_file))
+        QMessageBox.information(
+            self, "Load complete", f"{selected_file} was loaded as a shutter count file into "
+            f"{stack_to_add_shuttercounts_to}.")
+
     def load_180_deg_dialog(self):
         dataset_selector = DatasetSelectorDialog(main_window=self,
                                                  title="Dataset Selector",


### PR DESCRIPTION
### Issue

Work towards [#2094](https://github.com/mantidproject/mantidimaging/issues/2094)

### Description

*Add a description of the changes made*.
* Create ShutterCount Parser
* Create Loading Dialog interface for ShutterCount files
* Update existing tests to allow for additional ShutterCount type.
* Minor refactoring (Trying not to refactor much as part of this issue as we should do a much larger refactor later on.)

### Additional Information
* New tests will be added as a separate PR
* The Front end will be a separate PR
* A significant refactor how how we store file types to load into MI will be written up as an issue as part of [#1999](https://github.com/mantidproject/mantidimaging/issues/1999)

### Testing 

*Describe the tests that were used to verify your changes*.
* Manually play around with MI GUI to load files in a variety different ways.
* Verify Tests still pass

### Acceptance Criteria 

*How should the reviewer test your changes*?
* Loading Files into Mantid Imaging (drag and drop and using loading dialog) for ToF samples works as expected.
* Tests pass
* Find All Files still works correctly

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*

See docs: `docs/release_notes/next/feature-2094-load_shuttercounts`
