### PR TITLE
Make image view mixins into abstract base classes

### DIFF
--- a/mantidimaging/gui/utility/qt_helpers.py
+++ b/mantidimaging/gui/utility/qt_helpers.py
@@ -6,12 +6,13 @@ Module containing helper functions relating to PyQt.
 from __future__ import annotations
 
 import os
+from abc import ABCMeta
 from enum import IntEnum, auto
 from logging import getLogger
 from typing import Any
 from collections.abc import Callable
 
-from PyQt5 import uic  # type: ignore
+from PyQt5 import uic, sip  # type: ignore
 from PyQt5.QtCore import QObject, Qt
 from PyQt5.QtWidgets import (QLabel, QLineEdit, QSpinBox, QDoubleSpinBox, QCheckBox, QWidget, QSizePolicy, QAction,
                              QMenu, QPushButton, QLayout, QFileDialog, QComboBox)
@@ -266,3 +267,8 @@ def populate_menu(menu: QMenu, actions_list: list[QAction]) -> None:
             action = QAction(menu_text, menu)
             action.triggered.connect(func)
             menu.addAction(action)
+
+
+class _metaclass_sip_abc(sip.wrappertype, ABCMeta):
+    """Used for Mixins to avoid metaclass conflicts"""
+    ...

--- a/mantidimaging/gui/widgets/auto_colour_menu/auto_color_menu.py
+++ b/mantidimaging/gui/widgets/auto_colour_menu/auto_color_menu.py
@@ -1,10 +1,13 @@
 # Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
+
+from abc import abstractmethod, ABC
 from typing import TYPE_CHECKING
 
 from PyQt5.QtWidgets import QAction
 
+from mantidimaging.gui.utility.qt_helpers import _metaclass_sip_abc
 from mantidimaging.gui.widgets.palette_changer.view import PaletteChangerView
 
 if TYPE_CHECKING:
@@ -13,7 +16,7 @@ if TYPE_CHECKING:
     from PyQt5.QtWidgets import QWidget
 
 
-class AutoColorMenu:
+class AutoColorMenu(ABC, metaclass=_metaclass_sip_abc):
     """
     Mixin class to be used with MIImageView and MIMiniImageView
     """
@@ -22,12 +25,14 @@ class AutoColorMenu:
         self.auto_color_action: QAction | None = None
 
     @property
+    @abstractmethod
     def histogram(self) -> HistogramLUTItem:
-        raise NotImplementedError('Required histogram property not implemented')
+        ...
 
     @property
+    @abstractmethod
     def image_data(self) -> np.ndarray | None:
-        raise NotImplementedError('Required image_data property not implemented')
+        ...
 
     @property
     def other_histograms(self) -> list[HistogramLUTItem]:

--- a/mantidimaging/gui/widgets/auto_colour_menu/auto_color_menu.py
+++ b/mantidimaging/gui/widgets/auto_colour_menu/auto_color_menu.py
@@ -22,6 +22,7 @@ class AutoColorMenu(ABC, metaclass=_metaclass_sip_abc):
     """
 
     def __init__(self) -> None:
+        super().__init__()
         self.auto_color_action: QAction | None = None
 
     @property

--- a/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
+++ b/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
@@ -2,11 +2,13 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+from abc import abstractmethod, ABC
 from collections.abc import Callable
 
 import numpy as np
 from pyqtgraph import ColorMap, ImageItem, ViewBox
 
+from mantidimaging.gui.utility.qt_helpers import _metaclass_sip_abc
 from mantidimaging.gui.widgets.indicator_icon.view import IndicatorIconView
 from mantidimaging.core.utility import finder
 
@@ -54,7 +56,7 @@ class BadDataCheck:
         self.overlay.clear()
 
 
-class BadDataOverlay:
+class BadDataOverlay(ABC, metaclass=_metaclass_sip_abc):
     """
     Mixin class to be used with MIImageView and MIMiniImageView
     """
@@ -69,12 +71,14 @@ class BadDataOverlay:
             self.sigTimeChanged.connect(self.check_for_bad_data)
 
     @property
+    @abstractmethod
     def image_item(self) -> ImageItem:
-        raise NotImplementedError
+        ...
 
     @property
+    @abstractmethod
     def viewbox(self) -> ViewBox:
-        raise NotImplementedError
+        ...
 
     def enable_nan_check(self, enable: bool = True, actions: list[tuple[str, Callable]] | None = None) -> None:
         if enable:


### PR DESCRIPTION
### Issue

Closes #2373

Wait for #2349 to be merged to resolve any conflicts

### Description

Add a derived metaclass, to avoid metaclass conflicts. This is needed because the imageview has a `sip.wrappertype` metatype from qt.
Change `AutoColorMenu` and `BadDataOverlay` to abstract base classes.

### Testing & Acceptance Criteria 

Should not cause any problems, if the tests pass everything should work

### Documentation

Not needed.
