### PR TITLE
Only Redraw ROI and Subsequently Spectrum if isVisible is True

### DIFF
--- a/docs/release_notes/next/fix-2376-resolve_spectrum_visiblity_when_normalisation_toggled_on_and_off
+++ b/docs/release_notes/next/fix-2376-resolve_spectrum_visiblity_when_normalisation_toggled_on_and_off
@@ -1,0 +1,1 @@
+#2376: Fix spectrum visibility for ROIs where visibility is set to false are still displayed

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -231,6 +231,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         Redraw all ROIs and spectrum plots
         """
         for name in self.model.get_list_of_roi_names():
+            if name == "all" or self.view.spectrum_widget.roi_dict[name].isVisible() is False:
+                continue
             self.model.set_roi(name, self.view.spectrum_widget.get_roi(name))
             self.view.set_spectrum(
                 name,

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -429,7 +429,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         def spec_roi_mock(name):
             if name == "all":
                 return SensibleROI(0, 0, 10, 8)
-            elif name == "roi":
+            if name == "roi":
                 return SensibleROI(1, 4, 3, 2)
 
         self.view.spectrum_widget.get_roi = mock.Mock(side_effect=spec_roi_mock)
@@ -439,7 +439,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.redraw_all_rois()
         self.assertEqual(self.presenter.model.get_roi("all"), SensibleROI(0, 0, 10, 8))
         self.assertEqual(self.presenter.model.get_roi("roi"), SensibleROI(1, 4, 3, 2))
-        calls = [mock.call(a, b) for a, b in [("all", mock.ANY), ("roi", mock.ANY)]]
+        calls = [mock.call(a, b) for a, b in [("roi", mock.ANY)]]
         self.view.set_spectrum.assert_has_calls(calls)
 
     @parameterized.expand([("roi", "roi_clicked", "roi_clicked"), ("roi", ROI_RITS, "roi")])


### PR DESCRIPTION
### Issue

Closes #2376 

### Description

Prevent redrawing of ROI's and subsequently spectrum line plots where the ROI `isVisible` property is set to False

### Testing 

Manually Tested

### Acceptance Criteria 

* Selecting Normalise Spectrum when in ROI view does not display the Spectrum for any ROIs including the `RITS_ROI` where `isVisible` is set to False.

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*

`docs/release_notes/next/fix-2376-resolve_spectrum_visiblity_when_normalisation_toggled_on_and_off`