### PR TITLE
Fix Monitor Normalization Error for 180-Degree Stack

### DIFF
--- a/docs/release_notes/next/fix-2222-Monitor-normalisation-RuntimeError-No-logfile-stack
+++ b/docs/release_notes/next/fix-2222-Monitor-normalisation-RuntimeError-No-logfile-stack
@@ -1,0 +1,2 @@
+2222: Monitor normalisation: RuntimeError: No logfile available for this stack.
+

--- a/mantidimaging/core/operations/base_filter.py
+++ b/mantidimaging/core/operations/base_filter.py
@@ -28,6 +28,7 @@ class BaseFilter:
     link_histograms = False
     show_negative_overlay = True
     operate_on_sinograms = False
+    allow_for_180_projection = True
 
     SINOGRAM_FILTER_INFO = "This filter will work on a\nsinogram view of the data."
 

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -31,6 +31,7 @@ class MonitorNormalisation(BaseFilter):
     """
     filter_name = "Monitor Normalisation"
     link_histograms = True
+    allow_for_180_projection = False
 
     @staticmethod
     def filter_func(images: ImageStack, progress=None) -> ImageStack:

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -277,10 +277,11 @@ class FiltersWindowPresenter(BasePresenter):
                         use_new_data = self._wait_for_stack_choice(stack, stack.id)
                     # if the stack that was kept happened to have a proj180 stack - then apply the filter to that too
                     if stack.has_proj180deg() and use_new_data and not self.applying_to_all:
-                        # Apply to proj180 synchronously - this function is already running async
-                        # and running another async instance causes a race condition in the parallel module
-                        # where the shared data can be removed in the middle of the operation of another operation
-                        self._do_apply_filter_sync([stack.proj180deg])
+                        if self.model.selected_filter.allow_for_180_projection:
+                            # Apply to proj180 synchronously - this function is already running async
+                            # and running another async instance causes a race condition in the parallel module
+                            # where the shared data can be removed in the middle of the operation of another operation
+                            self._do_apply_filter_sync([stack.proj180deg])
                 if np.any(stack.data < 0):
                     negative_stacks.append(stack)
 


### PR DESCRIPTION
### Issue

Fix Monitor Normalization Error for 180-Degree Stack (#2222)

### Description

Added a condition to check if the stack name contains '180deg'.
If the stack is identified as the 180-degree stack, normalization is skipped, and a progress message is reported.
This prevents errors related to missing log files for the 180-degree stack.

### Testing 

Load a Dataset with a Log File: Loaded a dataset that includes both sample and 180-degree stacks with appropriate log files for the sample stack.

Perform Monitor Normalization:
Expected Behavior: Normalization is applied only to the sample stack.
Observed Behavior: The function successfully skips the 180-degree stack and applies normalization to the sample stack without errors.

### Acceptance Criteria 

Load a Dataset: Ensure that the dataset includes both sample and 180-degree stacks, with the log file available for the sample stack only.
Run Monitor Normalization: Execute the monitor normalization operation.
Check for Errors: Verify that no errors occur during the normalization process.

### Documentation

Updated the release notes to include the bug fix for monitor normalization.
