### PR TITLE
Fix test test_replace_image_stack

### DIFF
--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -236,6 +236,7 @@ class TestGuiSystemLoading(GuiSystemBase):
         self._load_data_set()
         self.assertEqual(len(self.main_window.presenter.get_active_stack_visualisers()), 5)
         self.assertEqual(100, list(self.main_window.presenter.datasets)[0].sample.data.shape[0])
+        initial_sample_id = list(self.main_window.presenter.datasets)[0].sample.id
 
         self.main_window.dataset_tree_widget.topLevelItem(0).setSelected(True)
         self._check_datasets_consistent()
@@ -248,8 +249,9 @@ class TestGuiSystemLoading(GuiSystemBase):
             gofn.return_value = (str(new_stack), None)
             self.main_window.add_to_dataset_dialog.chooseFileButton.click()
 
-        self.main_window.add_to_dataset_dialog.accepted.emit()
-        QTest.qWait(SHORT_DELAY)
+        self.main_window.add_to_dataset_dialog.accept()
+        wait_until(lambda: initial_sample_id not in self.main_window.presenter.all_stack_ids)
+
         self._check_datasets_consistent()
         self.assertEqual(20, list(self.main_window.presenter.datasets)[0].sample.data.shape[0])
 

--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -256,7 +256,6 @@ class TestGuiSystemLoading(GuiSystemBase):
         self.assertEqual(20, list(self.main_window.presenter.datasets)[0].sample.data.shape[0])
 
     def _check_datasets_consistent(self, show_datasets=False) -> None:
-        print("_check_datasets_consistent")
         if show_datasets:
             print("Main window datasets")
             for k, v in self.main_window.presenter.model.datasets.items():


### PR DESCRIPTION
### Issue
Closes #2333 

### Description

The issue was caused by not waiting for the new stack to finish loading. The delay was usually long enough but not always. When it was too slow, then `_add_images_to_existing_dataset()` would run after the dataset had been deleted in the `tearDown`. This caused an error dialog which then confused the ` _click_messageBox()` leading to a misleading error message.

This resolves the issue by doing a proper `wait_until()`, so that the test does not proceed until the stack is replaced.

Also add a check for any left open `QMessageBox` or `QDialog`, so that this would be caught sooner, or get a better error.

### Testing 

This fixes the tests

### Acceptance Criteria 

Tests should all pass

### Documentation

Not needed, small fix up to  #2317
