### PR TITLE
Cherry picks from 2.8 to main

### DIFF
--- a/.github/actions/publish-docs/action.yml
+++ b/.github/actions/publish-docs/action.yml
@@ -25,7 +25,7 @@ runs:
       git worktree add --track -b gh-pages gh-pages origin/gh-pages
       cd gh-pages
 
-      git rm -r -q -- ${dir_name}/[!0-9]* # remove everything apart from versioned directories
+      git rm -r -q -- ${dir_name}/[!0-9]* || true # remove everything apart from versioned directories
       cp -a ../docs/build/html/* ${dir_name}
       md5sum ${dir_name}/index.html # if no index then there must have been a problem
       if [ "$(git status --porcelain | wc -l)" -gt "0" ] ; then

--- a/.github/actions/publish-docs/action.yml
+++ b/.github/actions/publish-docs/action.yml
@@ -26,6 +26,7 @@ runs:
       cd gh-pages
 
       git rm -r -q -- ${dir_name}/[!0-9]* || true # remove everything apart from versioned directories
+      mkdir -p ${dir_name}
       cp -a ../docs/build/html/* ${dir_name}
       md5sum ${dir_name}/index.html # if no index then there must have been a problem
       if [ "$(git status --porcelain | wc -l)" -gt "0" ] ; then

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -77,13 +77,13 @@ jobs:
           make build-docs
 
       - name: publish docs
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: ./.github/actions/publish-docs
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: publish docs release
-        if: startsWith(github.ref, 'refs/heads/release')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release')
         uses: ./.github/actions/publish-docs
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/release_notes/2.8.rst
+++ b/docs/release_notes/2.8.rst
@@ -1,0 +1,52 @@
+Mantid Imaging 2.8
+==================
+
+New Features
+------------
+- #2046 : Enhancement: Implement Click Dialog for Changing ROI Colors in Table
+- #2051: Move operations to compute_function style
+- #2067 : Add ConfigurationManager Class to operations_tests.py
+- #2094: Add ShutterCount File type.
+- #2094: Front-end for loading ShutterCount files into Mantid Imaging.
+- #2094: Apply ShutterCount Normalisation within Spectrum Viewer
+- #2133: The Spectrum plot in the Spectrum Viewer can be zoomed via a click and drag zoom-box
+- #2144: MI UI theme can be changed in runtime via a settings menu
+- #2151: Neutron wavelength, energy and tof units can be selected in the Spectrum Viewer
+- #2151: Time of Flight user properties can be set in the Spectrum Viewer
+- #2206: Improve output naming for reconstructed slices and volumes
+- #2216: Add Wavelength, ToF and Energy unit conversions to Spectrum Viewer CSV Output
+- #2230: Create checkbox that can be toggled on or off to apply ShutterCount correction to ToF data within the spectrum viewer window
+
+Fixes
+-----
+- #2053: Fix unreliable tests due to viewbox
+- #2076: ROI speed up
+- #2113: Spectrum Viewer stacks now update with Main Window after operation applied
+- #2129 : fix menu position for new pyqtgraph
+- #2129 : fix: Pytest failure AttributeError: 'ImageStack' object has no attribute 'shape
+- #2167: The Spectrum Viewer no longer produces in different sizes
+- #2185: NaN warning icon now appears in the Spectrum Viewer when NaN are in averaged image
+- #2204: Live viewer, handle notification quickly and defer slow work
+- #2209: Mantid Imaging now switches between Fusion and qt-material themes correctly
+- #2219: Live viewer: informative error if live directory deleted
+- #2246: Don't duplicate ROI names after stack modification
+- #2250: A bug where a lock object was trying to be pickled has not been fixed, the median filter is now functional.
+
+Developer Changes
+-----------------
+- #1985 : Backend work for TGV reconstruction
+- #2008: Update mypy, remove --no-site-packages, fix issues
+- #2035: Add setting for number of processes to start in multiprocessing pool (default to 8)
+- #2080: Switch to pydata documentation theme
+- #2082: Normal, System, and Screenshot test are now explicitly separated in the Makefile
+- #2107: Fix operation test param defaults
+- #2109: Allow tuple params in operation test cases
+- #2114: Update ruff and fix some new warnings
+- #2116 : Don't run test suite when only doc changes
+- #2139 : Doc extensions: use StringList instead of ViewList
+- #2172: Unit tests for the UnitConversion class
+- #2177: Added unit tests for the Time of Flight user properties in the Spectrum Viewer
+- #2183 : Update CIL to 24.0, numpy 1.23, scipy 1.8
+- #2196 : Cancel in progress test runs when new commit pushed
+- #2213 : unit tests have been added to check that the Time of Flight modes behave correctly when switching between stacks
+- #2250 : Make systems tests stricter to catch operations errors

--- a/docs/release_notes/2.8.rst
+++ b/docs/release_notes/2.8.rst
@@ -31,6 +31,7 @@ Fixes
 - #2219: Live viewer: informative error if live directory deleted
 - #2246: Don't duplicate ROI names after stack modification
 - #2250: A bug where a lock object was trying to be pickled has not been fixed, the median filter is now functional.
+- #2242: In the Spectrum Viewer, the Export Tabs now disable when no image stacks are available to prevent a KeyError
 
 Developer Changes
 -----------------

--- a/docs/release_notes/2.8.rst
+++ b/docs/release_notes/2.8.rst
@@ -1,6 +1,16 @@
 Mantid Imaging 2.8
 ==================
 
+Mantid Imaging 2.8.0 continues to expand the capability to work with energy resolved imaging data.
+
+It is now possible to do a shutter count correction when normalising transmission data. The spectrum view can do unit conversion to show and export data in wavelength, energy or time of flight, with the ability to set path length and offset. The spectrum viewer now allows zoom by holding Ctrl and dragging a box and makes it easier to change ROI colours. NaN warnings have been added to the spectrum viewer.
+
+A settings dialog has been added which can be used to change themes and adjust the number of threads used for running operations. Note that themes are not well tested yet.
+
+There have been many bug fixes. The live viewer is now usable with large directories. Working with ROIs is more reliable.
+
+MI now has updated many dependent packages bringing performance improvements. There have been improvements to testing, type annotations and static analysis. Migration of operations to compute function style is almost complete. These changes improve stability and help developers find bugs faster.
+
 New Features
 ------------
 - #2046 : Enhancement: Implement Click Dialog for Changing ROI Colors in Table

--- a/docs/release_notes/index.rst
+++ b/docs/release_notes/index.rst
@@ -6,6 +6,7 @@ Release Notes
    :caption: Contents:
 
    next
+   2.8
    2.7
    2.6
    2.5

--- a/docs/release_notes/next/dev-1985-tgv-backend
+++ b/docs/release_notes/next/dev-1985-tgv-backend
@@ -1,1 +1,0 @@
-#1985 : Backend work for TGV reconstruction

--- a/docs/release_notes/next/dev-2008-mypy-site-packages
+++ b/docs/release_notes/next/dev-2008-mypy-site-packages
@@ -1,1 +1,0 @@
-#2008: Update mypy, remove --no-site-packages, fix issues

--- a/docs/release_notes/next/dev-2035-process-count
+++ b/docs/release_notes/next/dev-2035-process-count
@@ -1,1 +1,0 @@
-#2035: Add setting for number of processes to start in multiprocessing pool (default to 8)

--- a/docs/release_notes/next/dev-2080-sphinx-pydata
+++ b/docs/release_notes/next/dev-2080-sphinx-pydata
@@ -1,1 +1,0 @@
-#2080: Switch to pydata documentation theme

--- a/docs/release_notes/next/dev-2082-pytest_separation
+++ b/docs/release_notes/next/dev-2082-pytest_separation
@@ -1,1 +1,0 @@
-#2082: Normal, System, and Screenshot test are now explicitly separated in the Makefile

--- a/docs/release_notes/next/dev-2107-operation-test-params
+++ b/docs/release_notes/next/dev-2107-operation-test-params
@@ -1,1 +1,0 @@
-#2107: Fix operation test param defaults

--- a/docs/release_notes/next/dev-2109-operation-test-tuple
+++ b/docs/release_notes/next/dev-2109-operation-test-tuple
@@ -1,1 +1,0 @@
-#2109: Allow tuple params in operation test cases

--- a/docs/release_notes/next/dev-2114-update-ruff
+++ b/docs/release_notes/next/dev-2114-update-ruff
@@ -1,1 +1,0 @@
-#2114: Update ruff and fix some new warnings

--- a/docs/release_notes/next/dev-2116-tests-not-docs
+++ b/docs/release_notes/next/dev-2116-tests-not-docs
@@ -1,1 +1,0 @@
-#2116 : Don't run test suite when only doc changes

--- a/docs/release_notes/next/dev-2139-use-stringlist
+++ b/docs/release_notes/next/dev-2139-use-stringlist
@@ -1,1 +1,0 @@
-#2139 : Doc extensions: use StringList instead of ViewList

--- a/docs/release_notes/next/dev-2172-unit-conversion-tests
+++ b/docs/release_notes/next/dev-2172-unit-conversion-tests
@@ -1,1 +1,0 @@
-#2172: Unit tests for the UnitConversion class

--- a/docs/release_notes/next/dev-2177-spectrum-viewer-ToF-tests
+++ b/docs/release_notes/next/dev-2177-spectrum-viewer-ToF-tests
@@ -1,1 +1,0 @@
-#2177: Added unit tests for the Time of Flight user properties in the Spectrum Viewer

--- a/docs/release_notes/next/dev-2183-update-cil
+++ b/docs/release_notes/next/dev-2183-update-cil
@@ -1,2 +1,0 @@
-#2183 : Update CIL to 24.0, numpy 1.23, scipy 1.8
-

--- a/docs/release_notes/next/dev-2195-cancel-in-progress
+++ b/docs/release_notes/next/dev-2195-cancel-in-progress
@@ -1,1 +1,0 @@
-#2196 : Cancel in progress test runs when new commit pushed

--- a/docs/release_notes/next/dev-2213-spectrum-stack-switch-tests
+++ b/docs/release_notes/next/dev-2213-spectrum-stack-switch-tests
@@ -1,1 +1,0 @@
-#2213 : unit tests have been added to check that the Time of Flight modes behave correctly when switching between stacks

--- a/docs/release_notes/next/dev-2250-catch-operations-errors
+++ b/docs/release_notes/next/dev-2250-catch-operations-errors
@@ -1,2 +1,0 @@
-#2250 : Make systems tests stricter to catch operations errors
-

--- a/docs/release_notes/next/feature-2046-ROI_Colors _table
+++ b/docs/release_notes/next/feature-2046-ROI_Colors _table
@@ -1,1 +1,0 @@
-#2046 : Enhancement: Implement Click Dialog for Changing ROI Colors in Table

--- a/docs/release_notes/next/feature-2051-operations
+++ b/docs/release_notes/next/feature-2051-operations
@@ -1,1 +1,0 @@
-#2051: Move operations to compute_function style

--- a/docs/release_notes/next/feature-2067-configManger
+++ b/docs/release_notes/next/feature-2067-configManger
@@ -1,2 +1,0 @@
-#2067 : Add ConfigurationManager Class to operations_tests.py
-

--- a/docs/release_notes/next/feature-2094-Load_ShutterCount_files_front-end
+++ b/docs/release_notes/next/feature-2094-Load_ShutterCount_files_front-end
@@ -1,1 +1,0 @@
-#2094: Front-end for loading ShutterCount files into Mantid Imaging.

--- a/docs/release_notes/next/feature-2094-load_shuttercounts
+++ b/docs/release_notes/next/feature-2094-load_shuttercounts
@@ -1,1 +1,0 @@
-#2094: Add ShutterCount File type.

--- a/docs/release_notes/next/feature-2095-apply_shuttercounts_normalisation
+++ b/docs/release_notes/next/feature-2095-apply_shuttercounts_normalisation
@@ -1,1 +1,0 @@
-#2094: Apply ShutterCount Normalisation within Spectrum Viewer

--- a/docs/release_notes/next/feature-2133-zoomable-spectrum-plot
+++ b/docs/release_notes/next/feature-2133-zoomable-spectrum-plot
@@ -1,1 +1,0 @@
-#2133: The Spectrum plot in the Spectrum Viewer can be zoomed via a click and drag zoom-box

--- a/docs/release_notes/next/feature-2144-UI-theme-settings
+++ b/docs/release_notes/next/feature-2144-UI-theme-settings
@@ -1,1 +1,0 @@
-#2144: MI UI theme can be changed in runtime via a settings menu

--- a/docs/release_notes/next/feature-2151-spectrum-viewer-ToF-units
+++ b/docs/release_notes/next/feature-2151-spectrum-viewer-ToF-units
@@ -1,1 +1,0 @@
-#2151: Neutron wavelength, energy and tof units can be selected in the Spectrum Viewer

--- a/docs/release_notes/next/feature-2151-tof-user-properties
+++ b/docs/release_notes/next/feature-2151-tof-user-properties
@@ -1,1 +1,0 @@
-#2151: Time of Flight user properties can be set in the Spectrum Viewer

--- a/docs/release_notes/next/feature-2206-recon_file_naming
+++ b/docs/release_notes/next/feature-2206-recon_file_naming
@@ -1,1 +1,0 @@
-#2206: Improve output naming for reconstructed slices and volumes

--- a/docs/release_notes/next/feature-2216-export_tof_wavelength_and_energy_to_csv
+++ b/docs/release_notes/next/feature-2216-export_tof_wavelength_and_energy_to_csv
@@ -1,1 +1,0 @@
-#2216: Add Wavelength, ToF and Energy unit conversions to Spectrum Viewer CSV Output

--- a/docs/release_notes/next/feature-2230-ShutterCount_Correction_CheckBox
+++ b/docs/release_notes/next/feature-2230-ShutterCount_Correction_CheckBox
@@ -1,1 +1,0 @@
-#2230: Create checkbox that can be toggled on or off to apply ShutterCount correction to ToF data within the spectrum viewer window

--- a/docs/release_notes/next/fix-2053-viewbox-test-fail
+++ b/docs/release_notes/next/fix-2053-viewbox-test-fail
@@ -1,1 +1,0 @@
-#2053: Fix unreliable tests due to viewbox

--- a/docs/release_notes/next/fix-2076-ROI-speed
+++ b/docs/release_notes/next/fix-2076-ROI-speed
@@ -1,1 +1,0 @@
-#2076: ROI speed up

--- a/docs/release_notes/next/fix-2113-spectrum-viewer-sync-stacks
+++ b/docs/release_notes/next/fix-2113-spectrum-viewer-sync-stacks
@@ -1,1 +1,0 @@
-#2113: Spectrum Viewer stacks now update with Main Window after operation applied

--- a/docs/release_notes/next/fix-2119-pyqt-menu
+++ b/docs/release_notes/next/fix-2119-pyqt-menu
@@ -1,1 +1,0 @@
-#2129 : fix menu position for new pyqtgraph

--- a/docs/release_notes/next/fix-2129-median_cuda
+++ b/docs/release_notes/next/fix-2129-median_cuda
@@ -1,1 +1,0 @@
-#2129 : fix: Pytest failure AttributeError: 'ImageStack' object has no attribute 'shape

--- a/docs/release_notes/next/fix-2167-spectrum-viewer-window-sizing
+++ b/docs/release_notes/next/fix-2167-spectrum-viewer-window-sizing
@@ -1,1 +1,0 @@
-#2167: The Spectrum Viewer no longer produces in different sizes

--- a/docs/release_notes/next/fix-2185-spectrum-nan-warning
+++ b/docs/release_notes/next/fix-2185-spectrum-nan-warning
@@ -1,1 +1,0 @@
-#2185: NaN warning icon now appears in the Spectrum Viewer when NaN are in averaged image

--- a/docs/release_notes/next/fix-2204-live-viewer-fast-notifiy
+++ b/docs/release_notes/next/fix-2204-live-viewer-fast-notifiy
@@ -1,1 +1,0 @@
-#2204: Live viewer, handle notification quickly and defer slow work

--- a/docs/release_notes/next/fix-2209-theme_os_startup_instability
+++ b/docs/release_notes/next/fix-2209-theme_os_startup_instability
@@ -1,1 +1,0 @@
-#2209: Mantid Imaging now switches between Fusion and qt-material themes correctly

--- a/docs/release_notes/next/fix-2219-live-view-del-dir
+++ b/docs/release_notes/next/fix-2219-live-view-del-dir
@@ -1,1 +1,0 @@
-#2219: Live viewer: informative error if live directory deleted

--- a/docs/release_notes/next/fix-2242-spectrum-viewer-keyerror-export-tab
+++ b/docs/release_notes/next/fix-2242-spectrum-viewer-keyerror-export-tab
@@ -1,1 +1,0 @@
-#2242: In the Spectrum Viewer, the Export Tabs now disable when no image stacks are available to prevent a KeyError

--- a/docs/release_notes/next/fix-2246-roi-name-dupe
+++ b/docs/release_notes/next/fix-2246-roi-name-dupe
@@ -1,1 +1,0 @@
-#2246: Don't duplicate ROI names after stack modification

--- a/docs/release_notes/next/fix-2250-median-filter
+++ b/docs/release_notes/next/fix-2250-median-filter
@@ -1,1 +1,0 @@
-#2250: A bug where a lock object was trying to be pickled has not been fixed, the median filter is now functional.


### PR DESCRIPTION
### Issue

Part of #2249

~~Needs #2266~~

### Description
Cherry-pick changes from the release branch through to main

### Testing 

This is stuff that was tested on the release branch

### Acceptance Criteria 

Compare to https://github.com/mantidproject/mantidimaging/commits/release-2.8.0/

### Documentation

Not needed
