### PR TITLE
Updated Pyinstaller and h5py

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - cupy=10.2.*
     - astra-toolbox=2.0.*
     - requests=2.27.*
-    - h5py=3.6.*
+    - h5py=3.7.*
     - psutil=5.9.*
     - cil=24.0.*
     - ccpi-regulariser

--- a/docs/release_notes/next/dev-2269-update-pyinstaller
+++ b/docs/release_notes/next/dev-2269-update-pyinstaller
@@ -1,0 +1,1 @@
+#2269: Pyinstaller and h5py packages have been upgraded to 6.9.* and 3.7.* respectively

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -28,7 +28,7 @@ dependencies:
   - coveralls==3.3.*
   - pyfakefs==5.3.*
   - parameterized==0.9.*
-  - pyinstaller==6.7.*
+  - pyinstaller==6.9.*
   - make==4.3
   - ruff=0.3.3
   - pre-commit==3.5.*

--- a/packaging/PackageWithPyInstaller.py
+++ b/packaging/PackageWithPyInstaller.py
@@ -47,6 +47,8 @@ def add_hidden_imports(run_options):
     run_options.extend(add_conda_dynamic_libs('tomopy', 'tomo'))
     run_options.extend(add_conda_dynamic_libs('mkl', 'mkl'))
     run_options.extend(add_conda_dynamic_libs('cupy', 'nvrtc'))
+    run_options.extend(add_conda_dynamic_libs('curl', 'ssl'))
+    run_options.extend(add_conda_dynamic_libs('curl', 'crypto'))
 
 
 def add_missing_submodules(run_options):


### PR DESCRIPTION
### Issue

Closes #2269

### Description

Pyinstaller has been upgraded to a newer version 6.7.0 -> 6.9.0 to help with issues around Pyinstaller dealing with issues related to `setuptool` imports. In order to avoid dependency clashes, `h5py` has also been upgraded from 3.6 -> 3.7.

### Acceptance Criteria 

Rebuild the dev environment with `python setup.py create_dev_env` and make sure that the environment builds correctly.
If you can, make a Windows build via instructions here: https://stfc365.sharepoint.com/:w:/r/sites/mantidimaging/_layouts/15/doc2.aspx?sourcedoc=%7Bad7f061e-d554-4734-b9ac-eafb29b3d43b%7D&action=edit&wdPid=7fdef645

```
python ./setup.py create_dev_env 
conda activate mantidimaging-dev 
cd packaging 
python PackageWithPyInstaller.py 
```

This would make an `.exe` file in the `packaging` folder, which should work as normal.

### Documentation

Will add release note
