### PR TITLE
Workaround broken intel repo

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,7 +5,8 @@ channels:
   - conda-forge
   - ccpi
   - algotom
-  - intel
+  # https://github.com/mantidproject/mantidimaging/issues/2272
+  - samtygier-stfc/label/mirror
 dependencies:
   - mantidimaging>=2.5.0
   - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,8 @@ channels:
   - conda-forge
   - ccpi
   - algotom
-  - intel
+  # https://github.com/mantidproject/mantidimaging/issues/2272
+  - samtygier-stfc/label/mirror
 # Dependencies that can be installed with conda should be in conda/meta.yaml
 dependencies:
   - mantidimaging>=2.5.0


### PR DESCRIPTION
### Issue

Workaround for #2272

### Description

The intel conda mirror has been unreliable recently. Switch to a mirror as a workaround until this is resolved.

Use a mirror populated with packages files from our local caches.

### Testing 

If the tests pass then this as worked

### Documentation

Not needed
