### PR TITLE
AttributeError when right clicking no items in Main Window TreeView

### DIFF
--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -653,8 +653,8 @@ class MainWindowView(BaseMainWindowView):
         self.menuTreeView = QMenu()
 
         if self.dataset_tree_widget.itemAt(position) is not None:
-            if (self.dataset_tree_widget.itemAt(position).id in self.presenter.all_stack_ids or
-                    self.dataset_tree_widget.itemAt(position).id in self.presenter.all_dataset_ids):
+            if (self.dataset_tree_widget.itemAt(position).id in self.presenter.all_stack_ids
+                    or self.dataset_tree_widget.itemAt(position).id in self.presenter.all_dataset_ids):
                 add_action = self.menuTreeView.addAction("Add / Replace Stack")
                 add_action.triggered.connect(self._add_images_to_existing_dataset)
                 delete_action = self.menuTreeView.addAction("Delete")

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -652,17 +652,18 @@ class MainWindowView(BaseMainWindowView):
         """
         self.menuTreeView = QMenu()
 
-        add_action = self.menuTreeView.addAction("Add / Replace Stack")
-        add_action.triggered.connect(self._add_images_to_existing_dataset)
+        if self.dataset_tree_widget.itemAt(position) is not None:
+            if (self.dataset_tree_widget.itemAt(position).id in self.presenter.all_stack_ids or
+                    self.dataset_tree_widget.itemAt(position).id in self.presenter.all_dataset_ids):
+                add_action = self.menuTreeView.addAction("Add / Replace Stack")
+                add_action.triggered.connect(self._add_images_to_existing_dataset)
+                delete_action = self.menuTreeView.addAction("Delete")
+                delete_action.triggered.connect(self._delete_container)
+            if self.dataset_tree_widget.itemAt(position).id in self.presenter.all_stack_ids:
+                move_action = self.menuTreeView.addAction("Move Stack")
+                move_action.triggered.connect(self._move_stack)
 
-        if self.dataset_tree_widget.itemAt(position).id in self.presenter.all_stack_ids:
-            move_action = self.menuTreeView.addAction("Move Stack")
-            move_action.triggered.connect(self._move_stack)
-
-        delete_action = self.menuTreeView.addAction("Delete")
-        delete_action.triggered.connect(self._delete_container)
-
-        self.menuTreeView.exec_(self.dataset_tree_widget.viewport().mapToGlobal(position))
+            self.menuTreeView.exec_(self.dataset_tree_widget.viewport().mapToGlobal(position))
 
     def _delete_container(self) -> None:
         """


### PR DESCRIPTION
### Issue

Close #2466

### Description

When checking where in the tree view is being right clicked, if a stack is being selected then it will add the relevant options. If no stack is selected, then no right click options are added, so nothing happens.

### Testing 

make check

### Acceptance Criteria 

Load dataset in MI, right click the Tree view on a stack and in the whitespace below to check that the right click menu behaves as expected and that no errors occur.
