### PR TITLE
Qt-material theme bug fix

### DIFF
--- a/docs/release_notes/next/fix-2209-theme_os_startup_instability
+++ b/docs/release_notes/next/fix-2209-theme_os_startup_instability
@@ -1,0 +1,1 @@
+#2209: Mantid Imaging now switches between Fusion and qt-material themes correctly

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -10,11 +10,10 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 from collections.abc import Iterable
 
 import numpy as np
-from PyQt5.QtCore import QSettings, Qt, QCoreApplication
+from PyQt5.QtCore import QSettings, Qt
 from PyQt5.QtGui import QFont, QPalette, QColor
-from PyQt5.QtWidgets import QTabBar, QApplication, QTreeWidgetItem, QStyle
+from PyQt5.QtWidgets import QTabBar, QApplication, QTreeWidgetItem
 from qt_material import apply_stylesheet
-import qdarkstyle
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset, _get_stack_data_type
@@ -855,27 +854,23 @@ class MainWindowPresenter(BasePresenter):
         os_theme = settings.value('os_theme')
         font = QFont(settings.value('default_font_family'), int(extra_style['font_size'].replace('px', '')))
         app = QApplication.instance()
-        app.setStyle(theme)
+
         app.setFont(font)
-        for window in [
-                self.view, self.view.recon, self.view.live_viewer, self.view.spectrum_viewer, self.view.filters,
-                self.view.settings_window
-        ]:
-            if window:
-                if theme == 'Fusion':
-                    app.setStyleSheet('')
-                    if override_os_theme == 'False':
-                        if os_theme == 'Light':
-                            self.use_fusion_light_mode()
-                        elif os_theme == 'Dark':
-                            self.use_fusion_dark_mode()
-                    else:
-                        if use_dark_mode == 'True':
-                            self.use_fusion_dark_mode()
-                        else:
-                            self.use_fusion_light_mode()
+        if theme == 'Fusion':
+            if override_os_theme == 'False':
+                if os_theme == 'Light':
+                    self.use_fusion_light_mode()
+                elif os_theme == 'Dark':
+                    self.use_fusion_dark_mode()
+            else:
+                if use_dark_mode == 'True':
+                    self.use_fusion_dark_mode()
                 else:
-                    apply_stylesheet(app, theme=theme, invert_secondary=False, extra=extra_style)
+                    self.use_fusion_light_mode()
+            app.setStyle(theme)
+            app.setStyleSheet('')
+        else:
+            apply_stylesheet(app, theme=theme, invert_secondary=False, extra=extra_style)
 
     @staticmethod
     def use_fusion_dark_mode() -> None:

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -10,10 +10,11 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 from collections.abc import Iterable
 
 import numpy as np
-from PyQt5.QtCore import QSettings, Qt
+from PyQt5.QtCore import QSettings, Qt, QCoreApplication
 from PyQt5.QtGui import QFont, QPalette, QColor
-from PyQt5.QtWidgets import QTabBar, QApplication, QTreeWidgetItem
+from PyQt5.QtWidgets import QTabBar, QApplication, QTreeWidgetItem, QStyle
 from qt_material import apply_stylesheet
+import qdarkstyle
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset, _get_stack_data_type
@@ -853,14 +854,16 @@ class MainWindowPresenter(BasePresenter):
             override_os_theme = settings.value('override_os_theme')
         os_theme = settings.value('os_theme')
         font = QFont(settings.value('default_font_family'), int(extra_style['font_size'].replace('px', '')))
+        app = QApplication.instance()
+        app.setStyle(theme)
+        app.setFont(font)
         for window in [
                 self.view, self.view.recon, self.view.live_viewer, self.view.spectrum_viewer, self.view.filters,
                 self.view.settings_window
         ]:
             if window:
-                QApplication.instance().setFont(font)
-                window.setStyleSheet(theme)
                 if theme == 'Fusion':
+                    app.setStyleSheet('')
                     if override_os_theme == 'False':
                         if os_theme == 'Light':
                             self.use_fusion_light_mode()
@@ -871,10 +874,8 @@ class MainWindowPresenter(BasePresenter):
                             self.use_fusion_dark_mode()
                         else:
                             self.use_fusion_light_mode()
-                    QApplication.instance().setFont(font)
-                    window.setStyleSheet(theme)
                 else:
-                    apply_stylesheet(window, theme=theme, invert_secondary=False, extra=extra_style)
+                    apply_stylesheet(app, theme=theme, invert_secondary=False, extra=extra_style)
 
     @staticmethod
     def use_fusion_dark_mode() -> None:


### PR DESCRIPTION
### Issue

Closes #2209.

### Description

When the Theme in the settings menu is changed to `Fusion`, the Stylesheet of the `QApplication` is reset correctly. The UI bugs were caused by the `qt-material` function `apply_stylesheet` changing the applications stylesheet and those changes persisting once the theme was changed back to `Fusion`. 

### Acceptance Criteria 

Repeat the changes in the linked issue and check that the themes look as expected:

1. Start Mantid Imaging
2. Select File > Settings
3. Select an alternative theme to Fusion
4. Restart mantid Imaging
5. Select File > Settings
6. Select "Use OS Default"

Also change any and all combinations of settings in the Appearance Settings tab to check they are behaving correctly. MI should also correctly store and apply the last given settings upon startup.

Example screenshots are given here:

My default OS settings (I use dark mode!)

![image](https://github.com/mantidproject/mantidimaging/assets/30868085/306193f5-16f4-4749-a797-8632055f7e80)

changing to a qt-material theme:

![image](https://github.com/mantidproject/mantidimaging/assets/30868085/b27f488f-ba76-40d4-b1d6-d1c9b05eaa02)

restarting MI and clicking the `Use OS defaults` checkbox:

![image](https://github.com/mantidproject/mantidimaging/assets/30868085/4d958c04-fcbc-4ace-861b-ae588dbbad87)



### Documentation

Release Note
