### PR TITLE
Add spectrum plotting of data in the Live Viewer via Dask

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -41,6 +41,8 @@ requirements:
     - qt-material=2.14
     - darkdetect=0.8.0
     - qt-gtk-platformtheme # [linux]
+    - dask
+    - dask-image
 
 
 build:

--- a/docs/release_notes/next/dev-2311-dask-live-viewer
+++ b/docs/release_notes/next/dev-2311-dask-live-viewer
@@ -1,0 +1,1 @@
+#2311: The Live Viewer now uses Dask to load in images and create a delayed datastack for operations

--- a/mantidimaging/eyes_tests/live_viewer_window_test.py
+++ b/mantidimaging/eyes_tests/live_viewer_window_test.py
@@ -61,7 +61,7 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
     @mock.patch("time.time", return_value=4000.0)
     def test_live_view_opens_with_data(self, _mock_time, _mock_image_watcher, mock_load_image):
         file_list = self._make_simple_dir(self.live_directory)
-        image_list = [Image_Data(path) for path in file_list]
+        image_list = [Image_Data(path, create_delayed_array=False) for path in file_list]
         mock_load_image.return_value = self._generate_image()
         self.imaging.show_live_viewer(self.live_directory)
         self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list)
@@ -72,7 +72,7 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
     @mock.patch("time.time", return_value=4000.0)
     def test_live_view_opens_with_bad_data(self, _mock_time, _mock_image_watcher, mock_load_image):
         file_list = self._make_simple_dir(self.live_directory)
-        image_list = [Image_Data(path) for path in file_list]
+        image_list = [Image_Data(path, create_delayed_array=False) for path in file_list]
         mock_load_image.side_effect = ValueError
         self.imaging.show_live_viewer(self.live_directory)
         self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list)
@@ -83,7 +83,7 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
     @mock.patch("time.time", return_value=4000.0)
     def test_rotate_operation_rotates_image(self, _mock_time, _mock_image_watcher, mock_load_image):
         file_list = self._make_simple_dir(self.live_directory)
-        image_list = [Image_Data(path) for path in file_list]
+        image_list = [Image_Data(path, create_delayed_array=False) for path in file_list]
         mock_load_image.return_value = self._generate_image()
         self.imaging.show_live_viewer(self.live_directory)
         self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list)

--- a/mantidimaging/eyes_tests/live_viewer_window_test.py
+++ b/mantidimaging/eyes_tests/live_viewer_window_test.py
@@ -7,7 +7,7 @@ from unittest import mock
 import numpy as np
 import os
 from mantidimaging.core.operations.loader import load_filter_packages
-from mantidimaging.gui.windows.live_viewer.model import Image_Data
+from mantidimaging.gui.windows.live_viewer.model import Image_Data, DaskImageDataStack
 from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
 from pathlib import Path
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
@@ -61,10 +61,11 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
     @mock.patch("time.time", return_value=4000.0)
     def test_live_view_opens_with_data(self, _mock_time, _mock_image_watcher, mock_load_image):
         file_list = self._make_simple_dir(self.live_directory)
-        image_list = [Image_Data(path, create_delayed_array=False) for path in file_list]
+        image_list = [Image_Data(path) for path in file_list]
+        dask_image_stack = DaskImageDataStack(image_list, create_delayed_array=False)
         mock_load_image.return_value = self._generate_image()
         self.imaging.show_live_viewer(self.live_directory)
-        self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list)
+        self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list, dask_image_stack)
         self.check_target(widget=self.imaging.live_viewer)
 
     @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image')
@@ -72,10 +73,11 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
     @mock.patch("time.time", return_value=4000.0)
     def test_live_view_opens_with_bad_data(self, _mock_time, _mock_image_watcher, mock_load_image):
         file_list = self._make_simple_dir(self.live_directory)
-        image_list = [Image_Data(path, create_delayed_array=False) for path in file_list]
+        image_list = [Image_Data(path) for path in file_list]
+        dask_image_stack = DaskImageDataStack(image_list, create_delayed_array=False)
         mock_load_image.side_effect = ValueError
         self.imaging.show_live_viewer(self.live_directory)
-        self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list)
+        self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list, dask_image_stack)
         self.check_target(widget=self.imaging.live_viewer)
 
     @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image')
@@ -83,9 +85,10 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
     @mock.patch("time.time", return_value=4000.0)
     def test_rotate_operation_rotates_image(self, _mock_time, _mock_image_watcher, mock_load_image):
         file_list = self._make_simple_dir(self.live_directory)
-        image_list = [Image_Data(path, create_delayed_array=False) for path in file_list]
+        image_list = [Image_Data(path) for path in file_list]
+        dask_image_stack = DaskImageDataStack(image_list, create_delayed_array=False)
         mock_load_image.return_value = self._generate_image()
         self.imaging.show_live_viewer(self.live_directory)
-        self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list)
+        self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list, dask_image_stack)
         self.imaging.live_viewer.rotate_angles_group.actions()[1].trigger()
         self.check_target(widget=self.imaging.live_viewer)

--- a/mantidimaging/eyes_tests/live_viewer_window_test.py
+++ b/mantidimaging/eyes_tests/live_viewer_window_test.py
@@ -56,7 +56,7 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
         self.imaging.show_live_viewer(self.live_directory)
         self.check_target(widget=self.imaging.live_viewer)
 
-    @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image')
+    @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image_from_path')
     @mock.patch('mantidimaging.gui.windows.live_viewer.model.ImageWatcher')
     @mock.patch("time.time", return_value=4000.0)
     def test_live_view_opens_with_data(self, _mock_time, _mock_image_watcher, mock_load_image):
@@ -68,7 +68,7 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
         self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list, dask_image_stack)
         self.check_target(widget=self.imaging.live_viewer)
 
-    @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image')
+    @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image_from_path')
     @mock.patch('mantidimaging.gui.windows.live_viewer.model.ImageWatcher')
     @mock.patch("time.time", return_value=4000.0)
     def test_live_view_opens_with_bad_data(self, _mock_time, _mock_image_watcher, mock_load_image):
@@ -80,7 +80,7 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
         self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list, dask_image_stack)
         self.check_target(widget=self.imaging.live_viewer)
 
-    @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image')
+    @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image_from_path')
     @mock.patch('mantidimaging.gui.windows.live_viewer.model.ImageWatcher')
     @mock.patch("time.time", return_value=4000.0)
     def test_rotate_operation_rotates_image(self, _mock_time, _mock_image_watcher, mock_load_image):

--- a/mantidimaging/gui/windows/live_viewer/live_view_widget.py
+++ b/mantidimaging/gui/windows/live_viewer/live_view_widget.py
@@ -25,7 +25,7 @@ class LiveViewWidget(GraphicsLayoutWidget):
     image: MIMiniImageView
     image_shape: tuple
     roi_changed = pyqtSignal()
-    roi_object: SpectrumROI
+    roi_object: SpectrumROI | None = None
     sensible_roi: SensibleROI
 
     def __init__(self) -> None:

--- a/mantidimaging/gui/windows/live_viewer/live_view_widget.py
+++ b/mantidimaging/gui/windows/live_viewer/live_view_widget.py
@@ -25,7 +25,7 @@ class LiveViewWidget(GraphicsLayoutWidget):
     image: MIMiniImageView
     image_shape: tuple
     roi_changed = pyqtSignal()
-    roi_object: SpectrumROI | None = None
+    roi_object: SpectrumROI
     sensible_roi: SensibleROI
 
     def __init__(self) -> None:
@@ -76,8 +76,8 @@ class LiveViewWidget(GraphicsLayoutWidget):
         size = CloseEnoughPoint(roi.size())
         return SensibleROI.from_points(pos, size)
 
-    def set_roi_alpha(self, alpha: float) -> None:
-        self.roi_object.colour = self.roi_object.colour[:3] + (alpha,)
+    def set_roi_alpha(self, alpha: int) -> None:
+        self.roi_object.colour = self.roi_object.colour[:3] + (alpha, )
         self.roi_object.setPen(self.roi_object.colour)
         self.roi_object.hoverPen = mkPen(self.roi_object.colour, width=3)
         self.set_roi_visibility_flags(bool(alpha))
@@ -87,4 +87,3 @@ class LiveViewWidget(GraphicsLayoutWidget):
         for handle in handles:
             handle.setVisible(visible)
         self.roi_object.setVisible(visible)
-

--- a/mantidimaging/gui/windows/live_viewer/live_view_widget.py
+++ b/mantidimaging/gui/windows/live_viewer/live_view_widget.py
@@ -23,7 +23,7 @@ class LiveViewWidget(GraphicsLayoutWidget):
     @param parent: The parent widget
     """
     image: MIMiniImageView
-    image_shape: tuple
+    image_shape: tuple = (-1, -1)
     roi_changed = pyqtSignal()
     roi_object: SpectrumROI | None = None
     sensible_roi: SensibleROI
@@ -59,6 +59,8 @@ class LiveViewWidget(GraphicsLayoutWidget):
         self.image.show_message(message)
 
     def add_roi(self):
+        if self.image_shape == (-1, -1):
+            return
         height, width = self.image_shape
         roi = SensibleROI.from_list([0, 0, width, height])
         self.roi_object = SpectrumROI('roi', roi, rotatable=False, scaleSnap=True, translateSnap=True)

--- a/mantidimaging/gui/windows/live_viewer/live_view_widget.py
+++ b/mantidimaging/gui/windows/live_viewer/live_view_widget.py
@@ -71,18 +71,24 @@ class LiveViewWidget(GraphicsLayoutWidget):
         self.image_shape = shape
 
     def get_roi(self) -> SensibleROI:
+        if not self.roi_object:
+            return SensibleROI()
         roi = self.roi_object.roi
         pos = CloseEnoughPoint(roi.pos())
         size = CloseEnoughPoint(roi.size())
         return SensibleROI.from_points(pos, size)
 
     def set_roi_alpha(self, alpha: int) -> None:
+        if not self.roi_object:
+            return
         self.roi_object.colour = self.roi_object.colour[:3] + (alpha, )
         self.roi_object.setPen(self.roi_object.colour)
         self.roi_object.hoverPen = mkPen(self.roi_object.colour, width=3)
         self.set_roi_visibility_flags(bool(alpha))
 
     def set_roi_visibility_flags(self, visible: bool) -> None:
+        if not self.roi_object:
+            return
         handles = self.roi_object.getHandles()
         for handle in handles:
             handle.setVisible(visible)

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -123,7 +123,9 @@ class DaskImageDataStack:
                                           f"{image_list[0].image_path.suffix.lower()}")
         return delayed_stack
 
-    def update_delayed_stack(self, param_to_calc: list[str]) -> None:
+    def update_delayed_stack(self, param_to_calc=None) -> None:
+        if param_to_calc is None:
+            param_to_calc = []
         self.delayed_stack = self.create_delayed_stack_from_image_data(self.image_list)
         if 'mean' in param_to_calc:
             if len(self.mean) == len(self.image_list) - 1:
@@ -446,7 +448,8 @@ class ImageWatcher(QObject):
         self.image_stack.update_image_list(images)
 
         if self.image_stack.create_delayed_array:
-            self.image_stack.update_delayed_stack(['mean'])
+            #self.image_stack.update_delayed_stack(['mean'])
+            self.image_stack.update_delayed_stack()
             self.update_spectrum.emit(self.image_stack.mean)
 
         self.update_recent_watcher(images[-1:])

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -230,7 +230,7 @@ class ImageWatcher(QObject):
         for file_path in directory.iterdir():
             if self._is_image_file(file_path.name):
                 try:
-                    image_obj = Image_Data(file_path, create_delayed_array=self.create_delayed_array)
+                    image_obj = Image_Data(file_path)
                     image_files.append(image_obj)
                 except FileNotFoundError:
                     continue
@@ -305,9 +305,6 @@ class ImageWatcher(QObject):
         dask_image_stack = DaskImageDataStack(images)
         self.update_recent_watcher(images[-1:])
         self.image_changed.emit(images, dask_image_stack)
-
-        # arrsum = dask.array.sum(dask_image_stack.delayed_stack)
-        # print(f"{arrsum.compute()=}")
 
     @staticmethod
     def _is_image_file(file_name: str) -> bool:

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -14,8 +14,6 @@ from PyQt5.QtCore import QFileSystemWatcher, QObject, pyqtSignal, QTimer
 import dask_image.imread
 from astropy.io import fits
 
-from mantidimaging.core.utility import ExecutionProfiler
-
 if TYPE_CHECKING:
     from os import stat_result
     from mantidimaging.gui.windows.live_viewer.view import LiveViewerWindowPresenter

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -80,7 +80,8 @@ class DaskImageDataStack:
         try:
             image_to_compute = self.get_delayed_image(index)
             if image_to_compute is not None:
-                computed_image = image_to_compute.compute()
+                image_to_compute_opt = dask.optimize(image_to_compute)
+                computed_image = image_to_compute_opt[0].compute()
         except dask_image.imread.pims.api.UnknownFormatError:
             self.remove_image_data_by_index(index)
             self.get_computed_image(index - 1)
@@ -90,10 +91,9 @@ class DaskImageDataStack:
 
     def get_selected_computed_image(self):
         try:
-            self.get_computed_image(self.selected_index)
+            return self.get_computed_image(self.selected_index)
         except dask_image.imread.pims.api.UnknownFormatError:
             pass
-        return self.get_computed_image(self.selected_index)
 
     def remove_image_data_by_path(self, image_path: Path) -> None:
         image_paths = [image.image_path for image in self.image_list]

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -114,7 +114,6 @@ class DaskImageDataStack:
     def create_delayed_stack_from_image_data(self, image_list: list[Image_Data]) -> None | dask.array.Array:
         delayed_stack = None
         arrays = self.get_delayed_arrays(image_list)
-        arrays_vis = arrays.visualize()
         if arrays:
             if image_list[0].image_path.suffix.lower() in [".tif", ".tiff"]:
                 delayed_stack = dask.array.stack(dask.array.array(arrays))
@@ -131,10 +130,7 @@ class DaskImageDataStack:
         if self.delayed_stack is None:
             self.delayed_stack = self.create_delayed_stack_from_image_data(new_image_list)
         else:
-            new_images = [
-                image for image in new_image_list
-                if image.image_path not in self.image_paths
-            ]
+            new_images = [image for image in new_image_list if image.image_path not in self.image_paths]
             self.delayed_stack = dask.optimize(
                 dask.array.concatenate([self.delayed_stack,
                                         self.create_delayed_stack_from_image_data(new_images)]))[0]
@@ -175,7 +171,8 @@ class DaskImageDataStack:
     def calc_mean_fully_roi(self):
         if self.delayed_stack is not None:
             left, top, right, bottom = self.roi
-            self.mean = dask.array.mean(self.delayed_stack[:, top:bottom, left:right], axis=(1, 2)).compute()
+            self.mean = dask.optimize(dask.array.mean(self.delayed_stack[:, top:bottom, left:right],
+                                                      axis=(1, 2)))[0].compute()
 
     def set_roi(self, roi: SensibleROI):
         self.roi = roi

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -67,8 +67,8 @@ class DaskImageDataStack:
         else:
             return None
 
-    def get_delayed_image(self, index: int) -> dask.array.Array:
-        return self.delayed_stack[index]
+    def get_delayed_image(self, index: int) -> dask.array.Array | None:
+        return self.delayed_stack[index] if self.delayed_stack else None
 
     def get_image_data(self, index: int) -> Image_Data | None:
         return self.image_list[index] if self.image_list else None

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -24,8 +24,9 @@ class DaskImageDataStack:
     """
     A Dask Image Data Stack Class to hold a delayed array of all the images in the Live Viewer Path
     """
-    delayed_stack: dask.array.Array
+    delayed_stack: dask.array.Array | None = None
     image_list: list[Image_Data]
+    create_delayed_array: bool
 
     def __init__(self, image_list: list[Image_Data], create_delayed_array: bool = True):
         self.image_list = image_list
@@ -53,11 +54,11 @@ class DaskImageDataStack:
         else:
             return None
 
-    def get_delayed_image(self, index) -> dask.array.Array:
-        return self.delayed_stack[index]
+    def get_delayed_image(self, index: int) -> dask.array.Array | None:
+        return self.delayed_stack[index] if self.delayed_stack else None
 
-    def get_image_data(self, index) -> Image_Data:
-        return self.image_list[index]
+    def get_image_data(self, index: int) -> Image_Data | None:
+        return self.image_list[index] if self.image_list else None
 
 
 class Image_Data:

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -14,6 +14,8 @@ from PyQt5.QtCore import QFileSystemWatcher, QObject, pyqtSignal, QTimer
 import dask_image.imread
 from astropy.io import fits
 
+from mantidimaging.core.utility import ExecutionProfiler
+
 if TYPE_CHECKING:
     from os import stat_result
     from mantidimaging.gui.windows.live_viewer.view import LiveViewerWindowPresenter
@@ -28,6 +30,7 @@ class DaskImageDataStack:
     delayed_stack: dask.array.Array | None = None
     image_list: list[Image_Data]
     create_delayed_array: bool
+    _selected_index: int
 
     def __init__(self, image_list: list[Image_Data], create_delayed_array: bool = True):
         self.image_list = image_list
@@ -50,6 +53,14 @@ class DaskImageDataStack:
     def shape(self):
         return self.delayed_stack.shape
 
+    @property
+    def selected_index(self):
+        return self._selected_index
+
+    @selected_index.setter
+    def selected_index(self, index):
+        self._selected_index = index
+
     def get_delayed_arrays(self) -> list[dask.array.Array] | None:
         if self.image_list[0].image_path.suffix.lower() in [".tif", ".tiff"] and self.create_delayed_array:
             return [dask_image.imread.imread(image_data.image_path)[0] for image_data in self.image_list]
@@ -58,8 +69,8 @@ class DaskImageDataStack:
         else:
             return None
 
-    def get_delayed_image(self, index: int) -> dask.array.Array | None:
-        return self.delayed_stack[index] if self.delayed_stack is not None else None
+    def get_delayed_image(self, index: int) -> dask.array.Array:
+        return self.delayed_stack[index]
 
     def get_image_data(self, index: int) -> Image_Data | None:
         return self.image_list[index] if self.image_list else None

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -36,7 +36,7 @@ class DaskImageDataStack:
                     with fits.open(image_list[0].image_path.__str__()) as fit:
                         sample = fit[0].data
                     arrays = [image_data.delayed_array for image_data in image_list]
-                    lazy_arrays =[dask.array.from_delayed(x, shape=sample.shape, dtype=sample.dtype) for x in arrays]
+                    lazy_arrays = [dask.array.from_delayed(x, shape=sample.shape, dtype=sample.dtype) for x in arrays]
                     self.delayed_stack = dask.array.stack(lazy_arrays)
 
     @property

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -43,7 +43,8 @@ class DaskImageDataStack:
                     lazy_arrays = [dask.array.from_delayed(x, shape=sample.shape, dtype=sample.dtype) for x in arrays]
                     self.delayed_stack = dask.array.stack(lazy_arrays)
                 else:
-                    raise NotImplementedError(f"DaskImageDataStack does not support image with extension {image_list[0].image_path.suffix.lower()}")
+                    raise NotImplementedError(f"DaskImageDataStack does not support image with extension "
+                                              f"{image_list[0].image_path.suffix.lower()}")
 
     @property
     def shape(self):

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -88,6 +88,7 @@ class DaskImageDataStack:
             self.selected_index = 0
             self.delayed_stack = None
 
+
 class Image_Data:
     """
     Image Data Class to store represent image data.

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -195,7 +195,7 @@ class ImageWatcher(QObject):
     """
     image_changed = pyqtSignal(list, DaskImageDataStack)  # Signal emitted when an image is added or removed
     recent_image_changed = pyqtSignal(Path)
-    create_delayed_array: bool
+    create_delayed_array: bool = True
 
     def __init__(self, directory: Path):
         """
@@ -230,7 +230,7 @@ class ImageWatcher(QObject):
         for file_path in directory.iterdir():
             if self._is_image_file(file_path.name):
                 try:
-                    image_obj = Image_Data(file_path)
+                    image_obj = Image_Data(file_path, create_delayed_array=self.create_delayed_array)
                     image_files.append(image_obj)
                 except FileNotFoundError:
                     continue

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -136,7 +136,8 @@ class DaskImageDataStack:
             self.add_last_mean()
 
     def add_last_mean(self) -> None:
-        self.mean.append(dask.array.mean(self.delayed_stack[-1]).compute())
+        if self.delayed_stack is not None:
+            self.mean.append(dask.array.mean(self.delayed_stack[-1]).compute())
 
     def delete_all_data(self):
         self.image_list = []

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -30,6 +30,7 @@ class DaskImageDataStack:
 
     def __init__(self, image_list: list[Image_Data], create_delayed_array: bool = True):
         self.image_list = image_list
+        self.create_delayed_array = create_delayed_array
 
         if image_list and create_delayed_array:
             arrays = self.get_delayed_arrays()
@@ -47,9 +48,9 @@ class DaskImageDataStack:
         return self.delayed_stack.shape
 
     def get_delayed_arrays(self) -> list[dask.array.Array] | None:
-        if self.image_list[0].image_path.suffix.lower() in [".tif", ".tiff"]:
+        if self.image_list[0].image_path.suffix.lower() in [".tif", ".tiff"] and self.create_delayed_array:
             return [dask_image.imread.imread(image_data.image_path)[0] for image_data in self.image_list]
-        elif self.image_list[0].image_path.suffix.lower() == ".fits":
+        elif self.image_list[0].image_path.suffix.lower() == ".fits" and self.create_delayed_array:
             return [dask.delayed(fits.open)(image_data.image_path)[0].data for image_data in self.image_list]
         else:
             return None

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -145,7 +145,7 @@ class LiveViewerWindowModel:
         self._dataset_path: Path | None = None
         self.image_watcher: ImageWatcher | None = None
         self.images: list[Image_Data] = []
-        self.image_stack: DaskImageDataStack
+        self.image_stack: DaskImageDataStack | None
 
     @property
     def path(self) -> Path | None:
@@ -159,8 +159,9 @@ class LiveViewerWindowModel:
         self.image_watcher.recent_image_changed.connect(self.handle_image_modified)
         self.image_watcher._handle_notified_of_directry_change(str(path))
 
-    def _handle_image_changed_in_list(self, image_files: list[Image_Data],
-                                      dask_image_stack: DaskImageDataStack) -> None:
+    def _handle_image_changed_in_list(self,
+                                      image_files: list[Image_Data],
+                                      dask_image_stack: DaskImageDataStack | None = None) -> None:
         """
         Handle an image changed event. Update the image in the view.
         This method is called when the image_watcher detects a change

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -73,7 +73,6 @@ class Image_Data:
         if self.create_delayed_array:
             self.set_delayed_array()
 
-
     @property
     def stat(self) -> stat_result:
         return self._stat
@@ -148,7 +147,8 @@ class LiveViewerWindowModel:
         self.image_watcher.recent_image_changed.connect(self.handle_image_modified)
         self.image_watcher._handle_notified_of_directry_change(str(path))
 
-    def _handle_image_changed_in_list(self, image_files: list[Image_Data], dask_image_stack: DaskImageDataStack) -> None:
+    def _handle_image_changed_in_list(self, image_files: list[Image_Data],
+                                      dask_image_stack: DaskImageDataStack) -> None:
         """
         Handle an image changed event. Update the image in the view.
         This method is called when the image_watcher detects a change

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -75,7 +75,7 @@ class DaskImageDataStack:
             return None
         try:
             image_to_compute = self.get_delayed_image(index)
-            if image_to_compute:
+            if image_to_compute is not None:
                 computed_image = image_to_compute.compute()
         except dask_image.imread.pims.api.UnknownFormatError:
             self.remove_image_data_by_index(index)

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -80,14 +80,13 @@ class LiveViewerWindowPresenter(BasePresenter):
 
     def select_image(self, index: int) -> None:
         self.selected_image = self.model.images[index]
-        self.image_stack = self.model.image_stack
-        self.image_stack.selected_index = index
+        self.model.image_stack.selected_index = index
         if not self.selected_image:
             return
         image_timestamp = self.selected_image.image_modified_time_stamp
         self.view.label_active_filename.setText(f"{self.selected_image.image_name} - {image_timestamp}")
 
-        self.display_image(self.selected_image, self.image_stack)
+        self.display_image(self.selected_image, self.model.image_stack)
 
     def display_image(self, image_data_obj: Image_Data, delayed_image_stack: DaskImageDataStack | None) -> None:
         """
@@ -119,6 +118,7 @@ class LiveViewerWindowPresenter(BasePresenter):
         """
         Load a delayed stack from a DaskImageDataStack and compute
         """
+        delayed_image = None
         if delayed_image_stack is not None:
             delayed_image = delayed_image_stack.get_delayed_image(delayed_image_stack.selected_index)
         if delayed_image is not None:
@@ -146,14 +146,14 @@ class LiveViewerWindowPresenter(BasePresenter):
         Update the displayed image when the file is modified
         """
         if self.selected_image and image_path == self.selected_image.image_path:
-            self.display_image(self.selected_image, self.image_stack)
+            self.display_image(self.selected_image, self.model.image_stack)
 
     def update_image_operation(self) -> None:
         """
         Reload the current image if an operation has been performed on the current image
         """
         if self.selected_image is not None:
-            self.display_image(self.selected_image, self.image_stack)
+            self.display_image(self.selected_image, self.model.image_stack)
 
     def convert_image_to_imagestack(self, image_data) -> ImageStack:
         """

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -113,7 +113,7 @@ class LiveViewerWindowPresenter(BasePresenter):
         Load a .Tif, .Tiff or .Fits file only if it exists
         and returns as an ndarray
         """
-        if delayed_image:
+        if delayed_image is not None:
             image_data = delayed_image.compute()
         else:
             raise ValueError

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -41,7 +41,7 @@ class LiveViewerWindowPresenter(BasePresenter):
         self.main_window = main_window
         self.model = LiveViewerWindowModel(self)
         self.selected_image: Image_Data | None = None
-        self.selected_delayed_image: dask.array.Array
+        self.selected_delayed_image: dask.array.Array | None
 
         self.filters = {f.filter_name: f for f in load_filter_packages()}
 
@@ -85,7 +85,7 @@ class LiveViewerWindowPresenter(BasePresenter):
 
         self.display_image(self.selected_image, self.selected_delayed_image)
 
-    def display_image(self, image_data_obj: Image_Data, delayed_image: dask.array.Array) -> None:
+    def display_image(self, image_data_obj: Image_Data, delayed_image: dask.array.Array | None) -> None:
         """
         Display image in the view after validating contents
         """
@@ -108,12 +108,15 @@ class LiveViewerWindowPresenter(BasePresenter):
         self.view.live_viewer.show_error(None)
 
     @staticmethod
-    def load_image(delayed_image: dask.array.Array) -> np.ndarray:
+    def load_image(delayed_image: dask.array.Array | None) -> np.ndarray:
         """
         Load a .Tif, .Tiff or .Fits file only if it exists
         and returns as an ndarray
         """
-        image_data = delayed_image.compute()
+        if delayed_image:
+            image_data = delayed_image.compute()
+        else:
+            raise ValueError
         return image_data
 
     def update_image_modified(self, image_path: Path) -> None:

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -110,11 +110,8 @@ class LiveViewerWindowPresenter(BasePresenter):
         Load a .Tif, .Tiff or .Fits file only if it exists
         and returns as an ndarray
         """
-        if image_data_obj.image_path.suffix.lower() in [".tif", ".tiff"]:
-            image_data = image_data_obj.delayed_array.compute()[0]
-        elif image_data_obj.image_path.suffix.lower() == ".fits":
-            with fits.open(image_data_obj.image_path.__str__()) as fit:
-                image_data = fit[0].data
+        if image_data_obj.image_path.suffix.lower() in [".tif", ".tiff", ".fits"]:
+            image_data = image_data_obj.delayed_array.compute()
         return image_data
 
     def update_image_modified(self, image_path: Path) -> None:

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -81,7 +81,6 @@ class LiveViewerWindowPresenter(BasePresenter):
         self.view.set_image_index(len(images_list) - 1)
 
     def select_image(self, index: int) -> None:
-        print(f"OOOOOOOOOOOOO select_image: {index=}, {self.model.images=} 0000000000000000")
         if not self.model.images:
             self.update_image_list([])
             return
@@ -99,11 +98,9 @@ class LiveViewerWindowPresenter(BasePresenter):
         """
         Display image in the view after validating contents
         """
-        print(f"\n+++++++++++++++ display_image {delayed_image_stack=} ++++++++++++++++\n")
-        print(f"\n+++++++++++++++ display_image {delayed_image_stack.delayed_stack=} ++++++++++++++++\n")
-        #print(f"\n+++++++++++++++ display_image {delayed_image_stack.delayed_stack.shape=} ++++++++++++++++\n")
         try:
-            if delayed_image_stack is None or delayed_image_stack.delayed_stack is None or not delayed_image_stack.create_delayed_array:
+            if (delayed_image_stack is None or delayed_image_stack.delayed_stack is None
+                    or not delayed_image_stack.create_delayed_array):
                 image_data = self.load_image_from_path(image_data_obj.image_path)
             else:
                 try:
@@ -131,7 +128,6 @@ class LiveViewerWindowPresenter(BasePresenter):
         """
         Load a delayed stack from a DaskImageDataStack and compute
         """
-        delayed_image = None
         if delayed_image_stack is not None:
             image_data = delayed_image_stack.get_selected_computed_image()
         else:

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -9,7 +9,6 @@ from logging import getLogger
 import numpy as np
 
 from imagecodecs._deflate import DeflateError
-from tifffile import tifffile, TiffFileError
 from astropy.io import fits
 
 from mantidimaging.gui.mvp_base import BasePresenter
@@ -89,7 +88,7 @@ class LiveViewerWindowPresenter(BasePresenter):
         """
         try:
             image_data = self.load_image(image_data_obj)
-        except (OSError, KeyError, ValueError, TiffFileError, DeflateError) as error:
+        except (OSError, KeyError, ValueError, DeflateError) as error:
             message = f"{type(error).__name__} reading image: {image_data_obj.image_path}: {error}"
             logger.error(message)
             self.view.remove_image()

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -9,7 +9,6 @@ from logging import getLogger
 import numpy as np
 
 from imagecodecs._deflate import DeflateError
-from astropy.io import fits
 
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.windows.live_viewer.model import LiveViewerWindowModel, Image_Data

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -119,8 +119,10 @@ class LiveViewerWindowPresenter(BasePresenter):
         """
         Load a delayed stack from a DaskImageDataStack and compute
         """
-        if delayed_image_stack is not None and delayed_image_stack.delayed_stack is not None:
-            image_data = delayed_image_stack.get_delayed_image(delayed_image_stack.selected_index).compute()
+        if delayed_image_stack is not None:
+            delayed_image = delayed_image_stack.get_delayed_image(delayed_image_stack.selected_index)
+        if delayed_image is not None:
+            image_data = delayed_image.compute()
         else:
             raise ValueError
         return image_data

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from collections.abc import Callable
 from logging import getLogger
+
+import dask_image.imread
 import numpy as np
 import dask.array
 
@@ -79,24 +81,35 @@ class LiveViewerWindowPresenter(BasePresenter):
         self.view.set_image_index(len(images_list) - 1)
 
     def select_image(self, index: int) -> None:
+        print(f"OOOOOOOOOOOOO select_image: {index=}, {self.model.images=} 0000000000000000")
+        if not self.model.images:
+            self.update_image_list([])
+            return
         self.selected_image = self.model.images[index]
-        self.model.image_stack.selected_index = index
+        self.image_stack = self.model.image_stack
+        self.image_stack.selected_index = index
         if not self.selected_image:
             return
         image_timestamp = self.selected_image.image_modified_time_stamp
         self.view.label_active_filename.setText(f"{self.selected_image.image_name} - {image_timestamp}")
 
-        self.display_image(self.selected_image, self.model.image_stack)
+        self.display_image(self.selected_image, self.image_stack)
 
     def display_image(self, image_data_obj: Image_Data, delayed_image_stack: DaskImageDataStack | None) -> None:
         """
         Display image in the view after validating contents
         """
+        print(f"\n+++++++++++++++ display_image {delayed_image_stack=} ++++++++++++++++\n")
+        print(f"\n+++++++++++++++ display_image {delayed_image_stack.delayed_stack=} ++++++++++++++++\n")
+        #print(f"\n+++++++++++++++ display_image {delayed_image_stack.delayed_stack.shape=} ++++++++++++++++\n")
         try:
-            if delayed_image_stack is None or not delayed_image_stack.create_delayed_array:
+            if delayed_image_stack is None or delayed_image_stack.delayed_stack is None or not delayed_image_stack.create_delayed_array:
                 image_data = self.load_image_from_path(image_data_obj.image_path)
             else:
-                image_data = self.load_image_from_delayed_stack(delayed_image_stack)
+                try:
+                    image_data = self.load_image_from_delayed_stack(delayed_image_stack)
+                except (AttributeError, dask_image.imread.pims.api.UnknownFormatError):
+                    image_data = self.load_image_from_path(image_data_obj.image_path)
         except (OSError, KeyError, ValueError, DeflateError) as error:
             message = f"{type(error).__name__} reading image: {image_data_obj.image_path}: {error}"
             logger.error(message)
@@ -120,9 +133,7 @@ class LiveViewerWindowPresenter(BasePresenter):
         """
         delayed_image = None
         if delayed_image_stack is not None:
-            delayed_image = delayed_image_stack.get_delayed_image(delayed_image_stack.selected_index)
-        if delayed_image is not None:
-            image_data = delayed_image.compute()
+            image_data = delayed_image_stack.get_selected_computed_image()
         else:
             raise ValueError
         return image_data
@@ -146,14 +157,14 @@ class LiveViewerWindowPresenter(BasePresenter):
         Update the displayed image when the file is modified
         """
         if self.selected_image and image_path == self.selected_image.image_path:
-            self.display_image(self.selected_image, self.model.image_stack)
+            self.display_image(self.selected_image, self.image_stack)
 
     def update_image_operation(self) -> None:
         """
         Reload the current image if an operation has been performed on the current image
         """
         if self.selected_image is not None:
-            self.display_image(self.selected_image, self.model.image_stack)
+            self.display_image(self.selected_image, self.image_stack)
 
     def convert_image_to_imagestack(self, image_data) -> ImageStack:
         """
@@ -174,3 +185,6 @@ class LiveViewerWindowPresenter(BasePresenter):
             op_params = self.view.filter_params[operation]["params"]
             op_func(image_stack, **op_params)
         return image_stack.slice_as_array(0)[0]
+
+    def update_image_stack(self, image_stack: DaskImageDataStack):
+        self.image_stack = image_stack

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -15,6 +15,7 @@ from imagecodecs._deflate import DeflateError
 from tifffile import tifffile
 from astropy.io import fits
 
+from mantidimaging.core.utility import ExecutionProfiler
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.windows.live_viewer.model import LiveViewerWindowModel, Image_Data, DaskImageDataStack
 from mantidimaging.core.operations.loader import load_filter_packages
@@ -98,6 +99,8 @@ class LiveViewerWindowPresenter(BasePresenter):
         """
         Display image in the view after validating contents
         """
+        # print(f"display_image: {[image.image_path for image in delayed_image_stack.image_list]=}")
+        # print(f"display_image: {len(delayed_image_stack.delayed_stack)=}")
         try:
             if (delayed_image_stack is None or delayed_image_stack.delayed_stack is None
                     or not delayed_image_stack.create_delayed_array):
@@ -132,6 +135,7 @@ class LiveViewerWindowPresenter(BasePresenter):
         """
         Load a delayed stack from a DaskImageDataStack and compute
         """
+        #with ExecutionProfiler(msg=f"load_image_from_delayed_stack() with {len(delayed_image_stack.delayed_stack)=}"):
         if delayed_image_stack is not None:
             image_data = delayed_image_stack.get_selected_computed_image()
         else:

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -116,9 +116,9 @@ class LiveViewerWindowPresenter(BasePresenter):
             self.view.live_viewer.show_error(message)
             return
         self.view.live_viewer.set_image_shape(image_data.shape)
-        if not self.view.live_viewer.roi_object:
+        if not self.view.live_viewer.roi_object and self.view.spectrum_action.isChecked():
             self.view.live_viewer.add_roi()
-            self.model.image_stack.set_roi(self.view.live_viewer.get_roi())
+        self.model.image_stack.set_roi(self.view.live_viewer.get_roi())
         image_data = self.perform_operations(image_data)
         if image_data.size == 0:
             message = "reading image: {image_path}: Image has zero size"
@@ -126,6 +126,9 @@ class LiveViewerWindowPresenter(BasePresenter):
             self.view.remove_image()
             self.view.live_viewer.show_error(message)
             return
+        if np.any(np.isnan(self.model.image_stack.mean)):
+            self.model.image_stack.calc_mean_fully_roi()
+            self.update_spectrum(self.model.image_stack.mean)
         self.view.show_most_recent_image(image_data)
         self.view.live_viewer.show_error(None)
 

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -113,6 +113,10 @@ class LiveViewerWindowPresenter(BasePresenter):
             self.view.remove_image()
             self.view.live_viewer.show_error(message)
             return
+        self.view.live_viewer.set_image_shape(image_data.shape)
+        if not self.view.live_viewer.roi_object:
+            self.view.live_viewer.add_roi()
+            self.model.image_stack.set_roi(self.view.live_viewer.get_roi())
         image_data = self.perform_operations(image_data)
         if image_data.size == 0:
             message = "reading image: {image_path}: Image has zero size"
@@ -185,6 +189,13 @@ class LiveViewerWindowPresenter(BasePresenter):
     def update_image_stack(self, image_stack: DaskImageDataStack):
         self.image_stack = image_stack
 
-    def update_spectrum(self, spec_data: list):
+    def update_spectrum(self, spec_data: list | np.ndarray):
         self.view.spectrum.clearPlots()
         self.view.spectrum.plot(spec_data)
+
+    def handle_roi_moved(self, force_new_spectrums: bool = False):
+        print(f"handle_roi_moved")
+        roi = self.view.live_viewer.get_roi()
+        self.model.image_stack.set_roi(roi)
+        self.model.image_stack.calc_mean_fully_roi()
+        self.update_spectrum(self.model.image_stack.mean)

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -15,7 +15,6 @@ from imagecodecs._deflate import DeflateError
 from tifffile import tifffile
 from astropy.io import fits
 
-from mantidimaging.core.utility import ExecutionProfiler
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.windows.live_viewer.model import LiveViewerWindowModel, Image_Data, DaskImageDataStack
 from mantidimaging.core.operations.loader import load_filter_packages
@@ -135,7 +134,6 @@ class LiveViewerWindowPresenter(BasePresenter):
         """
         Load a delayed stack from a DaskImageDataStack and compute
         """
-        #with ExecutionProfiler(msg=f"load_image_from_delayed_stack() with {len(delayed_image_stack.delayed_stack)=}"):
         if delayed_image_stack is not None:
             image_data = delayed_image_stack.get_selected_computed_image()
         else:

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -184,3 +184,7 @@ class LiveViewerWindowPresenter(BasePresenter):
 
     def update_image_stack(self, image_stack: DaskImageDataStack):
         self.image_stack = image_stack
+
+    def update_spectrum(self, spec_data: list):
+        self.view.spectrum.clearPlots()
+        self.view.spectrum.plot(spec_data)

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -194,7 +194,6 @@ class LiveViewerWindowPresenter(BasePresenter):
         self.view.spectrum.plot(spec_data)
 
     def handle_roi_moved(self, force_new_spectrums: bool = False):
-        print(f"handle_roi_moved")
         roi = self.view.live_viewer.get_roi()
         self.model.image_stack.set_roi(roi)
         self.model.image_stack.calc_mean_fully_roi()

--- a/mantidimaging/gui/windows/live_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/model_test.py
@@ -183,7 +183,6 @@ class DaskImageDataStackTest(unittest.TestCase):
     def test_WHEN_not_create_delayed_array_THEN_no_delayed_array_created(self):
         image_data_list, _, _ = self._get_fake_data('.tif')
         self.delayed_image_stack = DaskImageDataStack(image_data_list, create_delayed_array=False)
-        self.assertIsNone(self.delayed_image_stack.get_delayed_arrays())
         self.assertIsNone(self.delayed_image_stack.delayed_stack)
         self.assertEqual(self.delayed_image_stack.image_list, image_data_list)
 

--- a/mantidimaging/gui/windows/live_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/model_test.py
@@ -189,3 +189,10 @@ class DaskImageDataStackTest(unittest.TestCase):
         self.delayed_image_stack = DaskImageDataStack(image_data_list, create_delayed_array=True)
         assert_array_equal(self.delayed_image_stack.delayed_stack, fake_data_stack)
         assert_array_equal(self.delayed_image_stack.delayed_stack.compute(), fake_data_stack.compute())
+
+    @mock.patch("mantidimaging.gui.windows.live_viewer.model.dask_image.imread.imread")
+    def test_WHEN_tif_file_THEN_dask_image_imread_called(self, mock_imread):
+        image_data_list, _, _ = self._get_fake_data('.tif')
+        calls = [mock.call(image.image_path) for image in image_data_list]
+        self.delayed_image_stack = DaskImageDataStack(image_data_list, create_delayed_array=True)
+        mock_imread.assert_has_calls(calls, any_order=True)

--- a/mantidimaging/gui/windows/live_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/model_test.py
@@ -9,7 +9,7 @@ from unittest import mock
 
 from PyQt5.QtCore import QFileSystemWatcher, pyqtSignal
 
-from mantidimaging.gui.windows.live_viewer.model import ImageWatcher
+from mantidimaging.gui.windows.live_viewer.model import ImageWatcher, Image_Data
 from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
 
 
@@ -26,8 +26,10 @@ class ImageWatcherTest(FakeFSTestCase):
 
             mocker.side_effect = [mock_dir_watcher, mock_file_watcher]
             self.watcher = ImageWatcher(self.top_path)
+            self.watcher.create_delayed_array = False
             self.mock_signal_image = mock.create_autospec(pyqtSignal, emit=mock.Mock())
             self.watcher.image_changed = self.mock_signal_image
+            self.watcher.create_delayed_array = False
 
     def _make_simple_dir(self, directory: Path, t0: float = 1000):
         file_list = [directory / f"abc_{i:06d}.tif" for i in range(5)]

--- a/mantidimaging/gui/windows/live_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/model_test.py
@@ -169,6 +169,9 @@ class ImageWatcherTest(FakeFSTestCase):
 
 class DaskImageDataStackTest(unittest.TestCase):
 
+    def setUp(self):
+        self.test_array = np.array([1, 3, 5, 12, 15])
+
     def _get_fake_data(self, ext: str):
         file_list = [Path(f"abc_{i:06d}" + ext) for i in range(5)]
         with mock.patch("mantidimaging.gui.windows.live_viewer.model.Path.stat"):
@@ -202,7 +205,7 @@ class DaskImageDataStackTest(unittest.TestCase):
     @mock.patch("mantidimaging.gui.windows.live_viewer.model.dask.delayed")
     @mock.patch("mantidimaging.gui.windows.live_viewer.model.DaskImageDataStack.get_fits_sample")
     def test_WHEN_fits_file_THEN_dask_delayed_called(self, mock_fits_sample, mock_dask_delayed):
-        mock_fits_sample.return_value = np.random.random(5)
+        mock_fits_sample.return_value = self.test_array
         image_data_list, _, _ = self._get_fake_data('.fits')
         calls = [mock.call()(image.image_path) for image in image_data_list]
         with mock.patch("mantidimaging.gui.windows.live_viewer.model.fits.open"):
@@ -221,8 +224,9 @@ class DaskImageDataStackTest(unittest.TestCase):
     @mock.patch("mantidimaging.gui.windows.live_viewer.model.dask.array.from_delayed")
     @mock.patch("mantidimaging.gui.windows.live_viewer.model.dask.delayed")
     @mock.patch("mantidimaging.gui.windows.live_viewer.model.DaskImageDataStack.get_fits_sample")
-    def test_WHEN_supported_file_THEN_no_error_raised(self, file_ext, mock_fits_sample, _, mock_from_delayed, mock_delayed_arrays):
-        mock_fits_sample.return_value = np.random.random(5)
+    def test_WHEN_supported_file_THEN_no_error_raised(self, file_ext, mock_fits_sample, _, mock_from_delayed,
+                                                      mock_delayed_arrays):
+        mock_fits_sample.return_value = self.test_array
         image_data_list, fake_data_array_list, _ = self._get_fake_data(file_ext)
         mock_delayed_arrays.return_value = fake_data_array_list
         mock_from_delayed.return_value = fake_data_array_list

--- a/mantidimaging/gui/windows/live_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/model_test.py
@@ -9,7 +9,7 @@ from unittest import mock
 
 from PyQt5.QtCore import QFileSystemWatcher, pyqtSignal
 
-from mantidimaging.gui.windows.live_viewer.model import ImageWatcher, Image_Data
+from mantidimaging.gui.windows.live_viewer.model import ImageWatcher
 from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
 
 

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from PyQt5.QtCore import QSignalBlocker
-from PyQt5.QtWidgets import QVBoxLayout
+from PyQt5.QtCore import QSignalBlocker, Qt
+from PyQt5.QtWidgets import QVBoxLayout, QSplitter
 from PyQt5.Qt import QAction, QActionGroup
 
 from mantidimaging.gui.mvp_base import BaseMainWindowView
@@ -13,6 +13,8 @@ from .live_view_widget import LiveViewWidget
 from .presenter import LiveViewerWindowPresenter
 
 import numpy as np
+
+from ..spectrum_viewer.spectrum_widget import SpectrumPlotWidget
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
@@ -32,9 +34,18 @@ class LiveViewerWindowView(BaseMainWindowView):
         self.main_window = main_window
         self.path = live_dir_path
         self.presenter = LiveViewerWindowPresenter(self, main_window)
+        self.splitter = QSplitter(Qt.Vertical)
         self.live_viewer = LiveViewWidget()
-        self.imageLayout.addWidget(self.live_viewer)
+        self.imageLayout.addWidget(self.splitter)
         self.live_viewer.z_slider.valueChanged.connect(self.presenter.select_image)
+
+        self.spectrum_plot_widget = SpectrumPlotWidget()
+        self.spectrum = self.spectrum_plot_widget.spectrum
+
+        self.splitter.addWidget(self.live_viewer)
+        self.splitter.addWidget(self.spectrum_plot_widget)
+        widget_height = self.frameGeometry().height()
+        self.splitter.setSizes([int(0.7 * widget_height), int(0.3 * widget_height)])
 
         self.filter_params: dict[str, dict] = {}
         self.right_click_menu = self.live_viewer.image.vb.menu

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -122,7 +122,8 @@ class LiveViewerWindowView(BaseMainWindowView):
     def set_spectrum_visibility(self):
         widget_height = self.frameGeometry().height()
         if self.spectrum_action.isChecked():
-            self.live_viewer.set_roi_alpha(255)
+            if self.live_viewer.roi_object: 
+                self.live_viewer.set_roi_alpha(255)
             self.splitter.setSizes([int(0.7 * widget_height), int(0.3 * widget_height)])
             self.presenter.model.image_stack.create_delayed_array = True
             self.presenter.model.image_stack.create_and_set_delayed_stack()

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -14,7 +14,7 @@ from .presenter import LiveViewerWindowPresenter
 
 import numpy as np
 
-from ..spectrum_viewer.spectrum_widget import SpectrumWidget, SpectrumPlotWidget
+from ..spectrum_viewer.spectrum_widget import SpectrumPlotWidget
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
@@ -67,6 +67,7 @@ class LiveViewerWindowView(BaseMainWindowView):
         self.spectrum_action.setCheckable(True)
         operations_menu.addAction(self.spectrum_action)
         self.spectrum_action.triggered.connect(self.set_spectrum_visibility)
+        self.presenter.model.image_stack.create_delayed_array = False
 
     def show(self) -> None:
         """Show the window"""
@@ -123,8 +124,11 @@ class LiveViewerWindowView(BaseMainWindowView):
         if self.spectrum_action.isChecked():
             self.live_viewer.set_roi_alpha(255)
             self.splitter.setSizes([int(0.7 * widget_height), int(0.3 * widget_height)])
+            self.presenter.model.image_stack.create_delayed_array = True
+            self.presenter.model.image_stack.create_and_set_delayed_stack()
+            self.presenter.model.image_stack.calc_mean_fully_roi()
+            self.presenter.update_spectrum(self.presenter.model.image_stack.mean)
         else:
             self.live_viewer.set_roi_alpha(0)
             self.splitter.setSizes([widget_height, 0])
-
-
+            self.presenter.model.image_stack.create_delayed_array = False

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -68,6 +68,8 @@ class LiveViewerWindowView(BaseMainWindowView):
         operations_menu.addAction(self.spectrum_action)
         self.spectrum_action.triggered.connect(self.set_spectrum_visibility)
         self.presenter.model.image_stack.create_delayed_array = False
+        self.live_viewer.set_roi_alpha(self.spectrum_action.isChecked() * 255)
+        self.live_viewer.set_roi_visibility_flags(False)
 
     def show(self) -> None:
         """Show the window"""
@@ -122,10 +124,12 @@ class LiveViewerWindowView(BaseMainWindowView):
     def set_spectrum_visibility(self):
         widget_height = self.frameGeometry().height()
         if self.spectrum_action.isChecked():
-            if self.live_viewer.roi_object:
-                self.live_viewer.set_roi_alpha(255)
+            if not self.live_viewer.roi_object:
+                self.live_viewer.add_roi()
+            self.live_viewer.set_roi_alpha(255)
             self.splitter.setSizes([int(0.7 * widget_height), int(0.3 * widget_height)])
             self.presenter.model.image_stack.create_delayed_array = True
+            self.presenter.model.image_stack.set_roi(self.live_viewer.get_roi())
             self.presenter.model.image_stack.create_and_set_delayed_stack()
             self.presenter.model.image_stack.calc_mean_fully_roi()
             self.presenter.update_spectrum(self.presenter.model.image_stack.mean)

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -14,7 +14,7 @@ from .presenter import LiveViewerWindowPresenter
 
 import numpy as np
 
-from ..spectrum_viewer.spectrum_widget import SpectrumPlotWidget
+from ..spectrum_viewer.spectrum_widget import SpectrumWidget, SpectrumPlotWidget
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
@@ -34,18 +34,19 @@ class LiveViewerWindowView(BaseMainWindowView):
         self.main_window = main_window
         self.path = live_dir_path
         self.presenter = LiveViewerWindowPresenter(self, main_window)
-        self.splitter = QSplitter(Qt.Vertical)
         self.live_viewer = LiveViewWidget()
+        self.splitter = QSplitter(Qt.Vertical)
         self.imageLayout.addWidget(self.splitter)
         self.live_viewer.z_slider.valueChanged.connect(self.presenter.select_image)
 
         self.spectrum_plot_widget = SpectrumPlotWidget()
         self.spectrum = self.spectrum_plot_widget.spectrum
+        self.live_viewer.roi_changed.connect(self.presenter.handle_roi_moved)
 
         self.splitter.addWidget(self.live_viewer)
         self.splitter.addWidget(self.spectrum_plot_widget)
         widget_height = self.frameGeometry().height()
-        self.splitter.setSizes([int(0.7 * widget_height), int(0.3 * widget_height)])
+        self.splitter.setSizes([widget_height, 0])
 
         self.filter_params: dict[str, dict] = {}
         self.right_click_menu = self.live_viewer.image.vb.menu
@@ -61,6 +62,11 @@ class LiveViewerWindowView(BaseMainWindowView):
             action.triggered.connect(self.set_image_rotation_angle)
             if angle == 0:
                 action.setChecked(True)
+
+        self.spectrum_action = QAction("Calculate Spectrum", self)
+        self.spectrum_action.setCheckable(True)
+        operations_menu.addAction(self.spectrum_action)
+        self.spectrum_action.triggered.connect(self.set_spectrum_visibility)
 
     def show(self) -> None:
         """Show the window"""
@@ -111,3 +117,14 @@ class LiveViewerWindowView(BaseMainWindowView):
             image_rotation_angle = int(self.rotate_angles_group.checkedAction().text().replace('°', ''))
             self.filter_params["Rotate Stack"] = {"params": {"angle": image_rotation_angle}}
         self.presenter.update_image_operation()
+
+    def set_spectrum_visibility(self):
+        widget_height = self.frameGeometry().height()
+        if self.spectrum_action.isChecked():
+            self.live_viewer.set_roi_alpha(255)
+            self.splitter.setSizes([int(0.7 * widget_height), int(0.3 * widget_height)])
+        else:
+            self.live_viewer.set_roi_alpha(0)
+            self.splitter.setSizes([widget_height, 0])
+
+

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -122,7 +122,7 @@ class LiveViewerWindowView(BaseMainWindowView):
     def set_spectrum_visibility(self):
         widget_height = self.frameGeometry().height()
         if self.spectrum_action.isChecked():
-            if self.live_viewer.roi_object: 
+            if self.live_viewer.roi_object:
                 self.live_viewer.set_roi_alpha(255)
             self.splitter.setSizes([int(0.7 * widget_height), int(0.3 * widget_height)])
             self.presenter.model.image_stack.create_delayed_array = True


### PR DESCRIPTION
### Issue

Progresses #2327

### Description

Dask has been used to create a DaskImageDataStack in the Live Viewer Model which lazily loads the incoming images into a Dask Array. This Dask Array is then used to display and do stack-wide operations (i.e. calculate the mean spectrum within an ROI) on the incoming data without having to load the full stack into RAM and could therefore be useful for PCs with low RAM. The Dask-style of handling the data can be toggled on or off by right-clicking the image > Operations > Calculate Spectrum. If the checkbox is unchecked, the Live Viewer falls back to its older functionality.

### Testing 

Make sure all tests pass

### Acceptance Criteria 

Open the Live Viewer and point it to a empty test folder, and toggle the Spectrum Calculation on via the right-click menu. 
Use the `simulate-live-date.py` script to move images into the test folder and check that the spectrum is calculated and updated with every new image, and it is at a level that you would expect (i.e. verify this with the Spectrum Viewer).
While in operation, try moving the ROI and check that the Spectrum is recalculated and updates in the window accordingly.

### Documentation

Release note