### PR TITLE
Handle TypeError in Live Viewer due to slow FITS files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test-screenshots:
 
 test-screenshots-win:
 	-mkdir ${TEST_RESULT_DIR}
-	${XVFBRUN} pytest -p no:xdist -p no:randomly -p no:cov mantidimaging/eyes_tests/ -vs --run-eyes-tests
+	${XVFBRUN} pytest -p no:xdist -p no:randomly -p no:cov mantidimaging/eyes_tests/live_viewer_window_test.py -vs --run-eyes-tests
 	@echo "Screenshots writen to" ${TEST_RESULT_DIR}
 
 mypy:

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test-screenshots:
 
 test-screenshots-win:
 	-mkdir ${TEST_RESULT_DIR}
-	${XVFBRUN} pytest -p no:xdist -p no:randomly -p no:cov mantidimaging/eyes_tests/live_viewer_window_test.py -vs --run-eyes-tests
+	${XVFBRUN} pytest -p no:xdist -p no:randomly -p no:cov mantidimaging/eyes_tests/ -vs --run-eyes-tests
 	@echo "Screenshots writen to" ${TEST_RESULT_DIR}
 
 mypy:

--- a/mantidimaging/eyes_tests/live_viewer_window_test.py
+++ b/mantidimaging/eyes_tests/live_viewer_window_test.py
@@ -8,6 +8,7 @@ import numpy as np
 import os
 from mantidimaging.core.operations.loader import load_filter_packages
 from mantidimaging.gui.windows.live_viewer.model import Image_Data
+from mantidimaging.gui.windows.live_viewer.presenter import ImageLoadFailError
 from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
 from pathlib import Path
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
@@ -73,7 +74,7 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
     def test_live_view_opens_with_bad_data(self, _mock_time, _mock_image_watcher, mock_load_image):
         file_list = self._make_simple_dir(self.live_directory)
         image_list = [Image_Data(path) for path in file_list]
-        mock_load_image.side_effect = ValueError
+        mock_load_image.side_effect = ImageLoadFailError(file_list[0], source_error=ValueError)
         self.imaging.show_live_viewer(self.live_directory)
         self.imaging.live_viewer_list[-1].presenter.model._handle_image_changed_in_list(image_list)
         self.check_target(widget=self.imaging.live_viewer_list[-1])

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -54,12 +54,7 @@ class ImageCache:
         if image in self.cache_dict.keys():
             return self.cache_dict[image]
         else:
-            try:
-                image_array = self.loading_func(image.image_path)
-            except ValueError as error:
-                message = f"{type(error).__name__} reading image: {image.image_path}: {error}"
-                LOG.error(message)
-                raise ValueError from error
+            image_array = self.loading_func(image.image_path)
             self._add_to_cache(image, image_array)
             return image_array
 

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -127,7 +127,7 @@ class LiveViewerWindowPresenter(BasePresenter):
         """
         try:
             image_data = self.model.image_cache.load_image(image_data_obj)
-        except (OSError, KeyError, ValueError, TiffFileError, DeflateError) as error:
+        except (OSError, KeyError, ValueError, TiffFileError, DeflateError, TypeError) as error:
             message = f"{type(error).__name__} reading image: {image_data_obj.image_path}: {error}"
             logger.error(message)
             self.view.remove_image()

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -126,7 +126,7 @@ class LiveViewerWindowPresenter(BasePresenter):
         """
         try:
             image_data = self.model.image_cache.load_image(image_data_obj)
-        except (OSError, KeyError, ValueError, DeflateError) as error:
+        except (OSError, KeyError, ValueError, DeflateError, TypeError) as error:
             message = f"{type(error).__name__} reading image: {image_data_obj.image_path}: {error}"
             logger.error(message)
             self.view.remove_image()

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -7,11 +7,12 @@ from typing import TYPE_CHECKING
 from collections.abc import Callable
 from logging import getLogger
 import numpy as np
-import tifffile
 from PyQt5.QtCore import pyqtSignal, QObject, QThread, QTimer
 from astropy.io import fits
 
 from imagecodecs._deflate import DeflateError
+from tifffile import tifffile
+from tifffile.tifffile import TiffFileError
 
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.windows.live_viewer.model import LiveViewerWindowModel, Image_Data
@@ -101,7 +102,7 @@ class LiveViewerWindowPresenter(BasePresenter):
                 try:
                     image_data = self.model.image_cache.load_image(images_list[-1])
                     self.model.add_mean(images_list[-1], image_data)
-                except (OSError, KeyError, ValueError, DeflateError) as error:
+                except (OSError, KeyError, ValueError, TiffFileError, DeflateError) as error:
                     message = f"{type(error).__name__} reading image: {images_list[-1].image_path}: {error}"
                     logger.error(message)
             self.update_intensity(self.model.mean)
@@ -126,7 +127,7 @@ class LiveViewerWindowPresenter(BasePresenter):
         """
         try:
             image_data = self.model.image_cache.load_image(image_data_obj)
-        except (OSError, KeyError, ValueError, DeflateError, TypeError) as error:
+        except (OSError, KeyError, ValueError, TiffFileError, DeflateError) as error:
             message = f"{type(error).__name__} reading image: {image_data_obj.image_path}: {error}"
             logger.error(message)
             self.view.remove_image()

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -26,6 +26,20 @@ if TYPE_CHECKING:
 logger = getLogger(__name__)
 
 
+class ImageLoadFailError(Exception):
+    """
+    Exception raised when an image is not loaded correctly
+    """
+
+    def __init__(self, image_path: Path, source_error, message: str = '') -> None:
+        error_name = type(source_error).__name__
+        if message == '':
+            self.message = f"{error_name} :Could not load image f{image_path}, Exception: {source_error} "
+        else:
+            self.message = message
+        super().__init__(message)
+
+
 class Worker(QObject):
     finished = pyqtSignal()
 
@@ -102,9 +116,8 @@ class LiveViewerWindowPresenter(BasePresenter):
                 try:
                     image_data = self.model.image_cache.load_image(images_list[-1])
                     self.model.add_mean(images_list[-1], image_data)
-                except (OSError, KeyError, ValueError, TiffFileError, DeflateError) as error:
-                    message = f"{type(error).__name__} reading image: {images_list[-1].image_path}: {error}"
-                    logger.error(message)
+                except ImageLoadFailError as error:
+                    logger.error(error.message)
             self.update_intensity(self.model.mean)
             self.view.set_image_range((0, len(images_list) - 1))
             self.view.set_image_index(len(images_list) - 1)
@@ -127,11 +140,10 @@ class LiveViewerWindowPresenter(BasePresenter):
         """
         try:
             image_data = self.model.image_cache.load_image(image_data_obj)
-        except (OSError, KeyError, ValueError, TiffFileError, DeflateError, TypeError) as error:
-            message = f"{type(error).__name__} reading image: {image_data_obj.image_path}: {error}"
-            logger.error(message)
+        except ImageLoadFailError as error:
+            logger.error(error.message)
             self.view.remove_image()
-            self.view.live_viewer.show_error(message)
+            self.view.live_viewer.show_error(error.message)
             return
         image_data = self.perform_operations(image_data)
         if image_data.size == 0:
@@ -150,15 +162,23 @@ class LiveViewerWindowPresenter(BasePresenter):
         and returns as an ndarray
         """
         if image_path.suffix.lower() in [".tif", ".tiff"]:
-            with tifffile.TiffFile(image_path) as tif:
-                image_data = tif.asarray()
-            return image_data
+            try:
+                with tifffile.TiffFile(image_path) as tif:
+                    image_data = tif.asarray()
+                return image_data
+            except (OSError, KeyError, ValueError, TiffFileError, DeflateError) as err:
+                raise ImageLoadFailError(image_path, err) from err
         elif image_path.suffix.lower() == ".fits":
-            with fits.open(image_path) as fits_hdul:
-                image_data = fits_hdul[0].data
-            return image_data
+            try:
+                with fits.open(image_path) as fits_hdul:
+                    image_data = fits_hdul[0].data
+                return image_data
+            except (OSError, TypeError, ValueError) as err:
+                raise ImageLoadFailError(image_path, err) from err
         else:
-            raise ValueError(f"Unsupported file type: {image_path.suffix}")
+            raise ImageLoadFailError(image_path,
+                                     source_error=FileNotFoundError,
+                                     message=f"Unsupported file type: {image_path.suffix}")
 
     def update_image_modified(self, image_path: Path) -> None:
         """


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2469

### Description

When loading an image inside `display_image`, we now include `TypeError` to catch the instance when the Live Viewer attempts to read a FITS file that has not completed moving to the LV path, leading to a TypeError raise from `astropy`.

### Developer Testing 

tests pass with `make check` and `make test-system`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `make check` and `make test-system`
- [ ] Open the LV and transfer FITS files to the path via `python simulate_live_data.py` using `--mode slow`
- [ ] Check that no error dialogs appear, even if errors and warnings appear in the terminal

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [ ] Release Notes have been updated
