### PR TITLE
Set static copyright year to 2021 in all relevant files

### DIFF
--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,3 +1,3 @@
 {
-  "**/*.py": "# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI\n# SPDX - License - Identifier: GPL-3.0-or-later"
+  "**/*.py": "# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI\n# SPDX - License - Identifier: GPL-3.0-or-later"
 }

--- a/AddLicensesToFiles.py
+++ b/AddLicensesToFiles.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/CheckLicensesInFiles.py
+++ b/CheckLicensesInFiles.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/conda/make_versions.py
+++ b/conda/make_versions.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import os

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/docs/ext/operations_user_doc.py
+++ b/docs/ext/operations_user_doc.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/docs/ext/release_notes.py
+++ b/docs/ext/release_notes.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/docs/release_notes/next/dev-2436-static-copywrite
+++ b/docs/release_notes/next/dev-2436-static-copywrite
@@ -1,0 +1,1 @@
+2436: Use static copyright years

--- a/mantidimaging/__init__.py
+++ b/mantidimaging/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 """

--- a/mantidimaging/__main__.py
+++ b/mantidimaging/__main__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import time

--- a/mantidimaging/core/__init__.py
+++ b/mantidimaging/core/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/data/__init__.py
+++ b/mantidimaging/core/data/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import uuid

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/data/reconlist.py
+++ b/mantidimaging/core/data/reconlist.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/data/test/__init__.py
+++ b/mantidimaging/core/data/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/data/test/dataset_test.py
+++ b/mantidimaging/core/data/test/dataset_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/data/test/fake_logfile.py
+++ b/mantidimaging/core/data/test/fake_logfile.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from pathlib import Path

--- a/mantidimaging/core/data/test/image_stack_test.py
+++ b/mantidimaging/core/data/test/image_stack_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/data/test/reconlist_test.py
+++ b/mantidimaging/core/data/test/reconlist_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import unittest

--- a/mantidimaging/core/data/utility.py
+++ b/mantidimaging/core/data/utility.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/gpu/__init__.py
+++ b/mantidimaging/core/gpu/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/gpu/test/__init__.py
+++ b/mantidimaging/core/gpu/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/gpu/test/gpu_test.py
+++ b/mantidimaging/core/gpu/test/gpu_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/gpu/test/import_test.py
+++ b/mantidimaging/core/gpu/test/import_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/gpu/utility.py
+++ b/mantidimaging/core/gpu/utility.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/io/__init__.py
+++ b/mantidimaging/core/io/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/io/csv_output.py
+++ b/mantidimaging/core/io/csv_output.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from typing import IO

--- a/mantidimaging/core/io/filenames.py
+++ b/mantidimaging/core/io/filenames.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/io/instrument_log.py
+++ b/mantidimaging/core/io/instrument_log.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/io/instrument_log_implmentations.py
+++ b/mantidimaging/core/io/instrument_log_implmentations.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/io/loader/__init__.py
+++ b/mantidimaging/core/io/loader/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/io/loader/img_loader.py
+++ b/mantidimaging/core/io/loader/img_loader.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 """
 This module handles the loading of FIT, FITS, TIF, TIFF

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import os

--- a/mantidimaging/core/io/loader/test/__init__.py
+++ b/mantidimaging/core/io/loader/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/io/loader/test/instrument_log_data.py
+++ b/mantidimaging/core/io/loader/test/instrument_log_data.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/io/loader/test/instrument_log_test.py
+++ b/mantidimaging/core/io/loader/test/instrument_log_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/io/loader/test/loader_test.py
+++ b/mantidimaging/core/io/loader/test/loader_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from pathlib import Path

--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import datetime

--- a/mantidimaging/core/io/test/__init__.py
+++ b/mantidimaging/core/io/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/io/test/filenames_test.py
+++ b/mantidimaging/core/io/test/filenames_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import datetime

--- a/mantidimaging/core/io/test/test_csv_output.py
+++ b/mantidimaging/core/io/test/test_csv_output.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import io

--- a/mantidimaging/core/io/test/utility_test.py
+++ b/mantidimaging/core/io/test/utility_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/net/__init__.py
+++ b/mantidimaging/core/net/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/net/help_pages.py
+++ b/mantidimaging/core/net/help_pages.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/net/test/__init__.py
+++ b/mantidimaging/core/net/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/net/test/help_pages_test.py
+++ b/mantidimaging/core/net/test/help_pages_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operation_history/__init__.py
+++ b/mantidimaging/core/operation_history/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operation_history/const.py
+++ b/mantidimaging/core/operation_history/const.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operation_history/operations.py
+++ b/mantidimaging/core/operation_history/operations.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operation_history/test/__init__.py
+++ b/mantidimaging/core/operation_history/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operation_history/test/operation_history_test.py
+++ b/mantidimaging/core/operation_history/test/operation_history_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/__init__.py
+++ b/mantidimaging/core/operations/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/arithmetic/__init__.py
+++ b/mantidimaging/core/operations/arithmetic/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/arithmetic/arithmetic.py
+++ b/mantidimaging/core/operations/arithmetic/arithmetic.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from functools import partial

--- a/mantidimaging/core/operations/arithmetic/test/__init__.py
+++ b/mantidimaging/core/operations/arithmetic/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/arithmetic/test/arithmetic_test.py
+++ b/mantidimaging/core/operations/arithmetic/test/arithmetic_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import unittest

--- a/mantidimaging/core/operations/base_filter.py
+++ b/mantidimaging/core/operations/base_filter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/circular_mask/__init__.py
+++ b/mantidimaging/core/operations/circular_mask/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/circular_mask/circular_mask.py
+++ b/mantidimaging/core/operations/circular_mask/circular_mask.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/circular_mask/test/__init__.py
+++ b/mantidimaging/core/operations/circular_mask/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/circular_mask/test/circular_mask_test.py
+++ b/mantidimaging/core/operations/circular_mask/test/circular_mask_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/clip_values/__init__.py
+++ b/mantidimaging/core/operations/clip_values/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/clip_values/clip_values.py
+++ b/mantidimaging/core/operations/clip_values/clip_values.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/clip_values/test/__init__.py
+++ b/mantidimaging/core/operations/clip_values/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/clip_values/test/clip_values_test.py
+++ b/mantidimaging/core/operations/clip_values/test/clip_values_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/crop_coords/__init__.py
+++ b/mantidimaging/core/operations/crop_coords/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/crop_coords/crop_coords.py
+++ b/mantidimaging/core/operations/crop_coords/crop_coords.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/crop_coords/test/__init__.py
+++ b/mantidimaging/core/operations/crop_coords/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
+++ b/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/divide/__init__.py
+++ b/mantidimaging/core/operations/divide/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/divide/divide.py
+++ b/mantidimaging/core/operations/divide/divide.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/divide/test/__init__.py
+++ b/mantidimaging/core/operations/divide/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/divide/test/divide_test.py
+++ b/mantidimaging/core/operations/divide/test/divide_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/flat_fielding/__init__.py
+++ b/mantidimaging/core/operations/flat_fielding/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/flat_fielding/test/__init__.py
+++ b/mantidimaging/core/operations/flat_fielding/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
+++ b/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/gaussian/__init__.py
+++ b/mantidimaging/core/operations/gaussian/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/gaussian/gaussian.py
+++ b/mantidimaging/core/operations/gaussian/gaussian.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/gaussian/test/__init__.py
+++ b/mantidimaging/core/operations/gaussian/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/gaussian/test/gaussian_test.py
+++ b/mantidimaging/core/operations/gaussian/test/gaussian_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/loader.py
+++ b/mantidimaging/core/operations/loader.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import os

--- a/mantidimaging/core/operations/median_filter/__init__.py
+++ b/mantidimaging/core/operations/median_filter/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/median_filter/median_filter.py
+++ b/mantidimaging/core/operations/median_filter/median_filter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/median_filter/test/__init__.py
+++ b/mantidimaging/core/operations/median_filter/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/median_filter/test/median_filter_test.py
+++ b/mantidimaging/core/operations/median_filter/test/median_filter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/median_filter/test/median_kernel_test.py
+++ b/mantidimaging/core/operations/median_filter/test/median_kernel_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/monitor_normalisation/__init__.py
+++ b/mantidimaging/core/operations/monitor_normalisation/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from functools import partial

--- a/mantidimaging/core/operations/monitor_normalisation/test/__init__.py
+++ b/mantidimaging/core/operations/monitor_normalisation/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/monitor_normalisation/test/monitor_normalisation_test.py
+++ b/mantidimaging/core/operations/monitor_normalisation/test/monitor_normalisation_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from functools import partial

--- a/mantidimaging/core/operations/nan_removal/__init__.py
+++ b/mantidimaging/core/operations/nan_removal/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/nan_removal/nan_removal.py
+++ b/mantidimaging/core/operations/nan_removal/nan_removal.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/nan_removal/test/__init__.py
+++ b/mantidimaging/core/operations/nan_removal/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/nan_removal/test/nan_removal_test.py
+++ b/mantidimaging/core/operations/nan_removal/test/nan_removal_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/outliers/__init__.py
+++ b/mantidimaging/core/operations/outliers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/outliers/test/__init__.py
+++ b/mantidimaging/core/operations/outliers/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/outliers/test/outliers_test.py
+++ b/mantidimaging/core/operations/outliers/test/outliers_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/rebin/__init__.py
+++ b/mantidimaging/core/operations/rebin/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/rebin/test/__init__.py
+++ b/mantidimaging/core/operations/rebin/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/rebin/test/rebin_test.py
+++ b/mantidimaging/core/operations/rebin/test/rebin_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/remove_all_stripe/__init__.py
+++ b/mantidimaging/core/operations/remove_all_stripe/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
+++ b/mantidimaging/core/operations/remove_all_stripe/remove_all_stripe.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/remove_all_stripe/test/__init__.py
+++ b/mantidimaging/core/operations/remove_all_stripe/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/remove_all_stripe/test/remove_all_stripe_test.py
+++ b/mantidimaging/core/operations/remove_all_stripe/test/remove_all_stripe_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/remove_dead_stripe/__init__.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/remove_dead_stripe.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/remove_dead_stripe/test/__init__.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/remove_dead_stripe/test/remove_dead_stripe_test.py
+++ b/mantidimaging/core/operations/remove_dead_stripe/test/remove_dead_stripe_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/remove_large_stripe/__init__.py
+++ b/mantidimaging/core/operations/remove_large_stripe/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
+++ b/mantidimaging/core/operations/remove_large_stripe/remove_large_stripe.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/remove_large_stripe/test/__init__.py
+++ b/mantidimaging/core/operations/remove_large_stripe/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/remove_large_stripe/test/remove_large_stripe_test.py
+++ b/mantidimaging/core/operations/remove_large_stripe/test/remove_large_stripe_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/remove_stripe_filtering/__init__.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/remove_stripe_filtering.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/remove_stripe_filtering/test/__init__.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/remove_stripe_filtering/test/remove_stripe_filtering_test.py
+++ b/mantidimaging/core/operations/remove_stripe_filtering/test/remove_stripe_filtering_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/__init__.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/remove_stripe_sorting_fitting.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/test/__init__.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/remove_stripe_sorting_fitting/test/remove_stripe_sorting_fitting_test.py
+++ b/mantidimaging/core/operations/remove_stripe_sorting_fitting/test/remove_stripe_sorting_fitting_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/rescale/__init__.py
+++ b/mantidimaging/core/operations/rescale/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/rescale/rescale_test.py
+++ b/mantidimaging/core/operations/rescale/rescale_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/ring_removal/__init__.py
+++ b/mantidimaging/core/operations/ring_removal/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/ring_removal/ring_removal.py
+++ b/mantidimaging/core/operations/ring_removal/ring_removal.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/ring_removal/test/__init__.py
+++ b/mantidimaging/core/operations/ring_removal/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/ring_removal/test/ring_removal_test.py
+++ b/mantidimaging/core/operations/ring_removal/test/ring_removal_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/roi_normalisation/__init__.py
+++ b/mantidimaging/core/operations/roi_normalisation/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/roi_normalisation/test/__init__.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/rotate_stack/__init__.py
+++ b/mantidimaging/core/operations/rotate_stack/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/rotate_stack/rotate_stack.py
+++ b/mantidimaging/core/operations/rotate_stack/rotate_stack.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/rotate_stack/test/__init__.py
+++ b/mantidimaging/core/operations/rotate_stack/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/rotate_stack/test/rotate_stack_test.py
+++ b/mantidimaging/core/operations/rotate_stack/test/rotate_stack_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/operations/test/__init__.py
+++ b/mantidimaging/core/operations/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/operations/test/operations_test.py
+++ b/mantidimaging/core/operations/test/operations_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/parallel/__init__.py
+++ b/mantidimaging/core/parallel/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/parallel/manager.py
+++ b/mantidimaging/core/parallel/manager.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/parallel/shared.py
+++ b/mantidimaging/core/parallel/shared.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/parallel/test/__init__.py
+++ b/mantidimaging/core/parallel/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/parallel/test/manager_test.py
+++ b/mantidimaging/core/parallel/test/manager_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import unittest

--- a/mantidimaging/core/parallel/test/shared_test.py
+++ b/mantidimaging/core/parallel/test/shared_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import unittest

--- a/mantidimaging/core/parallel/test/utility_test.py
+++ b/mantidimaging/core/parallel/test/utility_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/parallel/utility.py
+++ b/mantidimaging/core/parallel/utility.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/reconstruct/__init__.py
+++ b/mantidimaging/core/reconstruct/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/reconstruct/base_recon.py
+++ b/mantidimaging/core/reconstruct/base_recon.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/reconstruct/test/__init__.py
+++ b/mantidimaging/core/reconstruct/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/reconstruct/test/base_recon_test.py
+++ b/mantidimaging/core/reconstruct/test/base_recon_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/reconstruct/tomopy_recon.py
+++ b/mantidimaging/core/reconstruct/tomopy_recon.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/rotation/__init__.py
+++ b/mantidimaging/core/rotation/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/rotation/data_model.py
+++ b/mantidimaging/core/rotation/data_model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/rotation/polyfit_correlation.py
+++ b/mantidimaging/core/rotation/polyfit_correlation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from logging import getLogger

--- a/mantidimaging/core/rotation/test/__init__.py
+++ b/mantidimaging/core/rotation/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/rotation/test/data_model_test.py
+++ b/mantidimaging/core/rotation/test/data_model_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/rotation/test/polyfit_correlation_test.py
+++ b/mantidimaging/core/rotation/test/polyfit_correlation_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import unittest

--- a/mantidimaging/core/utility/__init__.py
+++ b/mantidimaging/core/utility/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/close_enough_point.py
+++ b/mantidimaging/core/utility/close_enough_point.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/command_line_arguments.py
+++ b/mantidimaging/core/utility/command_line_arguments.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from logging import getLogger

--- a/mantidimaging/core/utility/cor_interpolate.py
+++ b/mantidimaging/core/utility/cor_interpolate.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/cuda_check.py
+++ b/mantidimaging/core/utility/cuda_check.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from logging import getLogger

--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 """
 Containers for data. They don't do much apart from storing the data,

--- a/mantidimaging/core/utility/execution_timer.py
+++ b/mantidimaging/core/utility/execution_timer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 """
 Context managers for logging execution time or profile of code.

--- a/mantidimaging/core/utility/finder.py
+++ b/mantidimaging/core/utility/finder.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/func_call.py
+++ b/mantidimaging/core/utility/func_call.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/histogram.py
+++ b/mantidimaging/core/utility/histogram.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/imat_log_file_parser.py
+++ b/mantidimaging/core/utility/imat_log_file_parser.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/leak_tracker.py
+++ b/mantidimaging/core/utility/leak_tracker.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import gc

--- a/mantidimaging/core/utility/memory_usage.py
+++ b/mantidimaging/core/utility/memory_usage.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/optional_imports.py
+++ b/mantidimaging/core/utility/optional_imports.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 """
 A place for availability checking and import logic for optional dependencies to

--- a/mantidimaging/core/utility/progress_reporting/__init__.py
+++ b/mantidimaging/core/utility/progress_reporting/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/progress_reporting/console_progress_bar.py
+++ b/mantidimaging/core/utility/progress_reporting/console_progress_bar.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/progress_reporting/progress.py
+++ b/mantidimaging/core/utility/progress_reporting/progress.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/progress_reporting/test/__init__.py
+++ b/mantidimaging/core/utility/progress_reporting/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/utility/progress_reporting/test/progress_test.py
+++ b/mantidimaging/core/utility/progress_reporting/test/progress_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/projection_angle_parser.py
+++ b/mantidimaging/core/utility/projection_angle_parser.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/projection_angles.py
+++ b/mantidimaging/core/utility/projection_angles.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/sensible_roi.py
+++ b/mantidimaging/core/utility/sensible_roi.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/size_calculator.py
+++ b/mantidimaging/core/utility/size_calculator.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/test/__init__.py
+++ b/mantidimaging/core/utility/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/core/utility/test/close_enough_point_test.py
+++ b/mantidimaging/core/utility/test/close_enough_point_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 import unittest
 

--- a/mantidimaging/core/utility/test/command_line_arguments_test.py
+++ b/mantidimaging/core/utility/test/command_line_arguments_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import logging

--- a/mantidimaging/core/utility/test/cor_interpolate_test.py
+++ b/mantidimaging/core/utility/test/cor_interpolate_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 import unittest
 import numpy as np

--- a/mantidimaging/core/utility/test/cuda_checker_test.py
+++ b/mantidimaging/core/utility/test/cuda_checker_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import unittest

--- a/mantidimaging/core/utility/test/execution_timer_test.py
+++ b/mantidimaging/core/utility/test/execution_timer_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/test/histogram_test.py
+++ b/mantidimaging/core/utility/test/histogram_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/test/imat_log_file_parser_test.py
+++ b/mantidimaging/core/utility/test/imat_log_file_parser_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/test/leak_tracker_test.py
+++ b/mantidimaging/core/utility/test/leak_tracker_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/test/memory_usage_test.py
+++ b/mantidimaging/core/utility/test/memory_usage_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 import unittest
 from unittest.mock import patch, Mock

--- a/mantidimaging/core/utility/test/projection_angle_parser_test.py
+++ b/mantidimaging/core/utility/test/projection_angle_parser_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/test/sensibleROI_test.py
+++ b/mantidimaging/core/utility/test/sensibleROI_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/test/size_calculator_test.py
+++ b/mantidimaging/core/utility/test/size_calculator_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/test/unit_conversion_test.py
+++ b/mantidimaging/core/utility/test/unit_conversion_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/test/version_check_test.py
+++ b/mantidimaging/core/utility/test/version_check_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/unit_conversion.py
+++ b/mantidimaging/core/utility/unit_conversion.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/core/utility/version_check.py
+++ b/mantidimaging/core/utility/version_check.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/eyes_tests/__init__.py
+++ b/mantidimaging/eyes_tests/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/eyes_tests/compare_images_window_test.py
+++ b/mantidimaging/eyes_tests/compare_images_window_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/eyes_tests/eyes_manager.py
+++ b/mantidimaging/eyes_tests/eyes_manager.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/eyes_tests/image_load_dialog_test.py
+++ b/mantidimaging/eyes_tests/image_load_dialog_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/eyes_tests/image_save_dialog_test.py
+++ b/mantidimaging/eyes_tests/image_save_dialog_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from unittest import mock

--- a/mantidimaging/eyes_tests/live_viewer_window_test.py
+++ b/mantidimaging/eyes_tests/live_viewer_window_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from __future__ import annotations

--- a/mantidimaging/eyes_tests/main_window_test.py
+++ b/mantidimaging/eyes_tests/main_window_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/eyes_tests/nexus_load_dialog_test.py
+++ b/mantidimaging/eyes_tests/nexus_load_dialog_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/eyes_tests/nexus_save_dialog_test.py
+++ b/mantidimaging/eyes_tests/nexus_save_dialog_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/eyes_tests/operations_window_test.py
+++ b/mantidimaging/eyes_tests/operations_window_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from PyQt5.QtWidgets import QApplication, QWidget, QPushButton

--- a/mantidimaging/eyes_tests/reconstruct_window_test.py
+++ b/mantidimaging/eyes_tests/reconstruct_window_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/eyes_tests/spectrum_viewer_test.py
+++ b/mantidimaging/eyes_tests/spectrum_viewer_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from PyQt5.QtWidgets import QApplication

--- a/mantidimaging/eyes_tests/welcome_window_test.py
+++ b/mantidimaging/eyes_tests/welcome_window_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from unittest import mock

--- a/mantidimaging/gui/__init__.py
+++ b/mantidimaging/gui/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/dialogs/__init__.py
+++ b/mantidimaging/gui/dialogs/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/dialogs/async_task/__init__.py
+++ b/mantidimaging/gui/dialogs/async_task/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/dialogs/async_task/model.py
+++ b/mantidimaging/gui/dialogs/async_task/model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/dialogs/async_task/presenter.py
+++ b/mantidimaging/gui/dialogs/async_task/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/dialogs/async_task/task.py
+++ b/mantidimaging/gui/dialogs/async_task/task.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/dialogs/async_task/test/__init__.py
+++ b/mantidimaging/gui/dialogs/async_task/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/dialogs/async_task/test/model_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/model_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/dialogs/async_task/test/task_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/task_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/dialogs/async_task/test/view_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/view_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/dialogs/cor_inspection/__init__.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/dialogs/cor_inspection/model.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from dataclasses import replace

--- a/mantidimaging/gui/dialogs/cor_inspection/presenter.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/dialogs/cor_inspection/recon_slice_view.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/recon_slice_view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/dialogs/cor_inspection/test/__init__.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/dialogs/cor_inspection/test/model_test.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/test/model_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/dialogs/cor_inspection/test/presenter_test.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/dialogs/cor_inspection/types.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/types.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/dialogs/cor_inspection/view.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/dialogs/multiple_stack_select/__init__.py
+++ b/mantidimaging/gui/dialogs/multiple_stack_select/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/dialogs/multiple_stack_select/view.py
+++ b/mantidimaging/gui/dialogs/multiple_stack_select/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/gui.py
+++ b/mantidimaging/gui/gui.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/mvp_base/__init__.py
+++ b/mantidimaging/gui/mvp_base/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/mvp_base/presenter.py
+++ b/mantidimaging/gui/mvp_base/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/mvp_base/test/__init__.py
+++ b/mantidimaging/gui/mvp_base/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/mvp_base/test/presenter_test.py
+++ b/mantidimaging/gui/mvp_base/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/mvp_base/view.py
+++ b/mantidimaging/gui/mvp_base/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/test/__init__.py
+++ b/mantidimaging/gui/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/test/gui_system_operations_test.py
+++ b/mantidimaging/gui/test/gui_system_operations_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/test/gui_system_reconstruction_test.py
+++ b/mantidimaging/gui/test/gui_system_reconstruction_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from unittest import mock

--- a/mantidimaging/gui/test/gui_system_spectrum_test.py
+++ b/mantidimaging/gui/test/gui_system_spectrum_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/test/gui_system_windows_test.py
+++ b/mantidimaging/gui/test/gui_system_windows_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/utility/__init__.py
+++ b/mantidimaging/gui/utility/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/utility/common.py
+++ b/mantidimaging/gui/utility/common.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/utility/qt_helpers.py
+++ b/mantidimaging/gui/utility/qt_helpers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 """
 Module containing helper functions relating to PyQt.

--- a/mantidimaging/gui/widgets/__init__.py
+++ b/mantidimaging/gui/widgets/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/auto_colour_menu/__init__.py
+++ b/mantidimaging/gui/widgets/auto_colour_menu/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/widgets/auto_colour_menu/auto_color_menu.py
+++ b/mantidimaging/gui/widgets/auto_colour_menu/auto_color_menu.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/bad_data_overlay/__init__.py
+++ b/mantidimaging/gui/widgets/bad_data_overlay/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
+++ b/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/dataset_selector/__init__.py
+++ b/mantidimaging/gui/widgets/dataset_selector/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/dataset_selector/presenter.py
+++ b/mantidimaging/gui/widgets/dataset_selector/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/dataset_selector/test/__init__.py
+++ b/mantidimaging/gui/widgets/dataset_selector/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/widgets/dataset_selector/test/presenter_test.py
+++ b/mantidimaging/gui/widgets/dataset_selector/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/dataset_selector/test/view_test.py
+++ b/mantidimaging/gui/widgets/dataset_selector/test/view_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/dataset_selector/view.py
+++ b/mantidimaging/gui/widgets/dataset_selector/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/dataset_selector_dialog/__init__.py
+++ b/mantidimaging/gui/widgets/dataset_selector_dialog/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/widgets/dataset_selector_dialog/dataset_selector_dialog.py
+++ b/mantidimaging/gui/widgets/dataset_selector_dialog/dataset_selector_dialog.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import uuid

--- a/mantidimaging/gui/widgets/dataset_selector_dialog/test/__init__.py
+++ b/mantidimaging/gui/widgets/dataset_selector_dialog/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/widgets/dataset_selector_dialog/test/dataset_selector_dialog_test.py
+++ b/mantidimaging/gui/widgets/dataset_selector_dialog/test/dataset_selector_dialog_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/indicator_icon/__init__.py
+++ b/mantidimaging/gui/widgets/indicator_icon/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/widgets/indicator_icon/view.py
+++ b/mantidimaging/gui/widgets/indicator_icon/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/line_profile_plot/__init__.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/widgets/line_profile_plot/test/__init__.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/widgets/line_profile_plot/test/view_test.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/test/view_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import unittest

--- a/mantidimaging/gui/widgets/line_profile_plot/view.py
+++ b/mantidimaging/gui/widgets/line_profile_plot/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from typing import TYPE_CHECKING

--- a/mantidimaging/gui/widgets/mi_image_view/__init__.py
+++ b/mantidimaging/gui/widgets/mi_image_view/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/widgets/mi_image_view/presenter.py
+++ b/mantidimaging/gui/widgets/mi_image_view/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/mi_image_view/test/__init__.py
+++ b/mantidimaging/gui/widgets/mi_image_view/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/widgets/mi_image_view/test/presenter_test.py
+++ b/mantidimaging/gui/widgets/mi_image_view/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/mi_image_view/test/view_test.py
+++ b/mantidimaging/gui/widgets/mi_image_view/test/view_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from unittest import mock

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/mi_mini_image_view/__init__.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/widgets/mi_mini_image_view/test/__init__.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/widgets/mi_mini_image_view/test/view_test.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/test/view_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/palette_changer/__init__.py
+++ b/mantidimaging/gui/widgets/palette_changer/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/widgets/palette_changer/presenter.py
+++ b/mantidimaging/gui/widgets/palette_changer/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from typing import TYPE_CHECKING

--- a/mantidimaging/gui/widgets/palette_changer/test/presenter_test.py
+++ b/mantidimaging/gui/widgets/palette_changer/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/palette_changer/view.py
+++ b/mantidimaging/gui/widgets/palette_changer/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/removable_row_table_view.py
+++ b/mantidimaging/gui/widgets/removable_row_table_view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/roi_selector/__init__.py
+++ b/mantidimaging/gui/widgets/roi_selector/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/widgets/roi_selector/test/__init__.py
+++ b/mantidimaging/gui/widgets/roi_selector/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/widgets/roi_selector/test/view_test.py
+++ b/mantidimaging/gui/widgets/roi_selector/test/view_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/widgets/roi_selector/view.py
+++ b/mantidimaging/gui/widgets/roi_selector/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from typing import TYPE_CHECKING

--- a/mantidimaging/gui/widgets/spectrum_widgets/tof_properties.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/tof_properties.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from PyQt5 import QtCore, QtWidgets

--- a/mantidimaging/gui/widgets/stack_selector/test/__init__.py
+++ b/mantidimaging/gui/widgets/stack_selector/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/widgets/zslider/__init__.py
+++ b/mantidimaging/gui/widgets/zslider/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/widgets/zslider/zslider.py
+++ b/mantidimaging/gui/widgets/zslider/zslider.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/__init__.py
+++ b/mantidimaging/gui/windows/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/add_images_to_dataset_dialog/__init__.py
+++ b/mantidimaging/gui/windows/add_images_to_dataset_dialog/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/add_images_to_dataset_dialog/presenter.py
+++ b/mantidimaging/gui/windows/add_images_to_dataset_dialog/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import traceback

--- a/mantidimaging/gui/windows/add_images_to_dataset_dialog/test/__init__.py
+++ b/mantidimaging/gui/windows/add_images_to_dataset_dialog/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/add_images_to_dataset_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/add_images_to_dataset_dialog/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import unittest

--- a/mantidimaging/gui/windows/add_images_to_dataset_dialog/test/view_test.py
+++ b/mantidimaging/gui/windows/add_images_to_dataset_dialog/test/view_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/add_images_to_dataset_dialog/view.py
+++ b/mantidimaging/gui/windows/add_images_to_dataset_dialog/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import uuid

--- a/mantidimaging/gui/windows/image_load_dialog/__init__.py
+++ b/mantidimaging/gui/windows/image_load_dialog/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/image_load_dialog/field.py
+++ b/mantidimaging/gui/windows/image_load_dialog/field.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from pathlib import Path

--- a/mantidimaging/gui/windows/image_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/image_load_dialog/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/image_load_dialog/test/__init__.py
+++ b/mantidimaging/gui/windows/image_load_dialog/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/image_load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/image_load_dialog/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/image_load_dialog/view.py
+++ b/mantidimaging/gui/windows/image_load_dialog/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/live_viewer/__init__.py
+++ b/mantidimaging/gui/windows/live_viewer/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/live_viewer/live_view_widget.py
+++ b/mantidimaging/gui/windows/live_viewer/live_view_widget.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from typing import TYPE_CHECKING

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/live_viewer/test/__init__.py
+++ b/mantidimaging/gui/windows/live_viewer/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/live_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/model_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from pathlib import Path

--- a/mantidimaging/gui/windows/main/__init__.py
+++ b/mantidimaging/gui/windows/main/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/main/image_save_dialog.py
+++ b/mantidimaging/gui/windows/main/image_save_dialog.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import uuid

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import uuid

--- a/mantidimaging/gui/windows/main/nexus_save_dialog.py
+++ b/mantidimaging/gui/windows/main/nexus_save_dialog.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import os

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import traceback

--- a/mantidimaging/gui/windows/main/test/Image_save_test.py
+++ b/mantidimaging/gui/windows/main/test/Image_save_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/main/test/__init__.py
+++ b/mantidimaging/gui/windows/main/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/main/test/model_test.py
+++ b/mantidimaging/gui/windows/main/test/model_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/main/test/nexus_save_test.py
+++ b/mantidimaging/gui/windows/main/test/nexus_save_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import unittest

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/move_stack_dialog/__init__.py
+++ b/mantidimaging/gui/windows/move_stack_dialog/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/move_stack_dialog/presenter.py
+++ b/mantidimaging/gui/windows/move_stack_dialog/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from enum import Enum, auto

--- a/mantidimaging/gui/windows/move_stack_dialog/test/__init__.py
+++ b/mantidimaging/gui/windows/move_stack_dialog/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/move_stack_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/move_stack_dialog/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import unittest

--- a/mantidimaging/gui/windows/move_stack_dialog/test/view_test.py
+++ b/mantidimaging/gui/windows/move_stack_dialog/test/view_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import unittest

--- a/mantidimaging/gui/windows/move_stack_dialog/view.py
+++ b/mantidimaging/gui/windows/move_stack_dialog/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import uuid

--- a/mantidimaging/gui/windows/nexus_load_dialog/__init__.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import enum

--- a/mantidimaging/gui/windows/nexus_load_dialog/test/__init__.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/nexus_load_dialog/view.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/operations/__init__.py
+++ b/mantidimaging/gui/windows/operations/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import traceback

--- a/mantidimaging/gui/windows/operations/test/__init__.py
+++ b/mantidimaging/gui/windows/operations/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/operations/test/model_test.py
+++ b/mantidimaging/gui/windows/operations/test/model_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import logging

--- a/mantidimaging/gui/windows/operations/test/view_test.py
+++ b/mantidimaging/gui/windows/operations/test/view_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import functools

--- a/mantidimaging/gui/windows/recon/__init__.py
+++ b/mantidimaging/gui/windows/recon/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from math import isnan

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from logging import getLogger

--- a/mantidimaging/gui/windows/recon/point_table_model.py
+++ b/mantidimaging/gui/windows/recon/point_table_model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/recon/test/__init__.py
+++ b/mantidimaging/gui/windows/recon/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/recon/test/model_test.py
+++ b/mantidimaging/gui/windows/recon/test/model_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import uuid

--- a/mantidimaging/gui/windows/settings/__init__.py
+++ b/mantidimaging/gui/windows/settings/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/settings/presenter.py
+++ b/mantidimaging/gui/windows/settings/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/settings/view.py
+++ b/mantidimaging/gui/windows/settings/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from logging import getLogger

--- a/mantidimaging/gui/windows/spectrum_viewer/__init__.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import csv

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/spectrum_viewer/test/__init__.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import unittest

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import unittest

--- a/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import unittest

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/stack_choice/__init__.py
+++ b/mantidimaging/gui/windows/stack_choice/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/stack_choice/compare_presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/compare_presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/stack_choice/presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/stack_choice/presenter_base.py
+++ b/mantidimaging/gui/windows/stack_choice/presenter_base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/stack_choice/tests/__init__.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/stack_choice/tests/compare_presenter_test.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/compare_presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/stack_choice/tests/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/stack_choice/tests/view_test.py
+++ b/mantidimaging/gui/windows/stack_choice/tests/view_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import unittest

--- a/mantidimaging/gui/windows/stack_choice/view.py
+++ b/mantidimaging/gui/windows/stack_choice/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/stack_visualiser/__init__.py
+++ b/mantidimaging/gui/windows/stack_visualiser/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
+++ b/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/stack_visualiser/model.py
+++ b/mantidimaging/gui/windows/stack_visualiser/model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/stack_visualiser/test/__init__.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/view_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import unittest

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/welcome_screen/__init__.py
+++ b/mantidimaging/gui/windows/welcome_screen/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/welcome_screen/presenter.py
+++ b/mantidimaging/gui/windows/welcome_screen/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/welcome_screen/tests/__init__.py
+++ b/mantidimaging/gui/windows/welcome_screen/tests/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/welcome_screen/tests/presenter_test.py
+++ b/mantidimaging/gui/windows/welcome_screen/tests/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/welcome_screen/tests/view_test.py
+++ b/mantidimaging/gui/windows/welcome_screen/tests/view_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/welcome_screen/view.py
+++ b/mantidimaging/gui/windows/welcome_screen/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/wizard/__init__.py
+++ b/mantidimaging/gui/windows/wizard/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/wizard/model.py
+++ b/mantidimaging/gui/windows/wizard/model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/wizard/presenter.py
+++ b/mantidimaging/gui/windows/wizard/presenter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/wizard/test/__init__.py
+++ b/mantidimaging/gui/windows/wizard/test/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/mantidimaging/gui/windows/wizard/test/model_test.py
+++ b/mantidimaging/gui/windows/wizard/test/model_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/wizard/test/presenter_test.py
+++ b/mantidimaging/gui/windows/wizard/test/presenter_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/wizard/test/view_test.py
+++ b/mantidimaging/gui/windows/wizard/test/view_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/gui/windows/wizard/view.py
+++ b/mantidimaging/gui/windows/wizard/view.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/helper.py
+++ b/mantidimaging/helper.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 """
 Module for commonly used functions across the modules.

--- a/mantidimaging/ipython.py
+++ b/mantidimaging/ipython.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/test_helpers/__init__.py
+++ b/mantidimaging/test_helpers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 """
 This package contains testing helpers for unit tests across the application

--- a/mantidimaging/test_helpers/file_outputting_test_case.py
+++ b/mantidimaging/test_helpers/file_outputting_test_case.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/test_helpers/qt_mocks.py
+++ b/mantidimaging/test_helpers/qt_mocks.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/test_helpers/qt_test_helpers.py
+++ b/mantidimaging/test_helpers/qt_test_helpers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/test_helpers/start_qapplication.py
+++ b/mantidimaging/test_helpers/start_qapplication.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/packaging/PackageWithPyInstaller.py
+++ b/packaging/PackageWithPyInstaller.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/packaging/hooks/hook-cil.py
+++ b/packaging/hooks/hook-cil.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 

--- a/scripts/operations_tests/__init__.py
+++ b/scripts/operations_tests/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations

--- a/scripts/operations_tests/operations_tests.py
+++ b/scripts/operations_tests/operations_tests.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import argparse

--- a/scripts/simulate_live_data.py
+++ b/scripts/simulate_live_data.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 import os

--- a/scripts/tiff_unpacker.py
+++ b/scripts/tiff_unpacker.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 """
 This is a Utility script to unpack tiff files into a directory of images using lossless compression.

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2024 ISIS Rutherford Appleton Laboratory UKRI
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 


### PR DESCRIPTION
### Issue

In line with the discussions in python/cpython#126133, it has been decided that updating the copyright year each year is unnecessary and creates redundant churn. This practice has been discontinued in Python repositories, and we are applying a similar approach here.

### Description

All copyright headers have been updated to a static year of 2021.
This year is chosen as it marks the first end-user release of the MI project, and continuing to update it annually is no longer required.

### Acceptance Criteria 

Review the files listed to ensure that the copyright headers have been correctly updated to # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI.

Confirm that there is no outdated or unnecessary year information.


### Documentation

Added file in docs/release_notes
