### PR TITLE
Unify datasets 7 - tree views

### DIFF
--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -110,6 +110,10 @@ class Dataset:
     def recons(self) -> ReconList:
         return self._recons
 
+    @property
+    def stacks(self) -> list[ImageStack]:
+        return self._stacks
+
     def add_recon(self, recon: ImageStack) -> None:
         self.recons.append(recon)
 

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -178,6 +178,16 @@ class Dataset:
         else:
             raise AttributeError(f"StrictDataset does not have an attribute for {attr_name}")
 
+    def set_stack_by_type_name(self, file_type_name: str, image_stack: ImageStack) -> None:
+        file_type_name = file_type_name.upper().replace(" ", "_")
+        if file_type_name == "RECON":
+            self.add_recon(image_stack)
+        elif file_type_name == "IMAGES":
+            self.stacks.append(image_stack)
+        else:
+            file_type = getattr(FILE_TYPES, file_type_name)
+            self.set_stack(file_type, image_stack)
+
     @property
     def is_processed(self) -> bool:
         """

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -102,8 +102,10 @@ class BaseEyesTest(unittest.TestCase):
         image_stack = loader.load(filename_group, indices=Indices(0, 100, 2))
         dataset = StrictDataset(sample=image_stack)
         image_stack.name = "Stack 1"
-        vis = self.imaging.presenter.create_strict_dataset_stack_windows(dataset)
-        self.imaging.presenter.create_strict_dataset_tree_view_items(dataset)
+        self.imaging.presenter.model.add_dataset_to_model(dataset)
+        self.imaging.presenter._add_strict_dataset_to_view(dataset)
+        assert dataset.sample  # Dataset has a sample
+        vis = self.imaging.get_stack_visualiser(dataset.sample.id)
 
         if set_180:
             _180_array = image_stack.data[0:1]
@@ -121,8 +123,8 @@ class BaseEyesTest(unittest.TestCase):
     def _create_new_dataset(self) -> Dataset:
         new_dataset = Dataset(sample=generate_images(), name="new")
         self.imaging.presenter.create_strict_dataset_stack_windows(new_dataset)
-        self.imaging.presenter.create_strict_dataset_tree_view_items(new_dataset)
         self.imaging.presenter.model.add_dataset_to_model(new_dataset)
+        self.imaging.presenter.update_dataset_tree()
 
         QApplication.sendPostedEvents()
 

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -103,7 +103,7 @@ class BaseEyesTest(unittest.TestCase):
         dataset = StrictDataset(sample=image_stack)
         image_stack.name = "Stack 1"
         self.imaging.presenter.model.add_dataset_to_model(dataset)
-        self.imaging.presenter._add_strict_dataset_to_view(dataset)
+        self.imaging.presenter._add_dataset_to_view(dataset)
         assert dataset.sample  # Dataset has a sample
         vis = self.imaging.get_stack_visualiser(dataset.sample.id)
 

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -122,7 +122,7 @@ class BaseEyesTest(unittest.TestCase):
 
     def _create_new_dataset(self) -> Dataset:
         new_dataset = Dataset(sample=generate_images(), name="new")
-        self.imaging.presenter.create_strict_dataset_stack_windows(new_dataset)
+        self.imaging.presenter.create_dataset_stack_visualisers(new_dataset)
         self.imaging.presenter.model.add_dataset_to_model(new_dataset)
         self.imaging.presenter.update_dataset_tree()
 

--- a/mantidimaging/eyes_tests/spectrum_viewer_test.py
+++ b/mantidimaging/eyes_tests/spectrum_viewer_test.py
@@ -16,11 +16,8 @@ class SpectrumViewerWindowTest(BaseEyesTest):
         open_stack = generate_images(seed=666, shape=(20, 10, 10))
         open_stack.name = "Open Beam Stack"
         dataset = StrictDataset(sample=sample_stack, flat_before=open_stack)
-        vis = self.imaging.presenter.create_strict_dataset_stack_windows(dataset)
-        self.imaging.presenter.create_strict_dataset_tree_view_items(dataset)
         self.imaging.presenter.model.add_dataset_to_model(dataset)
         QApplication.sendPostedEvents()
-        return vis
 
     def test_spectrum_viewer_opens_with_data(self):
         self._generate_spectrum_dataset()

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -16,7 +16,7 @@ from PyQt5.QtWidgets import QTabBar, QApplication, QTreeWidgetItem
 from qt_material import apply_stylesheet
 
 from mantidimaging.core.data import ImageStack
-from mantidimaging.core.data.dataset import StrictDataset, MixedDataset, _get_stack_data_type, Dataset
+from mantidimaging.core.data.dataset import MixedDataset, _get_stack_data_type, Dataset
 from mantidimaging.core.io.loader.loader import create_loading_parameters_for_file_path
 from mantidimaging.core.io.utility import find_projection_closest_to_180, THRESHOLD_180
 from mantidimaging.core.utility.data_containers import ProjectionAngles
@@ -142,7 +142,7 @@ class MainWindowPresenter(BasePresenter):
         assert self.view.nexus_load_dialog is not None
         dataset, _ = self.view.nexus_load_dialog.presenter.get_dataset()
         self.model.add_dataset_to_model(dataset)
-        self._add_strict_dataset_to_view(dataset)
+        self._add_dataset_to_view(dataset)
         self.view.model_changed.emit()
 
     def save_nexus_file(self) -> None:
@@ -180,14 +180,14 @@ class MainWindowPresenter(BasePresenter):
     def _on_dataset_load_done(self, task: TaskWorkerThread) -> None:
 
         if task.was_successful():
-            self._add_strict_dataset_to_view(task.result)
+            self._add_dataset_to_view(task.result)
             self.view.model_changed.emit()
             task.result = None
             self._open_window_if_not_open()
         else:
             self._handle_task_error(self.LOAD_ERROR_STRING, task)
 
-    def _add_strict_dataset_to_view(self, dataset: StrictDataset) -> None:
+    def _add_dataset_to_view(self, dataset: Dataset) -> None:
         """
         Takes a loaded dataset and tries to find a substitute 180 projection (if required) then creates the stack window
         and dataset tree view items.
@@ -222,7 +222,7 @@ class MainWindowPresenter(BasePresenter):
     def get_all_180_projections(self) -> list[ImageStack]:
         return self.model.proj180s
 
-    def add_alternative_180_if_required(self, dataset: StrictDataset) -> None:
+    def add_alternative_180_if_required(self, dataset: Dataset) -> None:
         """
         Checks if the dataset has a 180 projection and tries to find an alternative if one is missing.
         :param dataset: The loaded dataset.

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -159,18 +159,8 @@ class MainWindowPresenter(BasePresenter):
                               busy=True)
 
     def load_image_stack(self, file_path: str) -> None:
-        start_async_task_view(self.view, self.model.load_images_into_mixed_dataset, self._on_stack_load_done,
+        start_async_task_view(self.view, self.model.load_images_into_mixed_dataset, self._on_dataset_load_done,
                               {'file_path': file_path})
-
-    def _on_stack_load_done(self, task: TaskWorkerThread) -> None:
-
-        if task.was_successful():
-            self.create_mixed_dataset_tree_view_items(task.result)
-            self.create_dataset_stack_visualisers(task.result)
-            self.view.model_changed.emit()
-            task.result = None
-        else:
-            self._handle_task_error(self.LOAD_ERROR_STRING, task)
 
     def _open_window_if_not_open(self) -> None:
         """
@@ -205,7 +195,8 @@ class MainWindowPresenter(BasePresenter):
         """
         self.update_dataset_tree()
         self.create_dataset_stack_visualisers(dataset)
-        self.add_alternative_180_if_required(dataset)
+        if dataset.sample:
+            self.add_alternative_180_if_required(dataset)
 
     def _handle_task_error(self, base_message: str, task: TaskWorkerThread) -> None:
         msg = base_message.format(task.error)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -366,6 +366,8 @@ class MainWindowPresenter(BasePresenter):
                 self.view.add_item_to_dataset_tree_widget("Dark After", dataset.dark_after.id, dataset_item)
             if dataset.proj180deg:
                 self.view.add_item_to_dataset_tree_widget("180", dataset.proj180deg.id, dataset_item)
+            if dataset.sinograms:
+                self.view.add_item_to_dataset_tree_widget("Sinograms", dataset.sinograms.id, dataset_item)
 
             if dataset.recons:
                 recon_item = self.view.add_item_to_dataset_tree_widget("Recons", dataset.recons.id, dataset_item)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -356,6 +356,16 @@ class MainWindowPresenter(BasePresenter):
 
             if dataset.sample:
                 self.view.add_item_to_dataset_tree_widget("Projections", dataset.sample.id, dataset_item)
+            if dataset.flat_before:
+                self.view.add_item_to_dataset_tree_widget("Flat Before", dataset.flat_before.id, dataset_item)
+            if dataset.flat_after:
+                self.view.add_item_to_dataset_tree_widget("Flat After", dataset.flat_after.id, dataset_item)
+            if dataset.dark_before:
+                self.view.add_item_to_dataset_tree_widget("Dark Before", dataset.dark_before.id, dataset_item)
+            if dataset.dark_after:
+                self.view.add_item_to_dataset_tree_widget("Dark After", dataset.dark_after.id, dataset_item)
+            if dataset.proj180deg:
+                self.view.add_item_to_dataset_tree_widget("180", dataset.proj180deg.id, dataset_item)
 
     def create_strict_dataset_tree_view_items(self, dataset: StrictDataset) -> None:
         """

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -372,6 +372,10 @@ class MainWindowPresenter(BasePresenter):
                 for recon in dataset.recons:
                     self.view.add_item_to_dataset_tree_widget(recon.name, recon.id, recon_item)
 
+            if dataset.stacks:
+                for image_stack in dataset.stacks:
+                    self.view.add_item_to_dataset_tree_widget(image_stack.name, image_stack.id, dataset_item)
+
     def create_strict_dataset_tree_view_items(self, dataset: StrictDataset) -> None:
         """
         Creates the tree view items for a strict dataset.

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -349,6 +349,14 @@ class MainWindowPresenter(BasePresenter):
     def _on_tab_clicked(self, stack: StackVisualiserView) -> None:
         self._set_tree_view_selection_with_id(stack.id)
 
+    def update_dataset_tree(self) -> None:
+        self.view.clear_dataset_tree_widget()
+        for dataset_id, dataset in self.model.datasets.items():
+            dataset_item = self.view.add_toplevel_item_to_dataset_tree_widget(dataset.name, dataset_id)
+
+            if dataset.sample:
+                self.view.add_item_to_dataset_tree_widget("Projections", dataset.sample.id, dataset_item)
+
     def create_strict_dataset_tree_view_items(self, dataset: StrictDataset) -> None:
         """
         Creates the tree view items for a strict dataset.

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -340,18 +340,6 @@ class MainWindowPresenter(BasePresenter):
                 for image_stack in dataset.stacks:
                     self.view.add_item_to_dataset_tree_widget(image_stack.name, image_stack.id, dataset_item)
 
-    def create_mixed_dataset_tree_view_items(self, dataset: MixedDataset) -> None:
-        """
-        Creates the tree view items for a mixed dataset.
-        :param dataset: The loaded dataset.
-        """
-        dataset_tree_item = self.view.create_dataset_tree_widget_item(dataset.name, dataset.id)
-
-        for i in range(len(dataset.all)):
-            self.view.create_child_tree_item(dataset_tree_item, dataset.all[i].id, dataset.all[i].name)
-
-        self.view.add_item_to_tree_view(dataset_tree_item)
-
     def save_image_files(self) -> None:
         assert isinstance(self.view.image_save_dialog, ImageSaveDialog)
         kwargs = {

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -367,6 +367,11 @@ class MainWindowPresenter(BasePresenter):
             if dataset.proj180deg:
                 self.view.add_item_to_dataset_tree_widget("180", dataset.proj180deg.id, dataset_item)
 
+            if dataset.recons:
+                recon_item = self.view.add_item_to_dataset_tree_widget("Recons", dataset.recons.id, dataset_item)
+                for recon in dataset.recons:
+                    self.view.add_item_to_dataset_tree_widget(recon.name, recon.id, recon_item)
+
     def create_strict_dataset_tree_view_items(self, dataset: StrictDataset) -> None:
         """
         Creates the tree view items for a strict dataset.

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -203,8 +203,8 @@ class MainWindowPresenter(BasePresenter):
         and dataset tree view items.
         :param dataset: The loaded dataset.
         """
+        self.update_dataset_tree()
         self.create_strict_dataset_stack_windows(dataset)
-        self.create_strict_dataset_tree_view_items(dataset)
         self.add_alternative_180_if_required(dataset)
 
     def _handle_task_error(self, base_message: str, task: TaskWorkerThread) -> None:
@@ -377,33 +377,6 @@ class MainWindowPresenter(BasePresenter):
             if dataset.stacks:
                 for image_stack in dataset.stacks:
                     self.view.add_item_to_dataset_tree_widget(image_stack.name, image_stack.id, dataset_item)
-
-    def create_strict_dataset_tree_view_items(self, dataset: StrictDataset) -> None:
-        """
-        Creates the tree view items for a strict dataset.
-        :param dataset: The loaded dataset.
-        """
-        assert dataset.sample is not None
-        dataset_tree_item = self.view.create_dataset_tree_widget_item(dataset.name, dataset.id)
-        self.view.create_child_tree_item(dataset_tree_item, dataset.sample.id, "Projections")
-
-        if dataset.flat_before and dataset.flat_before.filenames:
-            self.view.create_child_tree_item(dataset_tree_item, dataset.flat_before.id, "Flat Before")
-        if dataset.flat_after and dataset.flat_after.filenames:
-            self.view.create_child_tree_item(dataset_tree_item, dataset.flat_after.id, "Flat After")
-        if dataset.dark_before and dataset.dark_before.filenames:
-            self.view.create_child_tree_item(dataset_tree_item, dataset.dark_before.id, "Dark Before")
-        if dataset.dark_after and dataset.dark_after.filenames:
-            self.view.create_child_tree_item(dataset_tree_item, dataset.dark_after.id, "Dark After")
-        if dataset.sample.has_proj180deg() and dataset.sample.proj180deg.filenames:  # type: ignore
-            self.view.create_child_tree_item(
-                dataset_tree_item,
-                dataset.sample.proj180deg.id,  # type: ignore
-                "180")
-        for recon in dataset.recons:
-            self.add_recon_item_to_tree_view(dataset.id, recon.id, recon.name)
-
-        self.view.add_item_to_tree_view(dataset_tree_item)
 
     def create_mixed_dataset_tree_view_items(self, dataset: MixedDataset) -> None:
         """

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -316,20 +316,13 @@ class MainWindowPresenter(BasePresenter):
         for dataset_id, dataset in self.model.datasets.items():
             dataset_item = self.view.add_toplevel_item_to_dataset_tree_widget(dataset.name, dataset_id)
 
-            if dataset.sample:
-                self.view.add_item_to_dataset_tree_widget("Projections", dataset.sample.id, dataset_item)
-            if dataset.flat_before:
-                self.view.add_item_to_dataset_tree_widget("Flat Before", dataset.flat_before.id, dataset_item)
-            if dataset.flat_after:
-                self.view.add_item_to_dataset_tree_widget("Flat After", dataset.flat_after.id, dataset_item)
-            if dataset.dark_before:
-                self.view.add_item_to_dataset_tree_widget("Dark Before", dataset.dark_before.id, dataset_item)
-            if dataset.dark_after:
-                self.view.add_item_to_dataset_tree_widget("Dark After", dataset.dark_after.id, dataset_item)
-            if dataset.proj180deg:
-                self.view.add_item_to_dataset_tree_widget("180", dataset.proj180deg.id, dataset_item)
-            if dataset.sinograms:
-                self.view.add_item_to_dataset_tree_widget("Sinograms", dataset.sinograms.id, dataset_item)
+            attributes = [("Projections", dataset.sample), ("Flat Before", dataset.flat_before),
+                          ("Flat After", dataset.flat_after), ("Dark Before", dataset.dark_before),
+                          ("Dark After", dataset.dark_after), ("180", dataset.proj180deg),
+                          ("Sinograms", dataset.sinograms)]
+            for label, item in attributes:
+                if item:
+                    self.view.add_item_to_dataset_tree_widget(label, item.id, dataset_item)
 
             if dataset.recons:
                 recon_item = self.view.add_item_to_dataset_tree_widget("Recons", dataset.recons.id, dataset_item)

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -88,7 +88,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.assertFalse(task.was_successful())
 
         # Call the callback with a task that failed
-        self.presenter._on_stack_load_done(task)
+        self.presenter._on_dataset_load_done(task)
 
         # Expect error message
         self.view.show_error_dialog.assert_called_once_with(self.presenter.LOAD_ERROR_STRING.format(task.error))
@@ -122,7 +122,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.load_image_stack(file_path)
 
         start_async_mock.assert_called_once_with(self.view, self.presenter.model.load_images_into_mixed_dataset,
-                                                 self.presenter._on_stack_load_done, {'file_path': file_path})
+                                                 self.presenter._on_dataset_load_done, {'file_path': file_path})
 
     def test_add_stack(self):
         images = generate_images()
@@ -508,14 +508,15 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.create_child_tree_item.assert_called_once_with(dataset_item_mock, child_id, child_name)
 
     @mock.patch("mantidimaging.gui.windows.main.presenter.MainWindowPresenter.create_mixed_dataset_tree_view_items")
-    def test_on_stack_load_done_success(self, _):
+    @mock.patch("mantidimaging.gui.windows.main.presenter.MainWindowPresenter._open_window_if_not_open")
+    def test_on_stack_load_done_success(self, _, _1):
         task = mock.Mock()
         task.result = result_mock = mock.Mock()
         task.was_successful.return_value = True
         task.kwargs = {'file_path': "a/stack/path"}
         self.presenter.create_dataset_stack_visualisers = mock.Mock()
 
-        self.presenter._on_stack_load_done(task)
+        self.presenter._on_dataset_load_done(task)
         self.presenter.create_dataset_stack_visualisers.assert_called_once_with(result_mock)
         self.view.model_changed.emit.assert_called_once()
 

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -1095,6 +1095,36 @@ class MainWindowPresenterTest(unittest.TestCase):
         ]
         self.assertListEqual(expected_calls, self.view.add_item_to_dataset_tree_widget.mock_calls)
 
+    def test_update_dataset_tree_datasets_with_recons(self):
+        sample = generate_images((1, 1, 1))
+        recon1, recon2 = generate_images(), generate_images()
+        recon1.name = "recon1"
+        recon2.name = "recon2"
+        dataset = Dataset(name="ds1", sample=sample)
+        dataset.add_recon(recon1)
+        dataset.add_recon(recon2)
+
+        self.model.datasets = {dataset.id: dataset}
+        mock_top_level_widget = mock.Mock()
+        mock_recon_widget = mock.Mock()
+        self.view.add_toplevel_item_to_dataset_tree_widget.return_value = mock_top_level_widget
+        # 2nd call is to create the base of the recon list
+        self.view.add_item_to_dataset_tree_widget.side_effect = [None, mock_recon_widget, None, None]
+
+        self.presenter.update_dataset_tree()
+        self.view.clear_dataset_tree_widget.assert_called_once()
+        self.view.add_toplevel_item_to_dataset_tree_widget.assert_called_once_with("ds1", dataset.id)
+
+        expected_calls = [
+            call(*items) for items in (
+                ("Projections", dataset.sample.id, mock_top_level_widget),
+                ("Recons", dataset.recons.id, mock_top_level_widget),
+                ("recon1", recon1.id, mock_recon_widget),
+                ("recon2", recon2.id, mock_recon_widget),
+            )
+        ]
+        self.assertListEqual(expected_calls, self.view.add_item_to_dataset_tree_widget.mock_calls)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -562,34 +562,6 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter._tabify_stack_window(new_stack)
         self.view.tabifyDockWidget.assert_called_once_with(other_stack, new_stack)
 
-    def test_create_strict_dataset_tree_view_items(self):
-        stacks = generate_images_with_filenames(5)
-        dataset = StrictDataset(sample=stacks[0],
-                                flat_before=stacks[1],
-                                flat_after=stacks[2],
-                                dark_before=stacks[3],
-                                dark_after=stacks[4])
-        dataset.proj180deg = generate_images((1, 20, 20))
-        dataset.proj180deg.filenames = ["filename"]
-        recon = generate_images()
-        recon.name = recon_name = "Recon"
-        dataset.add_recon(recon)
-
-        dataset_tree_item_mock = self.view.create_dataset_tree_widget_item.return_value
-        self.presenter.add_recon_item_to_tree_view = mock.Mock()
-        self.presenter.create_strict_dataset_tree_view_items(dataset)
-
-        s_call = call(dataset_tree_item_mock, dataset.sample.id, "Projections")
-        fb_call = call(dataset_tree_item_mock, dataset.flat_before.id, "Flat Before")
-        fa_call = call(dataset_tree_item_mock, dataset.flat_after.id, "Flat After")
-        db_call = call(dataset_tree_item_mock, dataset.dark_before.id, "Dark Before")
-        da_call = call(dataset_tree_item_mock, dataset.dark_after.id, "Dark After")
-        _180_call = call(dataset_tree_item_mock, dataset.proj180deg.id, "180")
-
-        self.view.create_child_tree_item.assert_has_calls([s_call, fb_call, fa_call, db_call, da_call, _180_call])
-        self.presenter.add_recon_item_to_tree_view.assert_called_once_with(dataset.id, dataset.recons[0].id, recon_name)
-        self.view.add_item_to_tree_view.assert_called_once_with(dataset_tree_item_mock)
-
     def test_add_recon_item_to_tree_view_first_item(self):
         dataset_item_mock = self.view.get_dataset_tree_view_item.return_value
         dataset_item_mock.id = parent_id = "parent-id"

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -507,17 +507,17 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.add_child_item_to_tree_view(dataset_id, child_id, child_name)
         self.view.create_child_tree_item.assert_called_once_with(dataset_item_mock, child_id, child_name)
 
-    @mock.patch("mantidimaging.gui.windows.main.presenter.MainWindowPresenter.create_mixed_dataset_tree_view_items")
+    @mock.patch("mantidimaging.gui.windows.main.presenter.MainWindowPresenter.create_dataset_stack_visualisers")
     @mock.patch("mantidimaging.gui.windows.main.presenter.MainWindowPresenter._open_window_if_not_open")
     def test_on_stack_load_done_success(self, _, _1):
         task = mock.Mock()
-        task.result = result_mock = mock.Mock()
+        task.result = mock.Mock()
         task.was_successful.return_value = True
         task.kwargs = {'file_path': "a/stack/path"}
-        self.presenter.create_dataset_stack_visualisers = mock.Mock()
+        self.presenter.update_dataset_tree = mock.Mock()
 
         self.presenter._on_dataset_load_done(task)
-        self.presenter.create_dataset_stack_visualisers.assert_called_once_with(result_mock)
+        self.presenter.update_dataset_tree.assert_called_once()
         self.view.model_changed.emit.assert_called_once()
 
     @mock.patch("mantidimaging.gui.windows.main.view.CommandLineArguments")
@@ -600,23 +600,6 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         self.view.add_recon_group.assert_called_once()
         self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, name)
-
-    def test_created_mixed_dataset_tree_view_items(self):
-        n_images = 3
-        dataset = MixedDataset(stacks=[generate_images() for _ in range(n_images)])
-        dataset.name = dataset_name = "mixed-dataset"
-        dataset_tree_item_mock = self.view.create_dataset_tree_widget_item.return_value
-
-        calls = []
-        for i in range(n_images):
-            dataset.all[i].name = f"name-{i}"
-            calls.append(call(dataset_tree_item_mock, dataset.all[i].id, dataset.all[i].name))
-
-        self.presenter.create_mixed_dataset_tree_view_items(dataset)
-
-        self.view.create_dataset_tree_widget_item.assert_called_once_with(dataset_name, dataset.id)
-        self.view.create_child_tree_item.assert_has_calls(calls)
-        self.view.add_item_to_tree_view.assert_called_once_with(dataset_tree_item_mock)
 
     def test_cant_focus_on_recon_group(self):
         self.presenter.stack_visualisers = {}

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -525,12 +525,12 @@ class MainWindowPresenterTest(unittest.TestCase):
         task = mock.Mock()
         task.result = result_mock = mock.Mock()
         task.was_successful.return_value = True
-        self.presenter._add_strict_dataset_to_view = mock.Mock()
+        self.presenter._add_dataset_to_view = mock.Mock()
 
         with mock.patch.object(self.presenter, "_open_window_if_not_open") as _:
             self.presenter._on_dataset_load_done(task)
 
-        self.presenter._add_strict_dataset_to_view.assert_called_once_with(result_mock)
+        self.presenter._add_dataset_to_view.assert_called_once_with(result_mock)
         self.view.model_changed.emit.assert_called_once()
 
     @patch("mantidimaging.gui.windows.main.presenter.find_projection_closest_to_180")

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -172,7 +172,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         self.create_stack_mocks(self.dataset)
 
-        self.presenter.create_strict_dataset_stack_windows(self.dataset)
+        self.presenter.create_dataset_stack_visualisers(self.dataset)
 
         self.assertEqual(6, len(self.presenter.stack_visualisers))
 
@@ -182,7 +182,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.dataset.add_recon(generate_images())
         self.create_stack_mocks(self.dataset)
 
-        self.presenter.create_strict_dataset_stack_windows(self.dataset)
+        self.presenter.create_dataset_stack_visualisers(self.dataset)
         self.assertEqual(7, len(self.presenter.stack_visualisers))
 
     @mock.patch("mantidimaging.gui.windows.main.presenter.MainWindowPresenter.add_child_item_to_tree_view")
@@ -243,9 +243,9 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.nexus_load_dialog = mock.Mock()
         data_title = "data tile"
         self.view.nexus_load_dialog.presenter.get_dataset.return_value = self.dataset, data_title
-        self.presenter.create_strict_dataset_stack_windows = mock.Mock()
+        self.presenter.create_dataset_stack_visualisers = mock.Mock()
         self.presenter.load_nexus_file()
-        self.presenter.create_strict_dataset_stack_windows.assert_called_once_with(self.dataset)
+        self.presenter.create_dataset_stack_visualisers.assert_called_once_with(self.dataset)
 
     def test_get_stack_widget_by_name_success(self):
         stack_window = mock.Mock()
@@ -513,10 +513,10 @@ class MainWindowPresenterTest(unittest.TestCase):
         task.result = result_mock = mock.Mock()
         task.was_successful.return_value = True
         task.kwargs = {'file_path': "a/stack/path"}
-        self.presenter.create_mixed_dataset_stack_windows = mock.Mock()
+        self.presenter.create_dataset_stack_visualisers = mock.Mock()
 
         self.presenter._on_stack_load_done(task)
-        self.presenter.create_mixed_dataset_stack_windows.assert_called_once_with(result_mock)
+        self.presenter.create_dataset_stack_visualisers.assert_called_once_with(result_mock)
         self.view.model_changed.emit.assert_called_once()
 
     @mock.patch("mantidimaging.gui.windows.main.view.CommandLineArguments")
@@ -545,7 +545,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         n_stacks = 3
         dataset = MixedDataset(stacks=[generate_images() for _ in range(n_stacks)], name="cool-name")
         self.create_stack_mocks(dataset)
-        self.presenter.create_mixed_dataset_stack_windows(dataset)
+        self.presenter.create_dataset_stack_visualisers(dataset)
         assert len(self.presenter.stack_visualisers) == n_stacks
 
     def test_tabify_stack_window_to_sample_stack(self):

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -17,7 +17,7 @@ from mantidimaging.gui.dialogs.async_task import TaskWorkerThread
 from mantidimaging.gui.windows.image_load_dialog import ImageLoadDialog
 from mantidimaging.gui.windows.main import MainWindowView, MainWindowPresenter, MainWindowModel
 from mantidimaging.gui.windows.main.presenter import Notification, RECON_TEXT
-from mantidimaging.test_helpers.unit_test_helper import generate_images
+from mantidimaging.test_helpers.unit_test_helper import generate_images, generate_standard_dataset
 
 
 def generate_images_with_filenames(n_images: int) -> list[ImageStack]:
@@ -1072,6 +1072,28 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.add_toplevel_item_to_dataset_tree_widget.assert_called_once_with("ds1", dataset.id)
         self.view.add_item_to_dataset_tree_widget.assert_called_once_with("Projections", sample.id,
                                                                           mock_top_level_widget)
+
+    def test_update_dataset_tree_standard_dataset(self):
+        dataset, image_stacks = generate_standard_dataset()
+        self.model.datasets = {dataset.id: dataset}
+        mock_top_level_widget = mock.Mock()
+        self.view.add_toplevel_item_to_dataset_tree_widget.return_value = mock_top_level_widget
+
+        self.presenter.update_dataset_tree()
+        self.view.clear_dataset_tree_widget.assert_called_once()
+        self.view.add_toplevel_item_to_dataset_tree_widget.assert_called_once_with(dataset.name, dataset.id)
+
+        expected_calls = [
+            call(text, id, mock_top_level_widget) for text, id in (
+                ("Projections", dataset.sample.id),
+                ("Flat Before", dataset.flat_before.id),
+                ("Flat After", dataset.flat_after.id),
+                ("Dark Before", dataset.dark_before.id),
+                ("Dark After", dataset.dark_after.id),
+                ("180", dataset.proj180deg.id),
+            )
+        ]
+        self.assertListEqual(expected_calls, self.view.add_item_to_dataset_tree_widget.mock_calls)
 
 
 if __name__ == '__main__':

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -1125,6 +1125,32 @@ class MainWindowPresenterTest(unittest.TestCase):
         ]
         self.assertListEqual(expected_calls, self.view.add_item_to_dataset_tree_widget.mock_calls)
 
+    def test_update_dataset_tree_datasets_with_image_stacks(self):
+        sample = generate_images((1, 1, 1))
+        images1, images2 = generate_images(), generate_images()
+        images1.name = "stack1"
+        images2.name = "stack2"
+        dataset = Dataset(name="ds1", sample=sample)
+        dataset.add_stack(images1)
+        dataset.add_stack(images2)
+
+        self.model.datasets = {dataset.id: dataset}
+        mock_top_level_widget = mock.Mock()
+        self.view.add_toplevel_item_to_dataset_tree_widget.return_value = mock_top_level_widget
+
+        self.presenter.update_dataset_tree()
+        self.view.clear_dataset_tree_widget.assert_called_once()
+        self.view.add_toplevel_item_to_dataset_tree_widget.assert_called_once_with("ds1", dataset.id)
+
+        expected_calls = [
+            call(text, id, mock_top_level_widget) for text, id in (
+                ("Projections", dataset.sample.id),
+                ("stack1", images1.id),
+                ("stack2", images2.id),
+            )
+        ]
+        self.assertListEqual(expected_calls, self.view.add_item_to_dataset_tree_widget.mock_calls)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -634,6 +634,25 @@ class MainWindowView(BaseMainWindowView):
             f"Unable to find a 180 degree projection. The closest projection is {str(diff_deg)} degrees away from 180. "
             f"Use anyway?")
 
+    def clear_dataset_tree_widget(self) -> None:
+        self.dataset_tree_widget.clear()
+
+    def add_toplevel_item_to_dataset_tree_widget(self, title: str, id: uuid.UUID) -> QTreeDatasetWidgetItem:
+        item = self.new_dataset_tree_widget_item(title, id, self.dataset_tree_widget)
+        return item
+
+    def add_item_to_dataset_tree_widget(self, title: str, id: uuid.UUID,
+                                        parent_item: QTreeDatasetWidgetItem) -> QTreeDatasetWidgetItem:
+        item = self.new_dataset_tree_widget_item(title, id, parent_item)
+        return item
+
+    @staticmethod
+    def new_dataset_tree_widget_item(title: str, id: uuid.UUID,
+                                     parent_item: QTreeDatasetWidgetItem | QTreeWidget) -> QTreeDatasetWidgetItem:
+        dataset_tree_item = QTreeDatasetWidgetItem(parent_item, id)
+        dataset_tree_item.setText(0, title)
+        return dataset_tree_item
+
     def create_dataset_tree_widget_item(self, title: str, id: uuid.UUID) -> QTreeDatasetWidgetItem:
         dataset_tree_item = QTreeDatasetWidgetItem(self.dataset_tree_widget, id)
         dataset_tree_item.setText(0, title)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -644,6 +644,7 @@ class MainWindowView(BaseMainWindowView):
     def add_item_to_dataset_tree_widget(self, title: str, id: uuid.UUID,
                                         parent_item: QTreeDatasetWidgetItem) -> QTreeDatasetWidgetItem:
         item = self.new_dataset_tree_widget_item(title, id, parent_item)
+        parent_item.setExpanded(True)
         return item
 
     @staticmethod

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -126,7 +126,7 @@ class StackVisualiserPresenter(BasePresenter):
     def add_mixed_dataset_to_model_and_update_view(self, images: ImageStack):
         dataset = MixedDataset(stacks=[images], name=images.name)
         self.view._main_window.presenter.model.add_dataset_to_model(dataset)
-        self.view._main_window.presenter.create_mixed_dataset_tree_view_items(dataset)
+        self.view._main_window.presenter.update_dataset_tree()
         self.view._main_window.presenter.create_dataset_stack_visualisers(dataset)
         self.view._main_window.model_changed.emit()
 

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -127,7 +127,7 @@ class StackVisualiserPresenter(BasePresenter):
         dataset = MixedDataset(stacks=[images], name=images.name)
         self.view._main_window.presenter.model.add_dataset_to_model(dataset)
         self.view._main_window.presenter.create_mixed_dataset_tree_view_items(dataset)
-        self.view._main_window.presenter.create_mixed_dataset_stack_windows(dataset)
+        self.view._main_window.presenter.create_dataset_stack_visualisers(dataset)
         self.view._main_window.model_changed.emit()
 
     def get_num_images(self) -> int:

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -15,6 +15,7 @@ from io import StringIO
 import pyfakefs.fake_filesystem_unittest
 
 from mantidimaging.core.data import ImageStack
+from mantidimaging.core.data.dataset import Dataset
 from mantidimaging.core.parallel import utility as pu
 from mantidimaging.core.parallel.utility import SharedArray
 from mantidimaging.core.utility.data_containers import ProjectionAngles
@@ -37,13 +38,27 @@ def generate_images(shape=g_shape, dtype=np.float32, seed: int | None = None) ->
     return _set_random_data(d, shape, seed=seed)
 
 
-def generate_images_for_parallel(shape=(15, 8, 10), dtype=np.float32, seed: int | None = None) -> ImageStack:
+def generate_images_for_parallel(shape: tuple[int, int, int] = (15, 8, 10), dtype=np.float32,
+                                 seed: int | None = None) -> ImageStack:
     """
     Doesn't do anything special, just makes a number of images big enough to be
     ran in parallel from the logic of multiprocessing_necessary
     """
     d = pu.create_array(shape, dtype)
     return _set_random_data(d, shape, seed=seed)
+
+
+def generate_standard_dataset(shape: tuple[int, int, int] = (2, 5, 5)) -> tuple[Dataset, list[ImageStack]]:
+    image_stacks = [generate_images(shape) for _ in range(6)]
+    image_stacks[0].name = "samplename"
+
+    ds = Dataset(sample=image_stacks[0],
+                 flat_before=image_stacks[1],
+                 flat_after=image_stacks[2],
+                 dark_before=image_stacks[3],
+                 dark_after=image_stacks[4])
+    ds.proj180deg = image_stacks[5]
+    return ds, image_stacks
 
 
 def _set_random_data(shared_array, shape, seed: int | None = None):


### PR DESCRIPTION
### Issue

Work on #2199

### Description

Simplify handling of the dataset tree view.
Instead of handling a large number of possible edits, have a simple method to redraw from the current datasets

This removes `create_strict_dataset_tree_view_items` and `create_mixed_dataset_tree_view_items` and replaces them with `update_dataset_tree`.

Merges `create_strict_dataset_stack_windows` and `create_mixed_dataset_stack_windows` into `create_dataset_stack_visualisers`.

Removes `_on_stack_load_done` as it becomes identical to `_on_dataset_load_done`.

Removes `_add_recon_to_dataset_and_tree_view` and `_add_images_to_existing_mixed_dataset` as no longer needed.

`_move_stack` and `_add_images_to_existing_strict_dataset` become simpler.

Some cleanups in `MainWindowPresenterTest`, remove unused setup and extract useful `make_standard_dataset` function.

### Testing 

Check opening a dataset
Check interacting with the treeview

### Acceptance Criteria 

Everything should work as it used to

### Documentation

Not yet
