### PR TITLE
FLASH PR: Update Flight Path Default

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -183,7 +183,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         self.flightPathSpinBox.setMinimum(0)
         self.flightPathSpinBox.setMaximum(1e10)
-        self.flightPathSpinBox.setValue(56)
+        self.flightPathSpinBox.setValue(56.4)
         self.flightPathSpinBox.setSuffix(" m")
         self.timeDelaySpinBox.setMaximum(1e10)
         self.timeDelaySpinBox.setSuffix(" \u03BCs")


### PR DESCRIPTION
### Issue

NA

### Description

*Add a description of the changes made*.
Update Flight Path Default in Spectrum Viewer

### Testing 

Flight path default value is 56.4m to reflect flight path distance on IMAT in Spectrum Viewer

### Acceptance Criteria 

*How should the reviewer test your changes*?

Flight path default value is 56.4m to reflect flight path distance on IMAT in Spectrum Viewer

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*

N/A
