### PR TITLE
Don't duplicate ROI names after stack modification

### DIFF
--- a/docs/release_notes/next/fix-2246-roi-name-dupe
+++ b/docs/release_notes/next/fix-2246-roi-name-dupe
@@ -1,0 +1,1 @@
+#2246: Don't duplicate ROI names after stack modification

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -131,7 +131,6 @@ class SpectrumViewerWindowModel:
         self._stack = stack
         if stack is None:
             return
-        self._roi_id_counter = 0
         self.tof_range = (0, stack.data.shape[0] - 1)
         self.tof_range_full = self.tof_range
         self.tof_data = self.get_stack_time_of_flight()
@@ -552,6 +551,7 @@ class SpectrumViewerWindowModel:
         """
         Remove all ROIs from the model
         """
+        self._roi_id_counter = 0
         self._roi_ranges = {}
 
     def set_relevant_tof_units(self) -> None:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -59,6 +59,9 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.main_window.stack_changed.connect(self.handle_stack_changed)
 
     def handle_stack_changed(self) -> None:
+        """
+        Called when an image stack is modified somewhere else in MI, for example in the operations window
+        """
         if self.current_stack_uuid:
             self.model.set_stack(self.main_window.get_stack(self.current_stack_uuid))
         else:
@@ -79,6 +82,9 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.redraw_all_rois()
 
     def handle_sample_change(self, uuid: UUID | None) -> None:
+        """
+        Called when the stack has been changed in the stack selector.
+        """
         if uuid == self.current_stack_uuid:
             return
         else:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -318,6 +318,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         Add a new ROI to the spectrum
         """
         roi_name = self.model.roi_name_generator()
+        if roi_name in self.view.spectrum_widget.roi_dict:
+            raise ValueError(f"ROI name already exists: {roi_name}")
         self.model.set_new_roi(roi_name)
         self.view.spectrum_widget.add_roi(self.model.get_roi(roi_name), roi_name)
         self.view.set_spectrum(

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -56,9 +56,9 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.main_window = main_window
         self.model = SpectrumViewerWindowModel(self)
         self.export_mode = ExportMode.ROI_MODE
-        self.main_window.stack_changed.connect(self.handle_stack_changed)
+        self.main_window.stack_changed.connect(self.handle_stack_modified)
 
-    def handle_stack_changed(self) -> None:
+    def handle_stack_modified(self) -> None:
         """
         Called when an image stack is modified somewhere else in MI, for example in the operations window
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -366,6 +366,15 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         self.assertEqual(self.model.roi_name_generator(), "roi_2")
         self.assertEqual(self.model.roi_name_generator(), "roi_3")
 
+    def test_WHEN_rois_deleted_THEN_name_generator_is_reset(self):
+        self.assertEqual(self.model.roi_name_generator(), "roi")
+        self.assertEqual(self.model.roi_name_generator(), "roi_1")
+        self.assertEqual(self.model.roi_name_generator(), "roi_2")
+        self.model.remove_all_roi()
+        self.assertEqual(self.model.roi_name_generator(), "roi")
+        self.assertEqual(self.model.roi_name_generator(), "roi_1")
+        self.assertEqual(self.model.roi_name_generator(), "roi_2")
+
     def test_WHEN_get_list_of_roi_names_called_THEN_correct_list_returned(self):
         self.model.set_stack(generate_images())
         self.assertListEqual(self.model.get_list_of_roi_names(), ["all"])

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -234,6 +234,14 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.do_add_roi()
         self.assertEqual(["all", "roi", "roi_1"], self.presenter.model.get_list_of_roi_names())
 
+    def test_WHEN_do_add_roi_given_dupelicate_THEN_exception_raised(self):
+        self.presenter.model.set_stack(generate_images())
+        with (mock.patch.object(self.presenter.model, "roi_name_generator") as
+              mocked_generator, mock.patch.object(self.view, "spectrum_widget") as mocked_spectrum_widget):
+            mocked_generator.return_value = "roi"
+            mocked_spectrum_widget.roi_dict = {"all": mock.Mock, "roi": mock.Mock}
+            self.assertRaises(ValueError, self.presenter.do_add_roi)
+
     def test_WHEN_do_add_roi_to_table_called_THEN_roi_added_to_table(self):
         self.presenter.model.set_stack(generate_images())
         self.presenter.do_add_roi()


### PR DESCRIPTION
### Issue

Closes #2246 

### Description
Move the reset of `_roi_id_counter` so that it only happens when all the ROIs are cleared.
Add a check in the presenter so that this would be caught earlier.
Add some doc strings and rename a method, because it was not clear what the difference was,
Add a test.

### Testing 

Includes a new test

### Acceptance Criteria 

Use the test case on #2246

### Documentation

Release notes
