### PR TITLE
create_dev_env: Only try to remove old dev env if it exists

### DIFF
--- a/docs/release_notes/next/dev-2438-dev-env-fix
+++ b/docs/release_notes/next/dev-2438-dev-env-fix
@@ -1,0 +1,1 @@
+2438: Only try to remove old dev env if it exists

--- a/setup.py
+++ b/setup.py
@@ -141,9 +141,11 @@ class CreateDeveloperEnvironment(Command):
         return output_env_file.name
 
     def run(self):
-        print("Removing existing mantidimaging-dev environment")
-        command_conda_env_remove = [self.conda, "env", "remove", "-n", "mantidimaging-dev"]
-        subprocess.check_call(command_conda_env_remove)
+        existing_envs_output = subprocess.check_output([self.conda, "env", "list"], encoding="utf8")
+        if any(line.startswith("mantidimaging-dev ") for line in existing_envs_output.split("\n")):
+            print("Removing existing mantidimaging-dev environment")
+            command_conda_env_remove = [self.conda, "env", "remove", "-n", "mantidimaging-dev"]
+            subprocess.check_call(command_conda_env_remove)
         extra_deps = self.get_package_depends()
         env_file_path = self.make_environment_file(extra_deps)
         print("Creating conda environment for development")


### PR DESCRIPTION
### Issue
Closes #2438 

### Description

Normally it is safe to try to remove a non existent environment, but in some cases it causes an error. This adds a check, and only removes the env if it exists.

This should fix docker builds.

### Testing & Acceptance Criteria 

Check if the build docker workflow (`Build & Publish Docker Ubuntu18 & CentOS7`) succeeds on the PR

### Documentation
Release notes
