### PR TITLE
Add Init to Spectrum Widget Folder

### DIFF
--- a/mantidimaging/gui/widgets/spectrum_widgets/__init__.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations


### PR DESCRIPTION
### Issue

Closes #2442 

### Description

MI fails to start with the error message
ModuleNotFoundError: No module named 'mantidimaging.gui.widgets.spectrum_widgets'

Looks like an import error, where something is working fine from the source directory but not in the package.

After further investigation, A missing `__init__` seemed to be the culprit which has now been added to `mantidimaging/gui/widgets/spectrum_widgets/`

### Testing 

*Describe the tests that were used to verify your changes*.

- Build locally with make `build-conda-package` and install into `mantidimaging-nightly` using `mamba install /home/sam/mambaforge/envs/build-env/conda-bld/linux-64/mantidimaging-2.9.0a1.post402-py312_1.tar.bz2`
  - Verify if that that package bultds correctly and can be installed and ran wihtout any import errors
 

### Acceptance Criteria 

Mi can build successfully without returning a `ModuleNotFoundError` error

### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*

NA - This is a flash PR and does not change MI in any significant way.