### PR TITLE
 Fix Bin Size Validation Logic in RITS Export

### DIFF
--- a/docs/release_notes/next/fix-2420-rits-export-error-bin-step-equal
+++ b/docs/release_notes/next/fix-2420-rits-export-error-bin-step-equal
@@ -1,0 +1,1 @@
+2420: corrected RITS export error when bin size equals step size

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -387,7 +387,7 @@ class SpectrumViewerWindowModel:
         """
         if bin_size and step_size < 1:
             raise ValueError("Both bin size and step size must be greater than 0")
-        if bin_size <= step_size:
+        if bin_size < step_size:
             raise ValueError("Bin size must be larger than or equal to step size")
         if bin_size and step_size > min(roi.width, roi.height):
             raise ValueError("Both bin size and step size must be less than or equal to the ROI size")


### PR DESCRIPTION
### Issue

Closes #2420

### Description

This fix updates the validate_bin_and_step_size function in the model.py file. The logic was corrected to allow bin_size == step_size by changing the condition from bin_size <= step_size to bin_size < step_size.

### Acceptance Criteria 

Confirm RITS export works with bin_size = step_size.

### Documentation

Added a release note under docs/release_notes summarizing the fix.