### PR TITLE
Release doc action fix 2

### DIFF
--- a/.github/actions/publish-docs/action.yml
+++ b/.github/actions/publish-docs/action.yml
@@ -26,6 +26,7 @@ runs:
       cd gh-pages
 
       git rm -r -q -- ${dir_name}/[!0-9]* || true # remove everything apart from versioned directories
+      mkdir -p ${dir_name}
       cp -a ../docs/build/html/* ${dir_name}
       md5sum ${dir_name}/index.html # if no index then there must have been a problem
       if [ "$(git status --porcelain | wc -l)" -gt "0" ] ; then


### PR DESCRIPTION
### Issue

Doc deploy failed again because the directory did not exist
https://github.com/mantidproject/mantidimaging/actions/runs/9853764049/job/27205018978

```
cp: target '2.8.0' is not a directory
```


### Description

Use `mkdir -p` so it will create the directory, but not fail if it already exists.