### PR TITLE
Unify datasets part 8 

### DIFF
--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -184,6 +184,8 @@ class Dataset:
             self.add_recon(image_stack)
         elif file_type_name == "IMAGES":
             self.stacks.append(image_stack)
+        elif file_type_name == "SINOGRAMS":
+            self._sinograms = image_stack
         else:
             file_type = getattr(FILE_TYPES, file_type_name)
             self.set_stack(file_type, image_stack)

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -220,15 +220,14 @@ def _get_stack_data_type(stack_id: uuid.UUID, dataset: Dataset) -> str:
         return "Recon"
     if stack_id in [stack.id for stack in dataset._stacks]:
         return "Images"
-    if isinstance(dataset, StrictDataset):
-        if dataset.sample is not None and stack_id == dataset.sample.id:
-            return "Sample"
-        if dataset.flat_before is not None and stack_id == dataset.flat_before.id:
-            return "Flat Before"
-        if dataset.flat_after is not None and stack_id == dataset.flat_after.id:
-            return "Flat After"
-        if dataset.dark_before is not None and stack_id == dataset.dark_before.id:
-            return "Dark Before"
-        if dataset.dark_after is not None and stack_id == dataset.dark_after.id:
-            return "Dark After"
+    if dataset.sample is not None and stack_id == dataset.sample.id:
+        return "Sample"
+    if dataset.flat_before is not None and stack_id == dataset.flat_before.id:
+        return "Flat Before"
+    if dataset.flat_after is not None and stack_id == dataset.flat_after.id:
+        return "Flat After"
+    if dataset.dark_before is not None and stack_id == dataset.dark_before.id:
+        return "Dark Before"
+    if dataset.dark_after is not None and stack_id == dataset.dark_after.id:
+        return "Dark After"
     raise RuntimeError(f"No stack with ID {stack_id} found in dataset {dataset.id}")

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -237,19 +237,6 @@ class MainWindowModel:
                 return dataset.id
         self.raise_error_when_parent_dataset_not_found(member_id)
 
-    def add_recon_to_dataset(self, recon_data: ImageStack, stack_id: uuid.UUID) -> uuid.UUID:
-        """
-        Adds a recon to a dataset using recon data and an ID from one of the stacks in the dataset.
-        :param recon_data: The recon data.
-        :param stack_id: The ID of one of the member stacks.
-        :return: The ID of the parent dataset if found.
-        """
-        for dataset in self.datasets.values():
-            if stack_id in dataset:
-                dataset.recons.append(recon_data)
-                return dataset.id
-        self.raise_error_when_parent_strict_dataset_not_found(stack_id)
-
     @property
     def recon_list_ids(self) -> list[uuid.UUID]:
         return [dataset.recons.id for dataset in self.datasets.values()]

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -140,9 +140,6 @@ class MainWindowModel:
     def raise_error_when_parent_dataset_not_found(self, images_id: uuid.UUID) -> NoReturn:
         raise RuntimeError(f"Failed to find dataset containing ImageStack with ID {images_id}")
 
-    def raise_error_when_parent_strict_dataset_not_found(self, images_id: uuid.UUID) -> NoReturn:
-        raise RuntimeError(f"Failed to find strict dataset containing ImageStack with ID {images_id}")
-
     def add_log_to_sample(self, images_id: uuid.UUID, log_file: Path) -> None:
         images = self.get_images_by_uuid(images_id)
         if images is None:

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -91,7 +91,7 @@ class MainWindowPresenter(BasePresenter):
             elif signal == Notification.SHOW_ADD_STACK_DIALOG:
                 self._show_add_stack_to_dataset_dialog(**baggage)
             elif signal == Notification.DATASET_ADD:
-                self._add_images_to_existing_dataset()
+                self.handle_add_images_to_existing_dataset_from_dialog()
             elif signal == Notification.TAB_CLICKED:
                 self._on_tab_clicked(**baggage)
             elif signal == Notification.SHOW_MOVE_STACK_DIALOG:
@@ -665,7 +665,7 @@ class MainWindowPresenter(BasePresenter):
         stack_data_type = _get_stack_data_type(stack_id, dataset)
         self.view.show_move_stack_dialog(dataset_id, stack_id, dataset.name, stack_data_type)
 
-    def _add_images_to_existing_dataset(self) -> None:
+    def handle_add_images_to_existing_dataset_from_dialog(self) -> None:
         """
         Adds / replaces images to an existing dataset. Updates the tree view and deletes the previous stack if
         necessary.
@@ -673,14 +673,15 @@ class MainWindowPresenter(BasePresenter):
         assert self.view.add_to_dataset_dialog is not None
 
         dataset_id = self.view.add_to_dataset_dialog.dataset_id
-        dataset = self.get_dataset(dataset_id)
-        assert dataset is not None
-
         new_images = self.view.add_to_dataset_dialog.presenter.images
         images_type = self.view.add_to_dataset_dialog.images_type
 
-        dataset.set_stack_by_type_name(images_type, new_images)
+        self.add_images_to_existing_dataset(dataset_id, images_type, new_images)
 
+    def add_images_to_existing_dataset(self, dataset_id: uuid.UUID, images_type: str, new_images: ImageStack):
+        dataset = self.get_dataset(dataset_id)
+        assert dataset is not None
+        dataset.set_stack_by_type_name(images_type, new_images)
         self.create_single_tabbed_images_stack(new_images)
         self.update_dataset_tree()
         self._close_unused_visualisers()

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -610,10 +610,8 @@ class MainWindowPresenter(BasePresenter):
         :param recon_data: The recon data.
         :param stack_id: The ID of one of the stacks in the dataset that the recon data should be added to.
         """
-        parent_id = self.model.add_recon_to_dataset(recon_data, stack_id)
-        self.view.create_new_stack(recon_data)
-        self.add_recon_item_to_tree_view(parent_id, recon_data.id, recon_data.name)
-        self.view.model_changed.emit()
+        parent_id = self.model.get_parent_dataset(stack_id)
+        self.add_images_to_existing_dataset(parent_id, recon_data, "Recon")
 
     def add_sinograms_to_dataset_and_update_view(self, sino_stack: ImageStack, original_stack_id: uuid.UUID) -> None:
         """

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -620,26 +620,7 @@ class MainWindowPresenter(BasePresenter):
         :param original_stack_id: The ID of a stack in the dataset.
         """
         parent_id = self.model.get_parent_dataset(original_stack_id)
-        prev_sino = self.model.datasets[parent_id].sinograms
-        if prev_sino is not None:
-            self._delete_stack_visualiser(prev_sino.id)
-        self.model.datasets[parent_id].sinograms = sino_stack
-        self._add_sinograms_to_tree_view(sino_stack.id, parent_id)
-        self.create_single_tabbed_images_stack(sino_stack)
-        self.view.model_changed.emit()
-
-    def _add_sinograms_to_tree_view(self, sino_id: uuid.UUID, parent_id: uuid.UUID) -> None:
-        """
-        Adds a sinograms item to the tree view or updates the id of an existing one.
-        :param parent_id: The ID of the parent dataset.
-        :param sino_id: The ID of the corresponding ImageStack object.
-        """
-        dataset_item = self.view.get_dataset_tree_view_item(parent_id)
-        sinograms_item = self.view.get_sinograms_item(dataset_item)
-        if sinograms_item is None:
-            self.view.create_child_tree_item(dataset_item, sino_id, self.view.sino_text)
-        else:
-            sinograms_item._id = sino_id
+        self.add_images_to_existing_dataset(parent_id, sino_stack, "Sinograms")
 
     def _show_add_stack_to_dataset_dialog(self, container_id: uuid.UUID) -> None:
         """

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -542,21 +542,6 @@ class MainWindowPresenter(BasePresenter):
         dataset_item = self.view.get_dataset_tree_view_item(parent_id)
         self.view.create_child_tree_item(dataset_item, child_id, child_name)
 
-    def add_recon_item_to_tree_view(self, parent_id: uuid.UUID, child_id: uuid.UUID, name: str) -> None:
-        """
-        Adds a recon item to the tree view.
-        :param parent_id: The ID of the parent dataset.
-        :param child_id: The ID of the corresponding ImageStack object.
-        :param name: The name to display for the recon in the tree view.
-        """
-        dataset_item = self.view.get_dataset_tree_view_item(parent_id)
-
-        recon_group = self.view.get_recon_group(dataset_item)
-        if not recon_group:
-            recon_group = self.view.add_recon_group(dataset_item, self.model.get_recon_list_id(parent_id))
-
-        self.view.create_child_tree_item(recon_group, child_id, name)
-
     def add_stack_to_dictionary(self, stack: StackVisualiserView) -> None:
         self.stack_visualisers[stack.id] = stack
 

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -22,8 +22,6 @@ class MainWindowModelTest(unittest.TestCase):
 
     def setUp(self):
         self.model = MainWindowModel()
-        self.model_class_name = f"{self.model.__module__}.{self.model.__class__.__name__}"
-        self.stack_list_property = f"{self.model_class_name}.stack_list"
 
     def _add_mock_image(self):
         dataset_mock = mock.Mock()

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -416,17 +416,6 @@ class MainWindowModelTest(unittest.TestCase):
             self.model.add_dataset_to_model(ds)
         self.assertListEqual(all_ids, self.model.image_ids)
 
-    def test_add_recon_to_dataset(self):
-        sample = generate_images()
-        sample_id = sample.id
-        ds = StrictDataset(sample=sample)
-
-        recon = generate_images()
-        self.model.add_dataset_to_model(ds)
-        parent_id = self.model.add_recon_to_dataset(recon, sample_id)
-        self.assertIn(recon, ds.all)
-        assert parent_id == ds.id
-
     def test_proj180s(self):
 
         ds1 = StrictDataset(sample=generate_images())
@@ -442,10 +431,6 @@ class MainWindowModelTest(unittest.TestCase):
         self.model.add_dataset_to_model(ds3)
 
         self.assertListEqual(self.model.proj180s, proj180s)
-
-    def test_exception_when_dataset_for_recons_not_found(self):
-        with self.assertRaises(RuntimeError):
-            self.model.add_recon_to_dataset(generate_images(), "bad-id")
 
     def test_get_parent_strict_dataset_success(self):
         ds = StrictDataset(sample=generate_images())

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -28,7 +28,6 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter = MainWindowPresenter(self.view)
         self.dataset, self.images = generate_standard_dataset(shape=(10, 5, 5))
         self.presenter.model = self.model = mock.create_autospec(MainWindowModel, datasets={})
-        self.model.get_recons_id = mock.Mock()
 
         self.view.create_stack_window.return_value = mock.Mock()
         self.view.model_changed = mock.Mock()
@@ -137,10 +136,6 @@ class MainWindowPresenterTest(unittest.TestCase):
         images = generate_images()
         self.presenter._create_lone_stack_window(images)
         self.assertEqual(1, len(self.presenter.stack_visualisers))
-
-    @mock.patch("mantidimaging.gui.windows.main.presenter.QApplication")
-    def test_create_new_stack_images_focuses_newest_tab(self, mock_QApp):
-        pass
 
     def test_create_new_stack_with_180_in_sample(self):
         self.dataset.proj180deg = generate_images(shape=(1, 20, 20))

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -440,16 +440,18 @@ class MainWindowPresenterTest(unittest.TestCase):
 
     def test_add_recon(self):
         recon = generate_images()
-        stack_id = "stack-id"
-        parent_id = "parent-id"
-        self.model.add_recon_to_dataset.return_value = parent_id
-        self.presenter.add_recon_item_to_tree_view = mock.Mock()
+        recon.name = "New recon"
+        stack_id = self.dataset.sample.id
+        self.model.datasets[self.dataset.id] = self.dataset
+        self.model.get_parent_dataset.return_value = self.dataset.id
 
         self.presenter.notify(Notification.ADD_RECON, recon_data=recon, stack_id=stack_id)
-        self.model.add_recon_to_dataset.assert_called_once_with(recon, stack_id)
-        self.presenter.add_recon_item_to_tree_view.assert_called_with(parent_id, recon.id, recon.name)
-        self.view.create_new_stack.assert_called_once_with(recon)
+
+        self.view.create_stack_window.assert_called_once_with(recon)
         self.view.model_changed.emit.assert_called_once()
+        self.assertIn(recon.id, self.dataset)
+        last_add_widget_call = self.view.add_item_to_dataset_tree_widget.mock_calls[-1][1]
+        self.assertEqual(last_add_widget_call[:2], ("New recon", recon.id))
 
     def test_dataset_list(self):
         dataset_1 = StrictDataset(sample=generate_images())

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -11,7 +11,7 @@ from unittest.mock import patch, call
 import numpy as np
 from parameterized import parameterized
 
-from mantidimaging.core.data.dataset import StrictDataset, MixedDataset, Dataset
+from mantidimaging.core.data.dataset import Dataset
 from mantidimaging.core.utility.data_containers import ProjectionAngles
 from mantidimaging.gui.dialogs.async_task import TaskWorkerThread
 from mantidimaging.gui.windows.image_load_dialog import ImageLoadDialog
@@ -425,11 +425,11 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.assertEqual(last_add_widget_call[:2], ("New recon", recon.id))
 
     def test_dataset_list(self):
-        dataset_1 = StrictDataset(sample=generate_images())
+        dataset_1 = Dataset(sample=generate_images())
         dataset_1.name = "dataset-1"
-        dataset_2 = StrictDataset(sample=generate_images())
+        dataset_2 = Dataset(sample=generate_images())
         dataset_2.name = "dataset-2"
-        mixed_dataset = MixedDataset(stacks=[generate_images()])
+        mixed_dataset = Dataset(stacks=[generate_images()])
 
         self.model.datasets = {"id1": dataset_1, "id2": dataset_2, "id3": mixed_dataset}
 
@@ -464,7 +464,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
     @patch("mantidimaging.gui.windows.main.presenter.find_projection_closest_to_180")
     def test_no_need_for_alternative_180(self, find_180_mock: mock.Mock):
-        dataset = StrictDataset(sample=generate_images())
+        dataset = Dataset(sample=generate_images())
         dataset.proj180deg = generate_images((1, 20, 20))
         dataset.proj180deg.filenames = ["filename"]
 
@@ -473,7 +473,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
     def test_create_mixed_dataset_stack_windows(self):
         n_stacks = 3
-        dataset = MixedDataset(stacks=[generate_images() for _ in range(n_stacks)], name="cool-name")
+        dataset = Dataset(stacks=[generate_images() for _ in range(n_stacks)], name="cool-name")
         self.create_stack_mocks(dataset)
         self.presenter.create_dataset_stack_visualisers(dataset)
         assert len(self.presenter.stack_visualisers) == n_stacks
@@ -504,7 +504,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
     def test_add_sinograms_to_dataset_with_no_sinograms_and_update_view(self):
         sinograms = generate_images()
-        ds = StrictDataset(sample=generate_images())
+        ds = Dataset(sample=generate_images())
         self.model.datasets[ds.id] = ds
         self.model.get_parent_dataset.return_value = ds.id
 
@@ -595,8 +595,8 @@ class MainWindowPresenterTest(unittest.TestCase):
                                                  busy=True)
 
     def test_get_dataset(self):
-        test_ds = StrictDataset(sample=generate_images())
-        other_ds = StrictDataset(sample=generate_images())
+        test_ds = Dataset(sample=generate_images())
+        other_ds = Dataset(sample=generate_images())
         self.model.datasets[test_ds.id] = test_ds
         self.model.datasets[other_ds.id] = other_ds
 
@@ -604,7 +604,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.assertEqual(result, test_ds)
 
     def test_get_dataset_not_found(self):
-        ds = StrictDataset(sample=generate_images())
+        ds = Dataset(sample=generate_images())
         incorrect_id = uuid.uuid4()
         self.model.datasets[ds.id] = ds
 
@@ -716,14 +716,14 @@ class MainWindowPresenterTest(unittest.TestCase):
 
     def test_all_stack_ids(self):
         mixed_stacks = [generate_images() for _ in range(5)]
-        mixed_dataset = MixedDataset(stacks=mixed_stacks)
+        mixed_dataset = Dataset(stacks=mixed_stacks)
 
         strict_stacks = [generate_images() for _ in range(5)]
-        strict_dataset = StrictDataset(sample=strict_stacks[0],
-                                       flat_before=strict_stacks[1],
-                                       flat_after=strict_stacks[2],
-                                       dark_before=strict_stacks[3],
-                                       dark_after=strict_stacks[4])
+        strict_dataset = Dataset(sample=strict_stacks[0],
+                                 flat_before=strict_stacks[1],
+                                 flat_after=strict_stacks[2],
+                                 dark_before=strict_stacks[3],
+                                 dark_after=strict_stacks[4])
 
         all_ids = [stack.id for stack in mixed_stacks] + [stack.id for stack in strict_stacks]
         self.model.datasets[mixed_dataset.id] = mixed_dataset
@@ -733,7 +733,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
     def test_show_move_stack_dialog(self):
         sample = generate_images()
-        ds = StrictDataset(sample=sample)
+        ds = Dataset(sample=sample)
         ds.name = dataset_name = "dataset-name"
         self.presenter.get_dataset_id_for_stack = mock.Mock(return_value=ds.id)
         self.presenter.get_dataset = mock.Mock(return_value=ds)
@@ -748,19 +748,19 @@ class MainWindowPresenterTest(unittest.TestCase):
             self.presenter._show_move_stack_dialog("stack-id")
 
     def test_move_stack_raises_when_origin_dataset_not_found(self):
-        self.presenter.get_dataset = mock.Mock(side_effect=[None, StrictDataset(sample=generate_images())])
+        self.presenter.get_dataset = mock.Mock(side_effect=[None, Dataset(sample=generate_images())])
         with self.assertRaises(RuntimeError):
             self.presenter._move_stack("origin-dataset-id", "stack-id", "Flat After", "destination-dataset-id")
 
     def test_move_stack_raises_when_destination_dataset_not_found(self):
-        self.presenter.get_dataset = mock.Mock(side_effect=[StrictDataset(sample=generate_images()), None])
+        self.presenter.get_dataset = mock.Mock(side_effect=[Dataset(sample=generate_images()), None])
         with self.assertRaises(RuntimeError):
             self.presenter._move_stack("origin-dataset-id", "stack-id", "Flat After", "destination-dataset-id")
 
     def test_stack_moved_to_recon(self):
         stack_to_move = generate_images()
-        origin_dataset = MixedDataset(stacks=[stack_to_move])
-        destination_dataset = MixedDataset()
+        origin_dataset = Dataset(stacks=[stack_to_move])
+        destination_dataset = Dataset()
         self.model.datasets[origin_dataset.id] = origin_dataset
         self.model.datasets[destination_dataset.id] = destination_dataset
 
@@ -781,8 +781,8 @@ class MainWindowPresenterTest(unittest.TestCase):
 
     def test_stack_moved_to_mixed_dataset_images(self):
         stack_to_move = generate_images()
-        origin_dataset = StrictDataset(sample=stack_to_move)
-        destination_dataset = MixedDataset()
+        origin_dataset = Dataset(sample=stack_to_move)
+        destination_dataset = Dataset()
         self.model.datasets[origin_dataset.id] = origin_dataset
         self.model.datasets[destination_dataset.id] = destination_dataset
 
@@ -799,8 +799,8 @@ class MainWindowPresenterTest(unittest.TestCase):
 
     def test_move_stack_to_strict_dataset(self):
         stack_to_move = generate_images()
-        origin_dataset = MixedDataset(stacks=[stack_to_move])
-        destination_dataset = StrictDataset(sample=generate_images())
+        origin_dataset = Dataset(stacks=[stack_to_move])
+        destination_dataset = Dataset(sample=generate_images())
         self.model.datasets[origin_dataset.id] = origin_dataset
         self.model.datasets[destination_dataset.id] = destination_dataset
         self.presenter.get_stack = mock.Mock(return_value=stack_to_move)

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -750,7 +750,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         elif images_type in ["Recon", "Images"]:
             treeview_label = new_images.name
 
-        self.presenter._add_images_to_existing_dataset()
+        self.presenter.handle_add_images_to_existing_dataset_from_dialog()
 
         self.assertIn(call(treeview_label, new_images.id, mock_top_item),
                       self.view.add_item_to_dataset_tree_widget.mock_calls)

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -525,44 +525,6 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter._tabify_stack_window(new_stack)
         self.view.tabifyDockWidget.assert_called_once_with(other_stack, new_stack)
 
-    def test_add_recon_item_to_tree_view_first_item(self):
-        dataset_item_mock = self.view.get_dataset_tree_view_item.return_value
-        dataset_item_mock.id = parent_id = "parent-id"
-        child_id = "child-id"
-        name = "Recon"
-        recon_group_mock = self.view.add_recon_group.return_value
-        self.model.get_recon_list_id.return_value = recons_id = "recons-id"
-        self.view.get_recon_group.return_value = None
-
-        self.presenter.add_recon_item_to_tree_view(parent_id, child_id, name)
-        self.view.get_dataset_tree_view_item.assert_called_once_with(parent_id)
-        self.model.get_recon_list_id.assert_called_once_with(parent_id)
-        self.view.add_recon_group.assert_called_once_with(dataset_item_mock, recons_id)
-        self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, name)
-
-    def test_add_recon_item_to_tree_view_additional_item(self):
-        parent_id = "parent-id"
-        dataset_item_mock = self.view.get_dataset_tree_view_item.return_value
-        child_id = "child-id"
-        recon_group_mock = self.view.get_recon_group.return_value
-        name = "Recon_2"
-
-        self.presenter.add_recon_item_to_tree_view(parent_id, child_id, name)
-        self.view.get_dataset_tree_view_item.assert_called_once_with(parent_id)
-        self.view.get_recon_group.assert_called_once_with(dataset_item_mock)
-        self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, name)
-
-    def test_add_recon_item_to_tree_view_first_item_with_multiple_recons(self):
-        child_id = "child-id"
-        name = "Recon"
-        recon_group_mock = self.view.add_recon_group.return_value
-        self.view.get_recon_group.return_value = None
-
-        self.presenter.add_recon_item_to_tree_view("parent-id", child_id, name)
-
-        self.view.add_recon_group.assert_called_once()
-        self.view.create_child_tree_item.assert_called_once_with(recon_group_mock, child_id, name)
-
     def test_cant_focus_on_recon_group(self):
         self.presenter.stack_visualisers = {}
         self.presenter.stack_visualisers["stack-id"] = stack_mock = mock.Mock()

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -655,12 +655,6 @@ class MainWindowView(BaseMainWindowView):
         return dataset_tree_item
 
     @staticmethod
-    def create_child_tree_item(parent: QTreeDatasetWidgetItem, dataset_id: uuid.UUID, name: str) -> None:
-        child = QTreeDatasetWidgetItem(parent, dataset_id)
-        child.setText(0, name)
-        parent.addChild(child)
-
-    @staticmethod
     def get_sinograms_item(parent: QTreeDatasetWidgetItem) -> QTreeDatasetWidgetItem | None:
         """
         Tries to look for a sinograms entry in a dataset tree view item.

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -654,11 +654,6 @@ class MainWindowView(BaseMainWindowView):
         dataset_tree_item.setText(0, title)
         return dataset_tree_item
 
-    def create_dataset_tree_widget_item(self, title: str, id: uuid.UUID) -> QTreeDatasetWidgetItem:
-        dataset_tree_item = QTreeDatasetWidgetItem(self.dataset_tree_widget, id)
-        dataset_tree_item.setText(0, title)
-        return dataset_tree_item
-
     @staticmethod
     def create_child_tree_item(parent: QTreeDatasetWidgetItem, dataset_id: uuid.UUID, name: str) -> None:
         child = QTreeDatasetWidgetItem(parent, dataset_id)
@@ -676,10 +671,6 @@ class MainWindowView(BaseMainWindowView):
             if child.text(0) == SINO_TEXT:
                 return child
         return None
-
-    def add_item_to_tree_view(self, item: QTreeWidgetItem) -> None:
-        self.dataset_tree_widget.insertTopLevelItem(self.dataset_tree_widget.topLevelItemCount(), item)
-        item.setExpanded(True)
 
     def _open_tree_menu(self, position: QPoint) -> None:
         """


### PR DESCRIPTION
### Issue
More on #2199
~~Needs rebasing after #2341~~

### Description

Close follow up of #2341, continues the work of unifying and simplifying the MainWindowPresenter.

Refactor `_add_images_to_existing_dataset` to `handle_add_images_to_existing_dataset_from_dialog`, and split out useful parts to `add_images_to_existing_dataset`.

Refactor methods for adding stacks to use common code
`_add_recon_to_dataset`, `add_sinograms_to_dataset_and_update_view`, `add_180_deg_file_to_dataset`, `add_alternative_180_if_required`.

Remove several methods that are not longer needed.

### Testing 

Various tests were removed or updated

### Acceptance Criteria 

Test loading datasets, adding additional images, adding a 180, converting projections to sinograms
### Documentation

not yet
