### PR TITLE
Add warning for step size misalignment in save_rits_images

### DIFF
--- a/docs/release_notes/next/fix-2455-add-rits-error
+++ b/docs/release_notes/next/fix-2455-add-rits-error
@@ -1,0 +1,1 @@
+2455:Add warning for step size misalignment in save_rits_images

--- a/mantidimaging/gui/ui/spectrum_viewer.ui
+++ b/mantidimaging/gui/ui/spectrum_viewer.ui
@@ -117,7 +117,7 @@
              </property>
              <property name="minimumSize">
               <size>
-               <width>32</width>
+               <width>35</width>
                <height>32</height>
               </size>
              </property>
@@ -399,6 +399,31 @@
               <widget class="QPushButton" name="exportButtonRITS">
                <property name="text">
                 <string>Export to RITS</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="ritsWarningIcon">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>32</width>
+                 <height>32</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>32</width>
+                 <height>32</height>
+                </size>
+               </property>
+               <property name="text">
+                <string/>
                </property>
               </widget>
              </item>

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -402,7 +402,7 @@ class SpectrumViewerWindowModel:
                          bin_size: int,
                          step: int,
                          normalise: bool = False,
-                         progress: Progress | None = None) -> None:
+                         progress: Progress | None = None) -> None | str:
         """
         Saves multiple Region of Interest (ROI) images to RITS files.
 
@@ -422,13 +422,14 @@ class SpectrumViewerWindowModel:
         step (int): The step size to use when sliding the window across the ROI.
 
         Returns:
-        None
+        None | str: Returns a string with an error message if the step size does not evenly divide the ROI dimensions.
+        Otherwise, returns None.
         """
         roi = self._roi_ranges[ROI_RITS]
         left, top, right, bottom = roi
         if (right - left) % step != 0 or (bottom - top) % step != 0:
-            LOG.warning(f"Step size {step} does not evenly divide ROI dimensions "
-                        f"({right - left}x{bottom - top}). Some rows or columns may not be exported.")
+            return (f"Step size {step} does not evenly divide ROI dimensions "
+                    f"({right - left}x{bottom - top}). Some rows or columns may not be exported.")
 
         x_iterations = min(ceil((right - left) / step), ceil((right - left - bin_size) / step) + 1)
         y_iterations = min(ceil((bottom - top) / step), ceil((bottom - top - bin_size) / step) + 1)
@@ -449,6 +450,7 @@ class SpectrumViewerWindowModel:
                     break
             if sub_bottom == bottom:
                 break
+        return None
 
     def get_stack_time_of_flight(self) -> np.ndarray | None:
         if self._stack is None or self._stack.log_file is None:

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -426,6 +426,10 @@ class SpectrumViewerWindowModel:
         """
         roi = self._roi_ranges[ROI_RITS]
         left, top, right, bottom = roi
+        if (right - left) % step != 0 or (bottom - top) % step != 0:
+            LOG.warning(f"Step size {step} does not evenly divide ROI dimensions "
+                        f"({right - left}x{bottom - top}). Some rows or columns may not be exported.")
+
         x_iterations = min(ceil((right - left) / step), ceil((right - left - bin_size) / step) + 1)
         y_iterations = min(ceil((bottom - top) / step), ceil((bottom - top - bin_size) / step) + 1)
         progress = Progress.ensure_instance(progress, num_steps=x_iterations * y_iterations)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -296,6 +296,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
     def _async_save_done(self, task: TaskWorkerThread) -> None:
         if task.error is not None:
             self.view.show_error_dialog(f"Operation failed: {task.error}")
+        if task.result:
+            self.view.spectrum_widget.warning_triggered.emit(task.result)
 
     def handle_enable_normalised(self, enabled: bool) -> None:
         if enabled:

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -140,6 +140,7 @@ class SpectrumWidget(QWidget):
     roi_clicked = pyqtSignal(object)
     roi_changed = pyqtSignal()
     roiColorChangeRequested = pyqtSignal(str, tuple)
+    warning_triggered = pyqtSignal(str)
 
     spectrum_plot_widget: SpectrumPlotWidget
     image_widget: SpectrumProjectionWidget
@@ -148,7 +149,6 @@ class SpectrumWidget(QWidget):
         super().__init__()
 
         self.vbox = QVBoxLayout(self)
-
         self.image_widget = SpectrumProjectionWidget(main_window)
         self.image = self.image_widget.image
         self.spectrum_plot_widget = SpectrumPlotWidget()

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -89,6 +89,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.spectrum_widget.roi_clicked.connect(self.presenter.handle_roi_clicked)
         self.spectrum_widget.roi_changed.connect(self.presenter.handle_roi_moved)
         self.spectrum_widget.roiColorChangeRequested.connect(self.presenter.change_roi_colour)
+        self.spectrum_widget.warning_triggered.connect(self.display_warning)
 
         self.spectrum_right_click_menu = self.spectrum.spectrum_viewbox.menu
         self.units_menu = self.spectrum_right_click_menu.addMenu("Units")
@@ -236,6 +237,13 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.sampleStackSelector.unsubscribe_from_main_window()
         self.normaliseStackSelector.unsubscribe_from_main_window()
         self.main_window.spectrum_viewer = None
+
+    def display_warning(self, message: str) -> None:
+        """
+        Display the warning message in the GUI.
+        """
+        self.set_normalise_error(message)
+        self.display_normalise_error()
 
     def handle_change_tab(self, tab_index: int):
         self.imageTabs.setCurrentIndex(tab_index)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -67,6 +67,8 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         icon_path = finder.ROOT_PATH + "/gui/ui/images/exclamation-triangle-red.png"
         self.normalise_error_icon_pixmap = QPixmap(icon_path)
+        self.ritsWarningIcon.setPixmap(QPixmap())
+        self.ritsWarningIcon.setVisible(False)
 
         self.selected_row: int = 0
         self.last_clicked_roi = ""
@@ -240,10 +242,24 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
     def display_warning(self, message: str) -> None:
         """
-        Display the warning message in the GUI.
+        Display the warning message in the GUI for the appropriate icon.
         """
-        self.set_normalise_error(message)
-        self.display_normalise_error()
+        if "Step size" in message or "bin size" in message:
+            self.set_rits_warning(message)
+        else:
+            self.set_normalise_error(message)
+            self.display_normalise_error()
+
+    def set_rits_warning(self, message: str) -> None:
+        print("Setting RITS warning:", message)
+        if message:
+            self.ritsWarningIcon.setPixmap(self.normalise_error_icon_pixmap)
+            self.ritsWarningIcon.setToolTip(message)
+            self.ritsWarningIcon.setVisible(True)
+        else:
+            self.ritsWarningIcon.setPixmap(QPixmap())
+            self.ritsWarningIcon.setToolTip("")
+            self.ritsWarningIcon.setVisible(False)
 
     def handle_change_tab(self, tab_index: int):
         self.imageTabs.setCurrentIndex(tab_index)


### PR DESCRIPTION
### Issue

Closes #2455

### Description

Added a warning to save_rits_images to notify users when the step size does not evenly divide the ROI dimensions, specifying the unexported rows or columns.

### Acceptance Criteria 

Test with ROI dimensions and step sizes that cause misalignment.
Check for correct warning messages in logs.
Confirm the export completes as expected.

### Documentation

Added a note about this change in docs/release_notes.
