### PR TITLE
added fits file to choose file path

### DIFF
--- a/docs/release_notes/next/fix-2410-added-fits-file-to-choose-file-path
+++ b/docs/release_notes/next/fix-2410-added-fits-file-to-choose-file-path
@@ -1,0 +1,1 @@
+2410: Added fits file to choose file path

--- a/mantidimaging/gui/windows/add_images_to_dataset_dialog/view.py
+++ b/mantidimaging/gui/windows/add_images_to_dataset_dialog/view.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 import uuid
 
-from PyQt5.QtWidgets import QComboBox, QFileDialog, QDialogButtonBox, QPushButton, QLineEdit, QLabel, QMessageBox
+from PyQt5.QtWidgets import QComboBox, QFileDialog, QDialogButtonBox, QPushButton, QLineEdit, QLabel
 
 from mantidimaging.gui.mvp_base import BaseDialogView
 from mantidimaging.gui.windows.add_images_to_dataset_dialog.presenter import AddImagesToDatasetPresenter, Notification
@@ -37,15 +37,8 @@ class AddImagesToDatasetDialog(BaseDialogView):
         """
         Select a file in the stack path that we wish to add/replace in the dataset.
         """
-        file_filter = "Image Files (*.tif *.tiff *.fits);;All Files (*)"
-        selected_file, _ = QFileDialog.getOpenFileName(caption="Select Image File", filter=file_filter)
-
+        selected_file, _ = QFileDialog.getOpenFileName(caption="Images", filter="Image File (*.tif *.tiff *.fits)")
         if selected_file:
-            # Ensure file extension validation (optional, as filter already handles it)
-            if not selected_file.lower().endswith(('.tif', '.tiff', '.fits')):
-                QMessageBox.warning(self, "Unsupported File", "Please select a valid .tif, .tiff, or .fits file.")
-                return
-
             self.filePathLineEdit.setText(selected_file)
             self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(True)
 

--- a/mantidimaging/gui/windows/add_images_to_dataset_dialog/view.py
+++ b/mantidimaging/gui/windows/add_images_to_dataset_dialog/view.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 import uuid
 
-from PyQt5.QtWidgets import QComboBox, QFileDialog, QDialogButtonBox, QPushButton, QLineEdit, QLabel
+from PyQt5.QtWidgets import QComboBox, QFileDialog, QDialogButtonBox, QPushButton, QLineEdit, QLabel, QMessageBox
 
 from mantidimaging.gui.mvp_base import BaseDialogView
 from mantidimaging.gui.windows.add_images_to_dataset_dialog.presenter import AddImagesToDatasetPresenter, Notification
@@ -37,8 +37,15 @@ class AddImagesToDatasetDialog(BaseDialogView):
         """
         Select a file in the stack path that we wish to add/replace in the dataset.
         """
-        selected_file, _ = QFileDialog.getOpenFileName(caption="Images", filter="Image File (*.tif *.tiff)")
+        file_filter = "Image Files (*.tif *.tiff *.fits);;All Files (*)"
+        selected_file, _ = QFileDialog.getOpenFileName(caption="Select Image File", filter=file_filter)
+
         if selected_file:
+            # Ensure file extension validation (optional, as filter already handles it)
+            if not selected_file.lower().endswith(('.tif', '.tiff', '.fits')):
+                QMessageBox.warning(self, "Unsupported File", "Please select a valid .tif, .tiff, or .fits file.")
+                return
+
             self.filePathLineEdit.setText(selected_file)
             self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(True)
 


### PR DESCRIPTION
### Issue

Closes #2152 

### Description

Updated the choose_file_path method to include support for .fits files in addition to .tif and .tiff.
Modified the file dialog filter to Image Files (*.tif *.tiff *.fits) to allow users to select .fits files alongside existing formats.

### Testing 

Opened the file dialog to ensure .tif, .tiff, and .fits files are selectable.
Verified that selecting a .fits file updates the file path text field and enables the "OK" button.
Confirmed behavior remains consistent when selecting .tif or .tiff files.


