### PR TITLE
Display normalized values in spectrum viewer image view

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -130,6 +130,21 @@ class SpectrumViewerWindowModel:
     def set_normalise_stack(self, normalise_stack: ImageStack | None) -> None:
         self._normalise_stack = normalise_stack
 
+    def get_normalized_averaged_image(self) -> np.ndarray | None:
+        """
+        Get the normalized averaged image if both sample and normalization stacks are available.
+        """
+        if self._stack is None or self._normalise_stack is None:
+            return None
+
+        tof_slice = slice(self.tof_range[0], self.tof_range[1] + 1)
+        sample_data = self._stack.data[tof_slice].mean(axis=0)
+        norm_data = self._normalise_stack.data[tof_slice].mean(axis=0)
+        normalized_image = np.divide(sample_data, norm_data, out=np.zeros_like(sample_data), where=norm_data != 0)
+        shutter_correction = self.get_shuttercount_normalised_correction_parameter()
+        normalized_image /= shutter_correction
+        return normalized_image
+
     def get_averaged_image(self) -> np.ndarray | None:
         """
         Get the averaged image from the stack in the model returning as a numpy array

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -149,6 +149,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.set_shuttercount_error()
         if self.view.normalisation_enabled():
             self.redraw_all_rois()
+            self.update_displayed_image(autoLevels=True)
 
     def auto_find_flat_stack(self, new_dataset_id: UUID) -> None:
         if self.view.current_dataset_id != new_dataset_id:
@@ -164,14 +165,14 @@ class SpectrumViewerWindowPresenter(BasePresenter):
     def get_dataset_id_for_stack(self, stack_id: UUID | None) -> UUID | None:
         return None if stack_id is None else self.main_window.get_dataset_id_from_stack_uuid(stack_id)
 
-    def update_displayed_image(self) -> None:
+    def update_displayed_image(self, autoLevels: bool = True) -> None:
         """Fetches the correct image (normalized or not) and updates the display."""
         averaged_image = (self.model.get_normalized_averaged_image()
                           if self.view.normalisation_enabled() else self.model.get_averaged_image())
         if averaged_image is None:
             image_shape = self.model.get_image_shape()
             averaged_image = np.zeros(image_shape, dtype=np.float32)
-        self.view.set_image(averaged_image, autoLevels=False)
+        self.view.set_image(averaged_image, autoLevels=autoLevels)
 
     def show_new_sample(self) -> None:
         """
@@ -180,7 +181,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         averaged_image = self.model.get_averaged_image()
         assert averaged_image is not None
-        self.update_displayed_image()
+        self.update_displayed_image(autoLevels=True)
         self.view.spectrum_widget.spectrum_plot_widget.add_range(*self.model.tof_plot_range)
         self.view.spectrum_widget.spectrum_plot_widget.set_image_index_range_label(*self.model.tof_range)
         self.view.auto_range_image()
@@ -198,7 +199,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             self.model.tof_range = tuple(sorted((image_index_min, image_index_max)))
         self.view.spectrum_widget.spectrum_plot_widget.set_image_index_range_label(*self.model.tof_range)
         self.view.spectrum_widget.spectrum_plot_widget.set_tof_range_label(*self.model.tof_plot_range)
-        self.update_displayed_image()
+        self.update_displayed_image(autoLevels=False)
 
     def handle_roi_moved(self, force_new_spectrums: bool = False) -> None:
         """
@@ -311,7 +312,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             self.spectrum_mode = SpecType.SAMPLE
         self.redraw_all_rois()
         self.view.display_normalise_error()
-        self.update_displayed_image()
+        self.update_displayed_image(autoLevels=True)
 
     def set_shuttercount_error(self, enabled: bool = False) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -193,8 +193,11 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             self.model.tof_range = tuple(sorted((image_index_min, image_index_max)))
         self.view.spectrum_widget.spectrum_plot_widget.set_image_index_range_label(*self.model.tof_range)
         self.view.spectrum_widget.spectrum_plot_widget.set_tof_range_label(*self.model.tof_plot_range)
-        averaged_image = self.model.get_averaged_image()
-        assert averaged_image is not None
+        averaged_image = (self.model.get_normalized_averaged_image()
+                          if self.view.normalisation_enabled() else self.model.get_averaged_image())
+        if averaged_image is None:
+            image_shape = self.model.get_image_shape()
+            averaged_image = np.zeros(image_shape, dtype=np.float32)
         self.view.set_image(averaged_image, autoLevels=False)
 
     def handle_roi_moved(self, force_new_spectrums: bool = False) -> None:
@@ -308,6 +311,12 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             self.spectrum_mode = SpecType.SAMPLE
         self.redraw_all_rois()
         self.view.display_normalise_error()
+        averaged_image = (self.model.get_normalized_averaged_image()
+                          if self.view.normalisation_enabled() else self.model.get_averaged_image())
+        if averaged_image is None:
+            image_shape = self.model.get_image_shape()
+            averaged_image = np.zeros(image_shape, dtype=np.float32)
+        self.view.set_image(averaged_image)
 
     def set_shuttercount_error(self, enabled: bool = False) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -169,9 +169,12 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         Show the new sample in the view and update the spectrum and
         image view accordingly. Resets the ROIs.
         """
-
-        averaged_image = self.model.get_averaged_image()
+        if self.view.normalisation_enabled():
+            averaged_image = self.model.get_normalized_averaged_image()
+        else:
+            averaged_image = self.model.get_averaged_image()
         assert averaged_image is not None
+
         self.view.set_image(averaged_image)
         self.view.spectrum_widget.spectrum_plot_widget.add_range(*self.model.tof_plot_range)
         self.view.spectrum_widget.spectrum_plot_widget.set_image_index_range_label(*self.model.tof_range)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -179,6 +179,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view.normalise_ShutterCount_CheckBox.setEnabled.assert_called_once_with(False)
 
     def test_WHEN_show_sample_call_THEN_add_range_set(self):
+        self.presenter.view.normalisation_enabled.return_value = False
         self.presenter.model.set_stack(generate_images([10, 5, 5]))
         self.presenter.model.tof_plot_range = (0, 9)
         self.presenter.show_new_sample()


### PR DESCRIPTION
## Issue Closes #2456

### Description

- Updated spectrum viewer to display normalized values in the image view when normalization is enabled.
- Added `get_normalized_averaged_image()` to the model for normalized image data.
- Updated presenter to fetch and display the correct image based on normalization state.

### Developer Testing 

- Verified unit tests pass: `python -m pytest -vs`
- Tested normalized and non-normalized image rendering in the spectrum viewer.

### Acceptance Criteria

- [x] Unit tests pass: `python -m pytest -vs`
- [x] Normalized values display when normalization is enabled.
- [x] Non-normalized values display when normalization is disabled.
- [x] Edge cases (e.g., missing stacks) handled correctly.
