### PR TITLE
NaN warnings activated in the Spectrum Viewer

### DIFF
--- a/docs/release_notes/next/fix-2185-spectrum-nan-warning
+++ b/docs/release_notes/next/fix-2185-spectrum-nan-warning
@@ -1,0 +1,1 @@
+#2185: NaN warning icon now appears in the Spectrum Viewer when NaN are in averaged image

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -116,12 +116,12 @@ class SpectrumWidget(QWidget):
     spectrum_plot_widget: SpectrumPlotWidget
     image_widget: SpectrumProjectionWidget
 
-    def __init__(self, parent: MainWindowView) -> None:
+    def __init__(self, main_window: MainWindowView) -> None:
         super().__init__()
 
         self.vbox = QVBoxLayout(self)
 
-        self.image_widget = SpectrumProjectionWidget(parent)
+        self.image_widget = SpectrumProjectionWidget(main_window)
         self.image = self.image_widget.image
         self.spectrum_plot_widget = SpectrumPlotWidget()
         self.spectrum = self.spectrum_plot_widget.spectrum

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -15,6 +15,9 @@ from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
 
 if TYPE_CHECKING:
+    from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401   # pragma: no cover
+
+if TYPE_CHECKING:
     import numpy as np
 
 
@@ -113,12 +116,12 @@ class SpectrumWidget(QWidget):
     spectrum_plot_widget: SpectrumPlotWidget
     image_widget: SpectrumProjectionWidget
 
-    def __init__(self) -> None:
+    def __init__(self, parent: MainWindowView) -> None:
         super().__init__()
 
         self.vbox = QVBoxLayout(self)
 
-        self.image_widget = SpectrumProjectionWidget()
+        self.image_widget = SpectrumProjectionWidget(parent)
         self.image = self.image_widget.image
         self.spectrum_plot_widget = SpectrumPlotWidget()
         self.spectrum = self.spectrum_plot_widget.spectrum
@@ -351,8 +354,13 @@ class SpectrumPlotWidget(GraphicsLayoutWidget):
 class SpectrumProjectionWidget(GraphicsLayoutWidget):
     image: MIMiniImageView
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, parent: MainWindowView) -> None:
+        super().__init__(parent)
+        self._main_window = parent
         self.image = MIMiniImageView(name="Projection", view_box_type=CustomViewBox)
         self.addItem(self.image, 0, 0)
         self.ci.layout.setRowStretchFactor(0, 3)
+
+        nan_check_menu = [("Crop Coordinates", lambda: self._main_window.presenter.show_operation("Crop Coordinates")),
+                          ("NaN Removal", lambda: self._main_window.presenter.show_operation("NaN Removal"))]
+        self.image.enable_nan_check(actions=nan_check_menu)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
@@ -25,7 +25,7 @@ class SpectrumWidgetTest(unittest.TestCase):
         self.view = mock.create_autospec(SpectrumViewerWindowView)
         self.view.current_dataset_id = uuid.uuid4()
         self.view.parent = mock.create_autospec(SpectrumViewerWindowPresenter)
-        self.spectrum_widget = SpectrumWidget()
+        self.spectrum_widget = SpectrumWidget(self.main_window)
         self.spectrum_plot_widget = SpectrumPlotWidget()
         self.sensible_roi = SensibleROI.from_list([0, 0, 0, 0])
 

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -74,7 +74,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         self.presenter = SpectrumViewerWindowPresenter(self, main_window)
 
-        self.spectrum_widget = SpectrumWidget()
+        self.spectrum_widget = SpectrumWidget(main_window)
         self.spectrum = self.spectrum_widget.spectrum_plot_widget
 
         self.imageLayout.addWidget(self.spectrum_widget)


### PR DESCRIPTION
### Issue

Closes #2185

### Description

In the `SpectrumWidget` class, the MainWindow is now passed to the `SpectrumProjectionWidget` and the `BadDataOverlay` mixin class is used in the `SpectrumProjectionWidget`.  The warning icon now appears in the Spectrum viewer when a slice which has a NaN in it is shown on the averaged image (as the NaN will propagate). The warning icon retains the same functionality as in the Main Window where it can be clicked on to open the Operations Window such that NaN removal can be performed.

### Testing 

make check

### Acceptance Criteria 

- Open MI with data which has NaNs in it (e.g. the Fe dataset)
- Open the Spectrum Viewer
- Check that if a slice in the averaged image has NaNs, then the warning icon appears
- Test this by changing the Range Control on the Spectrum plot such that a "complete" part of the plot is in the range, and the warning icon should not show.
- Move the Range Control such that an "empty" part of the plot is in the range, and the warning icon should appear. See screenshots for examples.
- Check that clicking the warning icon has the correct functionality.

![image](https://github.com/mantidproject/mantidimaging/assets/30868085/06c92995-8734-426d-a23c-b40bd6fcfdba)

![image](https://github.com/mantidproject/mantidimaging/assets/30868085/f796a10c-cff4-4443-9f90-81a208b8ac93)



### Documentation

Will add release note
