### PR TITLE
FLASH PR: Add None to tof_mode type and default value of None on init

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -90,7 +90,7 @@ class SpectrumViewerWindowModel:
     tof_range: tuple[int, int] = (0, 0)
     tof_plot_range: tuple[float, float] | tuple[int, int] = (0, 0)
     _roi_ranges: dict[str, SensibleROI]
-    tof_mode: ToFUnitMode
+    tof_mode: ToFUnitMode = ToFUnitMode.WAVELENGTH
     tof_data: np.ndarray | None = None
     tof_range_full: tuple[int, int] = (0, 0)
 


### PR DESCRIPTION
### Issue

 Closes FLASH PR

### Description

*Add a description of the changes made*.
Noticed a failiure on main when trying to open the spectrum viewer:
```bash
2024-05-28 13:34:06,149 [mantidimaging.core.utility.progress_reporting.progress:L241] INFO: Elapsed time: 13 sec.
2024-05-28 13:34:06,149 [mantidimaging.core.utility.progress_reporting.progress:L242] DEBUG: Memory usage after execution: 6422464.0 KB, 6271.9375 MB
2024-05-28 13:34:06,150 [mantidimaging.core.io.loader.loader:L174] DEBUG: No metadata file found
Shutter count file: <mantidimaging.core.io.instrument_log.ShutterCount object at 0x7163e4d8a920>
2024-05-28 13:34:17,454 [mantidimaging.gui.windows.main.view:L566] ERROR: Traceback (most recent call last):
  File "/mantidimaging/mantidimaging/gui/windows/spectrum_viewer/presenter.py", line 98, in handle_sample_change
    self.model.set_tof_unit_mode_for_stack()
  File "/mantidimaging/mantidimaging/gui/windows/spectrum_viewer/model.py", line 518, in set_tof_unit_mode_for_stack
    elif self.tof_mode == ToFUnitMode.ENERGY:
AttributeError: 'SpectrumViewerWindowModel' object has no attribute 'tof_mode'

2024-05-28 13:34:17,455 [mantidimaging.gui.mvp_base.view:L46] ERROR: show_error_dialog(): Uncaught exception AttributeError: 'SpectrumViewerWindowModel' object has no attribute 'tof_mode'

2024-05-28 13:34:20,996 [mantidimaging.gui.windows.main.view:L566] ERROR: Traceback (most recent call last):
  File "/mantidimaging/mantidimaging/gui/windows/main/view.py", line 438, in show_spectrum_viewer_window
    self.spectrum_viewer = SpectrumViewerWindowView(self)
  File "/mantidimaging/mantidimaging/gui/windows/spectrum_viewer/view.py", line 125, in __init__
    self.presenter.handle_tof_unit_change()
  File "/mantidimaging/mantidimaging/gui/windows/spectrum_viewer/presenter.py", line 352, in handle_tof_unit_change
    self.model.set_relevant_tof_units()
  File "/mantidimaging/mantidimaging/gui/windows/spectrum_viewer/model.py", line 499, in set_relevant_tof_units
    if self.tof_mode == ToFUnitMode.IMAGE_NUMBER or self.tof_data is None:
AttributeError: 'SpectrumViewerWindowModel' object has no attribute 'tof_mode'

2024-05-28 13:34:20,996 [mantidimaging.gui.mvp_base.view:L46] ERROR: show_error_dialog(): Uncaught exception AttributeError: 'SpectrumViewerWindowModel' object has no attribute 'tof_mode'
```

This was resolved by setting `tof_mode`to `tof_mode: ToFUnitMode = ToFUnitMode.WAVELENGTH`

### Testing 

*Describe the tests that were used to verify your changes*.
* Load mantid imaging with sample, open beam and spectrum log
* Open spectrum viewer
* Without fix, you will get the above error
* With the fix, the spectrum viewer should now open without error

### Acceptance Criteria 

*How should the reviewer test your changes*?
* Spectrum viewer opens without error when if opened with a loaded sample, open beam and spectra log
* tests pass

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*

N/A