### PR TITLE
Reduce memory use during tests and relax memory limit

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -110,7 +110,7 @@ jobs:
         timeout-minutes: 10
         shell: bash -l {0}
         run: |
-          xvfb-run --auto-servernum python -m pytest --cov --cov-report=xml -n auto --maxprocesses=4 -o log_cli=true --ignore=mantidimaging/eyes_tests --durations=10
+          xvfb-run --auto-servernum python -m pytest --cov --cov-report=xml -n auto --maxprocesses=4 --dist loadgroup -o log_cli=true --ignore=mantidimaging/eyes_tests --durations=10
 
       - name: Get test data
         shell: bash -l {0}

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -110,7 +110,7 @@ jobs:
         timeout-minutes: 10
         shell: bash -l {0}
         run: |
-          xvfb-run --auto-servernum python -m pytest --cov --cov-report=xml -n auto -o log_cli=true --ignore=mantidimaging/eyes_tests --durations=10
+          xvfb-run --auto-servernum python -m pytest --cov --cov-report=xml -n auto --maxprocesses=4 -o log_cli=true --ignore=mantidimaging/eyes_tests --durations=10
 
       - name: Get test data
         shell: bash -l {0}

--- a/.github/workflows/rocky_testing.yml
+++ b/.github/workflows/rocky_testing.yml
@@ -53,5 +53,5 @@ jobs:
       timeout-minutes: 5
       uses: ./.github/actions/test
       with:
-        command: xvfb-run pytest -n auto -o log_cli=true --ignore=mantidimaging/eyes_tests --durations=10
+        command: xvfb-run pytest -n auto --maxprocesses=4 -o log_cli=true --ignore=mantidimaging/eyes_tests --durations=10
         label: rocky8

--- a/.github/workflows/rocky_testing.yml
+++ b/.github/workflows/rocky_testing.yml
@@ -53,5 +53,5 @@ jobs:
       timeout-minutes: 5
       uses: ./.github/actions/test
       with:
-        command: xvfb-run pytest -n auto --maxprocesses=4 -o log_cli=true --ignore=mantidimaging/eyes_tests --durations=10
+        command: xvfb-run pytest -n auto --maxprocesses=4 --dist loadgroup -o log_cli=true --ignore=mantidimaging/eyes_tests --durations=10
         label: rocky8

--- a/.github/workflows/u18_testing.yml
+++ b/.github/workflows/u18_testing.yml
@@ -52,5 +52,5 @@ jobs:
       timeout-minutes: 5
       uses: ./.github/actions/test
       with:
-        command: xvfb-run pytest -n auto -o log_cli=true --ignore=mantidimaging/eyes_tests --durations=10
+        command: xvfb-run pytest -n auto --maxprocesses=4 -o log_cli=true --ignore=mantidimaging/eyes_tests --durations=10
         label: ubuntu18

--- a/.github/workflows/u18_testing.yml
+++ b/.github/workflows/u18_testing.yml
@@ -52,5 +52,5 @@ jobs:
       timeout-minutes: 5
       uses: ./.github/actions/test
       with:
-        command: xvfb-run pytest -n auto --maxprocesses=4 -o log_cli=true --ignore=mantidimaging/eyes_tests --durations=10
+        command: xvfb-run pytest -n auto --maxprocesses=4 --dist loadgroup -o log_cli=true --ignore=mantidimaging/eyes_tests --durations=10
         label: ubuntu18

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -99,7 +99,7 @@ jobs:
         timeout-minutes: 10
         shell: bash -l {0}
         run: |
-          python -m pytest --cov --cov-report=xml -n auto -o log_cli=true --ignore=mantidimaging/eyes_tests --durations=10
+          python -m pytest --cov --cov-report=xml -n auto --maxprocesses=4 -o log_cli=true --ignore=mantidimaging/eyes_tests --durations=10
 
       - name: Get test data
         shell: bash -l {0}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -99,7 +99,7 @@ jobs:
         timeout-minutes: 10
         shell: bash -l {0}
         run: |
-          python -m pytest --cov --cov-report=xml -n auto --maxprocesses=4 -o log_cli=true --ignore=mantidimaging/eyes_tests --durations=10
+          python -m pytest --cov --cov-report=xml -n auto --maxprocesses=4 --dist loadgroup -o log_cli=true --ignore=mantidimaging/eyes_tests --durations=10
 
       - name: Get test data
         shell: bash -l {0}

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ install-dev-requirements:
 	python ./setup.py create_dev_env
 
 test:
-	python -m pytest -n auto
+	python -m pytest -n auto --maxprocesses=4
 
 test-verbose:
 	python -m pytest -vs -o log_cli=true

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ install-dev-requirements:
 	python ./setup.py create_dev_env
 
 test:
-	python -m pytest -n auto --maxprocesses=4
+	python -m pytest -n auto --maxprocesses=4 --dist loadgroup
 
 test-verbose:
 	python -m pytest -vs -o log_cli=true

--- a/mantidimaging/core/utility/memory_usage.py
+++ b/mantidimaging/core/utility/memory_usage.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 # Our Linux installation steps request 90% of RAM for shared memory and taking up nearly all of that makes it more
 # likely to get hit by SIGBUS by the OS. Even if the allocation is permitted, it could slow the
 # system down to the point of being unusable
-MEMORY_CAP_PERCENTAGE = 0.125
+MEMORY_CAP_PERCENTAGE = 0.05
 
 
 def system_free_memory():

--- a/mantidimaging/test_helpers/start_qapplication.py
+++ b/mantidimaging/test_helpers/start_qapplication.py
@@ -85,7 +85,7 @@ def start_qapplication(cls):
 def start_multiprocessing_pool(cls):
 
     def setUpClass():
-        create_and_start_pool(0)
+        create_and_start_pool(2)
 
     def tearDownClass():
         end_pool()

--- a/mantidimaging/test_helpers/start_qapplication.py
+++ b/mantidimaging/test_helpers/start_qapplication.py
@@ -90,6 +90,7 @@ def start_multiprocessing_pool(cls):
     def tearDownClass():
         end_pool()
 
+    cls = pytest.mark.xdist_group("uses_multiprocessing")(cls)
     return augment_test_setup_methods(cls, setup_class=setUpClass, teardown_class=tearDownClass)
 
 


### PR DESCRIPTION
### Issue

Closes #2417

### Description
Prevent a large number of python processes being started when running pytest

Previous Pytest would start a worker for each physical cpu core (though `pytest-xdist`), each of these could start a multiprocessing pool with a process for each logical core (hyperthread). On a 8-core 16-thread, this could launch many python processes and use 8GB of RAM.

This PR does several things
* Limit size of multiprocessing pool to 2 during tests (it is controlled by a setting for the application)
* Limit number of pytest workers to 4
* Keep all tests that use multiprocess in a single pytest worker (using [xdist loadgroup](https://pytest-xdist.readthedocs.io/en/stable/distribution.html))

### Testing 

*Describe the tests that were used to verify your changes*.

### Acceptance Criteria 

*How should the reviewer test your changes*?

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*
