### PR TITLE
Added setDecimals(3) to tof_properties.py

### DIFF
--- a/mantidimaging/gui/widgets/spectrum_widgets/tof_properties.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/tof_properties.py
@@ -47,6 +47,7 @@ class ExperimentSetupFormWidget(QtWidgets.QGroupBox):
         self.flightPathSpinBox.setSuffix(" m")
         self.flightPathSpinBox.setMinimum(0)
         self.flightPathSpinBox.setMaximum(1e10)
+        self.flightPathSpinBox.setDecimals(3)
         self.flightPathSpinBox.setObjectName("flightPathSpinBox")
         layout.addWidget(self.flightPathSpinBox, 0, 1)
 
@@ -58,6 +59,7 @@ class ExperimentSetupFormWidget(QtWidgets.QGroupBox):
         self.timeDelaySpinBox = QtWidgets.QDoubleSpinBox(self)
         self.timeDelaySpinBox.setSuffix(" \u03BCs")
         self.timeDelaySpinBox.setMaximum(1e10)
+        self.timeDelaySpinBox.setDecimals(3)
         self.timeDelaySpinBox.setObjectName("timeDelaySpinBox")
         layout.addWidget(self.timeDelaySpinBox, 1, 1)
 
@@ -71,7 +73,7 @@ class ExperimentSetupFormWidget(QtWidgets.QGroupBox):
         return self.flightPathSpinBox.value()
 
     @flight_path.setter
-    def flight_path(self, value: float):
+    def flight_path(self, value: float) -> None:
         self.flightPathSpinBox.setValue(value)
 
     @property


### PR DESCRIPTION
### Issue

Closes #2419

### Description

Updated flightPathSpinBox and timeDelaySpinBox to display values with three decimal places using setDecimals(3).

### Acceptance Criteria 

Spin boxes should always display values rounded to three decimal places.
Test by entering values manually and setting values 

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*
