### PR TITLE
FLASH PR: Sphinx Code Snippets Copy Extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
     'sphinx.ext.mathjax',
+    'sphinx_copybutton',
 ]
 
 # Add custom extensions

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -35,3 +35,4 @@ dependencies:
   - pre-commit==3.5.*
   - sphinx==7.2.*
   - pydata-sphinx-theme==0.15.*
+  - sphinx-copybutton==0.5.*


### PR DESCRIPTION
Add `Sphinx-copybutton` extension to allow for easy copying of code snippets

### Issue

Flash PR

### Description

Currently we, don't have a code snippet copy button. This PR adds the extension: [sphinx-copybutton](https://pypi.org/project/sphinx-copybutton/) to the project to add such a button (see screenshot below)

![image](https://github.com/mantidproject/mantidimaging/assets/32413847/b0cd9079-2fd0-461d-9faa-8d981ee85318)

* Add sphinx-copybutton dependency to environment-dev
* Add sphinx-copybutton to list of sphinx extensions within conf.py

### Testing 

*Describe the tests that were used to verify your changes*.
* Rebuild docs and check that code snippets not have a copy button on mouse hover

Rebuild docs: `rm -rf docs/build; make build-docs`
Run docs:  `python -m http.server` from`/mantidimaging/docs/build/html`



### Acceptance Criteria 

*How should the reviewer test your changes*?
* Code snippets now have a copy code button on mouse hover

### Documentation

N/A
