### PR TITLE
Remove sarepy from dependancies

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,7 +1,6 @@
 name: mantidimaging-dev
 channels:
   - mantidimaging/label/unstable
-  - dtasev
   - astra-toolbox
   - conda-forge
   - ccpi
@@ -29,7 +28,6 @@ dependencies:
   - pyfakefs==5.3.*
   - parameterized==0.9.*
   - pyinstaller==6.1.*
-  - sarepy=2020.07 # For building old docs
   - make==4.3
   - ruff=0.3.3
   - pre-commit==3.5.*

--- a/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
@@ -46,7 +46,7 @@ class RemoveStripeFilteringFilter(BaseFilter):
         :param window_dim: Whether to perform the median on 1D or 2D view of the
                            data.
         :param filtering_dim: Whether to use a 1D or 2D low-pass filter. This
-                              uses different Sarepy methods.
+                              uses different Algotom methods.
 
         :return: The ImageStack object with the stripes removed using the
                  filtering and sorting technique.
@@ -119,7 +119,7 @@ class RemoveStripeFilteringFilter(BaseFilter):
                                                 form=form,
                                                 on_change=on_change,
                                                 tooltip="Whether to use a 1D or 2D low-pass filter. "
-                                                "This uses different Sarepy methods")
+                                                "This uses different Algotom methods")
         return {'sigma': sigma, 'size': size, 'window_dim': window_dim, 'filtering_dim': filtering_dim}
 
     @staticmethod


### PR DESCRIPTION
### Issue

We migrated from sarepy to algotom in  #1023, but had to keep the dependency to enable building old documentation.

This was resolved in #1150, so now its possible to remove the package

### Description
Remove sarepy from dependancies and remove dtasev channel


### Acceptance Criteria 
Automated testing should all pass

### Documentation

Not needed
