### PR TITLE
Live view open dataset

### DIFF
--- a/docs/release_notes/next/feature-2351-live-view-load-dataset
+++ b/docs/release_notes/next/feature-2351-live-view-load-dataset
@@ -1,0 +1,2 @@
+#2351: Option in live view menu to load current images as dataset
+

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -69,10 +69,11 @@ class LiveViewerWindowPresenter(BasePresenter):
         """Update the image in the view."""
         if not images_list:
             self.handle_deleted()
-            return
-
-        self.view.set_image_range((0, len(images_list) - 1))
-        self.view.set_image_index(len(images_list) - 1)
+            self.view.set_load_as_dataset_enabled(False)
+        else:
+            self.view.set_image_range((0, len(images_list) - 1))
+            self.view.set_image_index(len(images_list) - 1)
+            self.view.set_load_as_dataset_enabled(True)
 
     def select_image(self, index: int) -> None:
         if not self.model.images:

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -153,3 +153,7 @@ class LiveViewerWindowPresenter(BasePresenter):
             op_params = self.view.filter_params[operation]["params"]
             op_func(image_stack, **op_params)
         return image_stack.slice_as_array(0)[0]
+
+    def load_as_dataset(self) -> None:
+        image_dir = self.model.images[0].image_path.parent
+        self.main_window.show_image_load_dialog_with_path(str(image_dir))

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -155,5 +155,6 @@ class LiveViewerWindowPresenter(BasePresenter):
         return image_stack.slice_as_array(0)[0]
 
     def load_as_dataset(self) -> None:
-        image_dir = self.model.images[0].image_path.parent
-        self.main_window.show_image_load_dialog_with_path(str(image_dir))
+        if self.model.images:
+            image_dir = self.model.images[0].image_path.parent
+            self.main_window.show_image_load_dialog_with_path(str(image_dir))

--- a/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from mantidimaging.gui.windows.live_viewer import LiveViewerWindowView, LiveViewerWindowModel, LiveViewerWindowPresenter
+from mantidimaging.gui.windows.live_viewer.model import Image_Data
+from mantidimaging.gui.windows.main import MainWindowView
+
+
+class MainWindowPresenterTest(unittest.TestCase):
+
+    def setUp(self):
+        self.view = mock.create_autospec(LiveViewerWindowView)
+        self.main_window = mock.create_autospec(MainWindowView)
+        self.model = mock.create_autospec(LiveViewerWindowModel)
+
+        with mock.patch("mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowModel") as mock_model:
+            mock_model.return_value = self.model
+            self.presenter = LiveViewerWindowPresenter(self.view, self.main_window)
+
+    def test_load_as_dataset(self):
+        image_dir = Path("/path/to/dir")
+        image_paths = [image_dir / f"image_{i:03d}.tif" for i in range(5)]
+        self.model.images = [mock.create_autospec(Image_Data, image_path=p) for p in image_paths]
+
+        self.presenter.load_as_dataset()
+
+        self.main_window.show_image_load_dialog_with_path.assert_called_once_with(str(image_dir))

--- a/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
@@ -30,3 +30,10 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.load_as_dataset()
 
         self.main_window.show_image_load_dialog_with_path.assert_called_once_with(str(image_dir))
+
+    def test_load_as_dataset_empty_dir(self):
+        self.model.images = []
+
+        self.presenter.load_as_dataset()
+
+        self.main_window.show_image_load_dialog_with_path.assert_not_called()

--- a/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
@@ -6,6 +6,8 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from parameterized import parameterized
+
 from mantidimaging.gui.windows.live_viewer import LiveViewerWindowView, LiveViewerWindowModel, LiveViewerWindowPresenter
 from mantidimaging.gui.windows.live_viewer.model import Image_Data
 from mantidimaging.gui.windows.main import MainWindowView
@@ -37,3 +39,13 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.load_as_dataset()
 
         self.main_window.show_image_load_dialog_with_path.assert_not_called()
+
+    @parameterized.expand([
+        ([], False),
+        ([mock.Mock()], True),
+    ])
+    def test_load_as_dataset_enabled_when_images(self, image_list, action_enabled):
+        with mock.patch.object(self.presenter, "handle_deleted"):
+            self.presenter.update_image_list(image_list)
+
+        self.view.set_load_as_dataset_enabled.assert_called_once_with(action_enabled)

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -51,8 +51,8 @@ class LiveViewerWindowView(BaseMainWindowView):
             if angle == 0:
                 action.setChecked(True)
 
-        load_as_dataset_action = self.right_click_menu.addAction("Load as dataset")
-        load_as_dataset_action.triggered.connect(self.presenter.load_as_dataset)
+        self.load_as_dataset_action = self.right_click_menu.addAction("Load as dataset")
+        self.load_as_dataset_action.triggered.connect(self.presenter.load_as_dataset)
 
     def show(self) -> None:
         """Show the window"""
@@ -103,3 +103,6 @@ class LiveViewerWindowView(BaseMainWindowView):
             image_rotation_angle = int(self.rotate_angles_group.checkedAction().text().replace('°', ''))
             self.filter_params["Rotate Stack"] = {"params": {"angle": image_rotation_angle}}
         self.presenter.update_image_operation()
+
+    def set_load_as_dataset_enabled(self, enabled: bool):
+        self.load_as_dataset_action.setEnabled(enabled)

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -51,6 +51,9 @@ class LiveViewerWindowView(BaseMainWindowView):
             if angle == 0:
                 action.setChecked(True)
 
+        load_as_dataset_action = self.right_click_menu.addAction("Load as dataset")
+        load_as_dataset_action.triggered.connect(self.presenter.load_as_dataset)
+
     def show(self) -> None:
         """Show the window"""
         super().show()

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -255,6 +255,8 @@ class MainWindowView(BaseMainWindowView):
         Open the dataset loading dialog with a given file_path preset as the sample
         """
         sample_file = find_first_file_that_is_possibly_a_sample(file_path)
+        if sample_file is None:
+            sample_file = find_first_file_that_is_possibly_a_sample(os.path.dirname(file_path))
         if sample_file is not None:
             self.image_load_dialog = ImageLoadDialog(self)
             self.image_load_dialog.presenter.do_update_sample(sample_file)


### PR DESCRIPTION
### Issue

Closes #2351 

### Description

Adds a "Load as Dataset" item to the right click menu

### Testing 

New tests for happy path and with no images loaded

### Acceptance Criteria 

Run the live viewer
Right click and choose "Load as Dataset"
This should launch the "Open dataset" dialog

### Documentation

Release notes
