### PR TITLE
FLASH PR - Spectrum Viewer: Export ShutterCount corrected all_norm if ShutterCount correction applied

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -357,7 +357,9 @@ class SpectrumViewerWindowModel:
                 if self._normalise_stack is None:
                     raise RuntimeError("No normalisation stack selected")
                 csv_output.add_column(roi_name + "_open", self.get_spectrum(roi_name, SpecType.OPEN), "Counts")
-                csv_output.add_column(roi_name + "_norm", self.get_spectrum(roi_name, SpecType.SAMPLE_NORMED), "Counts")
+                csv_output.add_column(roi_name + "_norm",
+                                      self.get_spectrum(roi_name, SpecType.SAMPLE_NORMED, normalise_with_shuttercount),
+                                      "Counts")
 
         with path.open("w") as outfile:
             csv_output.write(outfile)


### PR DESCRIPTION
### Issue

Not filed as issue

### Description

*Add a description of the changes made*.

Previously if a user exported the spectrum with normalisation applied and ShutterCount correction, `all_norm` would export the the normalised spectrum without the ShutterCount correction applied. This PR resolves this issue. the ShutterCount corrected normalised spectrum is not exported if ShutterCount correction has been applied. 

### Testing 

*Describe the tests that were used to verify your changes*.
* Manually tested by comparing output csv files for `all_norm` using applying only normalisation and normalisation with ShutterCount Correction

### Acceptance Criteria 

*How should the reviewer test your changes*?
* Compare `all_norm` column within exported data when exporting with only normalisation and applied against normalisation with ShutterCount correction applied. Also compare against the main branch with normalisation and ShutterCount correction applied which will only export the normalised spectrum for `all_norm`

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*
NA
