### PR TITLE
Exclude builtin test.support modules from being loaded with Operation Modules

### DIFF
--- a/mantidimaging/core/operations/loader.py
+++ b/mantidimaging/core/operations/loader.py
@@ -20,9 +20,11 @@ def _find_operation_modules() -> list[BaseFilterClass]:
         if not ispkg:
             continue
 
-        if getattr(sys, 'frozen', False) and "test.support" not in module_name:
-            # If we're running a PyInstaller executable then we need to use a full module path
+        if getattr(sys, 'frozen', False):
             # Need to prevent importing standard library test modules found by pkgutil
+            if "test.support" in module_name:
+                continue
+            # If we're running a PyInstaller executable then we need to use a full module path
             module_name = f'mantidimaging.core.operations.{module_name}'
 
         # near impossible to type check as find can be a pyinstaller specific type that we can't normally import

--- a/mantidimaging/core/operations/loader.py
+++ b/mantidimaging/core/operations/loader.py
@@ -20,8 +20,9 @@ def _find_operation_modules() -> list[BaseFilterClass]:
         if not ispkg:
             continue
 
-        if getattr(sys, 'frozen', False):
+        if getattr(sys, 'frozen', False) and "test.support" not in module_name:
             # If we're running a PyInstaller executable then we need to use a full module path
+            # Need to prevent importing standard library test modules found by pkgutil
             module_name = f'mantidimaging.core.operations.{module_name}'
 
         # near impossible to type check as find can be a pyinstaller specific type that we can't normally import

--- a/packaging/PackageWithPyInstaller.py
+++ b/packaging/PackageWithPyInstaller.py
@@ -38,7 +38,10 @@ def add_hidden_imports(run_options):
     path_to_operations = Path(__file__).parent.parent.joinpath('mantidimaging/core/operations')
     # COMPAT python 3.10 won't accept a Path: github.com/python/cpython/issues/88227
     for _, ops_module, _ in pkgutil.walk_packages([str(path_to_operations)]):
-        imports.append(f'mantidimaging.core.operations.{ops_module}')
+        # stop non-existent Hidden Imports
+        # https://github.com/mantidproject/mantidimaging/issues/2298
+        if "test.support" not in ops_module:
+            imports.append(f'mantidimaging.core.operations.{ops_module}')
 
     run_options.extend([f'--hidden-import={name}' for name in imports])
 


### PR DESCRIPTION
### Issue

Closes #2298

### Description

In both `mantidimaging/core/operations/loader.py` and `packaging/PackageWithPyInstaller.py` we now check if the module name aligns with that in the builtin test modules and exclude it if it does.

### Testing 

make check

### Acceptance Criteria 

rebuild dev env
make a Windows build via `packaging/PackageWithPyInstaller.py`
check that the Windows build does not contain any AssertionErrors related to the Operations modules.


### Documentation

release note