### PR TITLE
Spectrum viewer refactoring - Moving logic from the view to the presenter

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -10,7 +10,6 @@ from logging import getLogger
 
 import numpy as np
 from PyQt5.QtCore import QSignalBlocker
-from PyQt5.QtWidgets import QAction, QSpinBox
 
 from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.core.utility.sensible_roi import SensibleROI
@@ -18,7 +17,6 @@ from mantidimaging.gui.dialogs.async_task import start_async_task_view, TaskWork
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.windows.spectrum_viewer.model import SpectrumViewerWindowModel, SpecType, ROI_RITS, ErrorMode, \
     ToFUnitMode, allowed_modes
-from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumROI
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.spectrum_viewer.view import SpectrumViewerWindowView  # pragma: no cover
@@ -26,6 +24,7 @@ if TYPE_CHECKING:
     from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumROI
     from mantidimaging.core.data import ImageStack
     from uuid import UUID
+    from PyQt5.QtWidgets import QAction, QSpinBox
 
 LOG = getLogger(__name__)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -10,6 +10,7 @@ from logging import getLogger
 
 import numpy as np
 from PyQt5.QtCore import QSignalBlocker
+from PyQt5.QtWidgets import QAction
 
 from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.core.utility.sensible_roi import SensibleROI
@@ -382,9 +383,9 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         for action in self.view.tof_mode_select_group.actions():
             with QSignalBlocker(action):
                 if action.objectName() == opt:
-                    action.setChecked(True)
+                    self.check_action(action, True)
                 else:
-                    action.setChecked(False)
+                    self.check_action(action, False)
 
     def do_adjust_roi(self) -> None:
         roi_iter_order = ["Left", "Top", "Right", "Bottom"]
@@ -410,3 +411,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             if old_current_roi_name != ROI_RITS:
                 self.view.last_clicked_roi = old_current_roi_name
 
+    @staticmethod
+    def check_action(action: QAction, param: bool):
+        action.setChecked(param)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -393,26 +393,22 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.model.set_roi(self.view.current_roi_name, new_roi)
         self.view.spectrum_widget.adjust_roi(new_roi, self.view.current_roi_name)
 
-    def handle_storing_current_roi_name_on_tab_change(self):
+    def handle_storing_current_roi_name_on_tab_change(self) -> None:
         old_table_names = self.view.old_table_names
         old_current_roi_name = self.view.current_roi_name
         old_last_clicked_roi = self.view.last_clicked_roi
         if self.export_mode == ExportMode.ROI_MODE:
-            if old_current_roi_name in old_table_names and old_last_clicked_roi in old_table_names:
-                pass
-            elif old_current_roi_name == ROI_RITS and old_last_clicked_roi in old_table_names:
+            if old_current_roi_name == ROI_RITS and old_last_clicked_roi in old_table_names:
                 self.view.current_roi_name = old_last_clicked_roi
-            elif old_current_roi_name == ROI_RITS and old_last_clicked_roi not in old_table_names:
-                self.view.current_roi_name = self.view.roi_table_model.row_data(self.view.selected_row)[0]
             else:
                 self.view.last_clicked_roi = old_current_roi_name
         elif self.export_mode == ExportMode.IMAGE_MODE:
             if (old_current_roi_name != ROI_RITS and old_current_roi_name in old_table_names
-                    and old_last_clicked_roi in old_table_names):
+                    and old_last_clicked_roi != old_current_roi_name):
                 self.view.last_clicked_roi = old_current_roi_name
 
     @staticmethod
-    def check_action(action: QAction, param: bool):
+    def check_action(action: QAction, param: bool) -> None:
         action.setChecked(param)
 
     def convert_spinbox_roi_to_SpectrumROI(self, spinboxes: dict[str, QSpinBox]) -> SpectrumROI:

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -373,3 +373,13 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.handle_storing_current_roi_name_on_tab_change()
         self.assertEqual(self.view.current_roi_name, "roi_2")
         self.assertEqual(self.view.last_clicked_roi, "roi_2")
+
+    def test_WHEN_refresh_spectrum_plot_THEN_spectrum_plot_refreshed(self):
+        self.view.spectrum_widget.spectrum = mock.MagicMock()
+        self.presenter.model.tof_plot_range = (23, 45)
+        self.presenter.model.tof_range = (1, 80)
+        self.presenter.refresh_spectrum_plot()
+        self.view.show_visible_spectrums.assert_called_once()
+        self.view.spectrum_widget.spectrum_plot_widget.add_range.assert_called_once_with(23, 45)
+        self.view.spectrum_widget.spectrum_plot_widget.set_image_index_range_label.assert_called_once_with(1, 80)
+        self.view.auto_range_image.assert_called_once()

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -383,3 +383,24 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view.spectrum_widget.spectrum_plot_widget.add_range.assert_called_once_with(23, 45)
         self.view.spectrum_widget.spectrum_plot_widget.set_image_index_range_label.assert_called_once_with(1, 80)
         self.view.auto_range_image.assert_called_once()
+
+    def test_WHEN_redraw_all_rois_THEN_rois_set_correctly(self):
+
+        def spec_roi_mock(name):
+            if name == "all":
+                return SensibleROI(0, 0, 10, 8)
+            elif name == "roi":
+                return SensibleROI(1, 4, 3, 2)
+
+        self.view.spectrum_widget.get_roi = mock.Mock(side_effect=spec_roi_mock)
+        self.presenter.model.set_stack(generate_images())
+        self.presenter.do_add_roi()
+        self.presenter.model.get_spectrum = mock.Mock()
+        self.presenter.redraw_all_rois()
+        self.assertEqual(self.presenter.model.get_roi("all"), SensibleROI(0, 0, 10, 8))
+        self.assertEqual(self.presenter.model.get_roi("roi"), SensibleROI(1, 4, 3, 2))
+        calls = [
+            mock.call("all", mock.ANY),
+            mock.call("roi", mock.ANY),
+        ]
+        self.view.set_spectrum.assert_has_calls(calls)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -6,7 +6,7 @@ import uuid
 from pathlib import Path
 from unittest import mock
 
-from PyQt5.QtWidgets import QPushButton, QActionGroup, QGroupBox
+from PyQt5.QtWidgets import QPushButton, QActionGroup, QGroupBox, QAction
 from parameterized import parameterized
 
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
@@ -321,3 +321,20 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.refresh_spectrum_plot = mock.Mock()
         self.presenter.handle_time_delay_change()
         self.assertEqual(self.presenter.model.units.data_offset, 400 * 1e-6)
+
+    def test_WHEN_menu_option_selected_THEN_menu_option_changed(self):
+        menu_options = [QAction("opt1"), QAction("opt2"), QAction("opt3"), QAction("opt4")]
+        menu_options[0].setObjectName("opt1")
+        menu_options[1].setObjectName("opt2")
+        menu_options[2].setObjectName("opt3")
+        menu_options[3].setObjectName("opt4")
+        self.presenter.check_action = mock.Mock()
+        self.view.tof_mode_select_group.actions = mock.Mock(return_value=menu_options)
+        self.presenter.change_selected_menu_option("opt2")
+        calls = [
+            mock.call(menu_options[0], False),
+            mock.call(menu_options[1], True),
+            mock.call(menu_options[2], False),
+            mock.call(menu_options[3], False)
+        ]
+        self.presenter.check_action.assert_has_calls(calls)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -245,15 +245,15 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     def test_WHEN_roi_clicked_THEN_roi_updated(self):
         roi = SpectrumROI("themightyroi", SensibleROI())
         self.presenter.handle_roi_clicked(roi)
-        self.assertEqual(self.view.current_roi, "themightyroi")
+        self.assertEqual(self.view.current_roi_name, "themightyroi")
         self.assertEqual(self.view.last_clicked_roi, "themightyroi")
         self.view.set_roi_properties.assert_called_once()
 
     def test_WHEN_rits_roi_clicked_THEN_rois_not_updated(self):
-        self.view.current_roi = self.view.last_clicked_roi = "NOT_RITS_ROI"
+        self.view.current_roi_name = self.view.last_clicked_roi = "NOT_RITS_ROI"
         roi = SpectrumROI(ROI_RITS, SensibleROI())
         self.presenter.handle_roi_clicked(roi)
-        self.assertEqual(self.view.current_roi, "NOT_RITS_ROI")
+        self.assertEqual(self.view.current_roi_name, "NOT_RITS_ROI")
         self.assertEqual(self.view.last_clicked_roi, "NOT_RITS_ROI")
         self.view.set_roi_properties.assert_not_called()
 

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -404,3 +404,23 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
             mock.call("roi", mock.ANY),
         ]
         self.view.set_spectrum.assert_has_calls(calls)
+
+    def test_WHEN_roi_clicked_THEN_current_and_last_clicked_roi_updated(self):
+        self.view.current_roi_name = ""
+        self.view.last_clicked_roi = ""
+        self.presenter.handle_roi_clicked(SpectrumROI("roi_clicked", SensibleROI(), pos=(0, 0)))
+        self.assertEqual(self.view.current_roi_name, "roi_clicked")
+        self.assertEqual(self.view.last_clicked_roi, "roi_clicked")
+
+    def test_WHEN_roi_rits_clicked_THEN_current_and_last_clicked_roi_not_updated(self):
+        self.view.current_roi_name = "roi"
+        self.view.last_clicked_roi = "roi"
+        self.presenter.handle_roi_clicked(SpectrumROI(ROI_RITS, SensibleROI(), pos=(0, 0)))
+        self.assertEqual(self.view.current_roi_name, "roi")
+        self.assertEqual(self.view.last_clicked_roi, "roi")
+
+    def test_WHEN_roi_clicked_THEN_roi_properties_set(self):
+        self.view.current_roi_name = ""
+        self.view.last_clicked_roi = ""
+        self.presenter.handle_roi_clicked(SpectrumROI("roi_clicked", SensibleROI(), pos=(0, 0)))
+        self.view.set_roi_properties.assert_called_once()

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -357,7 +357,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.assertEqual(self.view.last_clicked_roi, "roi_2")
 
     def test_WHEN_delete_current_roi_and_changed_to_RITS_tab_THEN_last_clicked_roi_corrected(self):
-        self.view.old_table_names = ["roi_1", "roi_2", "roi_3"]
+        self.view.old_table_names = ["roi_1", "roi_3"]
         self.view.current_roi_name = "roi_3"
         self.view.last_clicked_roi = "roi_2"
         self.presenter.export_mode = ExportMode.IMAGE_MODE

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -18,7 +18,6 @@ from .presenter import SpectrumViewerWindowPresenter, ExportMode
 from mantidimaging.gui.widgets import RemovableRowTableView
 from .spectrum_widget import SpectrumWidget
 from mantidimaging.gui.windows.spectrum_viewer.roi_table_model import TableModel
-from mantidimaging.core.utility.sensible_roi import SensibleROI
 
 import numpy as np
 
@@ -524,8 +523,11 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         for _, label in self.roiPropertiesLabels.items():
             label.setText("0")
 
-    def get_roi_properties_spinboxes(self):
+    def get_roi_properties_spinboxes(self) -> dict[str, QSpinBox]:
         return self.roiPropertiesSpinBoxes
+
+    def get_checked_menu_option(self) -> QAction:
+        return self.tof_mode_select_group.checkedAction()
 
     def set_old_table_names(self):
         self.old_table_names = self.presenter.get_roi_names()


### PR DESCRIPTION
### Issue

Closes #2224 

### Description

The following functions have been moved from the view to the presenter:

- `do_adjust_roi`
- `handle_storing_current_roi_name_on_tab_change`
- parts of `on_visibility_change`

some new functions have been made to help with testing:

- `presenter.check_action`
- `view.get_roi_properties_spinboxes`
- `view.setup_roi_properties_spinboxes`

The logic for `presenter.handle_storing_current_roi_name_on_tab_change` has also been simplified.

Unit tests for the following functions have been added:

- `presenter.change_selected_menu_option`
- `presenter.do_adjust_roi`
- `presenter.handle_storing_current_roi_name_on_tab_change`
- `presenter.refresh_spectrum_plot`
- `presenter.redraw_all_rois`
- `presenter.handle_roi_clicked`
- `handle_enable_normalised`


### Testing 

make check

### Acceptance Criteria 

Open MI and load some data into it (with spectrum file if possible) and make sure that the functionality is the same as it was before this refactor and no bugs have been introduced.

run `make check` or `make test` and check that all tests pass

### Documentation

Will add release note