### PR TITLE
Prune Docker images between Docker builds

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -60,6 +60,10 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ubuntu18
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Purge Docker
+        run: |
+          docker image prune -a -f
+
       - name: Build and push Rocky8 Docker image
         uses: docker/build-push-action@v4
         with:

--- a/docs/release_notes/next/dev-2313-docker-purge
+++ b/docs/release_notes/next/dev-2313-docker-purge
@@ -1,0 +1,1 @@
+#2313: Docker images are pruned after being built and pushed to free up storage space


### PR DESCRIPTION
### Issue

Closes #2313

### Description

We now add a pruning step in the Docker Build Github Action, so the Ubuntu Docker is built and published, then deleted such that there is space available to build and push the Rocky8 Docker image.


### Acceptance Criteria 

Verify that both the Ubuntu and Rocky8 Docker images have built and been pushed successfully here: https://github.com/mantidproject/mantidimaging/actions/runs/10403131433/job/28808990908?pr=2319

Both Docker images should appear here: https://github.com/mantidproject/mantidimaging/pkgs/container/mantidimaging


### Documentation

Release note