### PR TITLE
Live viewer: informative error if live directory deleted

### DIFF
--- a/docs/release_notes/next/fix-2219-live-view-del-dir
+++ b/docs/release_notes/next/fix-2219-live-view-del-dir
@@ -1,0 +1,1 @@
+#2219: Live viewer: informative error if live directory deleted

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -247,6 +247,9 @@ class ImageWatcher(QObject):
             self.add_sub_directory(this_dir)
 
         self.clear_deleted_sub_directories(directory_path)
+        if not self.sub_directories:
+            raise FileNotFoundError(f"Live directory not found: {self.directory}"
+                                    "\nHas it been deleted?")
         self.find_sub_directories(directory_path)
         self.sort_sub_directory_by_modified_time()
 

--- a/mantidimaging/gui/windows/live_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/model_test.py
@@ -6,6 +6,7 @@ import os
 import time
 from pathlib import Path
 from unittest import mock
+import pytest
 
 from PyQt5.QtCore import QFileSystemWatcher, pyqtSignal
 
@@ -82,6 +83,23 @@ class ImageWatcherTest(FakeFSTestCase):
 
         images = [image.image_path for image in images_datas]
         self._file_list_count_equal(images, file_list[1:])
+
+    def test_WHEN_empty_dir_THEN_no_files(self):
+        self.watcher.changed_directory = self.top_path
+        self.watcher._handle_directory_change()
+
+        emitted_images = self._get_recent_emitted_files()
+        self._file_list_count_equal(emitted_images, [])
+
+    @pytest.mark.xfail(reason="Issue 2219")
+    def test_WHEN_missing_dir_THEN_useful_error(self):
+        self.fs.rmdir(self.top_path)
+        self.watcher.changed_directory = self.top_path
+
+        with self.assertRaises(FileNotFoundError) as context_manager:
+            self.watcher._handle_directory_change()
+        self.assertIn("Live directory not found", str(context_manager.exception))
+        self.assertIn(str(self.top_path), str(context_manager.exception))
 
     def test_WHEN_find_sub_directories_called_THEN_finds_subdirs(self):
         self._file_in_sequence(self.top_path, self.watcher.sub_directories.keys())

--- a/mantidimaging/gui/windows/live_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/model_test.py
@@ -6,7 +6,6 @@ import os
 import time
 from pathlib import Path
 from unittest import mock
-import pytest
 
 from PyQt5.QtCore import QFileSystemWatcher, pyqtSignal
 
@@ -91,7 +90,6 @@ class ImageWatcherTest(FakeFSTestCase):
         emitted_images = self._get_recent_emitted_files()
         self._file_list_count_equal(emitted_images, [])
 
-    @pytest.mark.xfail(reason="Issue 2219")
     def test_WHEN_missing_dir_THEN_useful_error(self):
         self.fs.rmdir(self.top_path)
         self.watcher.changed_directory = self.top_path


### PR DESCRIPTION
### Issue
Closes #2219 

### Description

Previously the error message was `UnboundLocalError` now the message explains the issue.

This should not happen in normal use and is tricky to recover from because we can't watch a non-existent directory. But the message should at least explain what has happened.

Added some tests

### Testing 
Add tests for the cases of directory exists but no files and for directory deleted.

### Acceptance Criteria 

Open the live viewer
Deleted the directory that it is watching

### Documentation

Release notes
