### PR TITLE
Unify datasets part 5

### DIFF
--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -22,7 +22,7 @@ def remove_nones(image_stacks: list[ImageStack | None]) -> list[ImageStack]:
     return [image_stack for image_stack in image_stacks if image_stack is not None]
 
 
-class BaseDataset:
+class Dataset:
 
     def __init__(
         self,
@@ -185,15 +185,15 @@ class BaseDataset:
         return False
 
 
-class MixedDataset(BaseDataset):
+class MixedDataset(Dataset):
     pass
 
 
-class StrictDataset(BaseDataset):
+class StrictDataset(Dataset):
     pass
 
 
-def _get_stack_data_type(stack_id: uuid.UUID, dataset: BaseDataset) -> str:
+def _get_stack_data_type(stack_id: uuid.UUID, dataset: Dataset) -> str:
     """
     Find the data type as a string of a stack.
     :param stack_id: The ID of the stack.

--- a/mantidimaging/eyes_tests/main_window_test.py
+++ b/mantidimaging/eyes_tests/main_window_test.py
@@ -87,11 +87,6 @@ class MainWindowTest(BaseEyesTest):
 
         self.check_target(widget=self.imaging.add_to_dataset_dialog)
 
-    def test_show_add_stack_to_existing_dataset_dialog_for_mixed_dataset(self):
-        self._create_mixed_dataset()
-        self.imaging.show_add_stack_to_existing_dataset_dialog(list(self.imaging.presenter.all_dataset_ids)[0])
-        self.check_target(widget=self.imaging.add_to_dataset_dialog)
-
     def test_clicking_tab_changes_tree_view_selection(self):
         self._load_strict_data_set()
         sample_vis = self._load_strict_data_set()

--- a/mantidimaging/gui/windows/add_images_to_dataset_dialog/test/view_test.py
+++ b/mantidimaging/gui/windows/add_images_to_dataset_dialog/test/view_test.py
@@ -22,7 +22,7 @@ class AddImagesToDatasetDialogTest(unittest.TestCase):
             self.main_window = MainWindowView()
         self.dataset_id = uuid.uuid4()
         self.dataset_name = "dataset-name"
-        self.view = AddImagesToDatasetDialog(self.main_window, self.dataset_id, True, self.dataset_name)
+        self.view = AddImagesToDatasetDialog(self.main_window, self.dataset_id, self.dataset_name)
         self.view.presenter = self.presenter = mock.MagicMock()
 
     def test_on_accepted(self):

--- a/mantidimaging/gui/windows/add_images_to_dataset_dialog/view.py
+++ b/mantidimaging/gui/windows/add_images_to_dataset_dialog/view.py
@@ -15,18 +15,15 @@ class AddImagesToDatasetDialog(BaseDialogView):
     filePathLineEdit: QLineEdit
     datasetNameText: QLabel
 
-    def __init__(self, parent, dataset_id: uuid.UUID, strict_dataset: bool, dataset_name: str):
+    def __init__(self, parent, dataset_id: uuid.UUID, dataset_name: str):
         super().__init__(parent, 'gui/ui/add_to_dataset.ui')
 
         self.parent_view = parent
         self.presenter = AddImagesToDatasetPresenter(self)
         self._dataset_id = dataset_id
 
-        if strict_dataset:
-            self.imageTypeComboBox.addItems(
-                ["Sample", "Flat Before", "Flat After", "Dark Before", "Dark After", "Recon"])
-        else:
-            self.imageTypeComboBox.addItems(["Images", "Recon"])
+        self.imageTypeComboBox.addItems(
+            ["Sample", "Flat Before", "Flat After", "Dark Before", "Dark After", "Recon", "Images"])
 
         self.datasetNameText.setText(dataset_name)
         self.chooseFileButton.clicked.connect(self.choose_file_path)

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import NoReturn, TYPE_CHECKING
 
 from mantidimaging.core.data import ImageStack
-from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
+from mantidimaging.core.data.dataset import StrictDataset, MixedDataset, Dataset
 from mantidimaging.core.io import loader, saver
 from mantidimaging.core.io.filenames import FilenameGroup
 from mantidimaging.core.io.loader.loader import LoadingParameters, ImageParameters
@@ -27,7 +27,7 @@ class MainWindowModel:
 
     def __init__(self) -> None:
         super().__init__()
-        self.datasets: dict[uuid.UUID, MixedDataset | StrictDataset] = {}
+        self.datasets: dict[uuid.UUID, Dataset] = {}
 
     def get_images_by_uuid(self, images_uuid: uuid.UUID) -> ImageStack | None:
         for dataset in self.datasets.values():
@@ -201,7 +201,7 @@ class MainWindowModel:
                     return ids_to_remove
         self.raise_error_when_images_not_found(container_id)
 
-    def add_dataset_to_model(self, dataset: StrictDataset | MixedDataset) -> None:
+    def add_dataset_to_model(self, dataset: Dataset) -> None:
         self.datasets[dataset.id] = dataset
 
     @property

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -102,8 +102,10 @@ class MainWindowModel:
         :return: The 180 ID if found, None otherwise.
         """
         dataset = self.datasets.get(dataset_id)
-        if not isinstance(dataset, StrictDataset):
-            raise RuntimeError(f"Failed to get StrictDataset with ID {dataset_id}")
+        if not dataset:
+            raise RuntimeError(f"Failed to get Dataset with ID {dataset_id}")
+        if not dataset.sample:
+            raise RuntimeError(f"Dataset with ID {dataset_id} does not have a sample")
 
         if isinstance(dataset.proj180deg, ImageStack):
             return dataset.proj180deg.id
@@ -116,13 +118,11 @@ class MainWindowModel:
         :param _180_deg_file: The location of the 180 projection.
         :return: The loaded 180 ImageStack object.
         """
-        if dataset_id in self.datasets:
-            dataset = self.datasets[dataset_id]
-        else:
+        dataset = self.datasets.get(dataset_id)
+        if not dataset:
             raise RuntimeError(f"Failed to get Dataset with ID {dataset_id}")
-
-        if not isinstance(dataset, StrictDataset):
-            raise RuntimeError(f"Wrong dataset type passed to add 180 method: {dataset_id}")
+        if not dataset.sample:
+            raise RuntimeError(f"Dataset with ID {dataset_id} does not have a sample")
 
         _180_deg = loader.load_stack_from_group(FilenameGroup.from_file(_180_deg_file))
         dataset.proj180deg = _180_deg

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -16,7 +16,7 @@ from PyQt5.QtWidgets import QTabBar, QApplication, QTreeWidgetItem
 from qt_material import apply_stylesheet
 
 from mantidimaging.core.data import ImageStack
-from mantidimaging.core.data.dataset import StrictDataset, MixedDataset, _get_stack_data_type
+from mantidimaging.core.data.dataset import StrictDataset, MixedDataset, _get_stack_data_type, Dataset
 from mantidimaging.core.io.loader.loader import create_loading_parameters_for_file_path
 from mantidimaging.core.io.utility import find_projection_closest_to_180, THRESHOLD_180
 from mantidimaging.core.utility.data_containers import ProjectionAngles
@@ -416,7 +416,7 @@ class MainWindowPresenter(BasePresenter):
         return sorted(stacks, key=lambda x: x.name)
 
     @property
-    def datasets(self) -> Iterable[MixedDataset | StrictDataset]:
+    def datasets(self) -> Iterable[Dataset]:
         return self.model.datasets.values()
 
     @property
@@ -442,7 +442,7 @@ class MainWindowPresenter(BasePresenter):
     def stack_visualiser_names(self) -> list[str]:
         return [widget.windowTitle() for widget in self.stack_visualisers.values()]
 
-    def get_dataset(self, dataset_id: uuid.UUID) -> MixedDataset | StrictDataset | None:
+    def get_dataset(self, dataset_id: uuid.UUID) -> Dataset | None:
         return self.model.datasets.get(dataset_id)
 
     def get_stack_visualiser(self, stack_id: uuid.UUID) -> StackVisualiserView:
@@ -757,7 +757,7 @@ class MainWindowPresenter(BasePresenter):
         self.create_single_tabbed_images_stack(new_images)
         self.view.model_changed.emit()
 
-    def _add_recon_to_dataset_and_tree_view(self, dataset: MixedDataset | StrictDataset, recon: ImageStack) -> None:
+    def _add_recon_to_dataset_and_tree_view(self, dataset: Dataset, recon: ImageStack) -> None:
         """
         Adds a recon to the dataset and updates the tree view.
         :param dataset: The dataset.
@@ -766,7 +766,7 @@ class MainWindowPresenter(BasePresenter):
         dataset.add_recon(recon)
         self.add_recon_item_to_tree_view(dataset.id, recon.id, recon.name)
 
-    def _add_images_to_existing_mixed_dataset(self, dataset: MixedDataset, new_images: ImageStack) -> None:
+    def _add_images_to_existing_mixed_dataset(self, dataset: Dataset, new_images: ImageStack) -> None:
         """
         Updates the stack list in the mixed dataset and updates the tree view.
         :param dataset: The MixedDataset to update.
@@ -775,8 +775,7 @@ class MainWindowPresenter(BasePresenter):
         dataset.add_stack(new_images)
         self.add_child_item_to_tree_view(dataset.id, new_images.id, new_images.name)
 
-    def _add_images_to_existing_strict_dataset(self, dataset: StrictDataset, new_images: ImageStack,
-                                               stack_type: str) -> None:
+    def _add_images_to_existing_strict_dataset(self, dataset: Dataset, new_images: ImageStack, stack_type: str) -> None:
         """
         Adds or replaces images in a StrictDataset and updates the tree view if required.
         :param dataset: The StrictDataset to change.

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -10,7 +10,7 @@ from parameterized import parameterized
 import numpy as np
 
 from mantidimaging.core.data import ImageStack
-from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
+from mantidimaging.core.data.dataset import StrictDataset, MixedDataset, Dataset
 from mantidimaging.core.io.loader.loader import LoadingParameters, ImageParameters
 from mantidimaging.core.utility.data_containers import ProjectionAngles, FILE_TYPES, Indices
 from mantidimaging.gui.windows.main import MainWindowModel
@@ -487,21 +487,21 @@ class MainWindowModelTest(unittest.TestCase):
             self.model.get_existing_180_id("bad-id")
 
     def test_wrong_dataset_type_for_180_raises(self):
-        md = MixedDataset()
+        md = Dataset()
         self.model.add_dataset_to_model(md)
 
         with self.assertRaises(RuntimeError):
             self.model.get_existing_180_id(md.id)
 
     def test_get_existing_180_id_finds_id(self):
-        sd = StrictDataset(sample=generate_images((5, 20, 20)))
+        sd = Dataset(sample=generate_images((5, 20, 20)))
         sd.proj180deg = _180 = generate_images((1, 20, 20))
         self.model.add_dataset_to_model(sd)
 
         assert self.model.get_existing_180_id(sd.id) == _180.id
 
     def test_get_existing_id_returns_none_for_dataset_without_180(self):
-        sd = StrictDataset(sample=generate_images((5, 20, 20)))
+        sd = Dataset(sample=generate_images((5, 20, 20)))
         self.model.add_dataset_to_model(sd)
 
         self.assertIsNone(self.model.get_existing_180_id(sd.id))

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -11,7 +11,7 @@ from unittest import mock
 import numpy as np
 from PyQt5.QtWidgets import QDialog
 
-from mantidimaging.core.data.dataset import StrictDataset, MixedDataset
+from mantidimaging.core.data.dataset import StrictDataset, MixedDataset, Dataset
 from mantidimaging.core.utility.data_containers import ProjectionAngles
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.main.presenter import Notification as PresNotification, Notification
@@ -200,24 +200,18 @@ class MainWindowViewTest(unittest.TestCase):
         QMessageBox.information.assert_called_once()
 
     def test_update_shortcuts_with_presenter_with_one_or_more_stacks(self):
-        self.presenter.datasets = [StrictDataset(sample=mock.Mock()), MixedDataset()]
+        self.presenter.datasets = [Dataset()]
 
-        self._update_shortcuts_test(False, True, True)
-        self._update_shortcuts_test(True, True, True)
-
-    def test_update_shortcuts_with_presenter_with_no_strict_datasets(self):
-        self.presenter.datasets = [MixedDataset(), MixedDataset()]
-
-        self._update_shortcuts_test(False, True, False)
-        self._update_shortcuts_test(True, True, False)
+        self._update_shortcuts_test(False, True)
+        self._update_shortcuts_test(True, True)
 
     def test_update_shortcuts_with_presenter_with_no_stacks(self):
         self.presenter.datasets = []
 
-        self._update_shortcuts_test(False, False, False)
-        self._update_shortcuts_test(True, False, False)
+        self._update_shortcuts_test(False, False)
+        self._update_shortcuts_test(True, False)
 
-    def _update_shortcuts_test(self, original_state, has_stacks, has_strict_datasets):
+    def _update_shortcuts_test(self, original_state, has_stacks):
         self.view.actionSaveImages.setEnabled(original_state)
         self.view.actionSampleLoadLog.setEnabled(original_state)
         self.view.actionLoad180deg.setEnabled(original_state)
@@ -229,7 +223,7 @@ class MainWindowViewTest(unittest.TestCase):
 
         self.assertEqual(has_stacks, self.view.actionSaveImages.isEnabled())
         self.assertEqual(has_stacks, self.view.actionSampleLoadLog.isEnabled())
-        self.assertEqual(has_strict_datasets, self.view.actionLoad180deg.isEnabled())
+        self.assertEqual(has_stacks, self.view.actionLoad180deg.isEnabled())
         self.assertEqual(has_stacks, self.view.actionLoadProjectionAngles.isEnabled())
         self.assertEqual(has_stacks, self.view.menuWorkflow.isEnabled())
         self.assertEqual(has_stacks, self.view.menuImage.isEnabled())

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -11,7 +11,7 @@ from unittest import mock
 import numpy as np
 from PyQt5.QtWidgets import QDialog
 
-from mantidimaging.core.data.dataset import StrictDataset, MixedDataset, Dataset
+from mantidimaging.core.data.dataset import Dataset
 from mantidimaging.core.utility.data_containers import ProjectionAngles
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.main.presenter import Notification as PresNotification, Notification
@@ -465,8 +465,8 @@ class MainWindowViewTest(unittest.TestCase):
         self.view._add_images_to_existing_dataset()
         self.presenter.notify.assert_called_once_with(PresNotification.SHOW_ADD_STACK_DIALOG, container_id=dataset_id)
 
-    def test_show_add_stack_to_existing_dataset_dialog_with_strict_dataset(self):
-        mock_strict_dataset = mock.Mock(spec=StrictDataset)
+    def test_show_add_stack_to_existing_dataset_dialog_with_dataset(self):
+        mock_strict_dataset = mock.Mock(spec=Dataset)
         mock_strict_dataset.id = strict_dataset_id = "strict-dataset-id"
         mock_strict_dataset.name = strict_dataset_name = "strict-dataset-name"
         self.presenter.get_dataset.return_value = mock_strict_dataset
@@ -474,18 +474,7 @@ class MainWindowViewTest(unittest.TestCase):
         with mock.patch("mantidimaging.gui.windows.main.view.AddImagesToDatasetDialog") as add_images_mock:
             self.view.show_add_stack_to_existing_dataset_dialog(strict_dataset_id)
 
-        add_images_mock.assert_called_once_with(self.view, strict_dataset_id, True, strict_dataset_name)
-
-    def test_show_add_stack_to_existing_dataset_dialog_with_mixed_dataset(self):
-        mock_mixed_dataset = mock.Mock(spec=MixedDataset)
-        mock_mixed_dataset.name = mixed_dataset_name = "mixed-dataset-name"
-        mixed_dataset_id = "mixed-dataset-id"
-        self.presenter.get_dataset.return_value = mock_mixed_dataset
-
-        with mock.patch("mantidimaging.gui.windows.main.view.AddImagesToDatasetDialog") as add_images_mock:
-            self.view.show_add_stack_to_existing_dataset_dialog(mixed_dataset_id)
-
-        add_images_mock.assert_called_once_with(self.view, mixed_dataset_id, False, mixed_dataset_name)
+        add_images_mock.assert_called_once_with(self.view, strict_dataset_id, strict_dataset_name)
 
     def test_tab_bar_clicked(self):
         mock_stack = mock.Mock()

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -228,13 +228,12 @@ class MainWindowView(BaseMainWindowView):
     def update_shortcuts(self) -> None:
         datasets = list(self.presenter.datasets)
         has_datasets = len(datasets) > 0
-        has_strict_datasets = any(isinstance(dataset, StrictDataset) for dataset in datasets)
 
         self.actionSaveImages.setEnabled(has_datasets)
-        self.actionSaveNeXusFile.setEnabled(has_strict_datasets)
+        self.actionSaveNeXusFile.setEnabled(has_datasets)
         self.actionSampleLoadLog.setEnabled(has_datasets)
         self.actionShutterCounts.setEnabled(has_datasets)
-        self.actionLoad180deg.setEnabled(has_strict_datasets)
+        self.actionLoad180deg.setEnabled(has_datasets)
         self.actionLoadProjectionAngles.setEnabled(has_datasets)
         self.menuWorkflow.setEnabled(has_datasets)
         self.menuImage.setEnabled(has_datasets)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -17,7 +17,6 @@ from PyQt5.QtWidgets import QAction, QDialog, QLabel, QMessageBox, QMenu, QFileD
     QTreeWidgetItem, QTreeWidget
 
 from mantidimaging.core.data import ImageStack
-from mantidimaging.core.data.dataset import StrictDataset
 from mantidimaging.core.io.utility import find_first_file_that_is_possibly_a_sample
 from mantidimaging.core.utility import finder
 from mantidimaging.core.utility.command_line_arguments import CommandLineArguments
@@ -766,8 +765,7 @@ class MainWindowView(BaseMainWindowView):
         dataset = self.presenter.get_dataset(dataset_id)
         if dataset is None:
             raise RuntimeError(f"Unable to find dataset with ID {dataset_id}")
-        self.add_to_dataset_dialog = AddImagesToDatasetDialog(self, dataset_id, isinstance(dataset, StrictDataset),
-                                                              dataset.name)
+        self.add_to_dataset_dialog = AddImagesToDatasetDialog(self, dataset_id, dataset.name)
         self.add_to_dataset_dialog.show()
 
     def _on_tab_bar_clicked(self, stack: StackVisualiserView) -> None:

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -47,7 +47,7 @@ from mantidimaging.gui.windows.wizard.presenter import WizardPresenter
 from mantidimaging.__main__ import process_start_time
 
 if TYPE_CHECKING:
-    from mantidimaging.core.data.dataset import MixedDataset
+    from mantidimaging.core.data.dataset import Dataset
 
 RECON_GROUP_TEXT = "Recons"
 SINO_TEXT = "Sinograms"
@@ -506,7 +506,7 @@ class MainWindowView(BaseMainWindowView):
     def get_dataset_id_from_stack_uuid(self, stack_id: uuid.UUID) -> uuid.UUID:
         return self.presenter.get_dataset_id_for_stack(stack_id)
 
-    def get_dataset(self, dataset_id: uuid.UUID) -> MixedDataset | StrictDataset | None:
+    def get_dataset(self, dataset_id: uuid.UUID) -> Dataset | None:
         return self.presenter.get_dataset(dataset_id)
 
     def get_all_stacks(self) -> list[ImageStack]:


### PR DESCRIPTION
### Issue

Work on #2199

### Description

This begins the work of simplifying use of datasets, now that they have not functional difference.

Rename BaseDataset to Dataset.
Remove menu differences.
Check if the dataset has a sample, rather than if it is a StrictDataset. (this fixes errors that could occur if you remove delete a sample from dataset)
Remove some type unions

### Testing & Acceptance Criteria 

MI starts and can open data.
"Load 180" should be enabled in the menu if a dataset is loaded.

### Documentation

Not yet
