### PR TITLE
Refactored set_new_roi into the presenter.py

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -134,15 +134,6 @@ class SpectrumViewerWindowModel:
     def set_normalise_stack(self, normalise_stack: ImageStack | None) -> None:
         self._normalise_stack = normalise_stack
 
-    def set_new_roi(self, name: str) -> None:
-        """
-        Sets a new ROI with the given name
-
-        @param name: The name of the new ROI
-        """
-        height, width = self.get_image_shape()
-        self._roi_ranges[name] = SensibleROI.from_list([0, 0, width, height])
-
     def get_averaged_image(self) -> np.ndarray | None:
         """
         Get the averaged image from the stack in the model returning as a numpy array

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -328,10 +328,9 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         roi_name = self.model.roi_name_generator()
         if roi_name in self.view.spectrum_widget.roi_dict:
             raise ValueError(f"ROI name already exists: {roi_name}")
-        self.model.set_new_roi(roi_name)
-        roi = self.model._roi_ranges.get(roi_name)
-        if roi is None:
-            raise ValueError(f"ROI for {roi_name} is not valid.")
+        height, width = self.model.get_image_shape()
+        roi = SensibleROI.from_list([0, 0, width, height])
+        self.model._roi_ranges[roi_name] = roi
         self.view.spectrum_widget.add_roi(roi, roi_name)
         spectrum = self.model.get_spectrum(roi, self.spectrum_mode, self.view.shuttercount_norm_enabled())
         self.view.set_spectrum(roi_name, spectrum)
@@ -351,8 +350,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.on_visibility_change()
 
     def add_rits_roi(self) -> None:
-        self.model.set_new_roi(ROI_RITS)
-        roi = self.model._roi_ranges[ROI_RITS]
+        roi = self.model._roi_ranges.setdefault(ROI_RITS, SensibleROI.from_list([0, 0, *self.model.get_image_shape()]))
         self.view.spectrum_widget.add_roi(roi, ROI_RITS)
         self.view.set_spectrum(ROI_RITS,
                                self.model.get_spectrum(roi, self.spectrum_mode, self.view.shuttercount_norm_enabled()))


### PR DESCRIPTION
### Issue

Closes #2297  

### Description
Set_roi removed from model 
refactored presenter to no longer use set_new_roi from model 

### Testing 

Updated unit tests to verify correct renaming behavior and proper exceptions for invalid operations.
Manually tested renaming ROIs in the UI to ensure changes are reflected correctly.
