### PR TITLE
Show attribute names in leak tracker

### DIFF
--- a/docs/release_notes/next/dev-2267-leak-tracker
+++ b/docs/release_notes/next/dev-2267-leak-tracker
@@ -1,0 +1,1 @@
+#2267: Show attribute names in leak tracker

--- a/mantidimaging/core/utility/leak_tracker.py
+++ b/mantidimaging/core/utility/leak_tracker.py
@@ -25,6 +25,11 @@ def obj_to_string(obj, relative=None) -> str:
         keys = {k for k, v in obj.items() if v is relative}
         extra_info += f" keys={keys}"
 
+    if hasattr(obj, '__dict__') and relative is not None:
+        attribute_names = {k for k, v in obj.__dict__.items() if v is relative}
+        if attribute_names:
+            extra_info += f" attribute={attribute_names}"
+
     try:
         if hasattr(obj, "name"):
             extra_info += f" obj.name={obj.name}"
@@ -69,7 +74,6 @@ def find_owners(obj, depth: int, path: list[str] | None = None, ignore: set[int]
             all_routes.extend(new_routes)
         else:
             all_routes.append(route)
-
     return all_routes
 
 

--- a/mantidimaging/core/utility/test/leak_tracker_test.py
+++ b/mantidimaging/core/utility/test/leak_tracker_test.py
@@ -18,7 +18,7 @@ class ExampleContainer:
         self.held_reference = obj
 
 
-class CommandLineArgumentsTest(unittest.TestCase):
+class LeakTrackerTest(unittest.TestCase):
 
     def setUp(self) -> None:
         self.leak_tracker = LeakTracker()


### PR DESCRIPTION
Needed for 3.11 classes with lazy dictionaries

### Issue
Needed for python 3.11 update ( see #2267 ), but works fine with 3.10

### Description

In python 3.11 classes only create the dictionary object if needed ( https://github.com/faster-cpython/ideas/issues/72 ).

When finding owners for objects in the leak tracker, and having an object held by a class like:
```python
class ExampleObject:
    pass

class ExampleContainer:
    def __init__(self, obj):
        self.held_reference = obj

ob1 = ExampleObject()
container = ExampleContainer(ob1)
```
previously we `gc.get_referrers(ob1)` would give us the `dict` (i.e. `container.__dict__`) and from that we would find the key. Now `gc.get_referrers(ob1)` gives us the instance, and it is not clear which attribute it is.

The change add a case for a class, and adds the attribute name to `extra_info`. The act of looking at the `__dict__` causes it to be created, so that we can get the name.

Also fix the test class name.

### Testing 

This fixes the leaktracker test when running with python 3.11 and above

### Acceptance Criteria 

Tests should pass

### Documentation

release notes
