### PR TITLE
Use applitools branches

### DIFF
--- a/docs/release_notes/next/dev-2324-applitools-branch
+++ b/docs/release_notes/next/dev-2324-applitools-branch
@@ -1,0 +1,1 @@
+#2324: Use branch feature on applitools

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -10,7 +10,7 @@ dependencies:
   - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774
   - pip
   - pip:
-      - eyes-images==5.20.*
+      - eyes-images==5.23.*
   - yapf==0.40.*
   - mypy==1.8
   - types-requests

--- a/mantidimaging/eyes_tests/eyes_manager.py
+++ b/mantidimaging/eyes_tests/eyes_manager.py
@@ -27,6 +27,10 @@ else:
 VIEWPORT_WIDTH = 1920
 VIEWPORT_HEIGHT = 1080
 
+BRANCH_NAME = None
+if 'GITHUB_HEAD_REF' in os.environ:
+    BRANCH_NAME = os.environ['GITHUB_HEAD_REF']
+
 
 class EyesManager:
 
@@ -35,6 +39,7 @@ class EyesManager:
         self.eyes = Eyes()
         self.eyes.match_level = MatchLevel.IGNORE_COLORS
         self.eyes.configure.host_os = sys.platform
+        self.eyes.branch_name = BRANCH_NAME
         self.image_directory = None
         self.imaging = None
         if test_name is None:


### PR DESCRIPTION
### Issue

Closes #2324 

### Description

Set the branch_name property to the name of the PR branch. This will cause applitools to consider these tests to be ona branch with their own baselines. This _might_ solve the issue of conflicts when making GUI changes.

### Acceptance Criteria 

Overall we want a solution that. Its not easy to test this in advance on a PR, so we'll have to merge and then see how it works.
* does not additional manual work on most PRs (We might not know until we are using this on real branches)
* catches and warns about changes in PRs (See comment below)


### Documentation

Release notes
