### PR TITLE
Fix conda package build with python 3.12

### DIFF
--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -31,7 +31,7 @@ runs:
       conda config --set always_yes yes --set changeps1 no
       # Install build requirements
       # We can't use the makefile target for this because the CONDA_ACTIVATE command is incompatible with GitHub Actions Windows runners
-      conda create -n build-env --yes boa anaconda-client conda-verify
+      conda create -n build-env --yes boa anaconda-client
       conda activate build-env
       # Configure the conda channels
       conda config --env $(cat environment.yml | sed -ne '/channels:/,/dependencies:/{//!p}' | grep '^  -' | sed 's/ - / --append channels /g' | tr -d '\n')

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -13,7 +13,7 @@ source:
 requirements:
   build:
     - python=3.12.*
-    - setuptools=62.*
+    - setuptools=72.*
   run:
     - python=3.12.*
     - pip


### PR DESCRIPTION
### Issue

Closes #2305

### Description

Remove conda-verify as it causes our build environment to use python 3.11 which causes build failure.

### Testing 

I have made a test commit to run the build action.

### Acceptance Criteria 

Check that build stage in [ebbc824](https://github.com/mantidproject/mantidimaging/pull/2306/commits/ebbc824278ad025b3152dc23f6efd8280f9b0f4c) ran

### Documentation
Not needed
