### PR TITLE
refactored roi_ranges out of the model

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -89,7 +89,6 @@ class SpectrumViewerWindowModel:
     _normalise_stack: ImageStack | None = None
     tof_range: tuple[int, int] = (0, 0)
     tof_plot_range: tuple[float, float] | tuple[int, int] = (0, 0)
-    _roi_ranges: dict[str, SensibleROI]
     tof_mode: ToFUnitMode = ToFUnitMode.WAVELENGTH
     tof_data: np.ndarray | None = None
     tof_range_full: tuple[int, int] = (0, 0)
@@ -97,7 +96,6 @@ class SpectrumViewerWindowModel:
     def __init__(self, presenter: SpectrumViewerWindowPresenter):
         self.presenter = presenter
         self._roi_id_counter = 0
-        self._roi_ranges = {}
         self.special_roi_list = [ROI_ALL]
 
         self.units = UnitConversion()
@@ -128,8 +126,6 @@ class SpectrumViewerWindowModel:
         self.tof_range = (0, stack.data.shape[0] - 1)
         self.tof_range_full = self.tof_range
         self.tof_data = self.get_stack_time_of_flight()
-        height, width = self.get_image_shape()
-        self._roi_ranges[ROI_ALL] = SensibleROI.from_list([0, 0, width, height])
 
     def set_normalise_stack(self, normalise_stack: ImageStack | None) -> None:
         self._normalise_stack = normalise_stack
@@ -337,14 +333,14 @@ class SpectrumViewerWindowModel:
             csv_output.write(outfile)
             self.save_roi_coords(self.get_roi_coords_filename(path))
 
-    def save_single_rits_spectrum(self, path: Path, error_mode: ErrorMode) -> None:
+    def save_single_rits_spectrum(self, path: Path, error_mode: ErrorMode, roi: SensibleROI) -> None:
         """
         Saves the spectrum for the RITS ROI to a RITS file.
 
         @param path: The path to save the CSV file to.
         @param error_mode: Which version (standard deviation or propagated) of the error to use in the RITS export.
         """
-        self.save_rits_roi(path, error_mode, self._roi_ranges[ROI_RITS])
+        self.save_rits_roi(path, error_mode, roi)
 
     def save_rits_roi(self, path: Path, error_mode: ErrorMode, roi: SensibleROI, normalise: bool = False) -> None:
         """
@@ -401,6 +397,7 @@ class SpectrumViewerWindowModel:
                          error_mode: ErrorMode,
                          bin_size: int,
                          step: int,
+                         roi: SensibleROI,
                          normalise: bool = False,
                          progress: Progress | None = None) -> None:
         """
@@ -420,11 +417,13 @@ class SpectrumViewerWindowModel:
         error_mode (ErrorMode): The error mode to use when saving the images.
         bin_size (int): The size of the sub-regions.
         step (int): The step size to use when sliding the window across the ROI.
+        roi (SensibleROI): The parent ROI to be subdivided.
+        normalise (bool): If True, the images will be normalised.
+        progress (Progress | None): Optional progress reporter.
 
         Returns:
         None
         """
-        roi = self._roi_ranges[ROI_RITS]
         left, top, right, bottom = roi
         x_iterations = min(ceil((right - left) / step), ceil((right - left - bin_size) / step) + 1)
         y_iterations = min(ceil((bottom - top) / step), ceil((bottom - top - bin_size) / step) + 1)
@@ -463,16 +462,17 @@ class SpectrumViewerWindowModel:
         """
         return path.with_stem(f"{path.stem}_roi_coords")
 
-    def save_roi_coords(self, path: Path) -> None:
+    def save_roi_coords(self, path: Path, rois: dict[str, SensibleROI]) -> None:
         """
         Save the coordinates of the ROIs to a csv file (ROI name, x_min, x_max, y_min, y_max)
         following Pascal VOC format.
         @param path: The path to save the CSV file to.
+        @param rois: A dictionary of ROI names and their coordinates.
         """
         with open(path, encoding='utf-8', mode='w') as f:
             csv_writer = csv.DictWriter(f, fieldnames=["ROI", "X Min", "X Max", "Y Min", "Y Max"])
             csv_writer.writeheader()
-            for roi_name, coords in self._roi_ranges.items():
+            for roi_name, coords in rois.items():
                 csv_writer.writerow({
                     "ROI": roi_name,
                     "X Min": coords.left,
@@ -494,7 +494,6 @@ class SpectrumViewerWindowModel:
         Remove all ROIs from the model
         """
         self._roi_id_counter = 0
-        self._roi_ranges = {}
 
     def set_relevant_tof_units(self) -> None:
         if self._stack is not None:

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -301,7 +301,6 @@ class SpectrumViewerWindowModel:
         Iterates over all ROIs and saves the spectrum for each one to a CSV file.
         @param path: The path to save the CSV file to.
         @param normalized: Whether to save the normalized spectrum.
-
         """
         if self._stack is None:
             raise ValueError("No stack selected")
@@ -329,9 +328,10 @@ class SpectrumViewerWindowModel:
                 csv_output.add_column(f"{roi_name}_norm",
                                       self.get_spectrum(roi, SpecType.SAMPLE_NORMED, normalise_with_shuttercount),
                                       "Counts")
+
         with path.open("w") as outfile:
             csv_output.write(outfile)
-            self.save_roi_coords(self.get_roi_coords_filename(path))
+            self.save_roi_coords(self.get_roi_coords_filename(path), rois)
 
     def save_single_rits_spectrum(self, path: Path, error_mode: ErrorMode, roi: SensibleROI) -> None:
         """
@@ -463,12 +463,6 @@ class SpectrumViewerWindowModel:
         return path.with_stem(f"{path.stem}_roi_coords")
 
     def save_roi_coords(self, path: Path, rois: dict[str, SensibleROI]) -> None:
-        """
-        Save the coordinates of the ROIs to a csv file (ROI name, x_min, x_max, y_min, y_max)
-        following Pascal VOC format.
-        @param path: The path to save the CSV file to.
-        @param rois: A dictionary of ROI names and their coordinates.
-        """
         with open(path, encoding='utf-8', mode='w') as f:
             csv_writer = csv.DictWriter(f, fieldnames=["ROI", "X Min", "X Max", "Y Min", "Y Max"])
             csv_writer.writeheader()
@@ -478,7 +472,7 @@ class SpectrumViewerWindowModel:
                     "X Min": coords.left,
                     "X Max": coords.right,
                     "Y Min": coords.top,
-                    "Y Max": coords.bottom
+                    "Y Max": coords.bottom,
                 })
 
     def export_spectrum_to_rits(self, path: Path, tof: np.ndarray, transmission: np.ndarray,

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -280,9 +280,9 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                 self.model.save_rits_images,
                 path,
                 error_mode,
-                roi,
                 self.view.bin_size,
                 self.view.bin_step,
+                roi,
                 normalise=self.view.shuttercount_norm_enabled(),
             )
             start_async_task_view(self.view, run_function, self._async_save_done)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -275,10 +275,12 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             if path is None:
                 LOG.debug("No path selected, aborting export")
                 return
+            roi = self.view.spectrum_widget.get_roi(ROI_RITS)
             run_function = partial(
                 self.model.save_rits_images,
                 path,
                 error_mode,
+                roi,
                 self.view.bin_size,
                 self.view.bin_step,
                 normalise=self.view.shuttercount_norm_enabled(),

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -275,15 +275,15 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             if path is None:
                 LOG.debug("No path selected, aborting export")
                 return
-            run_function = partial(self.model.save_rits_images,
-                                   path,
-                                   error_mode,
-                                   self.view.bin_size,
-                                   self.view.bin_step,
-                                   normalise=self.view.shuttercount_norm_enabled())
-
+            run_function = partial(
+                self.model.save_rits_images,
+                path,
+                error_mode,
+                self.view.bin_size,
+                self.view.bin_step,
+                normalise=self.view.shuttercount_norm_enabled(),
+            )
             start_async_task_view(self.view, run_function, self._async_save_done)
-
         else:
             path = self.view.get_rits_export_filename()
             if path is None:
@@ -291,7 +291,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                 return
             if path and path.suffix != ".dat":
                 path = path.with_suffix(".dat")
-            self.model.save_single_rits_spectrum(path, error_mode)
+            roi = self.view.spectrum_widget.get_roi(ROI_RITS)
+            self.model.save_single_rits_spectrum(path, error_mode, roi)
 
     def _async_save_done(self, task: TaskWorkerThread) -> None:
         if task.error is not None:
@@ -349,7 +350,10 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.on_visibility_change()
 
     def add_rits_roi(self) -> None:
-        roi = self.model._roi_ranges.setdefault(ROI_RITS, SensibleROI.from_list([0, 0, *self.model.get_image_shape()]))
+        """
+        Add the RITS ROI to the spectrum widget and initialize it with default dimensions.
+        """
+        roi = SensibleROI.from_list([0, 0, *self.model.get_image_shape()])
         self.view.spectrum_widget.add_roi(roi, ROI_RITS)
         self.view.set_spectrum(ROI_RITS,
                                self.model.get_spectrum(roi, self.spectrum_mode, self.view.shuttercount_norm_enabled()))

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -148,14 +148,6 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         self.model.set_normalise_stack(ImageStack(np.ones([10, 11, 12])))
         self.assertEqual("", self.model.normalise_issue())
 
-    def test_set_stack_sets_roi(self):
-        stack, _ = self._set_sample_stack()
-        roi_all = SensibleROI.from_list([0, 0, stack.data.shape[2], stack.data.shape[1]])
-        self.assertEqual(roi_all.top, 0)
-        self.assertEqual(roi_all.left, 0)
-        self.assertEqual(roi_all.right, 12)
-        self.assertEqual(roi_all.bottom, 11)
-
     def test_if_set_stack_called_THEN_do_remove_roi_not_called(self):
         self.model.set_stack(generate_images())
         self.presenter.do_remove_roi.assert_not_called()


### PR DESCRIPTION
### Issue

Closes #2297  

### Description
roi_range removed from model 
refactored presenter to no longer use roi_range from model 

### Testing 

Updated unit tests to verify correct renaming behavior and proper exceptions for invalid operations.
Manually tested renaming ROIs in the UI to ensure changes are reflected correctly.

