### PR TITLE
Upgrade packages post 2.8 release

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - scikit-image=0.19.*
     - tifffile=2023.7.18
     - imagecodecs=2023.1.23
-    - numpy=1.23.*
+    - numpy=1.24.*
     - numexpr=2.8.*
     - algotom=1.0.*
     - tomopy=1.12.*

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - imagecodecs=2023.1.23
     - numpy=1.26.*
     - numexpr=2.8.*
-    - algotom=1.0.*
+    - algotom=1.6.*
     - tomopy=1.12.*
     - cudatoolkit=11.8.*
     - cupy=10.2.*

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -27,14 +27,14 @@ requirements:
     - algotom=1.6.*
     - tomopy=1.12.*
     - cudatoolkit=11.8.*
-    - cupy=10.2.*
-    - astra-toolbox=2.0.*
+    - cupy=12.3.*
+    - astra-toolbox=2.0.0
     - requests=2.27.*
     - h5py=3.7.*
     - psutil=5.9.*
     - cil=24.0.*
     - ccpi-regulariser
-    - jenkspy=0.2.0
+    - jenkspy=0.4.*
     - pyqt=5.15.*
     - pyqtgraph=0.13.7
     - qt-material=2.14

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - python=3.10.*
     - pip
     - astropy=5.0.*
-    - scipy=1.8.*
+    - scipy=1.13.*
     - scikit-image=0.19.*
     - tifffile=2023.7.18
     - imagecodecs=2023.1.23

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - python=3.10.*
     - pip
     - astropy=5.0.*
-    - scipy=1.13.*
+    - scipy=1.14.*
     - scikit-image=0.19.*
     - tifffile=2023.7.18
     - imagecodecs=2023.1.23

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -22,11 +22,11 @@ requirements:
     - scikit-image=0.19.*
     - tifffile=2023.7.18
     - imagecodecs=2023.1.23
-    - numpy=1.24.*
+    - numpy=1.26.*
     - numexpr=2.8.*
     - algotom=1.0.*
     - tomopy=1.12.*
-    - cudatoolkit=10.2*
+    - cudatoolkit=11.8.*
     - cupy=10.2.*
     - astra-toolbox=2.0.*
     - requests=2.27.*

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -17,7 +17,7 @@ requirements:
   run:
     - python=3.10.*
     - pip
-    - astropy=5.0.*
+    - astropy=6.0.*
     - scipy=1.14.*
     - scikit-image=0.19.*
     - tifffile=2023.7.18

--- a/docs/release_notes/next/dev-2268-upgrade-packages
+++ b/docs/release_notes/next/dev-2268-upgrade-packages
@@ -1,0 +1,1 @@
+#2268: various python packages have been updated including astropy, scipy, nu,py, algotom, cudatoolkit, cupy, and jenkspy

--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -84,7 +84,8 @@ class AstraRecon(BaseRecon):
         return num_gpus
 
     @staticmethod
-    def find_cor(images: ImageStack, slice_idx: int, start_cor: float, recon_params: ReconstructionParameters) -> float:
+    def find_cor(images: ImageStack, slice_idx: int, start_cor: float | np.ndarray,
+                 recon_params: ReconstructionParameters) -> float:
         """
         Find the best CoR for this slice by maximising the squared sum of the reconstructed slice.
 
@@ -96,7 +97,7 @@ class AstraRecon(BaseRecon):
         def get_sumsq(image: np.ndarray) -> float:
             return np.sum(image**2)
 
-        def minimizer_function(cor: float):
+        def minimizer_function(cor: float) -> float:
             return -get_sumsq(AstraRecon.single_sino(images.sino(slice_idx), ScalarCoR(cor), proj_angles, recon_params))
 
         return minimize(minimizer_function, start_cor, method='nelder-mead', tol=0.1).x[0]

--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -97,7 +97,9 @@ class AstraRecon(BaseRecon):
         def get_sumsq(image: np.ndarray) -> float:
             return np.sum(image**2)
 
-        def minimizer_function(cor: float) -> float:
+        def minimizer_function(cor: float | np.ndarray) -> float:
+            if isinstance(cor, np.ndarray):
+                cor = float(cor[0])
             return -get_sumsq(AstraRecon.single_sino(images.sino(slice_idx), ScalarCoR(cor), proj_angles, recon_params))
 
         return minimize(minimizer_function, start_cor, method='nelder-mead', tol=0.1).x[0]

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -51,8 +51,6 @@ class ScalarCoR(SingleValue):
     value: float
 
     def to_vec(self, detector_width):
-        if isinstance(self.value, np.ndarray):
-            self.value = float(self.value[0])
         return VectorCoR(detector_width / 2 - self.value)
 
 

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -14,6 +14,8 @@ from enum import Enum
 from dataclasses import dataclass
 from typing import Any, NamedTuple, TYPE_CHECKING
 
+import numpy as np
+
 if TYPE_CHECKING:
     import numpy
 
@@ -49,6 +51,8 @@ class ScalarCoR(SingleValue):
     value: float
 
     def to_vec(self, detector_width):
+        if isinstance(self.value, np.ndarray):
+            self.value = float(self.value[0])
         return VectorCoR(detector_width / 2 - self.value)
 
 

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -14,8 +14,6 @@ from enum import Enum
 from dataclasses import dataclass
 from typing import Any, NamedTuple, TYPE_CHECKING
 
-import numpy as np
-
 if TYPE_CHECKING:
     import numpy
 


### PR DESCRIPTION
### Issue

Closes #2268, progresses #2267.

### Description

This PR updates the following packages used in MI:

`astropy` = 5.0.* -> 6.0.*
`scipy` = 1.8.* -> 1.14.*
`numpy` = 1.23.* -> 1.26.*
`algotom` = 1.0.* -> 1.6.*
`cudatoolkit` = 10.2.* -> 11.8.*
`cupy` = 10.2.* -> 12.3.*
`jenkspy` = 0.2.0 = 0.4.*


### Testing 

make check

### Acceptance Criteria 

Check that you can rebuild the dev environment without any conflicts with
`python ./setup.py create_dev_env`
and then MI runs as normal.

NOTE: There will be some depreciation warnings related to `numpy`, these will be dealt with in a future PR.
Also, some packages have been updated even though they were not in the original scope as there were conflicts with the dependencies of the packages we were trying to upgrade, e.g. `numpy` and `scipy`

### Documentation

Will add release note
