### PR TITLE
Make sure workflow jobs have unique ids

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  test-conda:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  docs:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/license_check.yaml
+++ b/.github/workflows/license_check.yaml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  license-check:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/rocky_testing.yml
+++ b/.github/workflows/rocky_testing.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  test-docker-rocky:
     # It is hosted on Ubuntu but the docker image is built on Rocky
     runs-on: ubuntu-latest
 

--- a/.github/workflows/u18_testing.yml
+++ b/.github/workflows/u18_testing.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  test-docker-ubuntu:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  test-windows:
     runs-on: windows-latest
     env:
       CONDA_OVERRIDE_CUDA: 11.8


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Might help with #2477

### Description

We currently have several workflows containing jobs with the id `test`

```
jobs:
  test:
```

https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_id says that job ids should be unqiue (though does not specify if this is per file or per project). This PR renames all the `test` to something more descriptive



### Developer Testing 

It is not possible to test locally.

### Acceptance Criteria and Reviewer Testing

It is not possible to test locally.

- [x] Check that the github actions have run as expected on the PR.
- [x] Review the Github workflow syntax document and check that the change is sensible


### Documentation and Additional Notes

Release notes not needed

When merging this PR. Check it the actions run on the merge queue. If so #2477 can be closed