### PR TITLE
Added stack properties dialog in the Main Window

### DIFF
--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -222,4 +222,6 @@ def _get_stack_data_type(stack_id: uuid.UUID, dataset: Dataset) -> str:
         return "Dark Before"
     if dataset.dark_after is not None and stack_id == dataset.dark_after.id:
         return "Dark After"
+    if dataset.proj180deg is not None and stack_id == dataset.proj180deg.id:
+        return "180"
     raise RuntimeError(f"No stack with ID {stack_id} found in dataset {dataset.id}")

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -57,6 +57,7 @@ class Notification(Enum):
     TAB_CLICKED = auto()
     SHOW_MOVE_STACK_DIALOG = auto()
     MOVE_STACK = auto()
+    SHOW_PROPERTIES_DIALOG = auto()
 
 
 class MainWindowPresenter(BasePresenter):
@@ -98,6 +99,8 @@ class MainWindowPresenter(BasePresenter):
                 self._show_move_stack_dialog(**baggage)
             elif signal == Notification.MOVE_STACK:
                 self._move_stack(**baggage)
+            elif signal == Notification.SHOW_PROPERTIES_DIALOG:
+                self._show_stack_properties_dialog(**baggage)
 
         except Exception as e:
             self.show_error(e, traceback.format_exc())
@@ -576,6 +579,14 @@ class MainWindowPresenter(BasePresenter):
             raise RuntimeError(f"Failed to find dataset with ID {dataset_id}")
         stack_data_type = _get_stack_data_type(stack_id, dataset)
         self.view.show_move_stack_dialog(dataset_id, stack_id, dataset.name, stack_data_type)
+
+    def _show_stack_properties_dialog(self, stack_id: uuid.UUID) -> None:
+        dataset_id = self.get_dataset_id_for_stack(stack_id)
+        dataset = self.get_dataset(dataset_id)
+        if dataset is None:
+            raise RuntimeError(f"Failed to find dataset with ID {dataset_id}")
+        stack_data_type = _get_stack_data_type(stack_id, dataset)
+        self.view.show_stack_properties_dialog(stack_id, dataset, stack_data_type)
 
     def handle_add_images_to_existing_dataset_from_dialog(self) -> None:
         """

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -40,6 +40,7 @@ from mantidimaging.gui.windows.settings.view import SettingsWindowView
 from mantidimaging.gui.windows.spectrum_viewer.view import SpectrumViewerWindowView
 from mantidimaging.gui.windows.live_viewer.view import LiveViewerWindowView
 from mantidimaging.gui.windows.stack_choice.compare_presenter import StackComparePresenter
+from mantidimaging.gui.windows.stack_properties_dialog.view import StackPropertiesDialog
 from mantidimaging.gui.windows.stack_visualiser import StackVisualiserView
 from mantidimaging.gui.windows.welcome_screen.presenter import WelcomeScreenPresenter
 from mantidimaging.gui.windows.wizard.presenter import WizardPresenter
@@ -660,6 +661,8 @@ class MainWindowView(BaseMainWindowView):
                 delete_action = self.menuTreeView.addAction("Delete")
                 delete_action.triggered.connect(self._delete_container)
             if self.dataset_tree_widget.itemAt(position).id in self.presenter.all_stack_ids:
+                properties_action = self.menuTreeView.addAction("Stack Properties")
+                properties_action.triggered.connect(self._stack_properties)
                 move_action = self.menuTreeView.addAction("Move Stack")
                 move_action.triggered.connect(self._move_stack)
 
@@ -682,6 +685,10 @@ class MainWindowView(BaseMainWindowView):
     def _move_stack(self) -> None:
         stack_id = self.dataset_tree_widget.selectedItems()[0].id
         self.presenter.notify(PresNotification.SHOW_MOVE_STACK_DIALOG, stack_id=stack_id)
+
+    def _stack_properties(self) -> None:
+        stack_id = self.dataset_tree_widget.selectedItems()[0].id
+        self.presenter.notify(PresNotification.SHOW_PROPERTIES_DIALOG, stack_id=stack_id)
 
     def _bring_stack_tab_to_front(self, item: QTreeDatasetWidgetItem) -> None:
         """
@@ -757,3 +764,9 @@ class MainWindowView(BaseMainWindowView):
         self.move_stack_dialog = MoveStackDialog(self, origin_dataset_id, stack_id, origin_dataset_name,
                                                  stack_data_type)
         self.move_stack_dialog.show()
+
+    def show_stack_properties_dialog(self, stack_id: uuid.UUID, origin_dataset: Dataset, stack_data_type: str) -> None:
+        stack = self.presenter.model.get_images_by_uuid(stack_id)
+        assert stack is not None
+        stack_properties_dialog = StackPropertiesDialog(self, stack, origin_dataset, stack_data_type)
+        stack_properties_dialog.show()

--- a/mantidimaging/gui/windows/stack_properties_dialog/__init__.py
+++ b/mantidimaging/gui/windows/stack_properties_dialog/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/stack_properties_dialog/presenter.py
+++ b/mantidimaging/gui/windows/stack_properties_dialog/presenter.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from mantidimaging.core.utility.size_calculator import full_size_MB
+from mantidimaging.gui.mvp_base import BasePresenter
+
+if TYPE_CHECKING:
+    from mantidimaging.gui.windows.stack_properties_dialog.view import StackPropertiesDialog
+
+
+class StackPropertiesPresenter(BasePresenter):
+
+    def __init__(self, view: StackPropertiesDialog):
+        super().__init__(view)
+
+    def set_stack_data(self) -> None:
+        if self.view.stack is not None:
+            self.view.stack_shape = self.view.stack.data.shape
+        self.view.stack_size_MB = self.get_stack_size_MB()
+
+    def set_stack_directory(self) -> None:
+        if self.view.stack.filenames is not None:
+            self.view.directory = Path(self.view.stack.filenames[0]).parent
+
+    def get_stack_size_MB(self) -> float:
+        return full_size_MB(self.view.stack.data.shape, self.view.stack.data.dtype)
+
+    def get_log_filename(self) -> str:
+        if 'log_file' in self.view.stack.metadata:
+            return self.view.stack.metadata['log_file']
+        else:
+            return "N/A"

--- a/mantidimaging/gui/windows/stack_properties_dialog/test/__init__.py
+++ b/mantidimaging/gui/windows/stack_properties_dialog/test/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/stack_properties_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_properties_dialog/test/presenter_test.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+
+from mantidimaging.gui.windows.stack_properties_dialog.presenter import StackPropertiesPresenter
+from mantidimaging.gui.windows.stack_properties_dialog.view import StackPropertiesDialog
+
+
+class StackPropertiesPresenterTest(unittest.TestCase):
+
+    def setUp(self):
+        self.view = mock.Mock(spec=StackPropertiesDialog)
+        self.view.parent_view = mock.Mock()
+        self.presenter = StackPropertiesPresenter(self.view)
+        self.view.datasetSelector = mock.Mock()
+        self.view.originDatasetName = mock.Mock()
+        self.view.destinationTypeComboBox = mock.Mock()
+        self.view.originDataType = mock.Mock()
+        self.view.stack = mock.Mock()
+
+    def test_WHEN_set_stack_data_THEN_stack_data_set_correctly(self):
+        self.view.stack.data = np.ones([3, 11, 12])
+        self.view.stack.filenames = ["test/filename/a.tif", "test/filename/b.tif", "test/filename/c.tif"]
+        self.presenter.get_stack_size_MB = mock.Mock()
+        self.presenter.get_stack_size_MB.return_value = 10
+        self.presenter.set_stack_data()
+        self.presenter.set_stack_directory()
+
+        self.assertEqual(self.view.directory, Path("test/filename/"))
+        self.assertEqual(self.view.stack_shape, (3, 11, 12))

--- a/mantidimaging/gui/windows/stack_properties_dialog/view.py
+++ b/mantidimaging/gui/windows/stack_properties_dialog/view.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from PyQt5.QtWidgets import QLabel, QGridLayout
+
+from mantidimaging.gui.mvp_base import BaseDialogView
+from mantidimaging.gui.windows.move_stack_dialog.presenter import Notification
+from mantidimaging.gui.windows.stack_properties_dialog.presenter import StackPropertiesPresenter
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
+    from mantidimaging.core.data.dataset import Dataset
+
+
+class StackPropertiesDialog(BaseDialogView):
+
+    stack: ImageStack
+
+    def __init__(self, parent, stack: ImageStack, origin_dataset: Dataset, origin_data_type: str):
+        super().__init__(parent)
+        self.parent_view = parent
+        self.origin_dataset = origin_dataset
+
+        self.presenter = StackPropertiesPresenter(self)
+
+        self.stack = stack
+
+        self.presenter.set_stack_data()
+        self.presenter.set_stack_directory()
+        self.log_filename = self.presenter.get_log_filename()
+
+        self.setWindowTitle(f"Stack Properties: {origin_dataset.name}")
+        self.layout = QGridLayout()
+        self.layout.addWidget(QLabel("Dataset Name: "), 1, 1)
+        self.layout.addWidget(QLabel("File Path: "), 2, 1)
+        self.layout.addWidget(QLabel("Data type: "), 3, 1)
+        self.layout.addWidget(QLabel("Memory size: "), 4, 1)
+        self.layout.addWidget(QLabel("Shape: "), 5, 1)
+        self.layout.addWidget(QLabel("Log file: "), 6, 1)
+
+        self.layout.addWidget(QLabel(f"{origin_dataset.name}"), 1, 2)
+        self.layout.addWidget(QLabel(f"{self.directory}"), 2, 2)
+        self.layout.addWidget(QLabel(f"{origin_data_type}"), 3, 2)
+        self.layout.addWidget(QLabel(f"{round(self.stack_size_MB, 4)} MB"), 4, 2)
+        self.layout.addWidget(QLabel(f"{self.stack_shape}"), 5, 2)
+        self.layout.addWidget(QLabel(f"{self.log_filename}"), 6, 2)
+
+        self.setLayout(self.layout)
+
+    def accept(self) -> None:
+        self.presenter.notify(Notification.ACCEPTED)
+        self.close()


### PR DESCRIPTION
### Issue

Closes #2368

### Description

Added a custom dialog window which can be accessed by right clicking a stack in the main window and clicking on "Stack properties". This gives information on the stack e.g, Dataset name, File Path, Data type, Memory size, Shape, Log file. More information can be added if needed. 

### Testing 

Make check

### Acceptance Criteria 

Load a dataset into MI and open the Stack Properties dialog window via the right click window. Check that all the information displayed is correct and that no errors occur

