### PR TITLE
Flash PR - Spectrum Viewer: ToF Range changed to Range

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -349,7 +349,7 @@ class SpectrumPlotWidget(GraphicsLayoutWidget):
         self.set_tof_range_label(range_min, range_max)
 
     def set_tof_range_label(self, range_min: float, range_max: float) -> None:
-        self._tof_range_label.setText(f'ToF range: {range_min:.3f} - {range_max:.3f}')
+        self._tof_range_label.setText(f'Range: {range_min:.3f} - {range_max:.3f}')
 
     def set_image_index_range_label(self, range_min: int, range_max: int) -> None:
         self._image_index_range_label.setText(f'Image index range: {range_min} - {range_max}')

--- a/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
@@ -112,8 +112,7 @@ class SpectrumWidgetTest(unittest.TestCase):
     def test_WHEN_add_range_called_THEN_region_and_label_set_correctly(self, _, range_min, range_max):
         self.spectrum_plot_widget.add_range(range_min, range_max)
         self.assertEqual(self.spectrum_plot_widget.range_control.getRegion(), (range_min, range_max))
-        self.assertEqual(self.spectrum_plot_widget._tof_range_label.text,
-                         f"ToF range: {range_min:.3f} - {range_max:.3f}")
+        self.assertEqual(self.spectrum_plot_widget._tof_range_label.text, f"Range: {range_min:.3f} - {range_max:.3f}")
 
     def test_WHEN_get_roi_called_THEN_SensibleROI_returned(self):
         spectrum_roi = SpectrumROI("roi", self.sensible_roi, rotatable=False, scaleSnap=True, translateSnap=True)
@@ -136,7 +135,7 @@ class SpectrumWidgetTest(unittest.TestCase):
 
     def test_WHEN_set_tof_range_called_THEN_range_control_set_correctly(self):
         self.spectrum_plot_widget.set_tof_range_label(0, 100)
-        self.assertEqual(self.spectrum_plot_widget._tof_range_label.text, "ToF range: 0.000 - 100.000")
+        self.assertEqual(self.spectrum_plot_widget._tof_range_label.text, "Range: 0.000 - 100.000")
 
     def test_WHEN_rename_roi_called_THEN_roi_renamed(self):
         spectrum_roi = SpectrumROI("roi_1", self.sensible_roi, rotatable=False, scaleSnap=True, translateSnap=True)


### PR DESCRIPTION
### Issue

FLASHPR

### Description

*Add a description of the changes made*.
Change ToF Range Label within the spectrum Viewer to just say Range

### Testing 

*Describe the tests that were used to verify your changes*.
* Manually inspected
* Tests Pass


### Acceptance Criteria 

*How should the reviewer test your changes*?
Spectrum Viewer "ToF Range" now only says "Range"

![image](https://github.com/mantidproject/mantidimaging/assets/32413847/d5e75ac4-b6e3-425a-919b-4db6b952b313)


### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*

N/A
