### PR TITLE
Refactor ROI Management in Spectrum Viewer

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -120,47 +120,18 @@ class SpectrumViewerWindowModel:
 
     def set_stack(self, stack: ImageStack | None) -> None:
         """
-        Sets the stack to be used by the model
-        If that stack is None, then the model will be reset
-        If the stack has changed, then the ROI ranges will be reset
-        and additional ROIs excluding default ROIs will be removed
-
-        @param stack: The new stack to be used by the model
+        Sets the stack to be used by the model.
+        If the stack is None, the model will be reset.
         """
-
         self._stack = stack
         if stack is None:
             return
         self.tof_range = (0, stack.data.shape[0] - 1)
         self.tof_range_full = self.tof_range
         self.tof_data = self.get_stack_time_of_flight()
-        self.set_new_roi(ROI_ALL)
-
-    def set_new_roi(self, name: str) -> None:
-        """
-        Sets a new ROI with the given name
-
-        @param name: The name of the new ROI
-        """
-        height, width = self.get_image_shape()
-        self.set_roi(name, SensibleROI.from_list([0, 0, width, height]))
 
     def set_normalise_stack(self, normalise_stack: ImageStack | None) -> None:
         self._normalise_stack = normalise_stack
-
-    def set_roi(self, roi_name: str, roi: SensibleROI) -> None:
-        self._roi_ranges[roi_name] = roi
-
-    def get_roi(self, roi_name: str) -> SensibleROI:
-        """
-        Get the ROI with the given name from the model
-
-        @param roi_name: The name of the ROI to get
-        @return: The ROI with the given name
-        """
-        if roi_name not in self._roi_ranges.keys():
-            raise KeyError(f"ROI {roi_name} does not exist in roi_ranges {self._roi_ranges.keys()}")
-        return self._roi_ranges[roi_name]
 
     def get_averaged_image(self) -> np.ndarray | None:
         """
@@ -218,15 +189,9 @@ class SpectrumViewerWindowModel:
             return "Need 2 different ShutterCount stacks"
         return ""
 
-    def get_spectrum(self,
-                     roi: str | SensibleROI,
-                     mode: SpecType,
-                     normalise_with_shuttercount: bool = False) -> np.ndarray:
+    def get_spectrum(self, roi: SensibleROI, mode: SpecType, normalise_with_shuttercount: bool = False) -> np.ndarray:
         if self._stack is None:
             return np.array([])
-
-        if isinstance(roi, str):
-            roi = self.get_roi(roi)
 
         if mode == SpecType.SAMPLE:
             return self.get_stack_spectrum(self._stack, roi)
@@ -516,36 +481,6 @@ class SpectrumViewerWindowModel:
         """
         rits_data = saver.create_rits_format(tof, transmission, absorption)
         saver.export_to_dat_rits_format(rits_data, path)
-
-    def remove_roi(self, roi_name: str) -> None:
-        """
-        Remove the selected ROI from the model
-
-        @param roi_name: The name of the ROI to remove
-        """
-        if roi_name in self._roi_ranges.keys():
-            if roi_name in self.special_roi_list:
-                raise RuntimeError(f"Cannot remove ROI: {roi_name}")
-            del self._roi_ranges[roi_name]
-        else:
-            raise KeyError(
-                f"Cannot remove ROI {roi_name} as it does not exist. \n Available ROIs: {self._roi_ranges.keys()}")
-
-    def rename_roi(self, old_name: str, new_name: str) -> None:
-        """
-        Rename the selected ROI from the model
-
-        @param old_name: The current name of the ROI
-        @param new_name: The new name of the ROI
-        @raises KeyError: If the ROI does not exist
-        @raises RuntimeError: If the ROI is 'all'
-        """
-        if old_name in self._roi_ranges.keys() and new_name not in self._roi_ranges.keys():
-            if old_name in self.special_roi_list:
-                raise RuntimeError(f"Cannot remove ROI: {old_name}")
-            self._roi_ranges[new_name] = self._roi_ranges.pop(old_name)
-        else:
-            raise KeyError(f"Cannot rename {old_name} to {new_name} Available:{self._roi_ranges.keys()}")
 
     def remove_all_roi(self) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -576,11 +576,3 @@ class SpectrumViewerWindowView(BaseMainWindowView):
                     spin_box.setMaximum(self.spectrum_widget.image.image_data.shape[1])
             spin_box.valueChanged.connect(self.presenter.do_adjust_roi)
             self.roiPropertiesSpinBoxes[prop] = spin_box
-
-        # Ensure "Width" and "Height" labels are created and added to the dictionary
-        self.roiPropertiesLabels["Width"] = QLabel()
-        self.roiPropertiesLabels["Height"] = QLabel()
-
-        # Set the ROI properties in the table widget
-        self.roiPropertiesTableWidget.setCellWidget(2, 1, self.roiPropertiesLabels["Width"])
-        self.roiPropertiesTableWidget.setCellWidget(2, 2, self.roiPropertiesLabels["Height"])


### PR DESCRIPTION
Overview
This PR refactors the ROI management across SpectrumViewerWindowModel, SpectrumWidget, and SpectrumViewerWindowView to resolve synchronization issues and improve stability. It consolidates ROI handling within SpectrumWidget, simplifying the architecture and avoiding errors related to duplicate state management.

Key Changes:

Refactor SpectrumViewerWindowModel:
Removed ROI-specific methods (set_new_roi, get_roi, etc.).
Updated get_spectrum() to accept SensibleROI instead of ROI name strings.
Removed _roi_ranges, delegating ROI management to SpectrumWidget.

Update SpectrumWidget as ROI Manager:
Added methods to handle all ROI operations (add, remove, adjust, etc.).
Introduced get_list_of_roi_names() to return ROI names from the widget.

Refactor SpectrumViewerWindowView:
Replaced model-based ROI interactions with SpectrumWidget.