### PR TITLE
FLASH: Upgrade Pyinstaller to 6.7.*

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -27,7 +27,7 @@ dependencies:
   - coveralls==3.3.*
   - pyfakefs==5.3.*
   - parameterized==0.9.*
-  - pyinstaller==6.1.*
+  - pyinstaller==6.7.*
   - make==4.3
   - ruff=0.3.3
   - pre-commit==3.5.*


### PR DESCRIPTION
### Description

`Pyinstaller` has been updated to version 6.7.*. 
This solves an issue where `No module named 'pkg_resources.extern'` error occurs when building using `Pyinstaller`. We normally get this module from `setuptools` but the way modules were imported changed recently with version 70.0.0. `Pyinstaller` was updated to take this into account and use a workaround. More details can be found here:

https://github.com/pypa/setuptools/issues/4374
