### PR TITLE
Spectrum Viewer type checking

### DIFF
--- a/mantidimaging/core/utility/sensible_roi.py
+++ b/mantidimaging/core/utility/sensible_roi.py
@@ -30,7 +30,7 @@ class SensibleROI(Iterable):
         return SensibleROI(position.x, position.y, position.x + size.x, position.y + size.y)
 
     @staticmethod
-    def from_list(roi: list[int] | list[float]):
+    def from_list(roi: list[int] | list[float]) -> SensibleROI:
         return SensibleROI(int(roi[0]), int(roi[1]), int(roi[2]), int(roi[3]))
 
     def __iter__(self) -> Iterator[int]:

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import csv
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, TypedDict, Final
 
 import numpy as np
 from math import ceil
@@ -23,8 +23,8 @@ if TYPE_CHECKING:
 
 LOG = getLogger(__name__)
 
-ROI_ALL = "all"
-ROI_RITS = "rits_roi"
+ROI_ALL: Final = "all"
+ROI_RITS: Final = "rits_roi"
 
 
 class SpecType(Enum):
@@ -149,7 +149,7 @@ class SpectrumViewerWindowModel:
     def set_normalise_stack(self, normalise_stack: ImageStack | None) -> None:
         self._normalise_stack = normalise_stack
 
-    def set_roi(self, roi_name: str, roi: SensibleROI):
+    def set_roi(self, roi_name: str, roi: SensibleROI) -> None:
         self._roi_ranges[roi_name] = roi
 
     def get_roi(self, roi_name: str) -> SensibleROI:
@@ -174,7 +174,7 @@ class SpectrumViewerWindowModel:
         return None
 
     @staticmethod
-    def get_stack_spectrum(stack: ImageStack | None, roi: SensibleROI):
+    def get_stack_spectrum(stack: ImageStack | None, roi: SensibleROI) -> np.ndarray:
         """
         Computes the mean spectrum of the given image stack within the specified region of interest (ROI).
         If the image stack is None, an empty numpy array is returned.
@@ -194,7 +194,7 @@ class SpectrumViewerWindowModel:
         return roi_data.mean(axis=(1, 2))
 
     @staticmethod
-    def get_stack_spectrum_summed(stack: ImageStack, roi: SensibleROI):
+    def get_stack_spectrum_summed(stack: ImageStack, roi: SensibleROI) -> np.ndarray:
         left, top, right, bottom = roi
         roi_data = stack.data[:, top:bottom, left:right]
         return roi_data.sum(axis=(1, 2))
@@ -401,7 +401,7 @@ class SpectrumViewerWindowModel:
 
         self.export_spectrum_to_rits(path, tof, transmission, transmission_error)
 
-    def validate_bin_and_step_size(self, roi, bin_size: int, step_size: int) -> None:
+    def validate_bin_and_step_size(self, roi: SensibleROI, bin_size: int, step_size: int) -> None:
         """
         Validates the bin size and step size for saving RITS images.
         This method checks the following conditions:
@@ -508,14 +508,15 @@ class SpectrumViewerWindowModel:
                     "Y Max": coords.bottom
                 })
 
-    def export_spectrum_to_rits(self, path: Path, tof, transmission, absorption) -> None:
+    def export_spectrum_to_rits(self, path: Path, tof: np.ndarray, transmission: np.ndarray,
+                                absorption: np.ndarray) -> None:
         """
         Export spectrum to RITS format
         """
         rits_data = saver.create_rits_format(tof, transmission, absorption)
         saver.export_to_dat_rits_format(rits_data, path)
 
-    def remove_roi(self, roi_name) -> None:
+    def remove_roi(self, roi_name: str) -> None:
         """
         Remove the selected ROI from the model
 

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -413,7 +413,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.model.set_relevant_tof_units()
         self.refresh_spectrum_plot()
 
-    def change_selected_menu_option(self, opt):
+    def change_selected_menu_option(self, opt: str) -> None:
         for action in self.view.tof_mode_select_group.actions():
             with QSignalBlocker(action):
                 if action.objectName() == opt:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -422,7 +422,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                     self.check_action(action, False)
 
     def do_adjust_roi(self) -> None:
-        new_roi = self.convert_spinbox_roi_to_SpectrumROI(self.view.roiPropertiesSpinBoxes)
+        new_roi = self.convert_spinbox_roi_to_SensibleROI(self.view.roiPropertiesSpinBoxes)
         self.model.set_roi(self.view.current_roi_name, new_roi)
         self.view.spectrum_widget.adjust_roi(new_roi, self.view.current_roi_name)
 
@@ -444,7 +444,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
     def check_action(action: QAction, param: bool) -> None:
         action.setChecked(param)
 
-    def convert_spinbox_roi_to_SpectrumROI(self, spinboxes: dict[str, QSpinBox]) -> SpectrumROI:
+    def convert_spinbox_roi_to_SensibleROI(self, spinboxes: dict[str, QSpinBox]) -> SensibleROI:
         roi_iter_order = ["Left", "Top", "Right", "Bottom"]
         new_points = [spinboxes[prop].value() for prop in roi_iter_order]
-        return SensibleROI().from_list(new_points)
+        return SensibleROI.from_list(new_points)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -387,7 +387,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
 
     def test_WHEN_roi_changed_via_spinboxes_THEN_roi_adjusted(self):
         self.presenter.view.roiPropertiesSpinBoxes = mock.Mock()
-        self.presenter.convert_spinbox_roi_to_SpectrumROI = mock.Mock(return_value=SensibleROI(10, 10, 20, 30))
+        self.presenter.convert_spinbox_roi_to_SensibleROI = mock.Mock(return_value=SensibleROI(10, 10, 20, 30))
         self.view.current_roi_name = "roi_1"
         self.presenter.do_adjust_roi()
         self.view.spectrum_widget.adjust_roi.assert_called_once_with(SensibleROI(10, 10, 20, 30), "roi_1")


### PR DESCRIPTION
### Issue

Some type checking for #2213 

### Description
Type checking in Spectrum viewer in the model

Reduces untyped lines in `mantidimaging.gui.windows.spectrum_viewer.model` from 17.35% to 14.75%.

### Acceptance Criteria 

Tests should all pass.
Check that moving ROIs with the spin boxes still works.
Have a play with the spectrum viewer

### Documentation

Not needed