### PR TITLE
Catch errors raised by operations in the system tests

### DIFF
--- a/docs/release_notes/next/dev-2250-catch-operations-errors
+++ b/docs/release_notes/next/dev-2250-catch-operations-errors
@@ -1,0 +1,2 @@
+#2250 : Make systems tests stricter to catch operations errors
+


### PR DESCRIPTION
With a filter for messages that are expected
* Crop coordinates after crop is applied
* Flat fielding causes negatives with test data

### Issue

Can be applied once #2250 is fixed.

### Description

Some of the operations raise exception under normal circumstances (e.g. after running a crop, the same parameters are used to redraw the preview, but fail because the input dimensions are different). So the operations window catches and displays the error. Unfortunately this hides actual errors from the system tests.

This change introduces a small allow list of error messages. Any thing else will count as a test failure.

### Testing & Acceptance Criteria 

Add a `raise RuntimeError("hello")` into one of the operations and check that the system-test fails

### Documentation

Release notes
