### PR TITLE
FLASH PR - Pin Pyright Version to 1.1.391

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -27,7 +27,7 @@ dependencies:
   - pyfakefs==5.3.*
   - parameterized==0.9.*
   - pyinstaller==6.9.*
-  - pyright==1.1.*
+  - pyright==1.1.391
   - make==4.3
   - ruff=0.3.7
   - pre-commit==3.5.*


### PR DESCRIPTION
### Issue

**FLASH PR**

### Description

Pinning version of Pyright to version [1.1.391](https://github.com/microsoft/pyright/releases/tag/1.1.391) as the most recent version of pyright published, [1.1.392](https://github.com/microsoft/pyright/releases/tag/1.1.392) picks up the following two errors `reportGeneralTypeIssues`'s:

```bash
mantidimaging/gui/windows/live_viewer/presenter.py
  mantidimaging/gui/windows/live_viewer/presenter.py:122:18 - error: Object of type "NoReturn" cannot be used with "with" because it does not correctly implement __enter__ (reportGeneralTypeIssues)
  mantidimaging/gui/windows/live_viewer/presenter.py:122:18 - error: Object of type "NoReturn" cannot be used with "with" because it does not correctly implement __exit__ (reportGeneralTypeIssues)
2 errors, 0 warnings, 0 informations
```

Going forward, this should be explored further, but pinning as a temporary fix for the moment.

### Testing 

* On main branch, rebuilt developer environment, ran pyright static analysis checks and verified that the `reportGeneralTypeIssues` pyright errors present in `mantidimaging/gui/windows/live_viewer/presenter.py` were returned
* Switched to PR branch, checked that pyright was pinned to [1.1.391](https://github.com/microsoft/pyright/releases/tag/1.1.391) in the `environment.yml`. Rebuilt developer environment, ran pyright static analysis checks again and verified that the pyright `reportGeneralTypeIssues` errors were no longer returned.

### Acceptance Criteria 

On main branch:
- [ ] Rebuild development environment
  - [ ] `mamba deactivate`
  - [ ] `python setup.py create_dev_env`
  - [ ] `mamba activate mantidimaging-dev`
- [ ] Run pyright: `pyright`
- [ ] Verify that the following issues are included in pyright logs:
  ```bash
   mantidimaging/gui/windows/live_viewer/presenter.py:122:18 - error: Object of type "NoReturn" cannot be used with "with" because it does not correctly implement __enter__ (reportGeneralTypeIssues)
    mantidimaging/gui/windows/live_viewer/presenter.py:122:18 - error: Object of type "NoReturn" cannot be used with "with" because it does not correctly implement __exit__ (reportGeneralTypeIssues)
  ```

Switch to PR branch: `git switch pyright_pin_version`
- [ ] Rebuild developer environment
   - [ ] `mamba deactivate`
  - [ ] `python setup.py create_dev_env`
  - [ ] `mamba activate mantidimaging-dev`
- [ ] Run pyright: `pyright`
- [ ] Verify that the `reportGeneralTypeIssues` previously seen on main are no longer returned. 

### Documentation

N/A - Not needed
