### PR TITLE
Refactor ROI management to delegate colour, visibility, and alpha to SpectrumROI

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -89,6 +89,15 @@ class SpectrumROI(ROI):
     def colour(self, colour: tuple[int, int, int, int]) -> None:
         self._colour = colour
         self.setPen(self._colour)
+        self.hoverPen = mkPen(self._colour, width=3)
+
+    def set_visibility(self, visible: bool) -> None:
+        """
+        Set the visibility of the ROI and its handles.
+        """
+        self.setVisible(visible)
+        for handle in self.getHandles():
+            handle.setVisible(visible)
 
     @property
     def selected_row(self) -> int | None:
@@ -166,12 +175,8 @@ class SpectrumWidget(QWidget):
     def change_roi_colour(self, name: str, colour: tuple[int, int, int, int]) -> None:
         """
         Change the colour of an existing ROI
-
-        @param name: The name of the ROI.
-        @param colour: The new colour of the ROI.
         """
         self.roi_dict[name].colour = colour
-        self.roi_dict[name].setPen(self.roi_dict[name].colour)
 
     def set_roi_visibility_flags(self, name: str, visible: bool) -> None:
         """
@@ -181,19 +186,14 @@ class SpectrumWidget(QWidget):
         @param name: The name of the ROI.
         @param visible: The new visibility of the ROI.
         """
-        handles = self.roi_dict[name].getHandles()
-        for handle in handles:
-            handle.setVisible(visible)
-        self.roi_dict[name].setVisible(visible)
+        self.roi_dict[name].set_visibility(visible)
 
     def set_roi_alpha(self, name: str, alpha: float) -> None:
         """
         Change the alpha value of an existing ROI
-
         @param name: The name of the ROI.
         @param alpha: The new alpha value of the ROI.
         """
-
         self.roi_dict[name].colour = self.roi_dict[name].colour[:3] + (alpha, )
         self.roi_dict[name].setPen(self.roi_dict[name].colour)
         self.roi_dict[name].hoverPen = mkPen(self.roi_dict[name].colour, width=3)
@@ -271,7 +271,7 @@ class SpectrumWidget(QWidget):
 class CustomViewBox(ViewBox):
 
     def __init__(self, *args, **kwds) -> None:
-        #kwds['enableMenu'] = False
+        # kwds['enableMenu'] = False
         ViewBox.__init__(self, *args, **kwds)
         self.setMouseMode(self.PanMode)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
@@ -90,7 +90,7 @@ class SpectrumWidgetTest(unittest.TestCase):
         self.spectrum_widget.set_roi_visibility_flags(name, alpha)
         self.assertEqual(bool(alpha), self.spectrum_widget.roi_dict[name].isVisible())
 
-    @parameterized.expand([("Visible", "visible_roi", 1), ("Invisible", "invisible_roi", 0)])
+    @parameterized.expand([("Visible", "visible_roi", 255), ("Invisible", "invisible_roi", 0)])
     def test_WHEN_set_roi_alpha_called_THEN_roi_alpha_updated(self, _, name, alpha):
         spectrum_roi = SpectrumROI(name, self.sensible_roi, rotatable=False, scaleSnap=True, translateSnap=True)
         self.spectrum_widget.roi_dict[name] = spectrum_roi


### PR DESCRIPTION
### Issue

Closes #2337

### Description

Refactored SpectrumWidget to delegate colour, visibility, and alpha updates to SpectrumROI. The colour, set_visibility(), and set_alpha() methods are now handled directly in SpectrumROI, simplifying SpectrumWidget's logic and improving encapsulation.


### Testing

Verified that ROIs change colour, visibility, and alpha as expected.
Tested that hoverPen updates correctly when colour or alpha changes.
Confirmed that ROI handles appear/disappear correctly with visibility and alpha updates.

### Acceptance Criteria 

Reviewer should verify that changing ROI colour, visibility, and alpha behaves correctly through the GUI.
Test that hoverPen and visibility behaviour is consistent with changes.
Check that the simplified methods in SpectrumWidget properly delegate to SpectrumROI.


### Documentation

Updated the relevant section in docs/release_notes to reflect the changes to SpectrumROI and SpectrumWidget.
