### PR TITLE
FLASH PR Refactor How Fits Files are Loaded to Remove String Formatting

### DIFF
--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -117,10 +117,13 @@ class LiveViewerWindowPresenter(BasePresenter):
         if image_path.suffix.lower() in [".tif", ".tiff"]:
             with tifffile.TiffFile(image_path) as tif:
                 image_data = tif.asarray()
+            return image_data
         elif image_path.suffix.lower() == ".fits":
-            with fits.open(image_path.__str__()) as fit:
-                image_data = fit[0].data
-        return image_data
+            with fits.open(image_path) as fits_hdul:
+                image_data = fits_hdul[0].data
+            return image_data
+        else:
+            raise ValueError(f"Unsupported file type: {image_path.suffix}")
 
     def update_image_modified(self, image_path: Path) -> None:
         """


### PR DESCRIPTION
### Issue

**FLASH PR**

### Description


Change implementation of how `.fits` files are read into the live viewer (`mantidimaging/gui/windows/live_viewer/presenter.py:112`).

Using `__str__()`, which is a special method directly which is normally used by `str()` does not respect the encapsulation of the object's implementation and can be less explicit. This in turn means using `__str__()` could be considered less Pythonic.  This PR removes the use of `__str__()` as string formatting is not necessary.

As `load_image()` states that an `np.ndarray` should be returned, I have also assigned `image_data` to an empty array (`np.array([])`) to cover the case where neither a `.tif`, `.tiff` or `.fits` file is in the suffix of the path used as an argument to `load_image()` to resolve `'image_data' before assignment - Pylint`  where `image_data` was not previously assigned if neither case was met. 


### Testing 

*Describe the tests that you were used to verify your changes*.
* Checked that unit tests pass
* Tested live viewer with simulate live viewer utility script (`scripts/simulate_live_data.py`) with `.fits` files.

### Acceptance Criteria 

*Acceptance criteria for reviewer to tick off in order to verify your changes*.
- [x] `.fits` files can correctly be loaded and read by live viewer
  - [x] Verify that opening a pre-existing dataset in the live viewer that uses `.fits` still works as it did on main
  - [x] Verify using the `scripts/simulate_live_data.py` script that the live viewer loads in `.fits` files as they arrive in a selected folder


### Documentation

*How have you changed the documentation to reflect your changes? All changes should be noted in the appropriate file in docs/release_notes*

N/A not needed.
