### PR TITLE
Fix for ROI Addition After Exporting CSV

### DIFF
--- a/docs/release_notes/next/fix-2422-Add-roi-after-export
+++ b/docs/release_notes/next/fix-2422-Add-roi-after-export
@@ -1,0 +1,1 @@
+2422: Spectrum viewer: Resolves a bug preventing a new ROI from being added after exporting to a CSV file

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -310,17 +310,15 @@ class SpectrumViewerWindowModel:
         csv_output = CSVOutput()
         csv_output.add_column("ToF_index", np.arange(self._stack.data.shape[0]), "Index")
 
-        self.tof_data = self.get_stack_time_of_flight()
-        if self.tof_data is not None:
-            self.units.set_data_to_convert(self.tof_data)
+        local_tof_data = self.get_stack_time_of_flight()
+        if local_tof_data is not None:
+            self.units.set_data_to_convert(local_tof_data)
             csv_output.add_column("Wavelength", self.units.tof_seconds_to_wavelength_in_angstroms(), "Angstrom")
             csv_output.add_column("ToF", self.units.tof_seconds_to_us(), "Microseconds")
             csv_output.add_column("Energy", self.units.tof_seconds_to_energy(), "MeV")
-
         for roi_name, roi in rois.items():
             csv_output.add_column(roi_name, self.get_spectrum(roi, SpecType.SAMPLE, normalise_with_shuttercount),
                                   "Counts")
-
             if normalise:
                 if self._normalise_stack is None:
                     raise RuntimeError("No normalisation stack selected")


### PR DESCRIPTION
### Issue

Closes #2422

### Description

This PR resolves an issue in the Spectrum Viewer where adding new ROIs fails after exporting a CSV file. The problem was caused by tof_data becoming unavailable post-export.

### Acceptance Criteria 

Open a dataset (without the spectra file), open the spectum viewer
Click "Add" to add an ROI
Click "Export Spectrum" and choose name to save an CSV file
Click "Add" to add an ROI
A new ROI should be successfully added and displayed in the Spectrum Viewer

### Documentation

All changes should be noted in the appropriate file in docs/release_notes
