### PR TITLE
Spectrum widget test fix

### DIFF
--- a/docs/release_notes/next/fix-2309-spectrum-widget-test-fix
+++ b/docs/release_notes/next/fix-2309-spectrum-widget-test-fix
@@ -1,0 +1,1 @@
+#2309: Fix SpectrumWidgetTest warnings

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -348,13 +348,12 @@ class SpectrumPlotWidget(GraphicsLayoutWidget):
 class SpectrumProjectionWidget(GraphicsLayoutWidget):
     image: MIMiniImageView
 
-    def __init__(self, parent: MainWindowView) -> None:
-        super().__init__(parent)
-        self._main_window = parent
+    def __init__(self, main_window: MainWindowView) -> None:
+        super().__init__()
         self.image = MIMiniImageView(name="Projection", view_box_type=CustomViewBox)
         self.addItem(self.image, 0, 0)
         self.ci.layout.setRowStretchFactor(0, 3)
 
-        nan_check_menu = [("Crop Coordinates", lambda: self._main_window.presenter.show_operation("Crop Coordinates")),
-                          ("NaN Removal", lambda: self._main_window.presenter.show_operation("NaN Removal"))]
+        nan_check_menu = [("Crop Coordinates", lambda: main_window.presenter.show_operation("Crop Coordinates")),
+                          ("NaN Removal", lambda: main_window.presenter.show_operation("NaN Removal"))]
         self.image.enable_nan_check(actions=nan_check_menu)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
@@ -48,8 +48,7 @@ class SpectrumROITest(unittest.TestCase):
 class SpectrumWidgetTest(unittest.TestCase):
 
     def setUp(self) -> None:
-        with mock.patch("mantidimaging.gui.windows.main.view.WelcomeScreenPresenter"):
-            self.main_window = MainWindowView()
+        self.main_window = mock.create_autospec(MainWindowView)
         self.view = mock.create_autospec(SpectrumViewerWindowView)
         self.view.current_dataset_id = uuid.uuid4()
         self.view.parent = mock.create_autospec(SpectrumViewerWindowPresenter)


### PR DESCRIPTION
### Issue

Closes #2309

### Description

I am not 100% sure what caused the error, as its happening deep in a destructor. But avoiding the test having a real `MainWindowView` instance prevents the warning.

Also avoid setting the main window as the parent of `SpectrumProjectionWidget` as that has specific meaning in Qt.

### Testing & Acceptance Criteria 

Run make check several times locally, and check that the warnings seen on #2309 do not show.

### Documentation

release notes