### PR TITLE
Live Viewer Image Timestamp

### DIFF
--- a/docs/release_notes/next/feature-2273-live-view-img-timestamp
+++ b/docs/release_notes/next/feature-2273-live-view-img-timestamp
@@ -1,0 +1,1 @@
+#2273: Display the modified image timestamp within the live viewer to allow for easier determination of what scan is being displayed within the live viewer. 

--- a/mantidimaging/eyes_tests/live_viewer_window_test.py
+++ b/mantidimaging/eyes_tests/live_viewer_window_test.py
@@ -1,20 +1,26 @@
 # Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+
 from __future__ import annotations
-
+from typing import TYPE_CHECKING
 from unittest import mock
-
 import numpy as np
-
+import os
 from mantidimaging.core.operations.loader import load_filter_packages
 from mantidimaging.gui.windows.live_viewer.model import Image_Data
 from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
 from pathlib import Path
-
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
+
+if TYPE_CHECKING:
+    import time  # noqa: F401
 
 
 class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.initial_time = 4000.0
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -30,26 +36,30 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
     def _generate_image(self):
         image = np.zeros((10, 10))
         image[5, :] = np.arange(10)
+        os.utime(self.live_directory, (10, self.initial_time))
+        self.initial_time += 1000
         return image
 
     def _make_simple_dir(self, directory: Path):
         file_list = [directory / f"abc_{i:06d}.tif" for i in range(5)]
-        if not directory.exists():
-            self.fs.create_dir(directory)
-
+        increment = 0
         for file in file_list:
             self.fs.create_file(file)
+            os.utime(file, (10, self.initial_time + increment))
+            increment += 1000
 
         return file_list
 
     @mock.patch('mantidimaging.gui.windows.live_viewer.model.ImageWatcher')
-    def test_live_view_opens_without_data(self, _mock_image_watcher):
+    @mock.patch("time.time", return_value=4000.0)
+    def test_live_view_opens_without_data(self, _mock_time, _mock_image_watcher):
         self.imaging.show_live_viewer(self.live_directory)
         self.check_target(widget=self.imaging.live_viewer)
 
     @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image')
     @mock.patch('mantidimaging.gui.windows.live_viewer.model.ImageWatcher')
-    def test_live_view_opens_with_data(self, _mock_image_watcher, mock_load_image):
+    @mock.patch("time.time", return_value=4000.0)
+    def test_live_view_opens_with_data(self, _mock_time, _mock_image_watcher, mock_load_image):
         file_list = self._make_simple_dir(self.live_directory)
         image_list = [Image_Data(path) for path in file_list]
         mock_load_image.return_value = self._generate_image()
@@ -59,7 +69,8 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
 
     @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image')
     @mock.patch('mantidimaging.gui.windows.live_viewer.model.ImageWatcher')
-    def test_live_view_opens_with_bad_data(self, _mock_image_watcher, mock_load_image):
+    @mock.patch("time.time", return_value=4000.0)
+    def test_live_view_opens_with_bad_data(self, _mock_time, _mock_image_watcher, mock_load_image):
         file_list = self._make_simple_dir(self.live_directory)
         image_list = [Image_Data(path) for path in file_list]
         mock_load_image.side_effect = ValueError
@@ -69,7 +80,8 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
 
     @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image')
     @mock.patch('mantidimaging.gui.windows.live_viewer.model.ImageWatcher')
-    def test_rotate_operation_rotates_image(self, _mock_image_watcher, mock_load_image):
+    @mock.patch("time.time", return_value=4000.0)
+    def test_rotate_operation_rotates_image(self, _mock_time, _mock_image_watcher, mock_load_image):
         file_list = self._make_simple_dir(self.live_directory)
         image_list = [Image_Data(path) for path in file_list]
         mock_load_image.return_value = self._generate_image()

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -55,6 +55,11 @@ class Image_Data:
         """Return the image modified time"""
         return self._stat.st_mtime
 
+    @property
+    def image_modified_time_stamp(self) -> str:
+        """Return the image modified time as a string"""
+        return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(self.image_modified_time))
+
 
 class SubDirectory:
 

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -78,7 +78,8 @@ class LiveViewerWindowPresenter(BasePresenter):
         if not self.model.images:
             return
         self.selected_image = self.model.images[index]
-        self.view.label_active_filename.setText(self.selected_image.image_name)
+        image_timestamp = self.selected_image.image_modified_time_stamp
+        self.view.label_active_filename.setText(f"{self.selected_image.image_name} - {image_timestamp}")
 
         self.display_image(self.selected_image.image_path)
 


### PR DESCRIPTION
### Issue

Closes #2273 

### Description

*Add a description of the changes made*.
Modify Live Viewer window current image label to display the modified file timestamp to improved distinguishability between two scans which overwrite the same file, but look similar. 

### Testing 

*Describe the tests that were used to verify your changes*.
- Manually tested using simulate live viewer utility script. 

### Acceptance Criteria 

*How should the reviewer test your changes*?
- The Live Viewer displays the current image filename and corresponding timestamp

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*

`docs/release_notes/next/feature-2273-live-view-img-timestamp`
