### PR TITLE
TypeError handling in Live Viewer when moving slow FITS files

### DIFF
--- a/docs/release_notes/next/fix-2475-handle-slow-fits-file-errors
+++ b/docs/release_notes/next/fix-2475-handle-slow-fits-file-errors
@@ -1,0 +1,1 @@
+#2469: handle TypeError which is raised when attempting to read an incomplete FITS file

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -91,7 +91,7 @@ class LiveViewerWindowPresenter(BasePresenter):
         """
         try:
             image_data = self.load_image(image_path)
-        except (OSError, KeyError, ValueError, TiffFileError, DeflateError) as error:
+        except (OSError, KeyError, ValueError, TiffFileError, DeflateError, TypeError) as error:
             message = f"{type(error).__name__} reading image: {image_path}: {error}"
             logger.error(message)
             self.view.remove_image()


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2469

### Description

When loading an image inside `display_image`, we now include `TypeError` to catch the instance when the Live Viewer attempts to read a FITS file that has not completed moving to the LV path, leading to a TypeError raise from `astropy`.

### Developer Testing 

tests pass with `make check` and `make test-system`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `make check` and `make test-system`
- [ ] Open the LV and transfer FITS files to the path via `python simulate_live_data.py` using `--mode slow`
- [ ] Check that no error dialogs appear, even if errors and warnings appear in the terminal

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [ ] Release Notes have been updated

