### PR TITLE
Live viewer: Quick handle notification and defer slow work

### DIFF
--- a/docs/release_notes/next/fix-2204-live-viewer-fast-notifiy
+++ b/docs/release_notes/next/fix-2204-live-viewer-fast-notifiy
@@ -1,0 +1,1 @@
+#2204: Live viewer, handle notification quickly and defer slow work

--- a/mantidimaging/gui/windows/live_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/model_test.py
@@ -97,7 +97,8 @@ class ImageWatcherTest(FakeFSTestCase):
         file_list = self._make_simple_dir(self.top_path)
         self.mock_signal_image.emit.assert_not_called()
 
-        self.watcher._handle_directory_change(self.top_path)
+        self.watcher.changed_directory = self.top_path
+        self.watcher._handle_directory_change()
 
         emitted_images = self._get_recent_emitted_files()
         self._file_list_count_equal(emitted_images, file_list)
@@ -110,7 +111,8 @@ class ImageWatcherTest(FakeFSTestCase):
         os.utime(self.top_path / "empty", [10, 2000])
         self.assertLess(self.top_path.stat().st_mtime, (self.top_path / 'empty').stat().st_mtime)
 
-        self.watcher._handle_directory_change(self.top_path / "empty")
+        self.watcher.changed_directory = self.top_path / "empty"
+        self.watcher._handle_directory_change()
 
         emitted_images = self._get_recent_emitted_files()
         self._file_list_count_equal(emitted_images, file_list)
@@ -123,7 +125,8 @@ class ImageWatcherTest(FakeFSTestCase):
         self.assertLess(self.top_path.stat().st_mtime, (self.top_path / 'more').stat().st_mtime)
         self.assertLess((self.top_path / 'more').stat().st_mtime, time.time())
 
-        self.watcher._handle_directory_change(self.top_path)
+        self.watcher.changed_directory = self.top_path
+        self.watcher._handle_directory_change()
 
         emitted_images = self._get_recent_emitted_files()
         self._file_list_count_equal(emitted_images, file_list)
@@ -135,7 +138,8 @@ class ImageWatcherTest(FakeFSTestCase):
         file_list2 = self._make_simple_dir(self.top_path / "more", t0=2000)
         self.assertLess(self.top_path.stat().st_mtime, (self.top_path / 'more').stat().st_mtime)
 
-        self.watcher._handle_directory_change(self.top_path / "more")
+        self.watcher.changed_directory = self.top_path / "more"
+        self.watcher._handle_directory_change()
 
         emitted_images = self._get_recent_emitted_files()
         self._file_list_count_equal(emitted_images, file_list2)


### PR DESCRIPTION
### Issue

Closes #2204 

### Description

When a diectory is updated we have to check the age of every file in it, to find the newest (QFileSystemWatcher does not give the changed file name). This can be slow on windows, e.g. a second for a few thousand images. During this time new notifications can arrive.

Previously, each notification as acted when it was received. If the rate of notification was to high, then a queue of signals would build up, and MI would appear stuck.

Now we can quickly handle the notification in `_handle_notified_of_directry_change()`, and defer the work with a timer. Any extra notifications can get aborbed by this, and the actuall work in `_handle_directory_change()` only needs to run once.

Also adds a stress test script. e.g.
`simulate_live_data_stress.py -d \mi_test\live -s 0 -f 1000 -r 0.1 -v`
Creates 1000 files at a rate of one every 0.1 seconds.

### Testing 

Not easy to add an automated test

### Acceptance Criteria 

See bug report for methods to trigger issue. Check that you can trigger it on main. Test that there are not long hangs with changes.

Not that this does nothing to make finding the new file faster. So with a large number of files there will still be a few seconds between a file arriving and being displayed.

### Documentation

release notes
