### PR TITLE
Upgrade to python 3.12 

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,6 +18,8 @@ concurrency:
 jobs:
   test:
     runs-on: windows-latest
+    env:
+      CONDA_OVERRIDE_CUDA: 11.8
 
     steps:
       - uses: actions/checkout@v4

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -12,16 +12,16 @@ source:
 
 requirements:
   build:
-    - python=3.10.*
+    - python=3.12.*
     - setuptools=62.*
   run:
-    - python=3.10.*
+    - python=3.12.*
     - pip
     - astropy=6.0.*
     - scipy=1.14.*
-    - scikit-image=0.20.*
+    - scikit-image=0.22.*
     - tifffile=2023.7.18
-    - imagecodecs=2023.1.23
+    - imagecodecs=2023.9.18
     - numpy=1.26.*
     - numexpr=2.8.*
     - algotom=1.6.*

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - tomopy=1.12.*
     - cudatoolkit=11.8.*
     - cupy=12.3.*
-    - astra-toolbox=2.0.0
+    - astra-toolbox=2.1.0=cuda*
     - requests=2.27.*
     - h5py=3.9.*
     - hdf5=1.14.2

--- a/docs/release_notes/next/dev-2267-upgrade-python
+++ b/docs/release_notes/next/dev-2267-upgrade-python
@@ -1,0 +1,1 @@
+#2267: Python has been upgraded to use version 3.12

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -24,8 +24,8 @@ dependencies:
   - pytest-xdist==3.3.*
   - testfixtures==7.2.*
   - gitpython==3.1.*
-  - coverage==6.5.*
-  - coveralls==3.3.*
+  - coverage==7.3.*
+  - coveralls==4.0.*
   - pyfakefs==5.3.*
   - parameterized==0.9.*
   - pyinstaller==6.9.*

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,7 +1,6 @@
 name: mantidimaging-dev
 channels:
   - mantidimaging/label/unstable
-  - astra-toolbox
   - conda-forge
   - ccpi
   - algotom

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: mantidimaging-nightly
 channels:
   - mantidimaging/label/unstable
-  - astra-toolbox
   - conda-forge
   - ccpi
   - algotom

--- a/mantidimaging/core/data/test/image_stack_test.py
+++ b/mantidimaging/core/data/test/image_stack_test.py
@@ -244,7 +244,7 @@ class ImageStackTest(unittest.TestCase):
         self.assertRaises(ValueError, lambda a, b: a == b, data_images, 1.0)
 
     def test_cant_change_id(self):
-        with self.assertRaisesRegex(Exception, "can't set attribute"):
+        with self.assertRaises(AttributeError):
             generate_images().id = "id"
 
     def test_default_name(self):

--- a/mantidimaging/core/data/test/strictdataset_test.py
+++ b/mantidimaging/core/data/test/strictdataset_test.py
@@ -50,7 +50,7 @@ class StrictDatasetTest(unittest.TestCase):
         self.assertIsNone(dataset.dark_after)
 
     def test_cant_change_dataset_id(self):
-        with self.assertRaisesRegex(Exception, "set attribute"):
+        with self.assertRaises(AttributeError):
             self.strict_dataset.id = "id"
 
     def test_set_flat_before(self):

--- a/packaging/PackageWithPyInstaller.py
+++ b/packaging/PackageWithPyInstaller.py
@@ -55,7 +55,7 @@ def add_hidden_imports(run_options):
 
 
 def add_missing_submodules(run_options):
-    imports = ['cupy']
+    imports = ['cupy', 'cupy_backends']
     run_options.extend([f'--collect-submodules={name}' for name in imports])
 
 


### PR DESCRIPTION
### Issue

Closes #2267
Requires #2280 and #2291 

### Description

This PR upgrades MI to be built with `Python 3.12`, the latest version of Python.
This PR will need to be rebased after #2280 is merged!

### Testing 

`make check`
`make test-system`

### Acceptance Criteria 

Run all tests and check that MI runs as normal without any issues or warnings, this transition should be seemless.

### Documentation

Release note
