### PR TITLE
Pin ipp version

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -34,3 +34,4 @@ dependencies:
   - pydata-sphinx-theme==0.15.*
   - sphinx-copybutton==0.5.*
   - sphinx-design==0.6.*
+  - ipp=2021.12 # https://github.com/mantidproject/mantidimaging/issues/2354

--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,4 @@ channels:
 dependencies:
   - mantidimaging>=2.5.0
   - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774
+  - ipp=2021.12 # https://github.com/mantidproject/mantidimaging/issues/2354


### PR DESCRIPTION
### Issue
Closes #2354

### Description

Add a pin in the environment for the working version of ipp.

This can be dropped once `cil` has a version pin.

### Testing & Acceptance Criteria 

Check that the `pytest` section of the `conda` tests passes

### Documentation
Not needed
