### PR TITLE
Stack change units tests added to Spectrum Viewer

### DIFF
--- a/docs/release_notes/next/dev-2213-spectrum-stack-switch-tests
+++ b/docs/release_notes/next/dev-2213-spectrum-stack-switch-tests
@@ -1,0 +1,1 @@
+#2213 : unit tests have been added to check that the Time of Flight modes behave correctly when switching between stacks

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -316,20 +316,14 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.assertEqual(self.presenter.model.tof_mode, expected_tof_mode)
 
     @parameterized.expand([
-        (None, "Image Index", ToFUnitMode.IMAGE_NUMBER, np.arange(1, 10), [mock.call(False),
-                                                                           mock.call(True)], ToFUnitMode.WAVELENGTH),
-        (np.arange(1, 10), "Wavelength", ToFUnitMode.WAVELENGTH, None, [mock.call(True),
-                                                                        mock.call(False)], ToFUnitMode.IMAGE_NUMBER),
-        (None, "Image Index", ToFUnitMode.IMAGE_NUMBER, None, [mock.call(False),
-                                                               mock.call(False)], ToFUnitMode.IMAGE_NUMBER),
-        (np.arange(1,
-                   10), "Wavelength", ToFUnitMode.WAVELENGTH, np.arange(2,
-                                                                        20), [mock.call(True),
-                                                                              mock.call(True)], ToFUnitMode.WAVELENGTH),
-        (np.arange(1, 10), "Energy", ToFUnitMode.ENERGY, np.arange(2, 20), [mock.call(True),
-                                                                            mock.call(True)], ToFUnitMode.ENERGY),
-        (np.arange(1, 10), "Time of Flight (\u03BCs)", ToFUnitMode.TOF_US, np.arange(2, 20),
-         [mock.call(True), mock.call(True)], ToFUnitMode.TOF_US)
+        (None, "Image Index", ToFUnitMode.IMAGE_NUMBER, np.arange(1, 10), [False, True], ToFUnitMode.WAVELENGTH),
+        (np.arange(1, 10), "Wavelength", ToFUnitMode.WAVELENGTH, None, [True, False], ToFUnitMode.IMAGE_NUMBER),
+        (None, "Image Index", ToFUnitMode.IMAGE_NUMBER, None, [False, False], ToFUnitMode.IMAGE_NUMBER),
+        (np.arange(1, 10), "Wavelength", ToFUnitMode.WAVELENGTH, np.arange(2, 20), [True,
+                                                                                    True], ToFUnitMode.WAVELENGTH),
+        (np.arange(1, 10), "Energy", ToFUnitMode.ENERGY, np.arange(2, 20), [True, True], ToFUnitMode.ENERGY),
+        (np.arange(1, 10), "Time of Flight (\u03BCs)", ToFUnitMode.TOF_US, np.arange(2, 20), [True,
+                                                                                              True], ToFUnitMode.TOF_US)
     ])
     @mock.patch("mantidimaging.gui.windows.spectrum_viewer.model.SpectrumViewerWindowModel.get_stack_time_of_flight")
     def test_WHEN_switch_between_no_spectra_to_spectra_files_THEN_tof_modes_availability_set(
@@ -346,6 +340,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
         get_stack_time_of_flight.return_value = tof_data_after
         self.presenter.handle_sample_change(uuid.uuid4())
+        expected_calls = [mock.call(b) for b in expected_calls]
         self.view.tof_mode_select_group.setEnabled.assert_has_calls(expected_calls)
         self.view.tofPropertiesGroupBox.setEnabled.assert_has_calls(expected_calls)
         self.assertEqual(self.presenter.model.tof_mode, expected_mode)
@@ -378,12 +373,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.check_action = mock.Mock()
         self.view.tof_mode_select_group.actions = mock.Mock(return_value=menu_options)
         self.presenter.change_selected_menu_option("opt2")
-        calls = [
-            mock.call(menu_options[0], False),
-            mock.call(menu_options[1], True),
-            mock.call(menu_options[2], False),
-            mock.call(menu_options[3], False)
-        ]
+        calls = [mock.call(menu_options[a], b) for a, b in [(0, False), (1, True), (2, False), (3, False)]]
         self.presenter.check_action.assert_has_calls(calls)
 
     def test_WHEN_roi_changed_via_spinboxes_THEN_roi_adjusted(self):
@@ -431,10 +421,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.redraw_all_rois()
         self.assertEqual(self.presenter.model.get_roi("all"), SensibleROI(0, 0, 10, 8))
         self.assertEqual(self.presenter.model.get_roi("roi"), SensibleROI(1, 4, 3, 2))
-        calls = [
-            mock.call("all", mock.ANY),
-            mock.call("roi", mock.ANY),
-        ]
+        calls = [mock.call(a, b) for a, b in [("all", mock.ANY), ("roi", mock.ANY)]]
         self.view.set_spectrum.assert_has_calls(calls)
 
     @parameterized.expand([("roi", "roi_clicked", "roi_clicked"), ("roi", ROI_RITS, "roi")])

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -346,8 +346,14 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
         get_stack_time_of_flight.return_value = tof_data_after
         self.presenter.handle_sample_change(uuid.uuid4())
+        self.view.tof_mode_select_group.setEnabled.assert_has_calls(expected_calls)
         self.view.tofPropertiesGroupBox.setEnabled.assert_has_calls(expected_calls)
         self.assertEqual(self.presenter.model.tof_mode, expected_mode)
+
+    def test_WHEN_no_stack_available_THEN_units_menu_disabled(self):
+        self.presenter.current_stack_uuid = uuid.uuid4()
+        self.presenter.handle_sample_change(None)
+        self.view.tof_mode_select_group.setEnabled.assert_called_once_with(False)
 
     def test_WHEN_tof_flight_path_changed_THEN_unit_conversion_flight_path_set(self):
         self.view.flightPathSpinBox = mock.Mock()


### PR DESCRIPTION
### Issue

Progresses #2213 and #2032

### Description

Added unit tests to check the tof mode is changed correctly when:

- switching from stack with no spectra file to stack with spectra file
- switching from stack with spectra file to stack with spectra file (for tof modes `ToFUnitMode.WAVELENGTH`, `ToFUnitMode.ENERGY`, `ToFUnitMode.TOF_US`)
- switching from stack with no spectra file to stack with no spectra file
- switching from stack with spectra file to stack with no spectra file

These tests check that the tof mode is changed as expected but also if the right click units menu has the correct behaviour (i.e. disabling when there is no spectra file and enabling when there is a spectrum file).

A test has also been added to check that when there is no stack available in the spectrum viewer (i.e. it has been deleted in the Main Window), then the tof mode and right click menu behaves appropriately.


### Acceptance Criteria 

Test that all tests pass with `make check`

### Documentation

Release note
