### PR TITLE
Backport: upgrade pyinstaller to 6.7

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -27,7 +27,7 @@ dependencies:
   - coveralls==3.3.*
   - pyfakefs==5.3.*
   - parameterized==0.9.*
-  - pyinstaller==6.1.*
+  - pyinstaller==6.7.*
   - make==4.3
   - ruff=0.3.3
   - pre-commit==3.5.*


### PR DESCRIPTION
Backport #2262 to release 2.8
