### PR TITLE
Use instance=True in create_autospec

### DIFF
--- a/docs/release_notes/next/dev-2433-autospec-speedup
+++ b/docs/release_notes/next/dev-2433-autospec-speedup
@@ -1,0 +1,1 @@
+#2433: Speedup autospec in tests

--- a/mantidimaging/core/data/test/image_stack_test.py
+++ b/mantidimaging/core/data/test/image_stack_test.py
@@ -73,7 +73,7 @@ class ImageStackTest(unittest.TestCase):
     def test_loading_metadata_preserves_existing_log(self):
         json_file = io.StringIO('{"pixel_size": 30.0, "log_file": "/old/logfile"}')
         mock_log_path = Path("/aaa/bbb")
-        mock_log_file = mock.create_autospec(InstrumentLog, source_file=mock_log_path)
+        mock_log_file = mock.create_autospec(InstrumentLog, source_file=mock_log_path, instance=True)
 
         imgs = ImageStack(np.asarray([1]))
         self.assertEqual({}, imgs.metadata)

--- a/mantidimaging/core/io/loader/test/loader_test.py
+++ b/mantidimaging/core/io/loader/test/loader_test.py
@@ -77,11 +77,11 @@ class LoaderTest(FakeFSTestCase):
         filenames = [Path(f"foo_{n}.tif") for n in range(20)]
         angles = np.array([(n * 137.507764) % 360 for n in range(20)])
 
-        mock_filename_group = mock.create_autospec(FilenameGroup, metadata_path=None)
+        mock_filename_group = mock.create_autospec(FilenameGroup, metadata_path=None, instance=True)
         mock_filename_group.all_files.return_value = filenames
         mock_filename_group.first_file.return_value = filenames[0]
 
-        mock_log_data = mock.create_autospec(InstrumentLog)
+        mock_log_data = mock.create_autospec(InstrumentLog, instance=True)
         mock_log_data.has_projection_angles.return_value = True
         mock_log_data.projection_angles.return_value = ProjectionAngles(np.deg2rad(angles))
 

--- a/mantidimaging/core/reconstruct/test/base_recon_test.py
+++ b/mantidimaging/core/reconstruct/test/base_recon_test.py
@@ -22,7 +22,7 @@ class BaseReconTest(unittest.TestCase):
     ])
     def test_prepare_recon_bhc(self, dtype, coefs, input, output):
         data = np.zeros([10, 10], dtype=dtype) + input
-        recon_params = mock.create_autospec(ReconstructionParameters)
+        recon_params = mock.create_autospec(ReconstructionParameters, instance=True)
         recon_params.beam_hardening_coefs = coefs
 
         result = BaseRecon.prepare_sinogram(data, recon_params)

--- a/mantidimaging/core/rotation/test/polyfit_correlation_test.py
+++ b/mantidimaging/core/rotation/test/polyfit_correlation_test.py
@@ -38,7 +38,7 @@ class PolyfitCorrelationTest(unittest.TestCase):
         images = generate_images((10, 10, 10))
         images.data[0] = np.identity(10)
         images.proj180deg = ImageStack(np.fliplr(images.data[0:1]))
-        mock_progress = mock.create_autospec(Progress)
+        mock_progress = mock.create_autospec(Progress, instance=True)
         res_cor, res_tilt = find_center(images, mock_progress)
         assert mock_progress.update.call_count == 11
         assert res_cor.value == 5.0, f"Found {res_cor.value}"
@@ -50,7 +50,7 @@ class PolyfitCorrelationTest(unittest.TestCase):
         images.proj180deg = ImageStack(np.fliplr(images.data[0:1]))
         self.crop_images(images, (2, 10, 0, 10))
         self.crop_images(images.proj180deg, (2, 10, 0, 10))
-        mock_progress = mock.create_autospec(Progress)
+        mock_progress = mock.create_autospec(Progress, instance=True)
         res_cor, res_tilt = find_center(images, mock_progress)
         assert res_cor.value == 4.0, f"Found {res_cor.value}"
         assert abs(res_tilt.value) < 1e-6, f"Found {res_tilt.value}"

--- a/mantidimaging/core/utility/progress_reporting/test/progress_test.py
+++ b/mantidimaging/core/utility/progress_reporting/test/progress_test.py
@@ -146,8 +146,8 @@ class ProgressTest(unittest.TestCase):
         self.assertEqual(p.completion(), 1.0)
 
     def test_callbacks(self):
-        cb1 = mock.create_autospec(ProgressHandler)
-        cb2 = mock.create_autospec(ProgressHandler)
+        cb1 = mock.create_autospec(ProgressHandler, instance=True)
+        cb2 = mock.create_autospec(ProgressHandler, instance=True)
         callbacks = [cb1, cb2]
 
         def assert_call(expected_completion, expected_step, expected_msg):

--- a/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
@@ -19,7 +19,7 @@ class AsyncTaskDialogPresenterTest(unittest.TestCase):
             time.sleep(0.1)
             return a + b
 
-        v = mock.create_autospec(AsyncTaskDialogView)
+        v = mock.create_autospec(AsyncTaskDialogView, instance=True)
 
         p = AsyncTaskDialogPresenter(v)
         p.set_task(f)

--- a/mantidimaging/gui/mvp_base/test/presenter_test.py
+++ b/mantidimaging/gui/mvp_base/test/presenter_test.py
@@ -13,21 +13,21 @@ from mantidimaging.gui.mvp_base import BaseDialogView, BaseMainWindowView, BaseP
 class MainWindowPresenterTest(unittest.TestCase):
 
     def test_default_notify_method_raises_exception(self):
-        view = mock.create_autospec(BaseMainWindowView)
+        view = mock.create_autospec(BaseMainWindowView, instance=True)
         presenter = BasePresenter(view)
 
         with self.assertRaises(NotImplementedError):
             presenter.notify(0)
 
     def test_show_error_message_forwarded_to_main_window_view(self):
-        view = mock.create_autospec(BaseMainWindowView)
+        view = mock.create_autospec(BaseMainWindowView, instance=True)
         presenter = BasePresenter(view)
 
         presenter.show_error("test message", traceback="")
         view.show_error_dialog.assert_called_once_with("test message")
 
     def test_show_error_message_forwarded_to_dialog_view(self):
-        view = mock.create_autospec(BaseDialogView)
+        view = mock.create_autospec(BaseDialogView, instance=True)
         presenter = BasePresenter(view)
 
         presenter.show_error("test message", traceback="")

--- a/mantidimaging/gui/widgets/dataset_selector/test/presenter_test.py
+++ b/mantidimaging/gui/widgets/dataset_selector/test/presenter_test.py
@@ -13,7 +13,7 @@ from mantidimaging.gui.widgets.dataset_selector.view import DatasetSelectorWidge
 class DatasetSelectorWidgetPresenterTests(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.view = mock.create_autospec(DatasetSelectorWidgetView)
+        self.view = mock.create_autospec(DatasetSelectorWidgetView, instance=True)
         self.presenter = DatasetSelectorWidgetPresenter(self.view)
 
         self.view.main_window = mock.Mock()

--- a/mantidimaging/gui/widgets/dataset_selector/test/view_test.py
+++ b/mantidimaging/gui/widgets/dataset_selector/test/view_test.py
@@ -19,7 +19,7 @@ class DatasetSelectorWidgetViewTest(unittest.TestCase):
         self.view.presenter = self.presenter = mock.Mock()
 
     def test_subscribe_to_main_window(self):
-        main_window_mock = mock.create_autospec(MainWindowView)
+        main_window_mock = mock.create_autospec(MainWindowView, instance=True)
         main_window_mock.model_changed.connect = mock.Mock()
 
         self.view.subscribe_to_main_window(main_window_mock)
@@ -27,7 +27,7 @@ class DatasetSelectorWidgetViewTest(unittest.TestCase):
         main_window_mock.model_changed.connect.assert_called_once_with(self.view._handle_loaded_datasets_changed)
 
     def test_unsubscribe_from_main_window(self):
-        self.view.main_window = main_window_mock = mock.create_autospec(MainWindowView)
+        self.view.main_window = main_window_mock = mock.create_autospec(MainWindowView, instance=True)
         main_window_mock.model_changed.disconnect = mock.Mock()
 
         self.view.unsubscribe_from_main_window()

--- a/mantidimaging/gui/windows/image_load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/image_load_dialog/test/presenter_test.py
@@ -19,7 +19,7 @@ class ImageLoadDialogPresenterTest(unittest.TestCase):
         self.assertEqual(Path(file1).absolute(), Path(file2).absolute())
 
     def setUp(self):
-        self.fields = {ft.fname: mock.create_autospec(Field) for ft in FILE_TYPES}
+        self.fields = {ft.fname: mock.create_autospec(Field, instance=True) for ft in FILE_TYPES}
         self.v = mock.MagicMock(fields=self.fields)
         self.v.sample = self.fields["Sample"]
         self.p = LoadPresenter(self.v)
@@ -48,7 +48,7 @@ class ImageLoadDialogPresenterTest(unittest.TestCase):
         mock_do_update_flat_or_dark.assert_not_called()
 
     def test_update_field_with_filegroup_sample(self):
-        mock_file_group = mock.create_autospec(FilenameGroup)
+        mock_file_group = mock.create_autospec(FilenameGroup, instance=True)
         file_list = [mock.Mock()]
         file_log_path = mock.Mock()
         mock_file_group.all_files.return_value = file_list
@@ -66,7 +66,7 @@ class ImageLoadDialogPresenterTest(unittest.TestCase):
         mock_field_path.assert_called_once_with(file_log_path)
 
     def test_update_field_with_filegroup_dark_before(self):
-        mock_file_group = mock.create_autospec(FilenameGroup)
+        mock_file_group = mock.create_autospec(FilenameGroup, instance=True)
         file_list = [mock.Mock()]
         mock_file_group.all_files.return_value = file_list
 
@@ -82,7 +82,7 @@ class ImageLoadDialogPresenterTest(unittest.TestCase):
     def test_do_update_sample_no_related(self, mock_update_field, mock_read_image_dimensions, mock_filename_group):
         selected_file = "/a/b/img_000.tif"
         mock_read_image_dimensions.return_value = [10, 11]
-        mock_sample_fg = mock.create_autospec(FilenameGroup)
+        mock_sample_fg = mock.create_autospec(FilenameGroup, instance=True)
         mock_filename_group.from_file.return_value = mock_sample_fg
         mock_sample_fg.all_indexes = [0, 1, 2, 3]
         mock_sample_fg.find_related.return_value = None
@@ -101,8 +101,8 @@ class ImageLoadDialogPresenterTest(unittest.TestCase):
                                                   mock_filename_group):
         selected_file = "/a/b/img_000.tif"
         mock_read_image_dimensions.return_value = [10, 11]
-        mock_sample_fg = mock.create_autospec(FilenameGroup)
-        mock_fb_fg = mock.create_autospec(FilenameGroup)
+        mock_sample_fg = mock.create_autospec(FilenameGroup, instance=True)
+        mock_fb_fg = mock.create_autospec(FilenameGroup, instance=True)
         mock_filename_group.from_file.return_value = mock_sample_fg
         mock_sample_fg.all_indexes = [0, 1, 2, 3]
         mock_sample_fg.find_related.side_effect = lambda ft: mock_fb_fg if ft == FILE_TYPES.FLAT_BEFORE else None
@@ -156,7 +156,7 @@ class ImageLoadDialogPresenterTest(unittest.TestCase):
 
         field = mock.MagicMock(file_info=FILE_TYPES.SAMPLE_LOG)
 
-        self.p.sample_fg = mock.create_autospec(FilenameGroup)
+        self.p.sample_fg = mock.create_autospec(FilenameGroup, instance=True)
         self.p.do_update_sample_log(field, file_name)
 
         mock_ensure.assert_called_once_with(field, file_name, [])
@@ -166,7 +166,7 @@ class ImageLoadDialogPresenterTest(unittest.TestCase):
         """
         Test behaviour when the number of projection angles and files matches
         """
-        mock_log = mock.create_autospec(InstrumentLog)
+        mock_log = mock.create_autospec(InstrumentLog, instance=True)
         mock_load_log.return_value = mock_log
         file_name = "file_name"
         field = mock.MagicMock()
@@ -183,7 +183,7 @@ class ImageLoadDialogPresenterTest(unittest.TestCase):
 
     @mock.patch("mantidimaging.gui.windows.image_load_dialog.presenter.load_log")
     def test_ensure_sample_log_consistency_exits_when_none_or_empty_str(self, mock_load_log):
-        mock_log = mock.create_autospec(InstrumentLog)
+        mock_log = mock.create_autospec(InstrumentLog, instance=True)
         mock_load_log.return_value = mock_log
         file_name = None
         field = mock.MagicMock()

--- a/mantidimaging/gui/windows/live_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/model_test.py
@@ -21,12 +21,12 @@ class ImageWatcherTest(FakeFSTestCase):
         self.fs.create_dir(self.top_path)
         os.utime(self.top_path, (10, 10))
         with mock.patch("mantidimaging.gui.windows.live_viewer.model.QFileSystemWatcher") as mocker:
-            mock_dir_watcher = mock.create_autospec(QFileSystemWatcher, directoryChanged=mock.Mock())
-            mock_file_watcher = mock.create_autospec(QFileSystemWatcher, fileChanged=mock.Mock())
+            mock_dir_watcher = mock.create_autospec(QFileSystemWatcher, directoryChanged=mock.Mock(), instance=True)
+            mock_file_watcher = mock.create_autospec(QFileSystemWatcher, fileChanged=mock.Mock(), instance=True)
 
             mocker.side_effect = [mock_dir_watcher, mock_file_watcher]
             self.watcher = ImageWatcher(self.top_path)
-            self.mock_signal_image = mock.create_autospec(pyqtSignal, emit=mock.Mock())
+            self.mock_signal_image = mock.create_autospec(pyqtSignal, emit=mock.Mock(), instance=True)
             self.watcher.image_changed = self.mock_signal_image
 
     def _make_simple_dir(self, directory: Path, t0: float = 1000):
@@ -76,7 +76,7 @@ class ImageWatcherTest(FakeFSTestCase):
         self.fs.remove(file_list[0])
 
         # mocked iterdir() gives full list, but first file as been deleted
-        mock_directory = mock.create_autospec(Path, iterdir=lambda: file_list)
+        mock_directory = mock.create_autospec(Path, iterdir=lambda: file_list, instance=True)
 
         images_datas = self.watcher.find_images(mock_directory)
 

--- a/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
@@ -16,9 +16,9 @@ from mantidimaging.gui.windows.main import MainWindowView
 class MainWindowPresenterTest(unittest.TestCase):
 
     def setUp(self):
-        self.view = mock.create_autospec(LiveViewerWindowView)
-        self.main_window = mock.create_autospec(MainWindowView)
-        self.model = mock.create_autospec(LiveViewerWindowModel)
+        self.view = mock.create_autospec(LiveViewerWindowView, instance=True)
+        self.main_window = mock.create_autospec(MainWindowView, instance=True)
+        self.model = mock.create_autospec(LiveViewerWindowModel, instance=True)
 
         with mock.patch("mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowModel") as mock_model:
             mock_model.return_value = self.model
@@ -27,7 +27,7 @@ class MainWindowPresenterTest(unittest.TestCase):
     def test_load_as_dataset(self):
         image_dir = Path("/path/to/dir")
         image_paths = [image_dir / f"image_{i:03d}.tif" for i in range(5)]
-        self.model.images = [mock.create_autospec(Image_Data, image_path=p) for p in image_paths]
+        self.model.images = [mock.create_autospec(Image_Data, image_path=p, instance=True) for p in image_paths]
 
         self.presenter.load_as_dataset()
 

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -23,11 +23,11 @@ from mantidimaging.test_helpers.unit_test_helper import generate_images, generat
 class MainWindowPresenterTest(unittest.TestCase):
 
     def setUp(self):
-        self.view = mock.create_autospec(MainWindowView)
-        self.view.image_load_dialog = mock.create_autospec(ImageLoadDialog)
+        self.view = mock.create_autospec(MainWindowView, instance=True)
+        self.view.image_load_dialog = mock.create_autospec(ImageLoadDialog, instance=True)
         self.presenter = MainWindowPresenter(self.view)
         self.dataset, self.images = generate_standard_dataset(shape=(10, 5, 5))
-        self.presenter.model = self.model = mock.create_autospec(MainWindowModel, datasets={})
+        self.presenter.model = self.model = mock.create_autospec(MainWindowModel, datasets={}, instance=True)
 
         self.view.create_stack_window.return_value = mock.Mock()
         self.view.model_changed = mock.Mock()

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -25,7 +25,7 @@ from mantidimaging.core.data import ImageStack
 class FiltersWindowPresenterTest(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.main_window = mock.create_autospec(MainWindowView)
+        self.main_window = mock.create_autospec(MainWindowView, instance=True)
         self.view = mock.MagicMock()
         self.presenter = FiltersWindowPresenter(self.view, self.main_window)
         self.presenter.model.filter_widget_kwargs = {"roi_field": None}

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -33,7 +33,7 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.uuid = self.data.id
 
     def make_view(self):
-        self.view = mock.create_autospec(ReconstructWindowView)
+        self.view = mock.create_autospec(ReconstructWindowView, instance=True)
         self.view.filterName = mock.Mock()
         self.view.filterNameLabel = mock.Mock()
         self.view.numIter = mock.Mock()

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -33,7 +33,7 @@ class ReconstructWindowViewTest(unittest.TestCase):
     def setUp(self, _) -> None:
         self.main_window = MockMainWindow()
         with mock.patch("mantidimaging.gui.windows.recon.view.ReconImagesView") as mock_riv:
-            self.image_view = mock.create_autospec(ReconImagesView, sigSliceIndexChanged=mock.Mock())
+            self.image_view = mock.create_autospec(ReconImagesView, sigSliceIndexChanged=mock.Mock(), instance=True)
             mock_riv.side_effect = [self.image_view]
             self.view = ReconstructWindowView(self.main_window)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -33,18 +33,18 @@ class CloseCheckStream(io.StringIO):
 class SpectrumViewerWindowModelTest(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.presenter = mock.create_autospec(SpectrumViewerWindowPresenter)
+        self.presenter = mock.create_autospec(SpectrumViewerWindowPresenter, instance=True)
         self.model = SpectrumViewerWindowModel(self.presenter)
 
     def _set_sample_stack(self, with_tof=False, with_shuttercount=False):
         spectrum = np.arange(0, 10)
         stack = ImageStack(np.ones([10, 11, 12]) * spectrum.reshape((10, 1, 1)))
         if with_tof:
-            mock_inst_log = mock.create_autospec(InstrumentLog, source_file="")
+            mock_inst_log = mock.create_autospec(InstrumentLog, source_file="", instance=True)
             mock_inst_log.get_column.return_value = np.arange(0, 10) * 0.1
             stack.log_file = mock_inst_log
         if with_shuttercount:
-            mock_shuttercounts = mock.create_autospec(ShutterCount, source_file="")
+            mock_shuttercounts = mock.create_autospec(ShutterCount, source_file="", instance=True)
             mock_shuttercounts.get_column.return_value = np.arange(5, 15)
             stack._shutter_count_file = mock_shuttercounts
         self.model.set_stack(stack)
@@ -56,14 +56,14 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         normalise_stack = ImageStack(np.ones([10, 11, 12]) * spectrum.reshape((10, 1, 1)))
         self.model.set_normalise_stack(normalise_stack)
         if with_shuttercount:
-            mock_shuttercounts = mock.create_autospec(ShutterCount, source_file="")
+            mock_shuttercounts = mock.create_autospec(ShutterCount, source_file="", instance=True)
             mock_shuttercounts.get_column.return_value = np.arange(10, 20)
             normalise_stack._shutter_count_file = mock_shuttercounts
         return normalise_stack
 
     def _make_mock_path_stream(self):
         mock_stream = CloseCheckStream()
-        mock_path = mock.create_autospec(Path)
+        mock_path = mock.create_autospec(Path, instance=True)
         mock_path.open.return_value = mock_stream
         return mock_stream, mock_path
 
@@ -275,7 +275,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         stack, _ = self._set_sample_stack()
         self.model.set_new_roi("rits_roi")
         self.model.set_normalise_stack(None)
-        mock_inst_log = mock.create_autospec(InstrumentLog, source_file="")
+        mock_inst_log = mock.create_autospec(InstrumentLog, source_file="", instance=True)
         stack.log_file = mock_inst_log
 
         mock_stream, mock_path = self._make_mock_path_stream()
@@ -466,7 +466,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         self.assertIsNone(self.model.get_stack_time_of_flight())
 
         # Log but not tof
-        mock_log = mock.create_autospec(InstrumentLog, source_file="foo.txt")
+        mock_log = mock.create_autospec(InstrumentLog, source_file="foo.txt", instance=True)
         mock_log.get_column.side_effect = KeyError()
         stack.log_file = mock_log
         self.assertIsNone(self.model.get_stack_time_of_flight())
@@ -547,7 +547,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         self.model.set_new_roi("rits_roi")
         self.model.set_roi("rits_roi", SensibleROI.from_list([1, 0, 6, 4]))
         self.model.set_normalise_stack(norm)
-        mock_path = mock.create_autospec(Path)
+        mock_path = mock.create_autospec(Path, instance=True)
 
         self.model.save_rits_images(mock_path, ErrorMode.STANDARD_DEVIATION, 3, 1)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -29,19 +29,20 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     def setUp(self) -> None:
         with mock.patch("mantidimaging.gui.windows.main.view.WelcomeScreenPresenter"):
             self.main_window = MainWindowView()
-        self.view = mock.create_autospec(SpectrumViewerWindowView)
+        self.view = mock.create_autospec(SpectrumViewerWindowView, instance=True)
         self.view.current_dataset_id = uuid.uuid4()
-        mock_spectrum_roi_dict = mock.create_autospec(dict)
-        self.view.spectrum_widget = mock.create_autospec(SpectrumWidget, roi_dict=mock_spectrum_roi_dict)
+        mock_spectrum_roi_dict = mock.create_autospec(dict, instance=True)
+        self.view.spectrum_widget = mock.create_autospec(SpectrumWidget, roi_dict=mock_spectrum_roi_dict, instance=True)
         self.view.spectrum_widget.spectrum_plot_widget = mock.create_autospec(SpectrumPlotWidget,
-                                                                              roi_dict=mock_spectrum_roi_dict)
-        self.view.exportButton = mock.create_autospec(QPushButton)
-        self.view.exportButtonRITS = mock.create_autospec(QPushButton)
-        self.view.normalise_ShutterCount_CheckBox = mock.create_autospec(QCheckBox)
-        self.view.addBtn = mock.create_autospec(QPushButton)
-        self.view.exportTabs = mock.create_autospec(QTabWidget)
-        self.view.tof_mode_select_group = mock.create_autospec(QActionGroup)
-        self.view.experimentSetupGroupBox = mock.create_autospec(QGroupBox)
+                                                                              roi_dict=mock_spectrum_roi_dict,
+                                                                              instance=True)
+        self.view.exportButton = mock.create_autospec(QPushButton, instance=True)
+        self.view.exportButtonRITS = mock.create_autospec(QPushButton, instance=True)
+        self.view.normalise_ShutterCount_CheckBox = mock.create_autospec(QCheckBox, instance=True)
+        self.view.addBtn = mock.create_autospec(QPushButton, instance=True)
+        self.view.exportTabs = mock.create_autospec(QTabWidget, instance=True)
+        self.view.tof_mode_select_group = mock.create_autospec(QActionGroup, instance=True)
+        self.view.experimentSetupGroupBox = mock.create_autospec(QGroupBox, instance=True)
         self.view.experimentSetupFormWidget = mock.Mock(spec=ExperimentSetupFormWidget)
         self.view.experimentSetupFormWidget.time_delay = 0.0
         self.presenter = SpectrumViewerWindowPresenter(self.view, self.main_window)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
@@ -53,10 +53,10 @@ class SpectrumROITest(unittest.TestCase):
 class SpectrumWidgetTest(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.main_window = mock.create_autospec(MainWindowView)
-        self.view = mock.create_autospec(SpectrumViewerWindowView)
+        self.main_window = mock.create_autospec(MainWindowView, instance=True)
+        self.view = mock.create_autospec(SpectrumViewerWindowView, instance=True)
         self.view.current_dataset_id = uuid.uuid4()
-        self.view.parent = mock.create_autospec(SpectrumViewerWindowPresenter)
+        self.view.parent = mock.create_autospec(SpectrumViewerWindowPresenter, instance=True)
         self.spectrum_widget = SpectrumWidget(self.main_window)
         self.spectrum_plot_widget = SpectrumPlotWidget()
         self.sensible_roi = SensibleROI.from_list([0, 0, 0, 0])

--- a/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
@@ -21,7 +21,7 @@ class StackVisualiserPresenterTest(unittest.TestCase):
     def setUp(self):
         self.test_data = th.generate_images()
         # mock the view so it has the same methods
-        self.view = mock.create_autospec(StackVisualiserView)
+        self.view = mock.create_autospec(StackVisualiserView, instance=True)
         self.presenter = StackVisualiserPresenter(self.view, self.test_data)
         self.presenter.model = mock.Mock()
         self.view._main_window = mock.Mock()


### PR DESCRIPTION
Save time, by preventing create_autospec creating both a class and instance mock.

### Issue

Closes #2433

### Description

Without setting `instance`, calls `create_autospec()` create a mock that behaves as an instance or a class. This doubles the already long time it takes to inspect the class to make the auto_spec.

Using the profiler on
`python -m cProfile -o profile-after -m pytest mantidimaging/gui/windows/main/test/presenter_test.py`
the line for `create_autospec` is reduced from
`513/264    0.693    0.001   31.746    0.120 mock.py:2697(create_autospec)`
to
`264    0.434    0.002   16.114    0.061 mock.py:2697(create_autospec)`
Showing that the time is halved (31.746 -> 16.114), and the internal second call is prevented (513 calls, reduced to 264).

Overall the runtime of the full unit test suite, was reduced from around 174s to 143s.
For running `python -m pytest -p no:xdist -p no:randomly`, and using the pytest reported time. There is more run to run variation without disabling randomly, but still a notable improvement.

Before: `173.64s 172.07s 174.11s 175.10s 173.90s`
After: `144.57s 141.80s 141.47s 144.13s 144.25s`

All tests were done with CPU set to 2GHz to avoid variations
`sudo cpupower frequency-set -g performance ; sudo cpupower frequency-set --max 2G`

### Testing & Acceptance Criteria 

Check that auto mocks, are still catching problems, by adding call to a non-existent method in `mantidimaging/gui/windows/main/test/presenter_test.py`
e.g.
`self.view.does_not_exist()`


### Documentation

Release notes


### Notes

Change was performed with Comby
`comby "create_autospec(:[arg1])"  "create_autospec(:[arg1], instance=True)" .py -stats -i`

