### PR TITLE
2307 auto find spectra

### DIFF
--- a/docs/release_notes/next/dev-2307-auto_find_spectra_and_shuttercounts
+++ b/docs/release_notes/next/dev-2307-auto_find_spectra_and_shuttercounts
@@ -1,0 +1,1 @@
+#2307: Try to find ShutterCount and Spectra log files within a selected dataset in the loading dialog menu

--- a/mantidimaging/core/io/test/filenames_test.py
+++ b/mantidimaging/core/io/test/filenames_test.py
@@ -188,6 +188,23 @@ class FilenameGroupTest(FakeFSTestCase):
 
         self._files_equal(fg.log_path, log)
 
+    @parameterized.expand([
+        ("/foo/tomo/IMAT_Flower_Tomo_000000.tif", "/foo/shuttercount.txt"),
+        ("/foo/Flat_Before/IMAT_Flower_Tomo_000000.tif", "/foo/Flat_Before_shuttercount.txt"),
+        ("/foo/Flat_After/IMAT_Flower_Tomo_000000.tif", "/foo/Flat_After_shuttercount.txt"),
+    ])
+    def test_find_shuttercount_log(self, sample_path, log_path):
+        log = Path(log_path)
+        self.fs.create_file(log)
+
+        sample = Path(sample_path)
+        self.fs.create_file(sample)
+
+        fg = FilenameGroup.from_file(sample)
+        fg.find_shutter_count_file()
+
+        self._files_equal(fg.shutter_count_path.resolve(), log.resolve())
+
     def test_find_log_best(self):
         log = Path("/foo", "Dark_log.txt")
         self.fs.create_file(log)
@@ -201,6 +218,64 @@ class FilenameGroupTest(FakeFSTestCase):
         fg.find_log_file()
 
         self._files_equal(fg.log_path, log)
+
+    def test_find_log_over_spectra_if_both(self):
+        spectra = Path("/foo", "spectra.txt")
+        self.fs.create_file(spectra)
+        log = Path("/foo", "TomoIMAT_Flower_Tomo_000000_log.txt")
+        self.fs.create_file(log)
+
+        sample = Path("/foo", "Tomo", "IMAT_Flower_Tomo_000000.tif")
+        self.fs.create_file(sample)
+
+        fg = FilenameGroup.from_file(sample)
+        fg.find_log_file()
+
+        self._files_equal(fg.log_path, log)
+
+    def test_find_spectra(self):
+        spectra = Path("/foo", "sample_spectra.txt")
+        self.fs.create_file(spectra)
+
+        sample = Path("/foo", "Tomo", "IMAT_Flower_Tomo_000000.tif")
+        self.fs.create_file(sample)
+
+        fg = FilenameGroup.from_file(sample)
+        fg.find_log_file()
+
+        self._files_equal(fg.log_path, spectra)
+
+    @parameterized.expand([
+        ("/foo/Tomo/IMAT_Flower_Tomo_000000.tif", "/foo/Flat_Before_ShutterCount.txt"),
+        ("/foo/Tomo/IMAT_Flower_Tomo_000000.tif", "/foo/Flat_After_ShutterCount.txt"),
+    ])
+    def test_find_shuttercount_no_flat_before_or_after(self, sample_path, log_path):
+        log = Path(log_path)
+        self.fs.create_file(log)
+
+        sample = Path(sample_path)
+        self.fs.create_file(sample)
+
+        fg = FilenameGroup.from_file(sample)
+        fg.find_shutter_count_file()
+
+        self.assertIsNone(fg.shutter_count_path)
+
+    @parameterized.expand([
+        ("/foo/Flat_Before/IMAT_Flower_Tomo_000000.tif", "/foo/Flat_Before_ShutterCount.txt"),
+        ("/foo/Flat_After/IMAT_Flower_Tomo_000000.tif", "/foo/Flat_After_ShutterCount.txt"),
+    ])
+    def test_find_shuttercount_if_flat_before(self, sample_path, log_path):
+        log = Path(log_path)
+        self.fs.create_file(log)
+
+        sample = Path(sample_path)
+        self.fs.create_file(sample)
+
+        fg = FilenameGroup.from_file(sample)
+        fg.find_shutter_count_file()
+
+        self._files_equal(fg.shutter_count_path, log)
 
     @parameterized.expand([
         ("/a/Tomo/foo_Tomo_%06d.tif", "/a/Flat_Before/foo_Flat_Before_%06d.tif"),

--- a/mantidimaging/gui/windows/image_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/image_load_dialog/presenter.py
@@ -108,7 +108,6 @@ class LoadPresenter:
         :return None
         """
         filename_group = FilenameGroup.from_file(Path(selected_file))
-        filename_group.find_shutter_count_file()
         field.set_images(list(filename_group.all_files()))
         self._update_field_action(field, selected_file)
         self.ensure_sample_shuttercount_consistency(field, selected_file)


### PR DESCRIPTION
### Issue

Closes #2307 

### Description

*Add a description of the changes made*.
Try to find spectra and shuttercount files when present under parent directory.
Only load flat before and/or flat after if flat before and/or after directories found under parent directory.

### Testing 

*Describe the tests that were used to verify your changes*.

#### Spectra
Test is a spectra file located directly under the parent directory can be found if the name of the file ends in "spectra.txt" for a given dataset.

If both a sample log and spectra file are present under the parent directory, the log file is prioritised over the spectra file.

#### Shutter Counts
Test if relevant shuttercount files can be found directly under the parent directory for the following directory structure:

- parent_dir/
  - tomo/img_000000.tif
  - 180deg/img_180deg_000000.tif
  - Flat_After/Flat_After_img_000000.tif
  - Dark_After/Dark_After_img_000000.tif
  - Flat_Before/Flat_Before_img_000000.tif
  - Flat_After_log.txt
  - Flat_After_ShutterCount.txt
  - ShutterCount.txt
  - Tomo_log.txt

- Shuttercount and flat after shuttercount files should be loaded automatically
- Delete Flat_After directory
- Try loading in again and notice that flat after shuttercount file does not get loaded in.

### Acceptance Criteria 

*How should the reviewer test your changes*?

* Spectra file can be found present
* If a dataset has a sample log and spectra file, the log file is automatically selected
* A level of auto-detection exists for shutter count files if named `ShutterCount.txt`, `Flat_Before_ShutterCount.txt` or `Flat_After_ShutterCount.txt`

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*

`docs/release_notes/next/dev-2307-auto_find_spectra_and_shuttercounts`
