### PR TITLE
unit test added for spectrum widget roi colour change

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -53,11 +53,18 @@ class SpectrumROI(ROI):
 
     def onChangeColor(self):
         current_color = QColor(*self._colour)
-        selected_color = QColorDialog.getColor(current_color)
-        if selected_color.isValid():
+        selected_color = self.openColorDialog(current_color)
+        color_valid = self.check_color_valid(selected_color)
+        if color_valid:
             new_color = (selected_color.red(), selected_color.green(), selected_color.blue(), 255)
             self._colour = new_color
             self.sig_colour_change.emit(self._name, new_color)
+
+    def openColorDialog(self, current_color) -> QColor:
+        return QColorDialog.getColor(current_color)
+
+    def check_color_valid(self, get_colour) -> bool:
+        return get_colour.isValid()
 
     def contextMenuEnabled(self):
         return True

--- a/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
@@ -5,6 +5,8 @@ import unittest
 import uuid
 import numpy as np
 from unittest import mock
+
+from PyQt5.QtGui import QColor
 from parameterized import parameterized
 
 from pyqtgraph import Point
@@ -20,11 +22,27 @@ from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumRO
 @start_qapplication
 class SpectrumROITest(unittest.TestCase):
 
+    def setUp(self) -> None:
+        self.roi = SensibleROI(10, 20, 30, 40)
+        self.spectrum_roi = SpectrumROI("test_roi", self.roi)
+
     def test_WHEN_initialise_THEN_pos_and_size_correct(self):
-        roi = SensibleROI(10, 20, 30, 40)
-        spectrum_roi = SpectrumROI("", roi)
-        self.assertEqual(spectrum_roi.getState()["pos"], Point(10, 20))
-        self.assertEqual(spectrum_roi.getState()["size"], Point(20, 20))
+        self.assertEqual(self.spectrum_roi.getState()["pos"], Point(10, 20))
+        self.assertEqual(self.spectrum_roi.getState()["size"], Point(20, 20))
+
+    def test_WHEN_colour_changed_THEN_roi_colour_is_set(self):
+        self._colour = (1, 2, 58, 255)
+        self.spectrum_roi.openColorDialog = mock.Mock(return_value=QColor(*self._colour))
+        self.spectrum_roi.check_color_valid = mock.Mock(return_value=True)
+        self.spectrum_roi.onChangeColor()
+        self.assertEqual(self.spectrum_roi.colour, self._colour)
+
+    def test_WHEN_colour_is_not_valid_THEN_roi_colour_is_unchanged(self):
+        self._colour = (10, 20, 48, 255)
+        self.spectrum_roi.openColorDialog = mock.Mock(return_value=QColor(*self._colour))
+        self.spectrum_roi.check_color_valid = mock.Mock(return_value=False)
+        self.spectrum_roi.onChangeColor()
+        self.assertEqual(self.spectrum_roi.colour, (0, 0, 0, 255))
 
 
 @mock_versions

--- a/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
@@ -31,16 +31,14 @@ class SpectrumROITest(unittest.TestCase):
         self.assertEqual(self.spectrum_roi.getState()["size"], Point(20, 20))
 
     def test_WHEN_colour_changed_THEN_roi_colour_is_set(self):
-        self._colour = (1, 2, 58, 255)
-        self.spectrum_roi.openColorDialog = mock.Mock(return_value=QColor(*self._colour))
-        self.spectrum_roi.check_color_valid = mock.Mock(return_value=True)
+        colour = (1, 2, 58, 255)
+        self.spectrum_roi.openColorDialog = mock.Mock(return_value=QColor(*colour))
         self.spectrum_roi.onChangeColor()
-        self.assertEqual(self.spectrum_roi.colour, self._colour)
+        self.assertEqual(self.spectrum_roi.colour, colour)
 
     def test_WHEN_colour_is_not_valid_THEN_roi_colour_is_unchanged(self):
-        self._colour = (10, 20, 48, 255)
-        self.spectrum_roi.openColorDialog = mock.Mock(return_value=QColor(*self._colour))
-        self.spectrum_roi.check_color_valid = mock.Mock(return_value=False)
+        colour = (10, 20, 480, 255)
+        self.spectrum_roi.openColorDialog = mock.Mock(return_value=QColor(*colour))
         self.spectrum_roi.onChangeColor()
         self.assertEqual(self.spectrum_roi.colour, (0, 0, 0, 255))
 


### PR DESCRIPTION
### Description

This pull request enhances the Spectrum Widget by adding unit tests to validate the ROI colour change functionality. Two main test scenarios have been implemented. 

Test 1: Valid Color Change

Verifies that when a valid colour is selected and applied using onChangeColor(), the ROI colour (colour attribute) in the Spectrum Widget is correctly updated.

Test 2: Invalid Color Handling

Ensures that if an invalid colour is selected (detected by check_color_valid() returning False), the ROI colour remains unchanged from its initial state.

These tests utilize mock.Mock to simulate the behaviour of the colour selection dialog (openColorDialog) and the validation function (check_color_valid), providing controlled testing environments.

### Testing

Added unit tests in spectrum_viewer/test/spectrum_test.py:

test_WHEN_colour_changed_THEN_roi_colour_is_set

test_WHEN_colour_is_not_valid_THEN_roi_colour_is_unchanged

Verified tests locally with Python unittest framework.

All tests passed successfully, confirming the accurate behaviour of ROI colour change handling.

### Acceptance Criteria

To consider this pull request ready for acceptance and merge into the main branch, the following criteria should be met:

Unit Test Coverage:

Ensure that all newly added unit tests (test_WHEN_colour_changed_THEN_roi_colour_is_set and test_WHEN_colour_is_not_valid_THEN_roi_colour_is_unchanged) pass without errors or failures.

Manual Verification:

Manually verify in a development environment that the Spectrum Widget responds correctly to valid and invalid colour changes as defined in the tests.
