### PR TITLE
Fixing Warnings During Documentation Build

### DIFF
--- a/docs/developer_guide/explanations/index.rst
+++ b/docs/developer_guide/explanations/index.rst
@@ -11,4 +11,4 @@ In-depth conceptual explanations of the architecture and development guidelines.
 
    documentation.rst
    developer_conventions.rst
-   release.rst
+   conda_packaging_and_docker_image.rst

--- a/docs/developer_guide/how-to-guides/command.rst
+++ b/docs/developer_guide/how-to-guides/command.rst
@@ -13,13 +13,3 @@ The following command line arguments will only work if a valid path containing i
 - :code:`-sv` `--spectrum_viewer` - Opens the spectrum viewer window on start up. A path to a dataset must be provided with the :code:`--path` argument for the spectrum viewer to open.
 
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Contents:
-
-   documentation
-   developer_conventions
-   debugging
-   conda_packaging_and_docker_image
-   release
-   testing

--- a/docs/developer_guide/how-to-guides/index.rst
+++ b/docs/developer_guide/how-to-guides/index.rst
@@ -11,5 +11,5 @@ Specific guides for common development tasks.
 
    command.rst
    debugging.rst
-   conda_packaging_and_docker_image.rst
    testing.rst
+   release.rst

--- a/docs/developer_guide/index.rst
+++ b/docs/developer_guide/index.rst
@@ -15,7 +15,7 @@ Welcome to the developer guide. This guide is divided into several sections base
 
         Set up your environment and get started with development.
 
-    .. grid-item-card:: 📘
+    .. grid-item-card:: 🧪
         :link: how-to-guides
         :link-type: ref
         :text-align: center
@@ -24,7 +24,7 @@ Welcome to the developer guide. This guide is divided into several sections base
 
         Practical steps for common development tasks.
 
-    .. grid-item-card:: 🧠
+    .. grid-item-card:: ⚛️
         :link: explanations
         :link-type: ref
         :text-align: center
@@ -33,7 +33,7 @@ Welcome to the developer guide. This guide is divided into several sections base
 
         Deep dive into key development concepts.
 
-    .. grid-item-card:: 📚
+    .. grid-item-card:: 🔬
         :link: reference
         :link-type: ref
         :text-align: center

--- a/docs/developer_guide/tutorials/started.rst
+++ b/docs/developer_guide/tutorials/started.rst
@@ -34,15 +34,3 @@ Mantid Imaging can be run directly from the checked-out git directory::
 or to run with additional diagnostics::
 
     python3 -X faulthandler -m mantidimaging --log-level DEBUG
-
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Contents:
-
-   documentation
-   developer_conventions
-   debugging
-   conda_packaging_and_docker_image
-   release
-   testing

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ Mantid Imaging is a graphical toolkit for performing 3D reconstruction of neutro
         :link-type: doc
         :text-align: center
 
-        **User Guide**
+        **User Documentation**
 
         Documentation for using Mantid Imaging.
 
@@ -20,9 +20,9 @@ Mantid Imaging is a graphical toolkit for performing 3D reconstruction of neutro
         :link-type: doc
         :text-align: center
 
-        **Developer Guide**
+        **Developer Documentation**
 
-        Guidance for contributing to Mantid Imaging development.
+        Documentation for contributing to Mantid Imaging development.
 
 .. toctree::
    :maxdepth: 1
@@ -34,6 +34,7 @@ Mantid Imaging is a graphical toolkit for performing 3D reconstruction of neutro
    developer_guide/index
    api
    release_notes/index
+   troubleshooting
 
 .. toctree::
    :caption: Links:

--- a/docs/user_guide/explanations/gui/loading_saving.rst
+++ b/docs/user_guide/explanations/gui/loading_saving.rst
@@ -52,7 +52,7 @@ Load NeXus File
 NeXus Files can be loaded by selecting the "Load NeXus file" on the File menu. This brings up the NeXus Load dialog
 shown below.
 
-.. image:: ../../_static/nexus_loading_window.png
+.. image:: ../../../_static/nexus_loading_window.png
     :alt: NeXus Load Dialog
 
 From here you can choose a NeXus file that you wish to load. The program will then scan its contents and check for a

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -17,7 +17,7 @@ Welcome to the user guide. This guide is organized based on the Diátaxis framew
 
         Step-by-step guides to get started with MantidImaging.
 
-    .. grid-item-card:: 📘
+    .. grid-item-card:: 🧪
         :link: user_how-to-guides
         :link-type: ref
         :text-align: center
@@ -26,7 +26,7 @@ Welcome to the user guide. This guide is organized based on the Diátaxis framew
 
         Instructions for specific tasks and workflows in MantidImaging.
 
-    .. grid-item-card:: 🧠
+    .. grid-item-card:: ⚛️
         :link: user_explanations
         :link-type: ref
         :text-align: center
@@ -35,7 +35,7 @@ Welcome to the user guide. This guide is organized based on the Diátaxis framew
 
         In-depth discussions of key concepts and operations.
 
-    .. grid-item-card:: 📚
+    .. grid-item-card:: 🔬
         :link: user_reference
         :link-type: ref
         :text-align: center


### PR DESCRIPTION
### Issue

Closes #2406 

### Description

- Addressed warnings during the documentation build process by fixing missing or incorrect references in `.rst` files.  
- Updated or added missing files and paths in the `toctree`.  
- Removed any unused or outdated content causing build issues.  
