### PR TITLE
Fix sphinx warnings

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,3 +1,5 @@
+.. _api-reference:
+
 API Reference
 =============
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,6 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
     'sphinx.ext.mathjax',
-    'sphinx.ext.autosectionlabel',
 ]
 
 # Add custom extensions

--- a/docs/developer_guide/index.rst
+++ b/docs/developer_guide/index.rst
@@ -1,3 +1,5 @@
+.. _developer_guide:
+
 Developer Guide
 ===============
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,13 +5,13 @@ Installation
 
 There are several options for installing:
 
-- :ref:`Installing with Windows installer` - Simplest method on Windows
+- :ref:`installing-windows` - Simplest method on Windows
 
-- :ref:`Installing with Mamba/Conda` - Linux or Windows. Most flexible. Does not need admin access.
+- :ref:`installing-mamba`- Linux or Windows. Most flexible. Does not need admin access.
 
-- :ref:`Using Mantid Imaging on IDAaaS` - For ISIS users
+- :ref:`installing-idaaas` - For ISIS users
 
-- For installation from source see the :ref:`Developer Guide`
+- For installation from source see the :ref:`developer_guide`
 
 Requirements
 ------------
@@ -25,6 +25,8 @@ GPU
 
 RAM
    A large amount of RAM is needed to hold a dataset in memory. A 2k x 2k resolution with 1k projections held as 32 bit floats uses 16 GB of RAM. To perform safe (undoable) operations the requirement is doubled. Requirements scale with increased resolution, projection counts and bit depth.
+
+.. _installing-windows:
 
 Installing with Windows installer
 ---------------------------------
@@ -48,6 +50,8 @@ Uninstalling
 ~~~~~~~~~~~~
 
 If Mantid Imaging has been installed using the Windows Installer, then it can be removed by right clicking the entry in the start menu and selecting :code:`Uninstall`.
+
+.. _installing-mamba:
 
 Installing with Mamba/Conda
 ---------------------------
@@ -131,8 +135,9 @@ To completely delete the Mantid Imaging environment follow these steps:
 
   - and press :code:`y` to confirm. Replace `mantidimaging` with any other environment you wish to remove
 
-- Follow steps 4 and 5 from Installing_.
+- Follow steps 4 and 5 from :ref:`installing-mamba`.
 
+.. _installing-idaaas:
 
 Using Mantid Imaging on IDAaaS
 ------------------------------
@@ -148,4 +153,3 @@ It can be launched from the menu :code:`Applications > Software > Manntid Imagin
     :alt: Launching Mantid Imaging on IDAaaS
     :width: 40%
     :align: center
-

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -7,7 +7,7 @@ Mantid Imaging makes use of a range of algorithms, some from external tools incl
 
 Mantid Imaging is written in Python and requires a CUDA capable GPU for full functionality. It runs on Linux and Windows. See :ref:`Installation` for more details.
 
-See the :ref:`User Guide` for an example taking data from a set of images to full reconstruction.
+See the :ref:`user-guide` for an example taking data from a set of images to full reconstruction.
 
 Features
 --------
@@ -41,7 +41,7 @@ The Operations Window provides a selection of tools and filters to process and e
 * Remove stripes with filtering
 * Remove stripes with sorting and fitting
 
-More details on using these are available in the :ref:`API Reference` and :ref:`User Guide`.
+More details on using these are available in the :ref:`api-reference` and :ref:`user-guide`.
 
 
 Reconstruction

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -55,7 +55,7 @@ Mantid Imaging offers several reconstruction algorithms
 * gridrec
 
 Spectrum Viewer
-^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^
 
 Mantid Imaging offers a spectrum viewer where users can select many regions of interest (ROI) for time of flight (TOF) data and view the spectrum of each ROI. 
 The spectrum viewer can be used to export the spectrum of each ROI and its respective coordinates to a separate csv file.

--- a/docs/release_notes/2.5.rst
+++ b/docs/release_notes/2.5.rst
@@ -32,7 +32,7 @@ Improved Nexus Support
    - Saving data as float32 (for NXtomoproc this is not yet in the official spec)
 
 Windows Installer
-   See :ref:`Installing with Windows installer`
+   See :ref:`installing-windows`
 
 There have also been many smaller changes and fixes which are listed below.
 

--- a/docs/user_guide/gui/image_view.rst
+++ b/docs/user_guide/gui/image_view.rst
@@ -1,3 +1,5 @@
+.. _image-view:
+
 Image view
 ==========
 

--- a/docs/user_guide/gui/loading_saving.rst
+++ b/docs/user_guide/gui/loading_saving.rst
@@ -1,3 +1,5 @@
+.. _loading-saving:
+
 Loading and Saving
 ==================
 
@@ -5,6 +7,8 @@ Loading and saving data is performed via the *Load* and *Save* options on the *F
 
 Loading
 -------
+
+.. _load-dataset:
 
 Load Dataset
 ************
@@ -79,7 +83,7 @@ and for a CSV file
 
 :code:`TIME STAMP,IMAGE TYPE,IMAGE COUNTER,COUNTS BM3 before image,COUNTS BM3 after image`
 
-Note that the log can also be chosen in the :ref:`Load Dataset` dialog.
+Note that the log can also be chosen in the :ref:`load-dataset` dialog.
 
 Load projection angles
 ----------------------
@@ -96,7 +100,7 @@ be asked if you wish to use the next closest image. Bear in mind that the absenc
 the "Correlate 0 and 180" algorithm will not be available for the reconstruction.
 
 A new 180 projection can be loaded with the :code:`Load 180 degree projection` option. This will override any already
-loaded 180 projection. This option will only work correctly with a stack loaded through the :ref:`Load dataset` method.
+loaded 180 projection. This option will only work correctly with a stack loaded through the :ref:`load-dataset` method.
 
 Saving
 ------

--- a/docs/user_guide/gui/operations_window.rst
+++ b/docs/user_guide/gui/operations_window.rst
@@ -1,3 +1,5 @@
+.. _operations-window:
+
 Operations Window
 =================
 
@@ -20,7 +22,7 @@ The [?] button next to filter selector will open a webpage with an explanation o
 
 The right hand panel shows a slice from the original image stack, a preview of the filter applied to the slice, and the pixel intensity difference.
 Below the previews is a slider that can be dragged horizontally to scroll through previews for each slice of the stack.
-At the bottom of the right hand panel, a histogram of pixel values before and after is shown. The image views can be navigated as described in the :ref:`Image View` help page.
+At the bottom of the right hand panel, a histogram of pixel values before and after is shown. The image views can be navigated as described in the :ref:`image-view` help page.
 
 Green pixels in the after preview indicate that a value has changed. Red pixels
 indicate that there are negative values in the result. Note that the negative

--- a/docs/user_guide/gui/recon_window.rst
+++ b/docs/user_guide/gui/recon_window.rst
@@ -1,3 +1,5 @@
+.. _recon-window:
+
 Reconstruction Window
 =====================
 

--- a/docs/user_guide/gui/spectrum_viewer.rst
+++ b/docs/user_guide/gui/spectrum_viewer.rst
@@ -1,5 +1,5 @@
 Spectrum Viewer
-=================
+===============
 
 
 The Spectrum Viewer is a tool for viewing the spectrum of each region of interest (ROI) in time of flight (TOF) data.

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -1,3 +1,5 @@
+.. _user-guide:
+
 User Guide
 ==========
 
@@ -6,7 +8,7 @@ Getting started
 
 See :ref:`installation`
 
-New users may want to :ref:`Quick start: Example Reconstruction`
+New users may want to :ref:`quick-start`
 
 .. toctree::
    :maxdepth: 2

--- a/docs/user_guide/quick_start.rst
+++ b/docs/user_guide/quick_start.rst
@@ -1,3 +1,5 @@
+.. _quick-start:
+
 Quick start: Example Reconstruction
 -----------------------------------
 
@@ -32,7 +34,7 @@ At this stage there is also the option to:
 #. Select the pixel size of the detector used in microns. This can also be changed at a later stage.
 #. Untick a category of files to not load. For example, if both "Dark Before" and "Dark After" images have been found this can be adjusted to only one.
 
-Read more about loading in :ref:`Loading and Saving`.
+Read more about loading in :ref:`loading-saving`.
 
 Project Window
 ##############
@@ -44,7 +46,7 @@ Project Window
 
 The main window allows you to view the currently loaded image stacks and gives access to operations and reconstruction tools.
 
-Read more about using and navigating in the :ref:`Image view`.
+Read more about using and navigating in the :ref:`image-view`.
 
 Operations
 ##########
@@ -75,7 +77,7 @@ Next let's take the sample we loaded and let's tidy it up with operations. To op
    :align: center
    :width: 70%
 
-At this point we have a sample ready to reconstruct. Note: operations such as a Median Filter could be used here, but in an effort to conserve grey value as accurately as possible it was avoided. To see the list of available operations go to the :ref:`Operations` help page and for more details on the GUI see :ref:`Operations Window`.
+At this point we have a sample ready to reconstruct. Note: operations such as a Median Filter could be used here, but in an effort to conserve grey value as accurately as possible it was avoided. To see the list of available operations go to the :ref:`Operations` help page and for more details on the GUI see :ref:`operations-window`.
 
 
 Reconstruction
@@ -113,7 +115,7 @@ There are many filter options. Experiment with the filters by looking at the sli
 
 Then click "Reconstruct Volume" to complete the reconstruction. This should take about 5 minutes.
 
-For more details on the reconstruction GUI see :ref:`reconstruction window`
+For more details on the reconstruction GUI see :ref:`recon-window`
 
 Post-reconstruction
 ###################


### PR DESCRIPTION
### Issue

Work on #2189 

### Description

This fixes the easy warnings when building the sphinx docs

Removing `autosectionlabel` to avoid generating duplicated labels
Create explicit labels when needed, and use those to link
Fix some title lengths

### Testing & Acceptance Criteria 

Test a full rebuild of the docs with
`rm -rf docs/build; make build-docs`
The number of warnings should be reduced


### Documentation

Not needed
