### PR TITLE
Live Viewer Intensity plotted correctly with slow/faulty files

### DIFF
--- a/docs/release_notes/next/fix-2497-LV-Intensity-slow-files
+++ b/docs/release_notes/next/fix-2497-LV-Intensity-slow-files
@@ -1,0 +1,1 @@
+#2497: Live Viewer Intensity now plots correctly with slow/faulty files

--- a/mantidimaging/core/utility/custom_exceptions.py
+++ b/mantidimaging/core/utility/custom_exceptions.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class ImageLoadFailError(Exception):
+    """
+    Exception raised when an image is not loaded correctly
+    """
+
+    def __init__(self, image_path: Path, source_error, message: str = '') -> None:
+        error_name = type(source_error).__name__
+        if message == '':
+            self.message = f"{error_name} :Could not load image f{image_path}, Exception: {source_error} "
+        else:
+            self.message = message
+        super().__init__(message)

--- a/mantidimaging/core/utility/custom_exceptions.py
+++ b/mantidimaging/core/utility/custom_exceptions.py
@@ -9,11 +9,21 @@ class ImageLoadFailError(Exception):
     """
     Exception raised when an image is not loaded correctly
     """
+    error_paths: dict[Path, list] = {}
 
     def __init__(self, image_path: Path, source_error, message: str = '') -> None:
-        error_name = type(source_error).__name__
+        self.error_name = type(source_error).__name__
+        self.image_path = image_path
         if message == '':
-            self.message = f"{error_name} :Could not load image f{image_path}, Exception: {source_error} "
+            self.message = f"{self.error_name} :Could not load image f{image_path}, Exception: {source_error} "
         else:
             self.message = message
+        if image_path in self.error_paths.keys():
+            self.error_paths[image_path].append(self.error_name)
+        else:
+            self.error_paths[image_path] = [self.error_name]
+
         super().__init__(message)
+
+    def is_logged(self):
+        return self.error_name in self.error_paths[self.image_path]

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -51,7 +51,7 @@ class ImageCache:
     def use_loading_function(self, func: typing.Callable) -> None:
         self.loading_func = func
 
-    def load_image(self, image: Image_Data) -> np.ndarray | None:
+    def load_image(self, image: Image_Data) -> np.ndarray:
         if image in self.cache_dict.keys():
             return self.cache_dict[image]
         else:

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -9,6 +9,7 @@ from logging import getLogger
 import numpy as np
 from PyQt5.QtCore import pyqtSignal, QObject, QThread, QTimer
 from astropy.io import fits
+from astropy.utils.exceptions import AstropyUserWarning
 
 from imagecodecs._deflate import DeflateError
 from tifffile import tifffile
@@ -160,7 +161,7 @@ class LiveViewerWindowPresenter(BasePresenter):
                 with fits.open(image_path) as fits_hdul:
                     image_data = fits_hdul[0].data
                 return image_data
-            except (OSError, TypeError, ValueError) as err:
+            except (OSError, TypeError, ValueError, AstropyUserWarning) as err:
                 raise ImageLoadFailError(image_path, err) from err
         else:
             raise ImageLoadFailError(image_path,

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -18,26 +18,13 @@ from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.windows.live_viewer.model import LiveViewerWindowModel, Image_Data
 from mantidimaging.core.operations.loader import load_filter_packages
 from mantidimaging.core.data import ImageStack
+from mantidimaging.core.utility.custom_exceptions import ImageLoadFailError
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.live_viewer.view import LiveViewerWindowView  # pragma: no cover
     from mantidimaging.gui.windows.main.view import MainWindowView  # pragma: no cover
 
 logger = getLogger(__name__)
-
-
-class ImageLoadFailError(Exception):
-    """
-    Exception raised when an image is not loaded correctly
-    """
-
-    def __init__(self, image_path: Path, source_error, message: str = '') -> None:
-        error_name = type(source_error).__name__
-        if message == '':
-            self.message = f"{error_name} :Could not load image f{image_path}, Exception: {source_error} "
-        else:
-            self.message = message
-        super().__init__(message)
 
 
 class Worker(QObject):

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -106,6 +106,7 @@ class LiveViewerWindowPresenter(BasePresenter):
                     self.model.add_mean(images_list[-1], image_data)
                 except ImageLoadFailError as error:
                     logger.error(error.message)
+                    self.model.add_mean(images_list[-1], None)
             self.update_intensity(self.model.mean)
             self.view.set_image_range((0, len(images_list) - 1))
             self.view.set_image_index(len(images_list) - 1)
@@ -233,7 +234,9 @@ class LiveViewerWindowPresenter(BasePresenter):
     def thread_cleanup(self) -> None:
         self.update_intensity_with_mean()
         self.set_roi_enabled(True)
-        self.try_next_mean_chunk()
+        if not self.model.mean_calc_finished:
+            self.try_next_mean_chunk()
+        self.model.mean_calc_finished = False
 
     def handle_notify_roi_moved(self) -> None:
         self.model.clear_mean_partial()

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -130,7 +130,8 @@ class LiveViewerWindowPresenter(BasePresenter):
         try:
             image_data = self.model.image_cache.load_image(image_data_obj)
         except ImageLoadFailError as error:
-            logger.error(error.message)
+            if not error.is_logged():
+                logger.error(error.message)
             self.view.remove_image()
             self.view.live_viewer.show_error(error.message)
             return

--- a/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
@@ -55,6 +55,10 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.roi_moving = True
         self.view.live_viewer = mock.Mock()
         self.view.intensity_profile = mock.Mock()
+        self.model.mean_readable = []
+        self.view.intensity_action = mock.Mock()
+        self.view.intensity_action.isChecked = mock.Mock()
+        self.view.intensity_action.isChecked.return_value = False
         with mock.patch.object(self.presenter, "handle_deleted"):
             self.presenter.update_image_list(image_list)
 

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -133,9 +133,10 @@ class LiveViewerWindowView(BaseMainWindowView):
             self.live_viewer.set_roi_visibility_flags(True)
             self.splitter.setSizes([int(0.7 * widget_height), int(0.3 * widget_height)])
             self.presenter.model.roi = self.live_viewer.get_roi()
-            self.presenter.model.mean = np.full(len(self.presenter.model.images), np.nan)
-            self.presenter.handle_roi_moved()
-            self.presenter.update_intensity(self.presenter.model.mean)
+            self.presenter.model.clear_mean_partial()
+            if self.presenter.model.images:
+                self.presenter.handle_roi_moved()
+                self.presenter.update_intensity(self.presenter.model.mean)
         else:
             self.live_viewer.set_roi_visibility_flags(False)
             self.splitter.setSizes([widget_height, 0])


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2487

### Description

The Live Viewer is now triggered to update images both when an image enters the directory (e.g. when an incomplete file is transferred) and when an image is modified (e.g. when the file has finished transferring). A custom exception class `ImageLoadFailError` is now used to catch errors involved when attempting to load a faulty file. Exception handling is used  to prevent the intensity from being calculated for an incomplete file, both when a file enters and when the ROI is moved.

### Developer Testing 

Both unit tests and system tests pass on both Windows and Linux

### Acceptance Criteria and Reviewer Testing

- [ ] Unit tests pass locally: `make check`, `make test-system`
- [ ] Open Live Viewer with the Intensity Plot activated.
- [ ] Run the simulator with slow mode and tiff files, e.g. `python scripts/simulate_live_data.py -s /data/imaging/tof/MCP_Fe_Calibration/Fe_Powder_Run1_PH60_Dis50mm_NewShutter/Corrected/ -d /tmp/live_test/ -r 1 --mode slow`
- [ ] Check that the intensity is being plotted as expected and no error dialog pops up
- [ ] Move the ROI with faulty files in the directory to check that the intensity plot ignores them and displays correctly

### Documentation and Additional Notes

 [ ] Release Notes have been updated
