### PR TITLE
Add the ruff INP001 rule

### DIFF
--- a/docs/release_notes/next/dev-2444-ruff-implicit-namespace-package
+++ b/docs/release_notes/next/dev-2444-ruff-implicit-namespace-package
@@ -1,0 +1,1 @@
+#2444: Ruff rule to check for missing __init__.py files

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -29,7 +29,7 @@ dependencies:
   - pyinstaller==6.9.*
   - pyright==1.1.*
   - make==4.3
-  - ruff=0.3.3
+  - ruff=0.3.7
   - pre-commit==3.5.*
   - sphinx==7.2.*
   - pydata-sphinx-theme==0.15.*

--- a/mantidimaging/gui/widgets/palette_changer/test/__init__.py
+++ b/mantidimaging/gui/widgets/palette_changer/test/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,12 @@ line-length = 120
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["F", "E", "W", "UP", "B", "C4", "FA", "NPY"]
+select = ["F", "E", "W", "UP", "B", "C4", "FA", "NPY", "INP"]
 fixable = ["UP"]
 ignore = ["UP014"]
+
+[tool.ruff.lint.per-file-ignores]
+"!mantidimaging/**.py" = ["INP"]
 
 [tool.pyright]
 typeCheckingMode = "basic"


### PR DESCRIPTION
### Issue

Closes #2444  

### Description

Enable ruff INP001 rule to catch missing `__init__.py` files.
Use `per-file-ignores` to prevent false positives on stand alone scripts
Update ruff to allow negative `per-file-ignores` rules
Add missing `__init__.py` in `palette_changer/test`

### Testing & Acceptance Criteria 

Try removing a `__init__.py` file and run `make ruff`

### Documentation

Release notes
