### PR TITLE
Pyinstaller add libcurl libraries

### DIFF
--- a/docs/release_notes/next/dev-2300-pyinstaller-libcurl
+++ b/docs/release_notes/next/dev-2300-pyinstaller-libcurl
@@ -1,0 +1,1 @@
+#2300: Pyinstaller add libcurl libraries

--- a/packaging/PackageWithPyInstaller.py
+++ b/packaging/PackageWithPyInstaller.py
@@ -50,8 +50,8 @@ def add_hidden_imports(run_options):
     run_options.extend(add_conda_dynamic_libs('tomopy', 'tomo'))
     run_options.extend(add_conda_dynamic_libs('mkl', 'mkl'))
     run_options.extend(add_conda_dynamic_libs('cupy', 'nvrtc'))
-    run_options.extend(add_conda_dynamic_libs('curl', 'ssl'))
-    run_options.extend(add_conda_dynamic_libs('curl', 'crypto'))
+    run_options.extend(add_conda_dynamic_libs('libcurl', 'ssl'))
+    run_options.extend(add_conda_dynamic_libs('libcurl', 'crypto'))
 
 
 def add_missing_submodules(run_options):


### PR DESCRIPTION
### Issue

Closes #2300 

### Description

When adding extra libraries to the pyinstaller package using `add_conda_dynamic_libs` use `libcurl` rather than `curl`.

### Acceptance Criteria 

Build package with pyinstaller

### Documentation

release notes
