### PR TITLE
PySide6 now excluded from PyInstaller 

### DIFF
--- a/docs/release_notes/next/dev-2330-PyInstaller-Qt-Bindings
+++ b/docs/release_notes/next/dev-2330-PyInstaller-Qt-Bindings
@@ -1,0 +1,1 @@
+#2330: The PySide6 module is now excluded when building via PyInstaller due to hook clashes

--- a/packaging/PackageWithPyInstaller.py
+++ b/packaging/PackageWithPyInstaller.py
@@ -89,7 +89,7 @@ def add_optional_arguments(run_options):
 
 
 def add_exclude_modules(run_options):
-    excludes = ['matplotlib', 'dask', 'pandas']
+    excludes = ['matplotlib', 'dask', 'pandas', 'PySide6']
     for exclude in excludes:
         run_options.extend(['--exclude-module', exclude])
 


### PR DESCRIPTION
### Issue

Closes #2330

### Description

Pyside6 has now been added to the excluded module list in `packaging/PackageWithPyInstaller.py`

### Acceptance Criteria 

Check that PyInstaller builds successfully

### Documentation

release note