### PR TITLE
Update environment files for stable branch

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,7 +5,8 @@ channels:
   - conda-forge
   - ccpi
   - algotom
-  - intel
+  # https://github.com/mantidproject/mantidimaging/issues/2272
+  - samtygier-stfc/label/mirror
 dependencies:
   - mantidimaging>=2.8.0,<2.9.0
   - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,13 +1,13 @@
 name: mantidimaging-dev
 channels:
-  - mantidimaging/label/unstable
+  - mantidimaging/label/main
   - astra-toolbox
   - conda-forge
   - ccpi
   - algotom
   - intel
 dependencies:
-  - mantidimaging>=2.5.0
+  - mantidimaging>=2.8.0,<2.9.0
   - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774
   - pip
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
-name: mantidimaging-nightly
+name: mantidimaging
 channels:
-  - mantidimaging/label/unstable
+  - mantidimaging/label/main
   - astra-toolbox
   - conda-forge
   - ccpi
@@ -8,5 +8,5 @@ channels:
   - intel
 # Dependencies that can be installed with conda should be in conda/meta.yaml
 dependencies:
-  - mantidimaging>=2.5.0
+  - mantidimaging>=2.8.0,<2.9.0
   - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,8 @@ channels:
   - conda-forge
   - ccpi
   - algotom
-  - intel
+  # https://github.com/mantidproject/mantidimaging/issues/2272
+  - samtygier-stfc/label/mirror
 # Dependencies that can be installed with conda should be in conda/meta.yaml
 dependencies:
   - mantidimaging>=2.8.0,<2.9.0


### PR DESCRIPTION
### Issue

Update environment files for stable branch

This includes switching to a mirror to work around #2272 

### Description

These will become the files used for
`mamba env create -f https://raw.githubusercontent.com/mantidproject/mantidimaging/stable/environment.yml`

### Testing & Acceptance Criteria 

Check that an environment can be made with
`mamba env create -f environment.yml`

### Documentation
Not needed
