### PR TITLE
Change from centos7 Dockerfile to rocky8

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -60,11 +60,11 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ubuntu18
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Build and push Centos Docker image
+      - name: Build and push Rocky8 Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: ./docker/centos7.Dockerfile
+          file: ./docker/rocky8.Dockerfile
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:centos7
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:rocky8
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker/rocky8.Dockerfile
+++ b/docker/rocky8.Dockerfile
@@ -3,7 +3,7 @@
 # This Dockerfile creates a developer image. It requires that the following things are mounted:
 # - Mantid Imaging source at /opt/mantidimaging.
 
-FROM centos:centos7
+FROM rockylinux:8
 
 WORKDIR /opt/
 


### PR DESCRIPTION
### Issue

Closes #2296

### Description

Due to Centos7 reaching End of Life, we have migrated towards Rocky8 to match IDaaS.

### Testing 

I locally built the failing Centos7 Dockerfile to confirm the error before switching to Rocky8 and confirming that the Docker Image built succesfully.

### Acceptance Criteria 

Check in the Github Actions that the Docker Images have been built successfully.
The Docker tags will have to be re-enabled first!

### Documentation

release note
