### PR TITLE
2297 remove roi ranges dict from spectrum viewer window model

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -205,6 +205,8 @@ class SpectrumViewerWindowModel:
                 return np.array([])
             roi_spectrum = self.get_stack_spectrum(self._stack, roi)
             roi_norm_spectrum = self.get_stack_spectrum(self._normalise_stack, roi)
+            if roi_norm_spectrum.size == 0:
+                return np.array([])
             spectrum = np.divide(roi_spectrum,
                                  roi_norm_spectrum,
                                  out=np.zeros_like(roi_spectrum),
@@ -213,6 +215,7 @@ class SpectrumViewerWindowModel:
                 average_shuttercount = self.get_shuttercount_normalised_correction_parameter()
                 spectrum = spectrum / average_shuttercount
             return spectrum
+        return np.array([])
 
     def get_shuttercount_normalised_correction_parameter(self) -> float:
         """
@@ -283,9 +286,9 @@ class SpectrumViewerWindowModel:
     def get_image_shape(self) -> tuple[int, int]:
         if self._stack is not None:
             assert len(self._stack.data.shape) == 3
-            return self._stack.data.shape[1:]
-        else:
-            return 0, 0
+            height, width = self._stack.data.shape[1:3]
+            return height, width
+        return 0, 0
 
     def has_stack(self) -> bool:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -112,12 +112,6 @@ class SpectrumViewerWindowModel:
         self._roi_id_counter += 1
         return new_name
 
-    def get_list_of_roi_names(self) -> list[str]:
-        """
-        Get a list of rois available in the model
-        """
-        return list(self._roi_ranges.keys())
-
     def set_stack(self, stack: ImageStack | None) -> None:
         """
         Sets the stack to be used by the model
@@ -134,33 +128,9 @@ class SpectrumViewerWindowModel:
         self.tof_range = (0, stack.data.shape[0] - 1)
         self.tof_range_full = self.tof_range
         self.tof_data = self.get_stack_time_of_flight()
-        self.set_new_roi(ROI_ALL)
-
-    def set_new_roi(self, name: str) -> None:
-        """
-        Sets a new ROI with the given name
-
-        @param name: The name of the new ROI
-        """
-        height, width = self.get_image_shape()
-        self.set_roi(name, SensibleROI.from_list([0, 0, width, height]))
 
     def set_normalise_stack(self, normalise_stack: ImageStack | None) -> None:
         self._normalise_stack = normalise_stack
-
-    def set_roi(self, roi_name: str, roi: SensibleROI) -> None:
-        self._roi_ranges[roi_name] = roi
-
-    def get_roi(self, roi_name: str) -> SensibleROI:
-        """
-        Get the ROI with the given name from the model
-
-        @param roi_name: The name of the ROI to get
-        @return: The ROI with the given name
-        """
-        if roi_name not in self._roi_ranges.keys():
-            raise KeyError(f"ROI {roi_name} does not exist in roi_ranges {self._roi_ranges.keys()}")
-        return self._roi_ranges[roi_name]
 
     def get_averaged_image(self) -> np.ndarray | None:
         """
@@ -218,15 +188,9 @@ class SpectrumViewerWindowModel:
             return "Need 2 different ShutterCount stacks"
         return ""
 
-    def get_spectrum(self,
-                     roi: str | SensibleROI,
-                     mode: SpecType,
-                     normalise_with_shuttercount: bool = False) -> np.ndarray:
+    def get_spectrum(self, roi: SensibleROI, mode: SpecType, normalise_with_shuttercount: bool = False) -> np.ndarray:
         if self._stack is None:
             return np.array([])
-
-        if isinstance(roi, str):
-            roi = self.get_roi(roi)
 
         if mode == SpecType.SAMPLE:
             return self.get_stack_spectrum(self._stack, roi)
@@ -241,14 +205,14 @@ class SpectrumViewerWindowModel:
                 return np.array([])
             roi_spectrum = self.get_stack_spectrum(self._stack, roi)
             roi_norm_spectrum = self.get_stack_spectrum(self._normalise_stack, roi)
-        spectrum = np.divide(roi_spectrum,
-                             roi_norm_spectrum,
-                             out=np.zeros_like(roi_spectrum),
-                             where=roi_norm_spectrum != 0)
-        if normalise_with_shuttercount:
-            average_shuttercount = self.get_shuttercount_normalised_correction_parameter()
-            spectrum = spectrum / average_shuttercount
-        return spectrum
+            spectrum = np.divide(roi_spectrum,
+                                 roi_norm_spectrum,
+                                 out=np.zeros_like(roi_spectrum),
+                                 where=roi_norm_spectrum != 0)
+            if normalise_with_shuttercount:
+                average_shuttercount = self.get_shuttercount_normalised_correction_parameter()
+                spectrum = spectrum / average_shuttercount
+            return spectrum
 
     def get_shuttercount_normalised_correction_parameter(self) -> float:
         """
@@ -349,22 +313,21 @@ class SpectrumViewerWindowModel:
             csv_output.add_column("ToF", self.units.tof_seconds_to_us(), "Microseconds")
             csv_output.add_column("Energy", self.units.tof_seconds_to_energy(), "MeV")
 
-        for roi_name in self.get_list_of_roi_names():
-            csv_output.add_column(roi_name, self.get_spectrum(roi_name, SpecType.SAMPLE, normalise_with_shuttercount),
+        for roi in rois:
+            csv_output.add_column(f"ROI_{roi}", self.get_spectrum(roi, SpecType.SAMPLE, normalise_with_shuttercount),
                                   "Counts")
             if normalise:
                 if self._normalise_stack is None:
                     raise RuntimeError("No normalisation stack selected")
-                csv_output.add_column(roi_name + "_open", self.get_spectrum(roi_name, SpecType.OPEN), "Counts")
-                csv_output.add_column(roi_name + "_norm",
-                                      self.get_spectrum(roi_name, SpecType.SAMPLE_NORMED, normalise_with_shuttercount),
+                csv_output.add_column(f"ROI_{roi}_open", self.get_spectrum(roi, SpecType.OPEN), "Counts")
+                csv_output.add_column(f"ROI_{roi}_norm",
+                                      self.get_spectrum(roi, SpecType.SAMPLE_NORMED, normalise_with_shuttercount),
                                       "Counts")
 
         with path.open("w") as outfile:
             csv_output.write(outfile)
-            self.save_roi_coords(self.get_roi_coords_filename(path))
 
-    def save_single_rits_spectrum(self, path: Path, error_mode: ErrorMode) -> None:
+    def save_single_rits_spectrum(self, path: Path, error_mode: ErrorMode, roi: SensibleROI) -> None:
         """
         Saves the spectrum for the RITS ROI to a RITS file.
 
@@ -372,7 +335,28 @@ class SpectrumViewerWindowModel:
         @param normalized: Whether to save the normalized spectrum.
         @param error_mode: Which version (standard deviation or propagated) of the error to use in the RITS export
         """
-        self.save_rits_roi(path, error_mode, self.get_roi(ROI_RITS))
+        if self._stack is None:
+            raise ValueError("No stack selected")
+
+        if self._normalise_stack is None:
+            raise ValueError("A normalise stack must be selected")
+
+        tof = self.get_stack_time_of_flight()
+        if tof is None:
+            raise ValueError("No Time of Flights for sample. Make sure spectra log has been loaded")
+
+        tof *= 1e6  # Convert ToF to μs for RITS format
+
+        transmission = self.get_spectrum(roi, SpecType.SAMPLE_NORMED)
+
+        if error_mode == ErrorMode.STANDARD_DEVIATION:
+            transmission_error = self.get_transmission_error_standard_dev(roi)
+        elif error_mode == ErrorMode.PROPAGATED:
+            transmission_error = self.get_transmission_error_propagated(roi)
+        else:
+            raise ValueError("Invalid error_mode provided")
+
+        self.export_spectrum_to_rits(path, tof, transmission, transmission_error)
 
     def save_rits_roi(self, path: Path, error_mode: ErrorMode, roi: SensibleROI, normalise: bool = False) -> None:
         """
@@ -386,6 +370,7 @@ class SpectrumViewerWindowModel:
 
         if self._normalise_stack is None:
             raise ValueError("A normalise stack must be selected")
+
         tof = self.get_stack_time_of_flight()
         if tof is None:
             raise ValueError("No Time of Flights for sample. Make sure spectra log has been loaded")
@@ -430,7 +415,8 @@ class SpectrumViewerWindowModel:
                          bin_size: int,
                          step: int,
                          normalise: bool = False,
-                         progress: Progress | None = None) -> None:
+                         progress: Progress | None = None,
+                         roi: SensibleROI | None = None) -> None:
         """
         Saves multiple Region of Interest (ROI) images to RITS files.
 
@@ -449,13 +435,19 @@ class SpectrumViewerWindowModel:
         bin_size (int): The size of the sub-regions.
         step (int): The step size to use when sliding the window across the ROI.
 
-        Returns:
-        None
+        @param directory: Directory where the RITS images will be saved.
+        @param error_mode: Error mode to use when saving images (e.g., standard deviation or propagated).
+        @param bin_size: Size of each sub-region.
+        @param step: Step size for sliding the window across the ROI.
+        @param normalise: Whether to normalise the images.
+        @param progress: Optional progress tracker.
+        @param roi: The ROI to be used for saving the RITS images.
+        @raises ValueError: If bin size or step size is invalid.
         """
-        roi = self.get_roi(ROI_RITS)
-        left, top, right, bottom = roi
-        x_iterations = min(ceil((right - left) / step), ceil((right - left - bin_size) / step) + 1)
-        y_iterations = min(ceil((bottom - top) / step), ceil((bottom - top - bin_size) / step) + 1)
+        rois = self.roi_dict.keys()
+        left, top, right, bottom = roi.left, roi.top, roi.right, roi.bottom
+        x_iterations = max(1, ceil((right - left - bin_size) / step) + 1)
+        y_iterations = max(1, ceil((bottom - top - bin_size) / step) + 1)
         progress = Progress.ensure_instance(progress, num_steps=x_iterations * y_iterations)
 
         self.validate_bin_and_step_size(roi, bin_size, step)
@@ -516,36 +508,6 @@ class SpectrumViewerWindowModel:
         """
         rits_data = saver.create_rits_format(tof, transmission, absorption)
         saver.export_to_dat_rits_format(rits_data, path)
-
-    def remove_roi(self, roi_name: str) -> None:
-        """
-        Remove the selected ROI from the model
-
-        @param roi_name: The name of the ROI to remove
-        """
-        if roi_name in self._roi_ranges.keys():
-            if roi_name in self.special_roi_list:
-                raise RuntimeError(f"Cannot remove ROI: {roi_name}")
-            del self._roi_ranges[roi_name]
-        else:
-            raise KeyError(
-                f"Cannot remove ROI {roi_name} as it does not exist. \n Available ROIs: {self._roi_ranges.keys()}")
-
-    def rename_roi(self, old_name: str, new_name: str) -> None:
-        """
-        Rename the selected ROI from the model
-
-        @param old_name: The current name of the ROI
-        @param new_name: The new name of the ROI
-        @raises KeyError: If the ROI does not exist
-        @raises RuntimeError: If the ROI is 'all'
-        """
-        if old_name in self._roi_ranges.keys() and new_name not in self._roi_ranges.keys():
-            if old_name in self.special_roi_list:
-                raise RuntimeError(f"Cannot remove ROI: {old_name}")
-            self._roi_ranges[new_name] = self._roi_ranges.pop(old_name)
-        else:
-            raise KeyError(f"Cannot rename {old_name} to {new_name} Available:{self._roi_ranges.keys()}")
 
     def remove_all_roi(self) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -297,7 +297,7 @@ class SpectrumViewerWindowModel:
         """
         return self._stack is not None
 
-    def save_csv(self, path: Path, normalise: bool, normalise_with_shuttercount: bool = False) -> None:
+    def save_csv(self, path: Path, normalise: bool, rois: list[SensibleROI], normalise_with_shuttercount: bool = False):
         """
         Iterates over all ROIs and saves the spectrum for each one to a CSV file.
 
@@ -421,22 +421,11 @@ class SpectrumViewerWindowModel:
                          progress: Progress | None = None,
                          roi: SensibleROI | None = None) -> None:
         """
-        Saves multiple Region of Interest (ROI) images to RITS files.
+        Save multiple sub-region images of an ROI to RITS files.
 
-        This method divides the ROI into multiple sub-regions of size 'bin_size' and saves each sub-region
-        as a separate RITS image.
-        The sub-regions are created by sliding a window of size 'bin_size' across the ROI with a step size of 'step'.
-
-        During each iteration on a given axis by the step size, a check is made to see if
-        the sub_roi has reached the end of the ROI on that axis and if so, the iteration for that axis is stopped.
-
-
-        Parameters:
-        directory (Path): The directory where the RITS images will be saved. If None, no images will be saved.
-        normalised (bool): If True, the images will be normalised.
-        error_mode (ErrorMode): The error mode to use when saving the images.
-        bin_size (int): The size of the sub-regions.
-        step (int): The step size to use when sliding the window across the ROI.
+        This method divides the RITS ROI into sub-regions of size `bin_size` and saves each sub-region
+        as a separate RITS image. Sub-regions are created by sliding a window of size `bin_size`
+        across the ROI with a step size of `step`.
 
         @param directory: Directory where the RITS images will be saved.
         @param error_mode: Error mode to use when saving images (e.g., standard deviation or propagated).
@@ -447,7 +436,9 @@ class SpectrumViewerWindowModel:
         @param roi: The ROI to be used for saving the RITS images.
         @raises ValueError: If bin size or step size is invalid.
         """
-        rois = self.roi_dict.keys()
+        if roi is None:
+            raise ValueError("ROI must be provided to save RITS images.")
+
         left, top, right, bottom = roi.left, roi.top, roi.right, roi.bottom
         x_iterations = max(1, ceil((right - left - bin_size) / step) + 1)
         y_iterations = max(1, ceil((bottom - top - bin_size) / step) + 1)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -171,7 +171,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         Show the new sample in the view and update the spectrum and
         image view accordingly. Resets the ROIs.
         """
-
         averaged_image = self.model.get_averaged_image()
         assert averaged_image is not None
         self.view.set_image(averaged_image)
@@ -218,7 +217,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         Redraw the spectrum with the given name.
         """
-        roi = self.view.spectrum_widget.get_roi(name)
+        roi = self.view.spectrum_widget.get_roi(name)  # Convert name to SensibleROI
         spectrum = self.model.get_spectrum(roi,
                                            self.spectrum_mode,
                                            normalise_with_shuttercount=self.view.shuttercount_norm_enabled())
@@ -426,9 +425,14 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                     self.check_action(action, False)
 
     def do_adjust_roi(self) -> None:
-        new_roi = self.convert_spinbox_roi_to_SensibleROI(self.view.roiPropertiesSpinBoxes)
-        self.model.set_roi(self.view.current_roi_name, new_roi)
-        self.view.spectrum_widget.adjust_roi(new_roi, self.view.current_roi_name)
+        """
+        Adjust the currently selected ROI based on the spinbox values.
+        """
+
+        new_roi = self.convert_spinbox_roi_to_SensibleROI(self.view.roiPropertiesSpinboxes)
+        roi_name = self.view.current_roi_name if self.view.current_roi_name is not None else "default_roi"
+        self.view.spectrum_widget.adjust_roi(new_roi, roi_name)
+        self.redraw_spectrum(roi_name)
 
     def handle_storing_current_roi_name_on_tab_change(self) -> None:
         old_table_names = self.view.old_table_names

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -242,23 +242,23 @@ class SpectrumWidget(QWidget):
             self.view.spectrum_widget.remove_roi(roi_name)
         self.view.clear_spectrum_data(roi_name)
 
-    def add_roi(self, roi: SensibleROI, name: str | None = None) -> str:
+    def add_roi(self, roi: SensibleROI, name: str) -> None:
         """
         Add an ROI to the image view.
 
         @param roi: The ROI to add.
-        @param name: The name of the ROI. If None, a new unique name will be generated.
-        @return: The name of the added ROI.
+        @param name: The name of the ROI.
         """
-        if name is None:
-            name = f"roi_{len(self.roi_dict)}"
         roi_object = SpectrumROI(name, roi, rotatable=False, scaleSnap=True, translateSnap=True)
         roi_object.colour = self.colour_generator()
         roi_object.sig_colour_change.connect(lambda name, color: self.roiColorChangeRequested.emit(name, color))
+
         self.roi_dict[name] = roi_object.roi
+        self.max_roi_size = roi_object.size()
+        self.roi_dict[name].sigRegionChangeFinished.connect(self.roi_changed.emit)
+        self.roi_dict[name].sigClicked.connect(self.roi_clicked.emit)
         self.image.vb.addItem(self.roi_dict[name])
         self.roi_dict[name].hoverPen = mkPen(self.roi_dict[name].colour, width=3)
-        return name
 
     def adjust_roi(self, new_roi: SensibleROI, roi_name: str) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -7,14 +7,14 @@ from pathlib import Path
 from unittest import mock
 
 import numpy as np
-from PyQt5.QtWidgets import QPushButton, QGroupBox, QCheckBox, QTabWidget
+from PyQt5.QtWidgets import QPushButton, QGroupBox, QCheckBox, QTabWidget, QAction, QActionGroup
 from parameterized import parameterized
 
 from mantidimaging.core.data.dataset import StrictDataset, Dataset
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowView, SpectrumViewerWindowPresenter
-from mantidimaging.gui.windows.spectrum_viewer.model import ToFUnitMode, ROI_RITS, SpecType
+from mantidimaging.gui.windows.spectrum_viewer.model import ToFUnitMode, ROI_RITS, SpecType, ErrorMode
 from mantidimaging.gui.windows.spectrum_viewer.presenter import ExportMode
 from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumWidget, SpectrumPlotWidget, SpectrumROI
 from mantidimaging.test_helpers import mock_versions, start_qapplication


### PR DESCRIPTION
### Issue

Closes #2297 

### Description

Remove _roi_ranges dictionary from SpectrumViewerWindowModel. The model no longer needs to maintain its own list of ROI names since SpectrumWidget handles ROI management. This eliminates redundant code and reduces synchronization issues.

### Testing 

Updated unit tests to reflect method signature changes.

### Acceptance Criteria 

Verify all removed methods are unused.
Ensure all tests pass and functionality remains intact.
