### PR TITLE
Remove "Specific Errors" and "Release Updates" from Table of Contents

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Mantid Imaging is a graphical toolkit for performing 3D reconstruction of neutro
     :align: center
 
 .. toctree::
-   :maxdepth:
+   :maxdepth: 1
    :caption: Contents:
 
    overview

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Mantid Imaging is a graphical toolkit for performing 3D reconstruction of neutro
     :align: center
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth:
    :caption: Contents:
 
    overview

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Mantid Imaging is a graphical toolkit for performing 3D reconstruction of neutro
     :align: center
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
    :caption: Contents:
 
    overview

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -7,6 +7,6 @@ The developers can be contacted at
 mantidimagingsupport@stfc365.onmicrosoft.com
 
 Release Updates
-===============
+---------------
 
 Sign up to our `mailing list <https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=MANTID-IMAGING-ANNOUNCE&A=1>`_ to receive updates on the project

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -38,7 +38,7 @@ Reinstalling CUDA on Linux can be quickly done with this script
 
 
 Specific Errors
-===============
+---------------
 
 
 SystemError: <built-in function connectSlotsByName> returned a result with an error set


### PR DESCRIPTION
### Issue

This pull request modifies the RST file to address the issue where "Specific Errors" and "Release Updates" were unintentionally displayed in the main table of contents. The proposed changes update these sections to use single underlines, ensuring consistency across the documentation.

Changes

Changed the underline style for "Specific Errors" and "Release Updates" from double underline to single underline.

### Acceptance Criteria 

These sections will not be featured in the main navigation panel. User's can still have access to these sections of the documentation.

