### PR TITLE
Refactor get_spectrum to no longer accept ROI as a string

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -110,6 +110,18 @@ class SpectrumROI(ROI):
     def rename_roi(self, new_name: str) -> None:
         self._name = new_name
 
+    def as_sensible_roi(self) -> SensibleROI:
+        """
+        Converts the SpectrumROI to a SensibleROI object.
+        """
+        pos = self.pos()
+        size = self.size()
+        left, top = pos
+        width, height = size
+        right = left + width
+        bottom = top + height
+        return SensibleROI.from_list([left, top, right, bottom])
+
 
 class SpectrumWidget(QWidget):
     """

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -205,13 +205,13 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view.get_csv_filename = mock.Mock(return_value=Path(path_name))
         self.view.shuttercount_norm_enabled.return_value = False
         mock_shuttercount_issue.return_value = "Something wrong"
-
         self.presenter.model.set_stack(generate_images())
-
         self.presenter.handle_export_csv()
 
         self.view.get_csv_filename.assert_called_once()
-        mock_save_csv.assert_called_once_with(Path("/fake/path.csv"), False, False)
+        mock_save_csv.assert_called_once_with(Path("/fake/path.csv"), {},
+                                              normalise=False,
+                                              normalise_with_shuttercount=False)
 
     @parameterized.expand(["/fake/path", "/fake/path.dat"])
     @mock.patch("mantidimaging.gui.windows.spectrum_viewer.model.SpectrumViewerWindowModel.save_rits_roi")

--- a/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
@@ -42,6 +42,11 @@ class SpectrumROITest(unittest.TestCase):
         self.spectrum_roi.onChangeColor()
         self.assertEqual(self.spectrum_roi.colour, (0, 0, 0, 255))
 
+    def test_WHEN_as_sensible_roi_called_THEN_correct_sensible_roi_returned(self):
+        sensible_roi = self.spectrum_roi.as_sensible_roi()
+        self.assertEqual((sensible_roi.left, sensible_roi.top, sensible_roi.right, sensible_roi.bottom),
+                         (10, 20, 30, 40))
+
 
 @mock_versions
 @start_qapplication


### PR DESCRIPTION
### Issue

Closes #2297 

### Description

Refactored get_spectrum to only accept SensibleROI objects. Updated all dependent methods (do_add_roi, do_remove_roi, redraw_spectrum, etc.) to retrieve and pass SensibleROI instead of strings.

### Testing 

updated unit test

### Acceptance Criteria 

Ran unit tests for methods like do_add_roi, do_remove_roi, redraw_spectrum, and redraw_all_rois to confirm they function correctly with the updated get_spectrum.

Manually tested adding, removing, and updating ROIs in the UI to validate proper behavior.

