### PR TITLE
Removed set_roi_alpha method and replaced it with set_roi_visibility

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -354,7 +354,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.spectrum_widget.add_roi(self.model.get_roi(roi_name), roi_name)
         self.view.set_spectrum(
             roi_name, self.model.get_spectrum(roi_name, self.spectrum_mode, self.view.shuttercount_norm_enabled()))
-        self.view.set_roi_alpha(0, ROI_RITS)
+        self.view.set_roi_visibility_flags(ROI_RITS, visible=True, alpha=0)
 
     def do_add_roi_to_table(self, roi_name: str) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -178,26 +178,19 @@ class SpectrumWidget(QWidget):
         """
         self.roi_dict[name].colour = colour
 
-    def set_roi_visibility_flags(self, name: str, visible: bool) -> None:
+    def set_roi_visibility_flags(self, name: str, visible: bool, alpha: float = 1.0) -> None:
         """
         Change the visibility of an existing ROI including handles and update
-        the ROI dictionary, sending a signal to the main window.
+        the ROI dictionary, setting the alpha (transparency) value at the same time.
 
         @param name: The name of the ROI.
         @param visible: The new visibility of the ROI.
+        @param alpha: The new alpha (transparency) value of the ROI.
         """
-        self.roi_dict[name].set_visibility(visible)
 
-    def set_roi_alpha(self, name: str, alpha: float) -> None:
-        """
-        Change the alpha value of an existing ROI
-        @param name: The name of the ROI.
-        @param alpha: The new alpha value of the ROI.
-        """
-        self.roi_dict[name].colour = self.roi_dict[name].colour[:3] + (alpha, )
-        self.roi_dict[name].setPen(self.roi_dict[name].colour)
-        self.roi_dict[name].hoverPen = mkPen(self.roi_dict[name].colour, width=3)
-        self.set_roi_visibility_flags(name, bool(alpha))
+        if alpha is not None:
+            self.roi_dict[name].colour = self.roi_dict[name].colour[:3] + (alpha, )
+        self.roi_dict[name].set_visibility(visible)
 
     def add_roi(self, roi: SensibleROI, name: str) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
@@ -91,22 +91,22 @@ class SpectrumWidgetTest(unittest.TestCase):
         self.assertEqual(bool(alpha), self.spectrum_widget.roi_dict[name].isVisible())
 
     @parameterized.expand([("Visible", "visible_roi", 255), ("Invisible", "invisible_roi", 0)])
-    def test_WHEN_set_roi_alpha_called_THEN_roi_alpha_updated(self, _, name, alpha):
+    def test_WHEN_set_roi_visibility_flags_called_THEN_roi_alpha_updated(self, _, name, alpha):
         spectrum_roi = SpectrumROI(name, self.sensible_roi, rotatable=False, scaleSnap=True, translateSnap=True)
         self.spectrum_widget.roi_dict[name] = spectrum_roi
         self.spectrum_widget.spectrum_data_dict[name] = np.array([0, 0, 0, 0])
-        self.spectrum_widget.set_roi_alpha(name, alpha)
+        self.spectrum_widget.set_roi_visibility_flags(name, visible=bool(alpha), alpha=alpha)
         self.assertEqual(self.spectrum_widget.roi_dict[name].pen.color().getRgb()[-1], alpha)
         self.assertEqual(self.spectrum_widget.roi_dict[name].hoverPen.color().getRgb()[-1], alpha)
 
     @parameterized.expand([("Visible", "visible_roi", 1), ("Invisible", "invisible_roi", 0)])
-    def test_WHEN_set_roi_alpha_called_THEN_set_roi_visibility_flags_called(self, _, name, alpha):
+    def test_WHEN_set_roi_visibility_flags_called_THEN_visibility_and_alpha_handled(self, _, name, alpha):
         spectrum_roi = SpectrumROI(name, self.sensible_roi, rotatable=False, scaleSnap=True, translateSnap=True)
         self.spectrum_widget.roi_dict[name] = spectrum_roi
         self.spectrum_widget.spectrum_data_dict[name] = np.array([0, 0, 0, 0])
-        with mock.patch.object(SpectrumWidget, "set_roi_visibility_flags") as mock_set_roi_visibility_flags:
-            self.spectrum_widget.set_roi_alpha(name, alpha)
-            mock_set_roi_visibility_flags.assert_called_once_with(name, alpha)
+        with mock.patch.object(spectrum_roi, "set_visibility") as mock_set_visibility:
+            self.spectrum_widget.set_roi_visibility_flags(name, visible=bool(alpha), alpha=alpha)
+            mock_set_visibility.assert_called_once_with(bool(alpha))
 
     @parameterized.expand([("range_100", 0, 100), ("range_200", 100, 300), ("range_300", 200, 500)])
     def test_WHEN_add_range_called_THEN_region_and_label_set_correctly(self, _, range_min, range_max):

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -249,22 +249,23 @@ class SpectrumViewerWindowView(BaseMainWindowView):
                 self.set_roi_properties()
             for roi_name, _, roi_visible in self.roi_table_model:
                 if roi_visible is False:
-                    self.set_roi_alpha(0, roi_name)
+                    self.set_roi_visibility_flags(roi_name, visible=False, alpha=0)
                 else:
-                    self.set_roi_alpha(255, roi_name)
+                    self.set_roi_visibility_flags(roi_name, visible=True, alpha=255)
                     self.presenter.redraw_spectrum(roi_name)
 
         if self.presenter.export_mode == ExportMode.IMAGE_MODE:
             for roi_name, _, _ in self.roi_table_model:
-                self.set_roi_alpha(0, roi_name)
-            self.set_roi_alpha(255, ROI_RITS)
+                self.set_roi_visibility_flags(roi_name, visible=False, alpha=0)
+
+            self.set_roi_visibility_flags(ROI_RITS, visible=True, alpha=255)
             self.presenter.redraw_spectrum(ROI_RITS)
             self.current_roi_name = ROI_RITS
             for _, spinbox in self.roiPropertiesSpinBoxes.items():
                 spinbox.setEnabled(True)
             self.set_roi_properties()
         else:
-            self.set_roi_alpha(0, ROI_RITS)
+            self.set_roi_visibility_flags(ROI_RITS, visible=False, alpha=0)
 
     @property
     def roi_table_model(self) -> TableModel:
@@ -415,17 +416,17 @@ class SpectrumViewerWindowView(BaseMainWindowView):
                 return row
         return None
 
-    def set_roi_alpha(self, alpha: float, roi_name: str) -> None:
+    def set_roi_visibility_flags(self, roi_name: str, visible: bool, alpha: float) -> None:
         """
-        Set the alpha value for the selected ROI and update the spectrum to reflect the change.
+        Set the visibility and alpha value for the selected ROI and update the spectrum to reflect the change.
         A check is made on the spectrum to see if it exists as it may not have been created yet.
 
-        @param alpha: The alpha value
+        @param visible: Whether the ROI is visible.
+        @param alpha: The alpha value (transparency) of the ROI.
         """
-        self.spectrum_widget.set_roi_alpha(roi_name, alpha)
+        self.spectrum_widget.set_roi_visibility_flags(roi_name, visible=visible, alpha=alpha)
         if alpha == 0:
             self.spectrum_widget.spectrum_data_dict[roi_name] = None
-
         self.spectrum_widget.spectrum.clearPlots()
         self.spectrum_widget.spectrum.update()
         self.show_visible_spectrums()


### PR DESCRIPTION
…flags to consolidate visibility and alpha management.

### Issue

Closes #2342

### Description

Removed set_roi_alpha and replaced it with set_roi_visibility_flags to handle both visibility and alpha transparency. Updated references in presenter.py, view.py, and spectrum_widget.py.

### Testing 

Refactored existing tests to validate the new set_roi_visibility_flags method.
Verified that ROIs are correctly shown/hidden and their transparency is adjusted as expected.

### Acceptance Criteria 

The reviewer should confirm that ROI visibility and alpha transparency are handled correctly.
Verify that set_roi_alpha references are fully replaced by set_roi_visibility_flags.
Run all tests to ensure they pass without errors.

### Documentation

No changes needed in the documentation since this refactor does not affect the external API or user-facing functionality. Internal functionality has been improved for better maintainability.