### PR TITLE
Fix unreliable test: viewbox

### DIFF
--- a/docs/release_notes/next/fix-2053-viewbox-test-fail
+++ b/docs/release_notes/next/fix-2053-viewbox-test-fail
@@ -1,0 +1,1 @@
+#2053: Fix unreliable tests due to viewbox

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -45,6 +45,7 @@ class MIMiniImageView(GraphicsLayout, BadDataOverlay, AutoColorMenu):
         self.vb.addItem(self.im)
         self.hist = HistogramLUTItem(self.im)
         graveyard.append(self.vb)
+        graveyard.append(self.hist.vb)
 
         # Sub-layout prevents resizing issues when details text changes
         image_layout = self.addLayout(colspan=2)


### PR DESCRIPTION
### Issue
Fixes #2053

~~Needs test commit removed before merge~~

### Description
This adds the viewbox in the histogram into the graveyard to prevent it ever being deleted

### Testing & Acceptance Criteria 

I have run this with the conda tests adjusted to do 10 runs of the system tests. See below

### Documentation

release notes
