### PR TITLE
Spectrum Viewer Export Tabs disable when no stacks are available

### DIFF
--- a/docs/release_notes/next/fix-2242-spectrum-viewer-keyerror-export-tab
+++ b/docs/release_notes/next/fix-2242-spectrum-viewer-keyerror-export-tab
@@ -1,0 +1,1 @@
+#2242: In the Spectrum Viewer, the Export Tabs now disable when no image stacks are available to prevent a KeyError

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -85,6 +85,11 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         Called when the stack has been changed in the stack selector.
         """
+        print("handle_sample_change")
+        if len(self.main_window.presenter.model.datasets) == 0:
+            self.view.exportTabs.setDisabled(True)
+        else:
+            self.view.exportTabs.setDisabled(False)
         if uuid == self.current_stack_uuid:
             return
         else:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -85,7 +85,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         Called when the stack has been changed in the stack selector.
         """
-        print("handle_sample_change")
         if len(self.main_window.presenter.model.datasets) == 0:
             self.view.exportTabs.setDisabled(True)
         else:

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from unittest import mock
 
 import numpy as np
-from PyQt5.QtWidgets import QPushButton, QActionGroup, QGroupBox, QAction, QCheckBox
+from PyQt5.QtWidgets import QPushButton, QActionGroup, QGroupBox, QAction, QCheckBox, QTabWidget
 from parameterized import parameterized
 
 from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
@@ -38,6 +38,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view.exportButtonRITS = mock.create_autospec(QPushButton)
         self.view.normalise_ShutterCount_CheckBox = mock.create_autospec(QCheckBox)
         self.view.addBtn = mock.create_autospec(QPushButton)
+        self.view.exportTabs = mock.create_autospec(QTabWidget)
         self.view.tof_mode_select_group = mock.create_autospec(QActionGroup)
         self.view.tofPropertiesGroupBox = mock.create_autospec(QGroupBox)
         self.presenter = SpectrumViewerWindowPresenter(self.view, self.main_window)


### PR DESCRIPTION
### Issue

Close #2242 

### Description

When a stack is modified from the main window (e.g. deleted), the spectrum viewer now checks to see if there is an imagestack available to display. If no data is available (i.e. all data has been deleted), then the Export Tab area is disabled. This prevents a KeyError from occurring when changing ExportTab while there is no imagestack.

### Testing 

make check

### Acceptance Criteria 

1. Open MI and load in data
2. Open the Spectrum Viewer
3. In the Main Window, delete the data you just loaded in
4. Check in the Spectrum Viewer that no sample stacks are available and that the Export Tabs have been disabled, and therefore no error occurs.
5. In the Main Window, load in some more data.
6. Check that the Export Tabs have now been re-enabled and function as normal.

### Documentation

Will add release note
