### PR TITLE
Multiple Live Viewers can be opened simultaneously

### DIFF
--- a/docs/release_notes/next/feature-2361-multiple-live-viewers
+++ b/docs/release_notes/next/feature-2361-multiple-live-viewers
@@ -1,0 +1,1 @@
+#2361: Multiple Live Viewers can now be opened and pointed to different directories simultaneously

--- a/mantidimaging/eyes_tests/live_viewer_window_test.py
+++ b/mantidimaging/eyes_tests/live_viewer_window_test.py
@@ -54,7 +54,7 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
     @mock.patch("time.time", return_value=4000.0)
     def test_live_view_opens_without_data(self, _mock_time, _mock_image_watcher):
         self.imaging.show_live_viewer(self.live_directory)
-        self.check_target(widget=self.imaging.live_viewer)
+        self.check_target(widget=self.imaging.live_viewer_list[-1])
 
     @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image')
     @mock.patch('mantidimaging.gui.windows.live_viewer.model.ImageWatcher')
@@ -64,8 +64,8 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
         image_list = [Image_Data(path) for path in file_list]
         mock_load_image.return_value = self._generate_image()
         self.imaging.show_live_viewer(self.live_directory)
-        self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list)
-        self.check_target(widget=self.imaging.live_viewer)
+        self.imaging.live_viewer_list[-1].presenter.model._handle_image_changed_in_list(image_list)
+        self.check_target(widget=self.imaging.live_viewer_list[-1])
 
     @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image')
     @mock.patch('mantidimaging.gui.windows.live_viewer.model.ImageWatcher')
@@ -75,8 +75,8 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
         image_list = [Image_Data(path) for path in file_list]
         mock_load_image.side_effect = ValueError
         self.imaging.show_live_viewer(self.live_directory)
-        self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list)
-        self.check_target(widget=self.imaging.live_viewer)
+        self.imaging.live_viewer_list[-1].presenter.model._handle_image_changed_in_list(image_list)
+        self.check_target(widget=self.imaging.live_viewer_list[-1])
 
     @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image')
     @mock.patch('mantidimaging.gui.windows.live_viewer.model.ImageWatcher')
@@ -86,6 +86,6 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
         image_list = [Image_Data(path) for path in file_list]
         mock_load_image.return_value = self._generate_image()
         self.imaging.show_live_viewer(self.live_directory)
-        self.imaging.live_viewer.presenter.model._handle_image_changed_in_list(image_list)
-        self.imaging.live_viewer.rotate_angles_group.actions()[1].trigger()
-        self.check_target(widget=self.imaging.live_viewer)
+        self.imaging.live_viewer_list[-1].presenter.model._handle_image_changed_in_list(image_list)
+        self.imaging.live_viewer_list[-1].rotate_angles_group.actions()[1].trigger()
+        self.check_target(widget=self.imaging.live_viewer_list[-1])

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -46,7 +46,8 @@ class LiveViewerWindowPresenter(BasePresenter):
 
     def close(self) -> None:
         """Close the window."""
-        self.model.close()
+        if self.model is not None:
+            self.model.close()
         self.model = None  # type: ignore # Presenter instance to be destroyed -type can be inconsistent
         self.view = None  # type: ignore # Presenter instance to be destroyed -type can be inconsistent
 

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -28,9 +28,9 @@ class LiveViewerWindowView(BaseMainWindowView):
 
     def __init__(self, main_window: MainWindowView, live_dir_path: Path) -> None:
         super().__init__(None, 'gui/ui/live_viewer_window.ui')
-        self.setWindowTitle("Mantid Imaging - Live Viewer")
         self.main_window = main_window
         self.path = live_dir_path
+        self.setWindowTitle(f"Mantid Imaging - Live Viewer - {str(self.path)}")
         self.presenter = LiveViewerWindowPresenter(self, main_window)
         self.live_viewer = LiveViewWidget()
         self.imageLayout.addWidget(self.live_viewer)

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -88,11 +88,8 @@ class LiveViewerWindowView(BaseMainWindowView):
 
     def closeEvent(self, e) -> None:
         """Close the window and remove it from the main window list"""
-        for live_viewer in self.main_window.live_viewer_list:
-            if live_viewer.path == self.path:
-                if live_viewer.presenter:
-                    live_viewer.presenter.close()
-                live_viewer.close()
+        self.main_window.live_viewer_list.remove(self)
+        self.presenter.close()
         self.live_viewer.handle_deleted()
         super().closeEvent(e)
         self.presenter = None  # type: ignore # View instance to be destroyed -type can be inconsistent

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -88,8 +88,11 @@ class LiveViewerWindowView(BaseMainWindowView):
 
     def closeEvent(self, e) -> None:
         """Close the window and remove it from the main window list"""
-        self.main_window.live_viewer = None
-        self.presenter.close()
+        for live_viewer in self.main_window.live_viewer_list:
+            if live_viewer.path == self.path:
+                if live_viewer.presenter:
+                    live_viewer.presenter.close()
+                live_viewer.close()
         self.live_viewer.handle_deleted()
         super().closeEvent(e)
         self.presenter = None  # type: ignore # View instance to be destroyed -type can be inconsistent

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -474,13 +474,6 @@ class MainWindowView(BaseMainWindowView):
             self.show_live_viewer(Path(live_data_directory))
 
     def show_live_viewer(self, live_data_path: Path) -> None:
-        # if not self.live_viewer:
-        #     self.live_viewer = LiveViewerWindowView(self, live_data_path)
-        #     self.live_viewer.show()
-        # else:
-        #     self.live_viewer.activateWindow()
-        #     self.live_viewer.raise_()
-        #     self.live_viewer.show()
         self.live_viewer = LiveViewerWindowView(self, live_data_path)
         self.live_viewer.activateWindow()
         self.live_viewer.raise_()

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -101,7 +101,7 @@ class MainWindowView(BaseMainWindowView):
     filters: FiltersWindowView | None = None
     recon: ReconstructWindowView | None = None
     spectrum_viewer: SpectrumViewerWindowView | None = None
-    live_viewer: LiveViewerWindowView | None = None
+    live_viewer_list: list[LiveViewerWindowView] = []
     settings_window: SettingsWindowView | None = None
 
     image_load_dialog: ImageLoadDialog | None = None
@@ -474,10 +474,11 @@ class MainWindowView(BaseMainWindowView):
             self.show_live_viewer(Path(live_data_directory))
 
     def show_live_viewer(self, live_data_path: Path) -> None:
-        self.live_viewer = LiveViewerWindowView(self, live_data_path)
-        self.live_viewer.activateWindow()
-        self.live_viewer.raise_()
-        self.live_viewer.show()
+        live_viewer = LiveViewerWindowView(self, live_data_path)
+        self.live_viewer_list.append(live_viewer)
+        self.live_viewer_list[-1].activateWindow()
+        self.live_viewer_list[-1].raise_()
+        self.live_viewer_list[-1].show()
 
     @property
     def stack_list(self) -> list[StackId]:
@@ -560,8 +561,8 @@ class MainWindowView(BaseMainWindowView):
             # Close additional windows which do not have the MainWindow as parent
             if self.recon:
                 self.recon.close()
-            if self.live_viewer:
-                self.live_viewer.close()
+            if self.live_viewer_list:
+                [live_viewer.close() for live_viewer in self.live_viewer_list]
             if self.spectrum_viewer:
                 self.spectrum_viewer.close()
             if self.filters:

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -476,8 +476,8 @@ class MainWindowView(BaseMainWindowView):
     def show_live_viewer(self, live_data_path: Path) -> None:
         live_viewer = LiveViewerWindowView(self, live_data_path)
         self.live_viewer_list.append(live_viewer)
-        self.live_viewer_list[-1].activateWindow()
-        self.live_viewer_list[-1].raise_()
+        # self.live_viewer_list[-1].activateWindow()
+        # self.live_viewer_list[-1].raise_()
         self.live_viewer_list[-1].show()
 
     @property
@@ -562,7 +562,8 @@ class MainWindowView(BaseMainWindowView):
             if self.recon:
                 self.recon.close()
             if self.live_viewer_list:
-                [live_viewer.close() for live_viewer in self.live_viewer_list]
+                while self.live_viewer_list:
+                    self.live_viewer_list[-1].close()
             if self.spectrum_viewer:
                 self.spectrum_viewer.close()
             if self.filters:

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -474,13 +474,17 @@ class MainWindowView(BaseMainWindowView):
             self.show_live_viewer(Path(live_data_directory))
 
     def show_live_viewer(self, live_data_path: Path) -> None:
-        if not self.live_viewer:
-            self.live_viewer = LiveViewerWindowView(self, live_data_path)
-            self.live_viewer.show()
-        else:
-            self.live_viewer.activateWindow()
-            self.live_viewer.raise_()
-            self.live_viewer.show()
+        # if not self.live_viewer:
+        #     self.live_viewer = LiveViewerWindowView(self, live_data_path)
+        #     self.live_viewer.show()
+        # else:
+        #     self.live_viewer.activateWindow()
+        #     self.live_viewer.raise_()
+        #     self.live_viewer.show()
+        self.live_viewer = LiveViewerWindowView(self, live_data_path)
+        self.live_viewer.activateWindow()
+        self.live_viewer.raise_()
+        self.live_viewer.show()
 
     @property
     def stack_list(self) -> list[StackId]:

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -476,8 +476,6 @@ class MainWindowView(BaseMainWindowView):
     def show_live_viewer(self, live_data_path: Path) -> None:
         live_viewer = LiveViewerWindowView(self, live_data_path)
         self.live_viewer_list.append(live_viewer)
-        # self.live_viewer_list[-1].activateWindow()
-        # self.live_viewer_list[-1].raise_()
         self.live_viewer_list[-1].show()
 
     @property
@@ -561,9 +559,8 @@ class MainWindowView(BaseMainWindowView):
             # Close additional windows which do not have the MainWindow as parent
             if self.recon:
                 self.recon.close()
-            if self.live_viewer_list:
-                while self.live_viewer_list:
-                    self.live_viewer_list[-1].close()
+            while self.live_viewer_list:
+                self.live_viewer_list[-1].close()
             if self.spectrum_viewer:
                 self.spectrum_viewer.close()
             if self.filters:


### PR DESCRIPTION
### Issue

Closes #2361

### Description

Removed the reraising of the currently opened Live Viewer to allow a second (or more) Live Viewer to be opened, each with a specified path.

### Testing 

`make check`
`make system-test`

### Acceptance Criteria 

Open multiple Live Viewer windows and point them to different directories. Check that the LVs behave independently of each other and behave as expected. You should be able to use multiple terminals with the `simulate_live_data.py` script to check that MI can process the various LVs simultaneously (see screenshot below)

### Documentation

Add release note

![image](https://github.com/user-attachments/assets/49c6cfde-c8e6-48d6-ba16-f57ce30e0a93)

