### PR TITLE
2397 fits support

### DIFF
--- a/docs/release_notes/next/fix-2397-fix-fits_file_support
+++ b/docs/release_notes/next/fix-2397-fix-fits_file_support
@@ -1,0 +1,1 @@
+#2397: Fix FITS file support for drag and drop functionality within Mantid Imaging. This fix also resolves FITS file support when launching Mantid Imaging via the CLI with the `--path` optional argument.

--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -67,7 +67,9 @@ def _fitsread(filename: Path | str) -> np.ndarray:
         raise RuntimeError(f"Could not load at least one FITS image/table file from: {filename}")
 
     # get the image data
-    return image[0].data
+    image_data = image[0].data
+    image.close(filename)
+    return image_data
 
 
 def _imread(filename: Path | str) -> np.ndarray:

--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -10,18 +10,24 @@ from logging import getLogger
 log = getLogger(__name__)
 
 DEFAULT_IO_FILE_FORMAT = 'tif'
-NEXUS_PROCESSED_DATA_PATH = "processed-data"
+NEXUS_PROCESSED_DATA_PATH = 'processed-data'
 
 THRESHOLD_180 = np.radians(1)
 
 
 def find_first_file_that_is_possibly_a_sample(file_path: str) -> str | None:
-    # Grab all .tif or .tiff files
-    possible_files = glob.glob(os.path.join(file_path, "**/*.tif*"), recursive=True)
-
+    """
+    Finds the first file that is possibly a tif, .tiff, .fit or .fits sample file.
+    If files are found, the files are sorted and filtered based on name and returned.
+    """
+    file_types = ['tif', 'tiff', 'fit', 'fits']
+    for file_type in file_types:
+        possible_files = glob.glob(os.path.join(file_path, f'**/*.{file_type}'), recursive=True)
+        if possible_files:
+            break
     for possible_file in sorted(possible_files):
         lower_filename = os.path.basename(possible_file).lower()
-        if "flat" not in lower_filename and "dark" not in lower_filename and "180" not in lower_filename:
+        if 'flat' not in lower_filename and 'dark' not in lower_filename and '180' not in lower_filename:
             return possible_file
     return None
 


### PR DESCRIPTION
### Issue

Closes #2397
 
### Description

Add support for FITS files to CLI `--path` optional argument and drag and drop functionality by including fits as a filetype to be searched in `mantidimaging/core/io/utility.find_first_file_that_is_possibly_a_sample`.

Upon adding FITS file support to `find_first_file_that_is_possibly_a_sample()`, a new warning appeared in DEBUG mode stating that the file loaded by `mantidimaging/core/io/loader/loader._fitsread` was not correctly closed after opening. `_fitsread` has been refactored so that it now correctly closes the image after reading.

### Testing 

* Verified unit tests pass
* Manually tested dragging and dropping a FITS dataset into MI.
* Manually tested loading a FITS dataset using CLI `--path` argument.

### Acceptance Criteria 

_Before testing, If you rename the folders associated with the FITS dataset you plan to use for testing to match a strict tiff dataset (_i.e. sample>Tomo, open>flat_before, dark>dark_before and so on_), drag and drop should identify all relevant files and add to loading dialog menu or load in as part of CLI `--path` operation._

- [x] Verify unit tests pass
- [x] In debug mode, verifying no warnings about files not being closed returned:
  - [x]  Check if you can drag and drop a `fit` and `fits` dataset into mantid imaging and that it is correctly identified as a valid dataset and loaded into loading dialog and then correctly into MI (Spectrum Viewer is the best place to check this)
  - [x] Check that you can load `fit` and `fits` data into MI using the CLI argument `--path` (Spectrum Viewer is the best place to check this).
- [x] Check that `tif` and `tiff` files can still be loaded via drag and drop and also via `--path` CLI argument.

### Documentation

`docs/release_notes/next/fix-2397-fix-fits_file_support`
