### PR TITLE
Fixed Median filter pickle bug

### DIFF
--- a/docs/release_notes/next/fix-2250-median-filter
+++ b/docs/release_notes/next/fix-2250-median-filter
@@ -1,0 +1,1 @@
+#2250: A bug where a lock object was trying to be pickled has not been fixed, the median filter is now functional.

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -90,9 +90,9 @@ class MedianFilter(BaseFilter):
         if size is None or size <= 1:
             raise ValueError(f'Size parameter must be greater than 1, but value provided was {size}')
 
-        params = {'mode': mode, 'size': size, 'force_cpu': force_cpu, 'progress': progress}
+        params = {'mode': mode, 'size': size, 'force_cpu': force_cpu}
         if force_cpu:
-            ps.run_compute_func(MedianFilter.compute_function, data.data.shape[0], data.shared_array, params)
+            ps.run_compute_func(MedianFilter.compute_function, data.data.shape[0], data.shared_array, params, progress)
         else:
             _execute_gpu(data.data, size, mode, progress=None)
         return data


### PR DESCRIPTION
### Issue

Closes #2250.

### Description

A bug has been fixed where there was a lock object in the `progress` dictionary which was attempting to be pickled. The lock object `progress` has been taken out of the dictionary and now passed directly as an argument.

### Testing 

`make test` but manually checked that no error has been shown even if the tests pass.

### Acceptance Criteria 

Load data into MI, open the Operations window and attempt to run the Median filter. The operations should complete successfully.

### Documentation

release note
