### PR TITLE
Resolved issues with duplicate ROIs being created when switching sample

### DIFF
--- a/docs/release_notes/next/fix-2473-sample-swicth-error
+++ b/docs/release_notes/next/fix-2473-sample-swicth-error
@@ -1,0 +1,1 @@
+2473: Resolved issues with duplicate ROIs being created when switching sample

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -109,7 +109,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.model.set_stack(self.main_window.get_stack(uuid))
         self.model.set_tof_unit_mode_for_stack()
         self.reset_units_menu()
-
         self.handle_tof_unit_change()
         normalise_uuid = self.view.get_normalise_stack()
         if normalise_uuid is not None:
@@ -118,7 +117,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             except RuntimeError:
                 norm_stack = None
             self.model.set_normalise_stack(norm_stack)
-
         self.do_add_roi()
         self.add_rits_roi()
         self.view.set_normalise_error(self.model.normalise_issue())
@@ -383,12 +381,14 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         Remove a given ROI from the table by ROI name or all ROIs from
         the table if no name is passed as an argument
+
         @param roi_name: Name of the ROI to remove
         """
         if roi_name is None:
-            self.view.spectrum_widget.roi_dict.clear()
             for name in self.get_roi_names():
                 self.view.spectrum_widget.remove_roi(name)
+            self.view.spectrum_widget.roi_dict.clear()
+            self.view.roi_table_model.clear_table()
             self.model.remove_all_roi()
         else:
             self.view.spectrum_widget.remove_roi(roi_name)


### PR DESCRIPTION
Fix ROI management and synchronization in spectrum viewer

## Issue Closes #2473

### Description

- Resolved issues with duplicate ROIs being created when switching samples.
- Simplified and improved `do_remove_roi` to ensure proper removal of all ROIs or specific ROIs, keeping the table, model, and view in sync.

### Developer Testing 

- I have verified unit tests pass locally: `python -m pytest -vs`
- Manually tested ROI removal and addition during sample switching to confirm no duplicates or errors occur.
- Verified UI behavior when switching export modes (ROI_MODE and IMAGE_MODE).

### Acceptance Criteria and Reviewer Testing

- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Verify no duplicate ROIs are created when switching samples.
- [ ] Ensure no `KeyError` occurs during ROI visibility updates.
- [ ] Confirm that the ROI table and properties UI are updated properly when ROIs are added or removed.
- [ ] Verify correct behavior when switching between ROI and image export modes.

### Documentation and Additional Notes

- [ ] Release Notes have been updated to include fixes to ROI management issues.


