### PR TITLE
Shuttercount Frontend - Part 2 of Part 1 of 2

### DIFF
--- a/docs/release_notes/next/feature-2094-Load_ShutterCount_files_front-end
+++ b/docs/release_notes/next/feature-2094-Load_ShutterCount_files_front-end
@@ -1,0 +1,1 @@
+#2094: Front-end for loading ShutterCount files into Mantid Imaging.

--- a/mantidimaging/core/io/instrument_log.py
+++ b/mantidimaging/core/io/instrument_log.py
@@ -246,6 +246,3 @@ class ShutterCount:
 
     def has_Pulse(self) -> bool:
         return ShutterCountColumn.PULSE in self.data
-
-    def raise_if_counts_missing(self):
-        pass

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -143,11 +143,11 @@ class FILE_TYPES(Enum):
     DARK_AFTER = ("Dark", "After", "images")
     PROJ_180 = ("180 degree", "", "180")
     SAMPLE_LOG = ("Sample Log", "", "log")
-    FLAT_BEFORE_LOG = ("Flat Before Log", "", "log")
-    FLAT_AFTER_LOG = ("Flat After Log", "", "log")
     SHUTTER_COUNTS = ("Sample Shutter Counts", "", "ShutterCount")
     FLAT_BEFORE_SHUTTER_COUNTS = ("Flat Before Shutter Counts", "", "ShutterCount")
     FLAT_AFTER_SHUTTER_COUNTS = ("Flat After Shutter Counts", "", "ShutterCount")
+    FLAT_BEFORE_LOG = ("Flat Before Log", "", "log")
+    FLAT_AFTER_LOG = ("Flat After Log", "", "log")
 
     def __init__(self, tname: str, suffix: str, mode: str) -> None:
         self.tname = tname

--- a/mantidimaging/gui/ui/image_load_dialog.ui
+++ b/mantidimaging/gui/ui/image_load_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>690</width>
-    <height>497</height>
+    <height>530</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -129,24 +129,30 @@
       </property>
      </item>
      <item>
-      <property name="text">
-       <string>Flat Before Log</string>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
+        <property name="text">
+            <string>Sample Shutter Counts</string>
+        </property>
      </item>
      <item>
-      <property name="text">
-       <string>Flat After Log</string>
-      </property>
+        <property name="text">
+            <string>Flat Before Shutter Counts</string>
+        </property>
+    </item>
+     <item>
+        <property name="text">
+            <string>Flat After Shutter Counts</string>
+        </property>
      </item>
+     <item>
+    <property name="text">
+            <string>Flat Before Log</string>
+      </property>
+    </item>
+    <item>
+        <property name="text">
+            <string>Flat After Log</string>
+        </property>
+    </item>
     </widget>
    </item>
    <item>

--- a/mantidimaging/gui/ui/main_window.ui
+++ b/mantidimaging/gui/ui/main_window.ui
@@ -38,6 +38,7 @@
     <addaction name="actionLoadImages"/>
     <addaction name="actionLoadNeXusFile"/>
     <addaction name="actionSampleLoadLog"/>
+    <addaction name="actionShutterCounts"/>
     <addaction name="actionLoadProjectionAngles"/>
     <addaction name="actionLoad180deg"/>
     <addaction name="separator"/>
@@ -189,6 +190,14 @@
     <string>Load log for stack...</string>
    </property>
   </action>
+  <action name="actionShutterCounts">
+    <property name="enabled">
+     <bool>false</bool>
+    </property>
+    <property name="text">
+     <string>Load ShutterCounts file for stack...</string>
+    </property>
+   </action>
   <action name="actionLoad180deg">
    <property name="enabled">
     <bool>false</bool>

--- a/mantidimaging/gui/windows/image_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/image_load_dialog/presenter.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from mantidimaging.core.io.filenames import FilenameGroup
-from mantidimaging.core.io.loader import load_log, load_shutter_counts
+from mantidimaging.core.io.loader import load_log
 from mantidimaging.core.io.loader.loader import LoadingParameters, ImageParameters, read_image_dimensions
 from mantidimaging.core.utility.data_containers import FILE_TYPES, log_for_file_type, shuttercounts_for_file_type
 from mantidimaging.gui.windows.image_load_dialog.field import Field
@@ -111,15 +111,11 @@ class LoadPresenter:
         filename_group.find_shutter_count_file()
         field.set_images(list(filename_group.all_files()))
         self._update_field_action(field, selected_file)
-        shuttercount_names = [p.name for p in filename_group.all_files()]
-        self.ensure_sample_shuttercount_consistency(field, selected_file, shuttercount_names)
+        self.ensure_sample_shuttercount_consistency(field, selected_file)
 
-    def ensure_sample_shuttercount_consistency(self, field: Field, file_name: str, image_filenames: list[str]) -> None:
+    def ensure_sample_shuttercount_consistency(self, field: Field, file_name: str) -> None:
         if file_name is None or file_name == "":
             return
-
-        shutter_count = load_shutter_counts(Path(file_name))
-        shutter_count.raise_if_counts_missing()
         self._update_field_action(field, file_name)
 
     def do_update_flat_or_dark(self, field: Field, selected_file: str) -> None:

--- a/mantidimaging/gui/windows/image_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/image_load_dialog/presenter.py
@@ -164,8 +164,7 @@ class LoadPresenter:
         if file_type in log_for_file_type:
             self._update_image_param(file_type, image_param, log_for_file_type, 'log_file')
         if file_type in shuttercounts_for_file_type:
-            # self._update_image_param(file_type, image_param, shuttercounts_for_file_type, 'shutter_count_file')
-            pass
+            self._update_image_param(file_type, image_param, shuttercounts_for_file_type, 'shutter_count_file')
 
         if file_type == FILE_TYPES.SAMPLE:
             image_param.indices = field.indices

--- a/mantidimaging/gui/windows/image_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/image_load_dialog/presenter.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from mantidimaging.core.io.filenames import FilenameGroup
-from mantidimaging.core.io.loader import load_log
+from mantidimaging.core.io.loader import load_log, load_shutter_counts
 from mantidimaging.core.io.loader.loader import LoadingParameters, ImageParameters, read_image_dimensions
 from mantidimaging.core.utility.data_containers import FILE_TYPES, log_for_file_type, shuttercounts_for_file_type
 from mantidimaging.gui.windows.image_load_dialog.field import Field
@@ -111,6 +111,16 @@ class LoadPresenter:
         filename_group.find_shutter_count_file()
         field.set_images(list(filename_group.all_files()))
         self._update_field_action(field, selected_file)
+        shuttercount_names = [p.name for p in filename_group.all_files()]
+        self.ensure_sample_shuttercount_consistency(field, selected_file, shuttercount_names)
+
+    def ensure_sample_shuttercount_consistency(self, field: Field, file_name: str, image_filenames: list[str]) -> None:
+        if file_name is None or file_name == "":
+            return
+
+        shutter_count = load_shutter_counts(Path(file_name))
+        shutter_count.raise_if_counts_missing()
+        self._update_field_action(field, file_name)
 
     def do_update_flat_or_dark(self, field: Field, selected_file: str) -> None:
         """

--- a/mantidimaging/gui/windows/image_load_dialog/view.py
+++ b/mantidimaging/gui/windows/image_load_dialog/view.py
@@ -39,8 +39,6 @@ class ImageLoadDialog(BaseDialogView):
         self.tree.setTabKeyNavigation(True)
 
         for n, file_info in enumerate(FILE_TYPES):
-            if file_info.fname in ["Sample Shutter Counts", "Flat Before Shutter Counts", "Flat After Shutter Counts"]:
-                continue
             self.fields[file_info.fname] = self.create_file_input(n, file_info)
 
         self.sample = self.fields["Sample"]

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -88,6 +88,7 @@ class MainWindowView(BaseMainWindowView):
     actionSpectrumViewer: QAction
     actionLiveViewer: QAction
     actionSampleLoadLog: QAction
+    actionShutterCounts: QAction
     actionLoadProjectionAngles: QAction
     actionLoad180deg: QAction
     actionLoadDataset: QAction
@@ -184,6 +185,7 @@ class MainWindowView(BaseMainWindowView):
         self.actionLoadImages.triggered.connect(self.load_image_stack)
         self.actionLoadNeXusFile.triggered.connect(self.show_nexus_load_dialog)
         self.actionSampleLoadLog.triggered.connect(self.load_sample_log_dialog)
+        self.actionShutterCounts.triggered.connect(self.load_shuttercounts_dialog)
         self.actionLoad180deg.triggered.connect(self.load_180_deg_dialog)
         self.actionLoadProjectionAngles.triggered.connect(self.load_projection_angles)
         self.actionSaveImages.triggered.connect(self.show_image_save_dialog)
@@ -227,6 +229,7 @@ class MainWindowView(BaseMainWindowView):
         self.actionSaveImages.setEnabled(has_datasets)
         self.actionSaveNeXusFile.setEnabled(has_strict_datasets)
         self.actionSampleLoadLog.setEnabled(has_datasets)
+        self.actionShutterCounts.setEnabled(has_datasets)
         self.actionLoad180deg.setEnabled(has_strict_datasets)
         self.actionLoadProjectionAngles.setEnabled(has_datasets)
         self.menuWorkflow.setEnabled(has_datasets)


### PR DESCRIPTION
### Issue

Closes #2094

### Description

*Add a description of the changes made*.
Create basic front end to allow a user to load in ShutterCount files alongside a sample. 
The GUI interface design for loading ShuttterCount files is temporary and will be reworked in the future to bring related files closer together. 

### Testing 

*Describe the tests that were used to verify your changes*.

- Try Loading ShutterCount files into mantid Imaging
- Loading in an unexpected format such as a spectra file triggers error dialog window on selection
- GUI tests pass
- Tests Pass

### Acceptance Criteria 

*How should the reviewer test your changes*?

- All tests pass
- ShutterCount files can be loaded into Mantid Imaging from the Loading Dialog
- Loading in an unexpected format such as a spectra file triggers error dialog window on selection
- ShutterCount Files can be loaded for a given stack after loading sample _File > Load ShutterCount file for stack..._

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*

Release Notes: `docs/release_notes/next/feature-2094-Load_ShutterCount_files_front-end`
