### PR TITLE
2370 Cancel recon

### DIFF
--- a/docs/release_notes/next/dev-2370-cancel_async_task_progress_dialog
+++ b/docs/release_notes/next/dev-2370-cancel_async_task_progress_dialog
@@ -1,0 +1,1 @@
+#2370: Add a cancel button to AsyncTaskDialog progress window

--- a/mantidimaging/core/utility/progress_reporting/progress.py
+++ b/mantidimaging/core/utility/progress_reporting/progress.py
@@ -197,7 +197,7 @@ class Progress:
 
         # Force cancellation on progress update
         if self.should_cancel and not force_continue:
-            raise RuntimeError('Task has been cancelled')
+            raise StopIteration('Task has been cancelled')
 
     @staticmethod
     def calculate_mean_time(progress_history: list[ProgressHistory]) -> float:

--- a/mantidimaging/core/utility/progress_reporting/test/progress_test.py
+++ b/mantidimaging/core/utility/progress_reporting/test/progress_test.py
@@ -241,7 +241,7 @@ class ProgressTest(unittest.TestCase):
                         self.assertTrue(p.should_cancel)
 
                 else:
-                    with self.assertRaises(RuntimeError):
+                    with self.assertRaises(StopIteration):
                         p.update()
 
         self.assertFalse(p.is_completed())

--- a/mantidimaging/gui/dialogs/async_task/presenter.py
+++ b/mantidimaging/gui/dialogs/async_task/presenter.py
@@ -65,3 +65,9 @@ class AsyncTaskDialogPresenter(QObject, ProgressHandler):
     def progress_update(self) -> None:
         msg = self.progress.last_status_message()
         self.progress_updated.emit(self.progress.completion(), msg if msg is not None else '')
+
+    def show_stop_button(self, show: bool = False) -> None:
+        self.view.show_cancel_button(show)
+
+    def stop_progress(self):
+        self.progress.cancel("Cancelled by user")

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -84,7 +84,8 @@ def start_async_task_view(parent: QMainWindow,
                           on_complete: Callable,
                           kwargs: dict | None = None,
                           tracker: set[Any] | None = None,
-                          busy: bool | None = False):
+                          busy: bool | None = False,
+                          cancelable: bool = False) -> None:
     atd = AsyncTaskDialogView(parent)
     if not kwargs:
         kwargs = {'progress': Progress()}
@@ -96,6 +97,7 @@ def start_async_task_view(parent: QMainWindow,
         atd.progressBar.setMinimum(0)
         atd.progressBar.setMaximum(0)
 
+    atd.presenter.show_stop_button(cancelable)
     atd.presenter.set_task(task)
     atd.presenter.set_on_complete(on_complete)
     atd.presenter.set_parameters(**kwargs)

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -25,6 +25,8 @@ class AsyncTaskDialogView(BaseDialogView):
         self.progressBar.setMaximum(1000)
 
         self.show_timer = QTimer(self)
+        self.cancelButton.clicked.connect(self.presenter.stop_progress)
+        self.cancelButton.hide()
         self.hide()
 
     @property
@@ -69,6 +71,12 @@ class AsyncTaskDialogView(BaseDialogView):
         # Might not run until after handle_completion
         if self._presenter is not None and self.presenter.task_is_running:
             self.show()
+
+    def show_cancel_button(self, cancelable: bool) -> None:
+        if cancelable:
+            self.cancelButton.show()
+        else:
+            self.cancelButton.hide()
 
 
 def start_async_task_view(parent: QMainWindow,

--- a/mantidimaging/gui/ui/async_task_dialog.ui
+++ b/mantidimaging/gui/ui/async_task_dialog.ui
@@ -39,6 +39,13 @@
       <bool>false</bool>
      </property>
     </widget>
+    <item>
+    <widget class="QPushButton" name="cancelButton">
+    <property name="text">
+        <string>Cancel</string>
+    </property>
+    </widget>
+    </item>
    </item>
   </layout>
  </widget>

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -225,7 +225,8 @@ class ReconstructWindowPresenter(BasePresenter):
         start_async_task_view(self.view,
                               self.model.run_full_recon,
                               self._on_volume_recon_done, {'recon_params': self.view.recon_params()},
-                              tracker=self.async_tracker)
+                              tracker=self.async_tracker,
+                              cancelable=True)
 
     def _get_reconstruct_slice(self, cor, slice_idx: int, call_back: Callable[[TaskWorkerThread], None]) -> None:
         # If no COR is provided and there are regression results then calculate
@@ -238,7 +239,8 @@ class ReconstructWindowPresenter(BasePresenter):
                                   'cor': cor,
                                   'recon_params': self.view.recon_params()
                               },
-                              tracker=self.async_tracker)
+                              tracker=self.async_tracker,
+                              cancelable=True)
 
     def _get_slice_index(self, slice_idx: int | None) -> int:
         if slice_idx is None:

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -217,7 +217,8 @@ class ReconWindowPresenterTest(unittest.TestCase):
                                                 self.presenter.model.run_full_recon,
                                                 self.presenter._on_volume_recon_done,
                                                 {'recon_params': self.view.recon_params()},
-                                                tracker=self.presenter.async_tracker)
+                                                tracker=self.presenter.async_tracker,
+                                                cancelable=True)
 
     @mock.patch('mantidimaging.gui.windows.recon.presenter.CORInspectionDialogView')
     def test_do_refine_selected_cor_declined(self, mock_corview):


### PR DESCRIPTION
### Issue

Closes #2370 

### Description

Add generic cancel button in AsyncTaskDialog progress window

### Testing 

Tested cancelling functions which make use of AsyncTaskDialog

### Acceptance Criteria 

* Cancelling loading data
* Cancelling COR and TILT minimise error and correlate 0 and 180 functions
* Cancelling Reconstructions on slice previews and full volumes


### Documentation

`docs/release_notes/next/dev-2370-cancel_async_task_progress_dialog`
