### PR TITLE
Fix numpy deprecation warnings

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - astra-toolbox=2.0.0
     - requests=2.27.*
     - h5py=3.9.*
+    - hdf5=1.14.2
     - psutil=5.9.*
     - cil=24.0.*
     - ccpi-regulariser

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - cupy=12.3.*
     - astra-toolbox=2.0.0
     - requests=2.27.*
-    - h5py=3.7.*
+    - h5py=3.9.*
     - psutil=5.9.*
     - cil=24.0.*
     - ccpi-regulariser

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - pip
     - astropy=6.0.*
     - scipy=1.14.*
-    - scikit-image=0.19.*
+    - scikit-image=0.20.*
     - tifffile=2023.7.18
     - imagecodecs=2023.1.23
     - numpy=1.26.*

--- a/docs/release_notes/next/dev-2289-fix-numpy-deprecation
+++ b/docs/release_notes/next/dev-2289-fix-numpy-deprecation
@@ -1,0 +1,1 @@
+#2289: updated packages to deal with numpy deprecation warnings leading towards 2.0


### PR DESCRIPTION
### Issue

Closes #2289.
Requires PR #2280

### Description

As we are upgrading the version of `Numpy`, a few of the other dependencies start showing DeprecationWarnings leading up to `Numpy 1.25.0` and `2.0.` Some of the dependencies have been updated to a point where these changes have been dealt with by the authors of our dependancies. 

### Testing 

make check
make test-system

### Acceptance Criteria 

Make sure that you can rebuild the dev env with no installation or dependency conflicts.
Run all tests and make sure that no DeprecationWarnings show for `Numpy`, an example of which can be seen in the linked issue #2289.
Ensure that MI runs as normal!

### Documentation

Will add release note