### PR TITLE
2375 convergence plots

### DIFF
--- a/docs/release_notes/next/feature-2375-display-convergence-plot-during-reconstruction
+++ b/docs/release_notes/next/feature-2375-display-convergence-plot-during-reconstruction
@@ -1,0 +1,2 @@
+#2375: Add Convergence Plot in AsyncTaskDialog Displayed During Reconstruction 
+

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -44,10 +44,14 @@ class MIProgressCallback(Callback):
 
     def __call__(self, algo: Algorithm) -> None:
         if self.progress:
-            self.progress.update(steps=1,
-                                 msg=f'CIL: Iteration {self.iteration_count } of {algo.max_iteration}'
-                                 f': Objective {algo.get_last_objective():.2f}',
-                                 force_continue=False)
+            extra_info = {'iterations': algo.iterations, 'losses': algo.loss}
+            self.progress.update(
+                steps=1,
+                msg=f'CIL: Iteration {self.iteration_count } of {algo.max_iteration}'
+                f': Objective {algo.get_last_objective():.2f}',
+                force_continue=False,
+                extra_info=extra_info,
+            )
             self.iteration_count += 1
 
 
@@ -407,6 +411,7 @@ class CILRecon(BaseRecon):
                 LOG.info(f'Reconstructed 3D volume with shape: {volume.shape}')
             t1 = time.perf_counter()
             LOG.info(f"full reconstruction time: {t1-t0}s for shape {images.data.shape}")
+            ImageStack(volume).metadata['convergence'] = {'iterations': algo.iterations, 'losses': algo.loss}
             return ImageStack(volume)
 
 

--- a/mantidimaging/core/utility/progress_reporting/progress.py
+++ b/mantidimaging/core/utility/progress_reporting/progress.py
@@ -9,7 +9,8 @@ from typing import NamedTuple, SupportsInt
 
 from mantidimaging.core.utility.memory_usage import get_memory_usage_linux_str
 
-ProgressHistory = NamedTuple('ProgressHistory', [('time', float), ('step', int), ('msg', str)])
+ProgressHistory = NamedTuple('ProgressHistory', [('time', float), ('step', int), ('msg', str),
+                                                 ('extra_info', dict | None)])
 
 
 class ProgressHandler:
@@ -167,7 +168,11 @@ class Progress:
         t = int(t)
         return f'{t // 3600:02}:{t % 3600 // 60:02}:{t % 60:02}'
 
-    def update(self, steps: int = 1, msg: str = "", force_continue: bool = False) -> None:
+    def update(self,
+               steps: int = 1,
+               msg: str = "",
+               force_continue: bool = False,
+               extra_info: dict | None = None) -> None:
         """
         Updates the progress of the task.
 
@@ -188,7 +193,7 @@ class Progress:
 
             msg = f"{f'{msg}' if len(msg) > 0 else ''} | {self.current_step}/{self.end_step} | " \
                   f"Time: {self._format_time(self.execution_time())}, ETA: {self._format_time(eta)}"
-            step_details = ProgressHistory(time.perf_counter(), self.current_step, msg)
+            step_details = ProgressHistory(time.perf_counter(), self.current_step, msg, extra_info)
             self.progress_history.append(step_details)
 
         # process progress callbacks

--- a/mantidimaging/core/utility/progress_reporting/test/progress_test.py
+++ b/mantidimaging/core/utility/progress_reporting/test/progress_test.py
@@ -257,20 +257,20 @@ class ProgressTest(unittest.TestCase):
     def test_calculate_mean_time(self):
         progress_history = []
 
-        progress_history.append(ProgressHistory(100, 0, ""))
+        progress_history.append(ProgressHistory(100, 0, "", None))
         self.assertEqual(Progress.calculate_mean_time(progress_history), 0)
 
         # first step 5 seconds
-        progress_history.append(ProgressHistory(105, 1, ""))
+        progress_history.append(ProgressHistory(105, 1, "", None))
         self.assertEqual(Progress.calculate_mean_time(progress_history), 5)
 
         # second step 10 seconds
-        progress_history.append(ProgressHistory(115, 2, ""))
+        progress_history.append(ProgressHistory(115, 2, "", None))
         self.assertEqual(Progress.calculate_mean_time(progress_history), 7.5)
 
         for i in range(1, 50):
             # add many 2 second steps
-            progress_history.append(ProgressHistory(115 + (i * 2), 2 + (i * 2), ""))
+            progress_history.append(ProgressHistory(115 + (i * 2), 2 + (i * 2), "", None))
         self.assertEqual(Progress.calculate_mean_time(progress_history), 2)
 
 

--- a/mantidimaging/gui/dialogs/async_task/presenter.py
+++ b/mantidimaging/gui/dialogs/async_task/presenter.py
@@ -20,12 +20,14 @@ class Notification(Enum):
 
 class AsyncTaskDialogPresenter(QObject, ProgressHandler):
     progress_updated = pyqtSignal(float, str)
+    progress_plot_updated = pyqtSignal(list, list)
 
     def __init__(self, view):
         super().__init__()
 
         self.view = view
         self.progress_updated.connect(self.view.set_progress)
+        self.progress_plot_updated.connect(self.view.set_progress_plot)
 
         self.model = AsyncTaskDialogModel()
         self.model.task_done.connect(self.view.handle_completion)
@@ -62,9 +64,18 @@ class AsyncTaskDialogPresenter(QObject, ProgressHandler):
     def task_is_running(self) -> None:
         return self.model.task_is_running
 
+    def update_progress_plot(self, iterations: list, losses: list) -> None:
+        y = [a[0] for a in losses]
+        self.progress_plot_updated.emit(iterations, y)
+
     def progress_update(self) -> None:
         msg = self.progress.last_status_message()
+        progress_info = self.progress.progress_history
+        extra_info = progress_info[-1].extra_info
         self.progress_updated.emit(self.progress.completion(), msg if msg is not None else '')
+
+        if extra_info:
+            self.update_progress_plot(extra_info['iterations'], extra_info['losses'])
 
     def show_stop_button(self, show: bool = False) -> None:
         self.view.show_cancel_button(show)

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 from collections.abc import Callable
+from pyqtgraph import PlotWidget
 
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.mvp_base import BaseDialogView
@@ -23,6 +24,11 @@ class AsyncTaskDialogView(BaseDialogView):
 
         self.progressBar.setMinimum(0)
         self.progressBar.setMaximum(1000)
+        self.progress_plot = PlotWidget()
+        self.PlotVerticalLayout.addWidget(self.progress_plot)
+        self.progress_plot.hide()
+        self.progress_plot.setLogMode(y=True)
+        self.progress_plot.setMinimumHeight(300)
 
         self.show_timer = QTimer(self)
         self.cancelButton.clicked.connect(self.presenter.stop_progress)
@@ -62,6 +68,10 @@ class AsyncTaskDialogView(BaseDialogView):
 
         # Update progress bar
         self.progressBar.setValue(int(progress * 1000))
+
+    def set_progress_plot(self, x: list, y: list):
+        self.progress_plot.show()
+        self.progress_plot.plotItem.plot(x, y)
 
     def show_delayed(self, timeout) -> None:
         self.show_timer.singleShot(timeout, self.show_from_timer)

--- a/mantidimaging/gui/ui/async_task_dialog.ui
+++ b/mantidimaging/gui/ui/async_task_dialog.ui
@@ -20,33 +20,36 @@
    <string>Progress</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QLabel" name="infoText">
-     <property name="text">
-      <string>Progress</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QProgressBar" name="progressBar">
-     <property name="value">
-      <number>0</number>
-     </property>
-     <property name="textVisible">
-      <bool>true</bool>
-     </property>
-     <property name="invertedAppearance">
-      <bool>false</bool>
-     </property>
-    </widget>
     <item>
-    <widget class="QPushButton" name="cancelButton">
-    <property name="text">
+        <widget class="QLabel" name="infoText">
+            <property name="text">
+            <string>Progress</string>
+            </property>
+        </widget>
+        </item>
+        <item>
+        <widget class="QProgressBar" name="progressBar">
+            <property name="value">
+            <number>0</number>
+            </property>
+            <property name="textVisible">
+            <bool>true</bool>
+            </property>
+            <property name="invertedAppearance">
+            <bool>false</bool>
+            </property>
+        </widget>   
+    </item>     
+     <item>
+      <layout class="QVBoxLayout" name="PlotVerticalLayout"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="cancelButton">
+       <property name="text">
         <string>Cancel</string>
-    </property>
-    </widget>
-    </item>
-   </item>
+       </property>
+      </widget>
+     </item>
   </layout>
  </widget>
  <resources/>


### PR DESCRIPTION
### Issue

Closes #2375 

### Description

*Add a description of the changes made*.
Expose Reconstruction Iterations and Losses through MIProgressCallback to AsyncTaskDialog progress bar to display convergence plot.

### Testing 

*Describe the tests that were used to verify your changes*.
* Manually tested
* Updated unit tests

### Acceptance Criteria 

*How should the reviewer test your changes*?
* Unit tests pass
* Convergence plot is displayed when reconstructing using PDHG.

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*

`docs/release_notes/next/feature-2375-display-convergence-plot-during-reconstruction`
