### PR TITLE
Fix add or replace stack in dataset

### DIFF
--- a/docs/release_notes/next/fix-2315-add-replace-stack
+++ b/docs/release_notes/next/fix-2315-add-replace-stack
@@ -1,0 +1,1 @@
+#2315: Fix adding or replacing a stack within a dataset 

--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -235,6 +235,7 @@ class TestGuiSystemLoading(GuiSystemBase):
         self.assertEqual(100, list(self.main_window.presenter.datasets)[0].sample.data.shape[0])
 
         self.main_window.dataset_tree_widget.topLevelItem(0).setSelected(True)
+        self._check_datasets_consistent()
 
         self.main_window._add_images_to_existing_dataset()
         QTest.qWait(SHORT_DELAY)
@@ -246,5 +247,51 @@ class TestGuiSystemLoading(GuiSystemBase):
 
         self.main_window.add_to_dataset_dialog.accepted.emit()
         QTest.qWait(SHORT_DELAY)
-
+        self._check_datasets_consistent()
         self.assertEqual(20, list(self.main_window.presenter.datasets)[0].sample.data.shape[0])
+
+    def _check_datasets_consistent(self, show_datasets=False) -> None:
+        print("_check_datasets_consistent")
+        if show_datasets:
+            print("Main window datasets")
+            for k, v in self.main_window.presenter.model.datasets.items():
+                print("  dataset:", k)
+                for image_stack in v.all:
+                    print("    ", image_stack.id, image_stack.name)
+            print("Main window visualisers/tabs")
+            for vis in self.main_window.presenter.get_active_stack_visualisers():
+                print("  ", vis.id, vis.name)
+            print("Main window treeview")
+            for i in range(self.main_window.dataset_tree_widget.topLevelItemCount()):
+                tree_ds = self.main_window.dataset_tree_widget.topLevelItem(i)
+                print(f"  dataset: {tree_ds.id} {tree_ds.text(0)}")
+                for j in range(tree_ds.childCount()):
+                    tree_is = tree_ds.child(j)
+                    print(f"    {tree_is.id} {tree_is.text(0)}")
+
+        # Datasets
+        open_dataset_ids = list(self.main_window.presenter.model.datasets.keys())
+        self.assertEqual(len(open_dataset_ids), len(set(open_dataset_ids)))
+        image_stack_ids = self.main_window.presenter.model.image_ids
+        self.assertEqual(len(image_stack_ids), len(set(image_stack_ids)))
+
+        # Visualisers/Tabs
+        visualiser_ids = [vis.id for vis in self.main_window.presenter.get_active_stack_visualisers()]
+        self.assertEqual(len(visualiser_ids), len(set(visualiser_ids)))
+        self.assertEqual(len(visualiser_ids), len(image_stack_ids))
+        for visualiser_id in visualiser_ids:
+            self.assertIn(visualiser_id, image_stack_ids)
+
+        #Tree view
+        tree_datasets = [
+            self.main_window.dataset_tree_widget.topLevelItem(i)
+            for i in range(self.main_window.dataset_tree_widget.topLevelItemCount())
+        ]
+        tree_image_stack_ids = []
+        self.assertEqual(len(open_dataset_ids), len(tree_datasets))
+        for tree_dataset in tree_datasets:
+            self.assertIn(tree_dataset.id, open_dataset_ids)
+            for i in range(tree_dataset.childCount()):
+                tree_image_stack_ids.append(tree_dataset.child(i).id)
+        self.assertEqual(len(tree_image_stack_ids), len(set(tree_image_stack_ids)))
+        self.assertEqual(len(tree_image_stack_ids), len(image_stack_ids))

--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -28,6 +28,7 @@ class TestGuiSystemLoading(GuiSystemBase):
 
     def tearDown(self) -> None:
         self._close_image_stacks()
+        self._check_datasets_consistent()
         super().tearDown()
         self.assertFalse(self.main_window.isVisible())
 
@@ -43,6 +44,7 @@ class TestGuiSystemLoading(GuiSystemBase):
             return (current_stacks - initial_stacks) >= 1
 
         wait_until(test_func, max_retry=600)
+        self._check_datasets_consistent()
 
     @classmethod
     def _click_stack_selector(cls):
@@ -89,6 +91,7 @@ class TestGuiSystemLoading(GuiSystemBase):
         self.assertEqual(len(stacks_after), 5)
         self.assertIn(stacks[0], stacks_after)
         self.assertTrue(stacks[0].presenter.images.has_proj180deg())
+        self._check_datasets_consistent()
 
     def _get_log_angle(self, log_path):
         with open(log_path) as log_file:

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -61,12 +61,16 @@ class MainWindowModel:
         return ds
 
     def load_images_into_mixed_dataset(self, file_path: str, progress: Progress) -> MixedDataset:
-        group = FilenameGroup.from_file(Path(file_path))
-        group.find_all_files()
-        images = loader.load_stack_from_group(group, progress)
+        images = self.load_image_stack(file_path, progress)
         sd = MixedDataset(stacks=[images], name=images.name)
         self.datasets[sd.id] = sd
         return sd
+
+    def load_image_stack(self, file_path: str, progress: Progress) -> ImageStack:
+        group = FilenameGroup.from_file(Path(file_path))
+        group.find_all_files()
+        images = loader.load_stack_from_group(group, progress)
+        return images
 
     def do_images_saving(self, images_id: uuid.UUID, output_dir: str, name_prefix: str, image_format: str,
                          overwrite: bool, pixel_depth: str, progress: Progress) -> bool:

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -792,6 +792,9 @@ class MainWindowPresenter(BasePresenter):
         else:
             # the image type already exists in the dataset and needs to be replaced
             prev_images_id = getattr(dataset, image_attr).id
+            if image_attr == "sample" and dataset.proj180deg:
+                self._delete_stack(dataset.proj180deg.id)
+                self.remove_item_from_tree_view(dataset.proj180deg.id)
             self.replace_child_item_id(dataset.id, prev_images_id, new_images.id)
             self._delete_stack(prev_images_id)
 


### PR DESCRIPTION
### Issue
Closes #2315

### Description
An old refactoring (e4441731593dbeb0b9ce8d773141c905854bc820) had inlined the `load_image_stack` method without realising that it was used in `AddImagesToDatasetDialog`.

This restores a modern version of it, and adds a test.

Also fixes the issue of removing the old 180 projection when replacing the sample.

### Testing 

Added a system test for the case

### Acceptance Criteria 

Follow steps on #2315

### Documentation

Release notes
