### PR TITLE
Recon Slice Naming

### DIFF
--- a/docs/release_notes/next/feature-2206-recon_file_naming
+++ b/docs/release_notes/next/feature-2206-recon_file_naming
@@ -1,0 +1,1 @@
+#2206: Improve output naming for reconstructed slices and volumes

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -412,6 +412,6 @@ class CILRecon(BaseRecon):
 
 def allowed_recon_kwargs() -> dict[str, list[str]]:
     return {
-        'CIL: PDHG-TV':
+        'CIL_PDHG-TV':
         ['alpha', 'num_iter', 'non_negative', 'stochastic', 'projections_per_subset', 'regularisation_percent']
     }

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -289,10 +289,7 @@ class ReconstructWindowPresenter(BasePresenter):
             slice_idx = self._get_slice_index(None)
             if images is not None:
                 assert self.model.images is not None
-                filter_name = self.view.recon_params().filter_name
-                algorithm_name = self.view.recon_params().algorithm
-                images.name = f"Recon_Slice{algorithm_name}"
-                images.name = f"{images.name}_{filter_name}" if filter_name else images.name
+                images.name = self.create_recon_output_filename("Recon_Slice")
                 self._replace_inf_nan(images)  # pyqtgraph workaround
                 self.view.show_recon_volume(images, self.model.stack_id)
                 images.record_operation('AstraRecon.single_sino',
@@ -352,7 +349,7 @@ class ReconstructWindowPresenter(BasePresenter):
         try:
             self._replace_inf_nan(task.result)  # pyqtgraph workaround
             assert self.model.images is not None
-            task.result.name = "Recon"
+            task.result.name = self.create_recon_output_filename("Recon_Vol")
             self.view.show_recon_volume(task.result, self.model.stack_id)
         finally:
             self.view.set_recon_buttons_enabled(True)
@@ -471,3 +468,18 @@ class ReconstructWindowPresenter(BasePresenter):
         :param images: The ImageStack object.
         """
         images.data[np.isinf(images.data)] = np.nan
+
+    def create_recon_output_filename(self, prefix: str) -> str:
+        """
+        Takes a naming prefix and creates a descriptive recon output
+        filename based on algorithm and filter if filter kwargs used in recon
+
+        :param prefix: The filename prefix to add more detail about format
+        :return: The formatted filename
+        """
+        recon_name = self.view.recon_params().algorithm
+        filter_name = self.view.recon_params().filter_name \
+            if "filter_name" in self.allowed_recon_kwargs[recon_name] else None
+
+        algorithm_name = f"{prefix}_{recon_name}"
+        return f"{algorithm_name}_{filter_name}" if filter_name else algorithm_name

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -289,7 +289,10 @@ class ReconstructWindowPresenter(BasePresenter):
             slice_idx = self._get_slice_index(None)
             if images is not None:
                 assert self.model.images is not None
-                images.name = "Recon"
+                filter_name = self.view.recon_params().filter_name
+                algorithm_name = self.view.recon_params().algorithm
+                images.name = f"Recon_Slice{algorithm_name}"
+                images.name = f"{images.name}_{filter_name}" if filter_name else images.name
                 self._replace_inf_nan(images)  # pyqtgraph workaround
                 self.view.show_recon_volume(images, self.model.stack_id)
                 images.record_operation('AstraRecon.single_sino',

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -346,7 +346,7 @@ class ReconWindowPresenterTest(unittest.TestCase):
         test_data = ImageStack(np.ndarray(shape=(200, 250), dtype=np.float32))
         test_data.record_operation = mock.Mock()
         task_mock = mock.Mock(result=test_data, error=None)
-        recon_params = ReconstructionParameters("FBP_CUDA", "ram-lak", 10)
+        recon_params = ReconstructionParameters("gridrec", "ram-lak", 10)
         self.view.recon_params.return_value = recon_params
         self.presenter._get_slice_index = mock.Mock(return_value=7)
         self.presenter._on_stack_reconstruct_slice_done(task_mock)
@@ -417,6 +417,8 @@ class ReconWindowPresenterTest(unittest.TestCase):
         task = mock.Mock()
         task.error = None
         task.result.data = np.array([np.inf, -np.inf])
+        recon_params = ReconstructionParameters("gridrec", "ram-lak", 10)
+        self.view.recon_params.return_value = recon_params
 
         self.presenter._on_volume_recon_done(task)
         assert not np.isinf(self.view.show_recon_volume.call_args[0][0].data).any()
@@ -425,7 +427,7 @@ class ReconWindowPresenterTest(unittest.TestCase):
         task = mock.Mock()
         task.error = None
         task.result.data = np.array([np.inf, -np.inf])
-        recon_params = ReconstructionParameters("FBP_CUDA", "ram-lak", 10)
+        recon_params = ReconstructionParameters("gridrec", "ram-lak", 10)
         self.view.recon_params.return_value = recon_params
 
         self.presenter._on_stack_reconstruct_slice_done(task)
@@ -436,6 +438,8 @@ class ReconWindowPresenterTest(unittest.TestCase):
         task = mock.Mock()
         task.error = error
         task.result.data = np.ones((5, 10, 10))
+        recon_params = ReconstructionParameters("gridrec", "ram-lak", 10)
+        self.view.recon_params.return_value = recon_params
 
         self.presenter._on_volume_recon_done(task)
         self.view.set_recon_buttons_enabled.assert_called_once_with(True)

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -346,8 +346,9 @@ class ReconWindowPresenterTest(unittest.TestCase):
         test_data = ImageStack(np.ndarray(shape=(200, 250), dtype=np.float32))
         test_data.record_operation = mock.Mock()
         task_mock = mock.Mock(result=test_data, error=None)
+        recon_params = ReconstructionParameters("FBP_CUDA", "ram-lak", 10)
+        self.view.recon_params.return_value = recon_params
         self.presenter._get_slice_index = mock.Mock(return_value=7)
-
         self.presenter._on_stack_reconstruct_slice_done(task_mock)
 
         self.view.show_recon_volume.assert_called_once()
@@ -424,6 +425,8 @@ class ReconWindowPresenterTest(unittest.TestCase):
         task = mock.Mock()
         task.error = None
         task.result.data = np.array([np.inf, -np.inf])
+        recon_params = ReconstructionParameters("FBP_CUDA", "ram-lak", 10)
+        self.view.recon_params.return_value = recon_params
 
         self.presenter._on_stack_reconstruct_slice_done(task)
         assert not np.isinf(self.view.show_recon_volume.call_args[0][0].data).any()

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -90,7 +90,7 @@ class ReconstructWindowView(BaseMainWindowView):
 
         self.algorithmName.insertItem(1, "FBP_CUDA")
         self.algorithmName.insertItem(2, "SIRT_CUDA")
-        self.algorithmName.insertItem(3, "CIL: PDHG-TV")
+        self.algorithmName.insertItem(3, "CIL_PDHG-TV")
         self.algorithmName.setCurrentIndex(1)
         if not CudaChecker().cuda_is_present():
             self.algorithmName.model().item(1).setEnabled(False)


### PR DESCRIPTION
### Issue

Closes #2206 

### Description

Modify recon output name to include if it is a slice, the algorithm name and filter name if a filter is available

### Testing 

- Reconstruct multiple individual slices with the same algorithm and filter
- Reconstruct slices with varying algorithms and filters and verify in the main window that names are easy to compare
- Reconstruct volume with the same algorithm and filter twice
- Reconstruct volumes with varying algorithms and filters and verify in the main window that names are easy to compare

### Acceptance Criteria 

*How should the reviewer test your changes*?
- Reconstructed slices follow the naming convention: Recon_slice_<Algorithm>_<Filter>
- Reconstructed volumes follow the naming convention: Recon_Vol_<Algorithm>_<Filter>
- If a filter is not present, not filter is added to filename

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*

`docs/release_notes/next/feature-2206-recon_file_naming`
