### PR TITLE
2380 tof widget

### DIFF
--- a/docs/release_notes/next/dev-2380-ExperimentSetupFormWidget
+++ b/docs/release_notes/next/dev-2380-ExperimentSetupFormWidget
@@ -1,0 +1,1 @@
+#2380: Rename Spectrum Viewer tofPropertiesGroupBox to experimentSetupGroupBox and place into a custom widget.

--- a/mantidimaging/gui/ui/spectrum_viewer.ui
+++ b/mantidimaging/gui/ui/spectrum_viewer.ui
@@ -440,54 +440,8 @@
          </widget>
         </item>
         <item>
-         <widget class="QGroupBox" name="tofPropertiesGroupBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>300</width>
-            <height>84</height>
-           </size>
-          </property>
-          <property name="title">
-           <string>Time of Flight Properties</string>
-          </property>
-            <layout class="QFormLayout" name="formLayout">
-                <item row="0" column="0">
-                <widget class="QLabel" name="label_3">
-                <property name="text">
-                <string>Flight path:</string>
-                </property>
-                </widget>
-                </item>
-                <item row="0" column="1">
-                    <widget class="QDoubleSpinBox" name="flightPathSpinBox">
-                    <property name="suffix">
-                    <string/>
-                    </property>
-                    </widget>
-                </item>
-                <item row="1" column="0">
-                    <widget class="QLabel" name="label_4">
-                    <property name="text">
-                    <string>Time delay: </string>
-                    </property>
-                    </widget>
-                </item>
-                <item row="1" column="1">
-                    <widget class="QDoubleSpinBox" name="timeDelaySpinBox">
-                    <property name="suffix">
-                    <string/>
-                    </property>
-                    </widget>
-                </item>
-            </layout>
-        </widget>
-    </item>
+            <widget class="QWidget" name="experimentSetupGroupBox"></widget>
+        </item>
         <item>
          <spacer name="verticalSpacer">
           <property name="orientation">

--- a/mantidimaging/gui/widgets/spectrum_widgets/tof_properties.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/tof_properties.py
@@ -1,0 +1,87 @@
+# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+from PyQt5 import QtCore, QtWidgets
+
+
+class ExperimentSetupFormWidget(QtWidgets.QGroupBox):
+    """
+    A custom Qt widget for setting up experiment properties related to Time of Flight (ToF).
+
+    This widget contains input fields for flight path and time delay.
+
+    Attributes:
+        timeDelayLabel: Label for the time delay input field.
+        flightPathSpinBox: Spin box for inputting the flight path value.
+        flightPathLabel: Label for the flight path input field.
+        timeDelaySpinBox: Spin box for inputting the time delay value.
+
+    """
+
+    def __init__(self, parent: QtWidgets.QWidget = None):
+        super().__init__(parent)
+        self.setupUi()
+
+    def setupUi(self):
+        self.setObjectName("experimentSetupGroupBox")
+
+        self.resize(300, 94)
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.MinimumExpanding)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.sizePolicy().hasHeightForWidth())
+
+        target = self.parent() if self.parent() else self
+        target.setSizePolicy(sizePolicy)
+        target.setMinimumSize(QtCore.QSize(300, 94))
+        target.setContextMenuPolicy(QtCore.Qt.DefaultContextMenu)
+
+        layout = QtWidgets.QGridLayout(self)
+
+        self.flightPathLabel = QtWidgets.QLabel(self)
+        self.flightPathLabel.setObjectName("flightPathLabel")
+        self.flightPathLabel.setText("Flight path: ")
+        layout.addWidget(self.flightPathLabel, 0, 0)
+
+        self.flightPathSpinBox = QtWidgets.QDoubleSpinBox(self)
+        self.flightPathSpinBox.setSuffix(" m")
+        self.flightPathSpinBox.setMinimum(0)
+        self.flightPathSpinBox.setMaximum(1e10)
+        self.flightPathSpinBox.setObjectName("flightPathSpinBox")
+        layout.addWidget(self.flightPathSpinBox, 0, 1)
+
+        self.timeDelayLabel = QtWidgets.QLabel(self)
+        self.timeDelayLabel.setObjectName("timeDelayLabel")
+        self.timeDelayLabel.setText("Time delay: ")
+        layout.addWidget(self.timeDelayLabel, 1, 0)
+
+        self.timeDelaySpinBox = QtWidgets.QDoubleSpinBox(self)
+        self.timeDelaySpinBox.setSuffix(" \u03BCs")
+        self.timeDelaySpinBox.setMaximum(1e10)
+        self.timeDelaySpinBox.setObjectName("timeDelaySpinBox")
+        layout.addWidget(self.timeDelaySpinBox, 1, 1)
+
+        self.setWindowTitle("Time of Flight Properties")
+        self.setTitle("Time of Flight Properties")
+
+        QtCore.QMetaObject.connectSlotsByName(self)
+
+    @property
+    def flight_path(self) -> float:
+        return self.flightPathSpinBox.value()
+
+    @flight_path.setter
+    def flight_path(self, value: float):
+        self.flightPathSpinBox.setValue(value)
+
+    @property
+    def time_delay(self) -> float:
+        return self.timeDelaySpinBox.value()
+
+    @time_delay.setter
+    def time_delay(self, value: float):
+        self.timeDelaySpinBox.setValue(value)
+
+    def connect_value_changed(self, handler: QtCore.pyqtSlot):
+        self.flightPathSpinBox.valueChanged.connect(handler)
+        self.timeDelaySpinBox.valueChanged.connect(handler)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -129,13 +129,13 @@ class SpectrumViewerWindowPresenter(BasePresenter):
     def reset_units_menu(self) -> None:
         if self.model.tof_data is None:
             self.view.tof_mode_select_group.setEnabled(False)
-            self.view.tofPropertiesGroupBox.setEnabled(False)
+            self.view.experimentSetupGroupBox.setEnabled(False)
             self.model.tof_mode = ToFUnitMode.IMAGE_NUMBER
             self.change_selected_menu_option("Image Index")
             self.view.tof_mode_select_group.setEnabled(False)
         else:
             self.view.tof_mode_select_group.setEnabled(True)
-            self.view.tofPropertiesGroupBox.setEnabled(True)
+            self.view.experimentSetupGroupBox.setEnabled(True)
 
     def handle_normalise_stack_change(self, normalise_uuid: UUID | None) -> None:
         if normalise_uuid == self.current_norm_stack_uuid:
@@ -417,13 +417,9 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.spectrum_widget.spectrum_plot_widget.set_image_index_range_label(*self.model.tof_range)
         self.view.auto_range_image()
 
-    def handle_flight_path_change(self) -> None:
-        self.model.units.target_to_camera_dist = self.view.flightPathSpinBox.value()
-        self.model.set_relevant_tof_units()
-        self.refresh_spectrum_plot()
-
-    def handle_time_delay_change(self) -> None:
-        self.model.units.data_offset = self.view.timeDelaySpinBox.value() * 1e-6
+    def handle_experiment_setup_properties_change(self) -> None:
+        self.model.units.target_to_camera_dist = self.view.experimentSetupFormWidget.flight_path
+        self.model.units.data_offset = self.view.experimentSetupFormWidget.time_delay * 1e-6
         self.model.set_relevant_tof_units()
         self.refresh_spectrum_plot()
 

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import QCheckBox, QVBoxLayout, QFileDialog, QPushButton, QLabel, QAbstractItemView, QHeaderView, \
-    QTabWidget, QComboBox, QSpinBox, QTableWidget, QTableWidgetItem, QGroupBox, QActionGroup, QAction, QDoubleSpinBox
+    QTabWidget, QComboBox, QSpinBox, QTableWidget, QTableWidgetItem, QGroupBox, QActionGroup, QAction
 from PyQt5.QtCore import QSignalBlocker, Qt, QModelIndex
 
 from mantidimaging.core.utility import finder
@@ -18,7 +18,7 @@ from .presenter import SpectrumViewerWindowPresenter, ExportMode
 from mantidimaging.gui.widgets import RemovableRowTableView
 from .spectrum_widget import SpectrumWidget
 from mantidimaging.gui.windows.spectrum_viewer.roi_table_model import TableModel
-
+from mantidimaging.gui.widgets.spectrum_widgets.tof_properties import ExperimentSetupFormWidget
 import numpy as np
 
 if TYPE_CHECKING:
@@ -55,9 +55,8 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
     number_roi_properties_procced: int = 0
 
-    tofPropertiesGroupBox: QGroupBox
-    flightPathSpinBox: QDoubleSpinBox
-    timeDelaySpinBox: QDoubleSpinBox
+    experimentSetupGroupBox: QGroupBox
+    experimentSetupFormWidget: ExperimentSetupFormWidget
 
     def __init__(self, main_window: MainWindowView):
         super().__init__(None, 'gui/ui/spectrum_viewer.ui')
@@ -174,15 +173,9 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.current_roi_name = self.last_clicked_roi = self.roi_table_model.roi_names()[0]
         self.set_roi_properties()
 
-        self.flightPathSpinBox.setMinimum(0)
-        self.flightPathSpinBox.setMaximum(1e10)
-        self.flightPathSpinBox.setValue(56.4)
-        self.flightPathSpinBox.setSuffix(" m")
-        self.timeDelaySpinBox.setMaximum(1e10)
-        self.timeDelaySpinBox.setSuffix(" \u03BCs")
-
-        self.flightPathSpinBox.valueChanged.connect(self.presenter.handle_flight_path_change)
-        self.timeDelaySpinBox.valueChanged.connect(self.presenter.handle_time_delay_change)
+        self.experimentSetupFormWidget = ExperimentSetupFormWidget(self.experimentSetupGroupBox)
+        self.experimentSetupFormWidget.flight_path = 56.4
+        self.experimentSetupFormWidget.connect_value_changed(self.presenter.handle_experiment_setup_properties_change)
 
         def on_row_change(item: QModelIndex, _: Any) -> None:
             """


### PR DESCRIPTION
### Issue

Closes #2380 

### Description

 Rename Spectrum Viewer `tofPropertiesGroupBox` to `experimentSetupGroupBox` and place into a custom widget (`ExperimentSetupFormWidget`)

### Testing 

*Describe the tests that were used to verify your changes*.
* Unit test
* manual testing:
    * Verified that experimentSetupGroupBox is correctly disabled when no ToF data available
    * Verify that  ExperimentSetupFormWidget correctly handles value changed signal for any widgets added to `connect_value_changed()`

### Acceptance Criteria 

* Unit tests pass
* experimentSetupGroupBox is correctly disabled when no ToF data available
* ExperimentSetupFormWidget correctly handles value changed signal and update GUI

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*

`docs/release_notes/next/dev-2380-ExperimentSetupFormWidget`
