### PR TITLE
Unify datasets part 4

### DIFF
--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -119,13 +119,6 @@ class BaseDataset:
             raise RuntimeError("Can't set a 180 projection without a sample")
         self.sample.proj180deg = proj180deg
 
-
-class MixedDataset(BaseDataset):
-    pass
-
-
-class StrictDataset(BaseDataset):
-
     @property
     def _nexus_stack_order(self) -> list[ImageStack]:
         return list(filter(None, [self.dark_before, self.flat_before, self.sample, self.flat_after, self.dark_after]))
@@ -158,6 +151,13 @@ class StrictDataset(BaseDataset):
         if self.dark_after is not None:
             image_keys += _image_key_list(2, self.dark_after.data.shape[0])
         return image_keys
+
+
+class MixedDataset(BaseDataset):
+    pass
+
+
+class StrictDataset(BaseDataset):
 
     def delete_stack(self, images_id: uuid.UUID) -> None:
         if isinstance(self.sample, ImageStack) and self.sample.id == images_id:

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -174,13 +174,6 @@ class BaseDataset:
         else:
             raise AttributeError(f"StrictDataset does not have an attribute for {attr_name}")
 
-
-class MixedDataset(BaseDataset):
-    pass
-
-
-class StrictDataset(BaseDataset):
-
     @property
     def is_processed(self) -> bool:
         """
@@ -190,6 +183,14 @@ class StrictDataset(BaseDataset):
             if image.is_processed:
                 return True
         return False
+
+
+class MixedDataset(BaseDataset):
+    pass
+
+
+class StrictDataset(BaseDataset):
+    pass
 
 
 def _get_stack_data_type(stack_id: uuid.UUID, dataset: BaseDataset) -> str:

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -165,13 +165,6 @@ class BaseDataset:
             image_keys += _image_key_list(2, self.dark_after.data.shape[0])
         return image_keys
 
-
-class MixedDataset(BaseDataset):
-    pass
-
-
-class StrictDataset(BaseDataset):
-
     def set_stack(self, file_type: FILE_TYPES, image_stack: ImageStack) -> None:
         attr_name = file_type.fname.lower().replace(" ", "_")
         if file_type == FILE_TYPES.PROJ_180:
@@ -180,6 +173,13 @@ class StrictDataset(BaseDataset):
             setattr(self, attr_name, image_stack)
         else:
             raise AttributeError(f"StrictDataset does not have an attribute for {attr_name}")
+
+
+class MixedDataset(BaseDataset):
+    pass
+
+
+class StrictDataset(BaseDataset):
 
     @property
     def is_processed(self) -> bool:

--- a/mantidimaging/core/data/test/dataset_test.py
+++ b/mantidimaging/core/data/test/dataset_test.py
@@ -105,3 +105,30 @@ class DatasetTest(unittest.TestCase):
         images_id = images.id
         dataset = BaseDataset(stacks=[images])
         self.assertEqual(_get_stack_data_type(images_id, dataset), "Images")
+
+    def test_attribute_not_set_returns_none(self):
+        sample = mock.Mock()
+        dataset = BaseDataset(sample=sample)
+
+        self.assertIsNone(dataset.flat_before)
+        self.assertIsNone(dataset.flat_after)
+        self.assertIsNone(dataset.dark_before)
+        self.assertIsNone(dataset.dark_after)
+
+    def test_set_flat_before(self):
+        sample = mock.Mock()
+        dataset = BaseDataset(sample=sample)
+        flat_before = mock.Mock(id="1234")
+        dataset.flat_before = flat_before
+        self.assertIs(flat_before, dataset.flat_before)
+        self.assertIn("1234", dataset)
+
+    def test_all_images_ids(self):
+        self.images = [generate_images() for _ in range(5)]
+        self.strict_dataset = BaseDataset(sample=self.images[0],
+                                          flat_before=self.images[1],
+                                          flat_after=self.images[2],
+                                          dark_before=self.images[3],
+                                          dark_after=self.images[4])
+
+        self.assertCountEqual(self.strict_dataset.all_image_ids, [images.id for images in self.images])

--- a/mantidimaging/core/data/test/dataset_test.py
+++ b/mantidimaging/core/data/test/dataset_test.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.dataset import BaseDataset, _get_stack_data_type
-from mantidimaging.core.utility.data_containers import ProjectionAngles
+from mantidimaging.core.utility.data_containers import ProjectionAngles, FILE_TYPES
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
 
@@ -256,3 +256,26 @@ class DatasetTest(unittest.TestCase):
         ds, images = _make_standard_dataset()
         ds.delete_stack(images[4].id)
         self.assertIsNone(ds.dark_after)
+
+    def test_set_stack_by_type_sample(self):
+        ds = BaseDataset()
+        sample = mock.Mock()
+        ds.set_stack(FILE_TYPES.SAMPLE, sample)
+
+        self.assertEqual(ds.sample, sample)
+
+    def test_set_stack_by_type_flat_before(self):
+        ds = BaseDataset()
+        stack = mock.Mock()
+        ds.set_stack(FILE_TYPES.FLAT_BEFORE, stack)
+
+        self.assertEqual(ds.flat_before, stack)
+
+    def test_set_stack_by_type_180(self):
+        ds = BaseDataset()
+        sample = mock.Mock()
+        stack = mock.Mock()
+        ds.set_stack(FILE_TYPES.SAMPLE, sample)
+        ds.set_stack(FILE_TYPES.PROJ_180, stack)
+
+        self.assertEqual(ds.proj180deg, stack)

--- a/mantidimaging/core/data/test/dataset_test.py
+++ b/mantidimaging/core/data/test/dataset_test.py
@@ -231,3 +231,28 @@ class DatasetTest(unittest.TestCase):
         ]
 
         assert np.array_equal(expected_list, ds.nexus_rotation_angles)
+
+    def test_delete_sample(self):
+        ds, images = _make_standard_dataset()
+        ds.delete_stack(images[0].id)
+        self.assertIsNone(ds.sample)
+
+    def test_delete_flat_before(self):
+        ds, images = _make_standard_dataset()
+        ds.delete_stack(images[1].id)
+        self.assertIsNone(ds.flat_before)
+
+    def test_delete_flat_after(self):
+        ds, images = _make_standard_dataset()
+        ds.delete_stack(images[2].id)
+        self.assertIsNone(ds.flat_after)
+
+    def test_delete_dark_before(self):
+        ds, images = _make_standard_dataset()
+        ds.delete_stack(images[3].id)
+        self.assertIsNone(ds.dark_before)
+
+    def test_delete_dark_after(self):
+        ds, images = _make_standard_dataset()
+        ds.delete_stack(images[4].id)
+        self.assertIsNone(ds.dark_after)

--- a/mantidimaging/core/data/test/dataset_test.py
+++ b/mantidimaging/core/data/test/dataset_test.py
@@ -70,6 +70,22 @@ class DatasetTest(unittest.TestCase):
         ds = BaseDataset(stacks=image_stacks)
         self.assertListEqual(ds.all, image_stacks)
 
+    def test_sample_in_all(self):
+        image_sample = mock.Mock(proj180deg=None)
+        ds = BaseDataset(sample=image_sample)
+        self.assertCountEqual(ds.all, [image_sample])
+
+    def test_all_for_full_dataset(self):
+        image_180 = mock.Mock(0)
+        image_sample = mock.Mock(proj180deg=image_180)
+        image_stacks = [mock.Mock() for _ in range(4)]
+        ds = BaseDataset(sample=image_sample,
+                         flat_before=image_stacks[0],
+                         flat_after=image_stacks[1],
+                         dark_before=image_stacks[2],
+                         dark_after=image_stacks[3])
+        self.assertCountEqual(ds.all, image_stacks + [image_sample, image_180])
+
     def test_delete_stack_from_stacks_list(self):
         image_stacks = [mock.Mock() for _ in range(3)]
         ds = BaseDataset(stacks=image_stacks)

--- a/mantidimaging/core/data/test/dataset_test.py
+++ b/mantidimaging/core/data/test/dataset_test.py
@@ -279,3 +279,12 @@ class DatasetTest(unittest.TestCase):
         ds.set_stack(FILE_TYPES.PROJ_180, stack)
 
         self.assertEqual(ds.proj180deg, stack)
+
+    def test_processed_is_true(self):
+        ds = BaseDataset(sample=generate_images())
+        ds.sample.record_operation("", "")
+        self.assertTrue(ds.is_processed)
+
+    def test_processed_is_false(self):
+        ds = BaseDataset(sample=generate_images())
+        self.assertFalse(ds.is_processed)


### PR DESCRIPTION
### Issue

Work on #2199

~~Needs #2295 merged first~~

### Description

This moves the remaining functionality from `StrictDataset` to `BaseDataset`.

`StrictDataset`, `MixedDataset` are now just aliases for `BaseDataset`

### Testing 

All existing tests are still there and pass. New tests added to `BaseDataset`

### Acceptance Criteria 

Open a dataset
Delete a stack from a dataset

### Documentation

Not yet