### PR TITLE
Specview export tof wavelength

### DIFF
--- a/docs/release_notes/next/feature-2216-export_tof_wavelength_and_energy_to_csv
+++ b/docs/release_notes/next/feature-2216-export_tof_wavelength_and_energy_to_csv
@@ -1,0 +1,1 @@
+#2216: Add Wavelength, ToF and Energy unit conversions to Spectrum Viewer CSV Output

--- a/mantidimaging/core/io/csv_output.py
+++ b/mantidimaging/core/io/csv_output.py
@@ -11,18 +11,22 @@ class CSVOutput:
     def __init__(self) -> None:
         self.columns: dict[str, np.ndarray] = {}
         self.num_rows: int | None = None
+        self.units: dict[str, str] = {}
 
-    def add_column(self, name: str, values: np.ndarray) -> None:
+    def add_column(self, name: str, values: np.ndarray, units: str) -> None:
         as_column = values.reshape((-1, 1))
-        if self.num_rows is not None:
-            if as_column.size != self.num_rows:
-                raise ValueError("Column sizes must match")
-        else:
-            self.num_rows = as_column.size
+        if self.num_rows is not None and as_column.size != self.num_rows:
+            raise ValueError('Column sizes must match')
 
+        if units:
+            self.units[name] = units
+
+        self.num_rows = as_column.size if self.num_rows is None else self.num_rows
         self.columns[name] = as_column
 
     def write(self, outstream: IO[str]) -> None:
-        header = ",".join(self.columns.keys())
+        header = ','.join(self.columns.keys())
+        units = ','.join(self.units.values())
+        outstream.write('# ' + header + '\n' + '# ' + units + '\n')
         data = np.hstack(list(self.columns.values()))
-        np.savetxt(outstream, data, header=header, fmt="%s", delimiter=",")
+        np.savetxt(outstream, data, fmt='%s', delimiter=',')

--- a/mantidimaging/core/io/test/test_csv_output.py
+++ b/mantidimaging/core/io/test/test_csv_output.py
@@ -19,7 +19,7 @@ class CSVOutputTest(unittest.TestCase):
         col_name = "new_col"
         values = np.arange(10)
 
-        self.csv_output.add_column(col_name, values)
+        self.csv_output.add_column(col_name, values, "")
 
         self.assertIn(col_name, self.csv_output.columns)
         np.testing.assert_array_equal(self.csv_output.columns[col_name].flatten(), values.flatten())
@@ -27,29 +27,29 @@ class CSVOutputTest(unittest.TestCase):
     def test_column_order(self):
         col_names = "red orange yellow green blue indigo violet".split()
         for col_name in col_names:
-            self.csv_output.add_column(col_name, np.arange(10))
+            self.csv_output.add_column(col_name, np.arange(10), "")
 
         self.assertEqual(col_names, list(self.csv_output.columns.keys()))
 
     def test_write_single(self):
         col_name = "new_col"
         values = np.arange(5, dtype=np.float32)
-        expected_out = "# new_col\n0.0\n1.0\n2.0\n3.0\n4.0\n"
-        self.csv_output.add_column(col_name, values)
+        expected_out = "# new_col\n# \n0.0\n1.0\n2.0\n3.0\n4.0\n"
+        self.csv_output.add_column(col_name, values, "")
 
         self.csv_output.write(self.stream)
         self.assertEqual(self.stream.getvalue(), expected_out)
 
     def test_write_2_cols(self):
-        expected_out = "# col_1,col_2\n0.0,5.0\n1.0,6.0\n2.0,7.0\n3.0,8.0\n4.0,9.0\n"
-        self.csv_output.add_column("col_1", np.arange(5, dtype=np.float32))
-        self.csv_output.add_column("col_2", np.arange(5, 10, dtype=np.float32))
+        expected_out = "# col_1,col_2\n# \n0.0,5.0\n1.0,6.0\n2.0,7.0\n3.0,8.0\n4.0,9.0\n"
+        self.csv_output.add_column("col_1", np.arange(5, dtype=np.float32), "")
+        self.csv_output.add_column("col_2", np.arange(5, 10, dtype=np.float32), "")
 
         self.csv_output.write(self.stream)
         self.assertEqual(self.stream.getvalue(), expected_out)
 
     def test_add_column_wrong_size(self):
-        self.csv_output.add_column("col_1", np.arange(5, dtype=np.float32))
+        self.csv_output.add_column("col_1", np.arange(5, dtype=np.float32), "")
 
         with self.assertRaises(ValueError):
-            self.csv_output.add_column("col_2", np.arange(6, dtype=np.float32))
+            self.csv_output.add_column("col_2", np.arange(6, dtype=np.float32), "")

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -282,15 +282,21 @@ class SpectrumViewerWindowModel:
             raise ValueError("No stack selected")
 
         csv_output = CSVOutput()
-        csv_output.add_column("tof_index", np.arange(self._stack.data.shape[0]))
+        csv_output.add_column("ToF_index", np.arange(self._stack.data.shape[0]), "Index")
+        self.tof_data = self.get_stack_time_of_flight()
+        if self.tof_data is not None:
+            self.units.set_data_to_convert(self.tof_data)
+            csv_output.add_column("Wavelength", self.units.tof_seconds_to_wavelength_in_angstroms(), "Angstrom")
+            csv_output.add_column("ToF", self.units.tof_seconds_to_us(), "Microseconds")
+            csv_output.add_column("Energy", self.units.tof_seconds_to_energy(), "MeV")
 
         for roi_name in self.get_list_of_roi_names():
-            csv_output.add_column(roi_name, self.get_spectrum(roi_name, SpecType.SAMPLE))
+            csv_output.add_column(roi_name, self.get_spectrum(roi_name, SpecType.SAMPLE), "Counts")
             if normalized:
                 if self._normalise_stack is None:
                     raise RuntimeError("No normalisation stack selected")
-                csv_output.add_column(roi_name + "_open", self.get_spectrum(roi_name, SpecType.OPEN))
-                csv_output.add_column(roi_name + "_norm", self.get_spectrum(roi_name, SpecType.SAMPLE_NORMED))
+                csv_output.add_column(roi_name + "_open", self.get_spectrum(roi_name, SpecType.OPEN), "Counts")
+                csv_output.add_column(roi_name + "_norm", self.get_spectrum(roi_name, SpecType.SAMPLE_NORMED), "Counts")
 
         with path.open("w") as outfile:
             csv_output.write(outfile)


### PR DESCRIPTION
### Issue

Closes #2216 

### Description

* Add columns to the CSV file exported by the spectrum viewer to include the unit conversions: ToF, Wavelength and Energy
* Add row below header to specify units
* Update tests to reflect changes made as part of this issue to spectrum viewer CSV export format
### Testing 

* Manually tested and compared old output to new output (see screenshots)
* Checked unit tests pass

CSV output format with the following files loaded: sample, open
<img width="646" alt="image" src="https://github.com/mantidproject/mantidimaging/assets/32413847/17ad7b73-9fb5-49ab-b79a-a17cb9a44d84">

CSV output format with the following files loaded: sample, open, spectra log
<img width="810" alt="image" src="https://github.com/mantidproject/mantidimaging/assets/32413847/ef8ff761-e9b6-4300-a8b1-99095cca31c7">

### Acceptance Criteria 

* Spectrum Viewer CSV export without spectrum loaded exports in the same format as previously (no ToF, Wavelength or Energy)
* Spectrum viewer CSV export with spectrum file loaded includes ToF, Wavelength and Energy Units including recon row denoting unit of measurement
* Tests Pass

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*

Updated Release Notes: `docs/release_notes/next/feature-2216-export_tof_wavelength_and_energy_to_csv`
