### PR TITLE
When building release docs, don't fail if nothing to clean

### DIFF
--- a/.github/actions/publish-docs/action.yml
+++ b/.github/actions/publish-docs/action.yml
@@ -25,7 +25,7 @@ runs:
       git worktree add --track -b gh-pages gh-pages origin/gh-pages
       cd gh-pages
 
-      git rm -r -q -- ${dir_name}/[!0-9]* # remove everything apart from versioned directories
+      git rm -r -q -- ${dir_name}/[!0-9]* || true # remove everything apart from versioned directories
       cp -a ../docs/build/html/* ${dir_name}
       md5sum ${dir_name}/index.html # if no index then there must have been a problem
       if [ "$(git status --porcelain | wc -l)" -gt "0" ] ; then

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -77,13 +77,13 @@ jobs:
           make build-docs
 
       - name: publish docs
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: ./.github/actions/publish-docs
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: publish docs release
-        if: startsWith(github.ref, 'refs/heads/release')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release')
         uses: ./.github/actions/publish-docs
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Issue

When building docs on a new release branch for the first time, the step to clean the existing contents fails, because there is none.

### Description

Add an `|| true`, so that it does not matter if the `git rm` command finds nothing to remove

Also add `github.event_name == 'push'` to publish doc rules, so they don't trigger based on the branch name of a PR

### Testing 

After merging, the docs should build and publish