### PR TITLE
 Update Outdated Documentation Links in the Spectrum Viewer

### DIFF
--- a/docs/release_notes/next/fix-2463-quick-start-link
+++ b/docs/release_notes/next/fix-2463-quick-start-link
@@ -1,0 +1,1 @@
+2463: fix Quick Start Guide link

--- a/docs/user_guide/explanations/gui/spectrum_viewer.rst
+++ b/docs/user_guide/explanations/gui/spectrum_viewer.rst
@@ -6,7 +6,7 @@ The Spectrum Viewer is a tool for viewing the spectrum of each region of interes
 
 The spectrum viewer can be accessed from the main menu under "Workflow" > "Spectrum Viewer".
 
-To try out the spectrum viewer, you can find a basic example workflow to follow within `quick start <https://mantidproject.github.io/mantidimaging/user_guide/quick_start.html>`_
+To try out the spectrum viewer, you can find a basic example workflow to follow within `quick start <https://mantidproject.github.io/mantidimaging/user_guide/tutorials/quick_start.html>`_
 
 .. image:: ../../../_static/spectrum_viewer.png
     :alt: Spectrum Viewer ROI Mode


### PR DESCRIPTION
### Issue

Closes #2643

### Description

The outdated links in the "Spectrum Viewer" documentation have been updated to

"Quick Start" now points to docs/user_guide/tutorials/quick_start.rst.

### Acceptance Criteria 

Build the Sphinx documentation.
Confirm the updated links in the generated HTML point to the correct sections.

### Documentation

Changes noted in docs/release_notes 

