### PR TITLE
Fix ROI movement not updating spectrum unless selected

### DIFF
--- a/docs/release_notes/next/fix-2486-spec-plot-update
+++ b/docs/release_notes/next/fix-2486-spec-plot-update
@@ -1,0 +1,1 @@
+2486: Fix ROI movement not updating spectrum unless selected

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -397,8 +397,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             self.view.roi_table_model.clear_table()
             self.model.remove_all_roi()
         else:
-            if roi_name not in self.view.spectrum_widget.roi_dict:
-                return
             self.view.spectrum_widget.remove_roi(roi_name)
 
     def handle_export_tab_change(self, index: int) -> None:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -391,12 +391,14 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         @param roi_name: Name of the ROI to remove
         """
         if roi_name is None:
-            for name in self.get_roi_names():
+            for name in list(self.get_roi_names()):
                 self.view.spectrum_widget.remove_roi(name)
             self.view.spectrum_widget.roi_dict.clear()
             self.view.roi_table_model.clear_table()
             self.model.remove_all_roi()
         else:
+            if roi_name not in self.view.spectrum_widget.roi_dict:
+                return
             self.view.spectrum_widget.remove_roi(roi_name)
 
     def handle_export_tab_change(self, index: int) -> None:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -201,19 +201,17 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.spectrum_widget.spectrum_plot_widget.set_tof_range_label(*self.model.tof_plot_range)
         self.update_displayed_image(autoLevels=False)
 
-    def handle_roi_moved(self, force_new_spectrums: bool = False) -> None:
+    def handle_roi_moved(self, roi: SpectrumROI) -> None:
         """
         Handle changes to any ROI position and size.
         """
-        for name in self.view.spectrum_widget.roi_dict:
-            current_roi = self.view.spectrum_widget.get_roi(name)
-            if force_new_spectrums:
-                spectrum = self.model.get_spectrum(
-                    current_roi,
-                    self.spectrum_mode,
-                    self.view.shuttercount_norm_enabled(),
-                )
-                self.view.set_spectrum(name, spectrum)
+        spectrum = self.model.get_spectrum(
+            roi.as_sensible_roi(),
+            self.spectrum_mode,
+            self.view.shuttercount_norm_enabled(),
+        )
+        self.view.set_spectrum(roi.name, spectrum)
+        self.view.spectrum_widget.spectrum.update()
 
     def handle_roi_clicked(self, roi: SpectrumROI) -> None:
         if not roi.name == ROI_RITS:

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -279,8 +279,7 @@ class SpectrumWidget(QWidget):
 
     def _emit_roi_changed(self):
         sender_roi = self.sender()
-        if sender_roi in self.roi_dict.values():
-            self.roi_changed.emit(sender_roi)
+        self.roi_changed.emit(sender_roi)
 
 
 class CustomViewBox(ViewBox):

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -211,9 +211,9 @@ class SpectrumWidget(QWidget):
         roi_object.colour = self.colour_generator()
         roi_object.sig_colour_change.connect(lambda name, color: self.roiColorChangeRequested.emit(name, color))
 
-        self.roi_dict[name] = roi_object.roi
+        self.roi_dict[name] = roi_object
         self.max_roi_size = roi_object.size()
-        self.roi_dict[name].sigRegionChangeFinished.connect(lambda: self.roi_changed.emit(self.roi_dict[name]))
+        self.roi_dict[name].sigRegionChangeFinished.connect(self._emit_roi_changed)
         self.roi_dict[name].sigClicked.connect(self.roi_clicked.emit)
         self.image.vb.addItem(self.roi_dict[name])
         self.roi_dict[name].hoverPen = mkPen(self.roi_dict[name].colour, width=3)
@@ -276,6 +276,11 @@ class SpectrumWidget(QWidget):
         self.roi_dict[new_name] = self.roi_dict.pop(old_name)
         self.spectrum_data_dict[new_name] = self.spectrum_data_dict.pop(old_name)
         self.roi_dict[new_name].rename_roi(new_name)
+
+    def _emit_roi_changed(self):
+        sender_roi = self.sender()
+        if sender_roi in self.roi_dict.values():
+            self.roi_changed.emit(sender_roi)
 
 
 class CustomViewBox(ViewBox):

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -138,7 +138,7 @@ class SpectrumWidget(QWidget):
 
     range_changed = pyqtSignal(object)
     roi_clicked = pyqtSignal(object)
-    roi_changed = pyqtSignal()
+    roi_changed = pyqtSignal(object)
     roiColorChangeRequested = pyqtSignal(str, tuple)
 
     spectrum_plot_widget: SpectrumPlotWidget
@@ -213,7 +213,7 @@ class SpectrumWidget(QWidget):
 
         self.roi_dict[name] = roi_object.roi
         self.max_roi_size = roi_object.size()
-        self.roi_dict[name].sigRegionChangeFinished.connect(self.roi_changed.emit)
+        self.roi_dict[name].sigRegionChangeFinished.connect(lambda: self.roi_changed.emit(self.roi_dict[name]))
         self.roi_dict[name].sigClicked.connect(self.roi_clicked.emit)
         self.image.vb.addItem(self.roi_dict[name])
         self.roi_dict[name].hoverPen = mkPen(self.roi_dict[name].colour, width=3)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -189,7 +189,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.spectrum.range_changed.connect(self.presenter.handle_range_slide_moved)
 
         self.spectrum_widget.roi_clicked.connect(self.presenter.handle_roi_clicked)
-        self.spectrum_widget.roi_changed.connect(self.presenter.handle_roi_moved)
+        self.spectrum_widget.roi_changed.connect(lambda roi: self.presenter.handle_roi_moved(roi))
         self.spectrum_widget.roiColorChangeRequested.connect(self.presenter.change_roi_colour)
 
         self.spectrum_right_click_menu = self.spectrum.spectrum_viewbox.menu

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -189,7 +189,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.spectrum.range_changed.connect(self.presenter.handle_range_slide_moved)
 
         self.spectrum_widget.roi_clicked.connect(self.presenter.handle_roi_clicked)
-        self.spectrum_widget.roi_changed.connect(lambda roi: self.presenter.handle_roi_moved(roi))
+        self.spectrum_widget.roi_changed.connect(self.presenter.handle_roi_moved)
         self.spectrum_widget.roiColorChangeRequested.connect(self.presenter.change_roi_colour)
 
         self.spectrum_right_click_menu = self.spectrum.spectrum_viewbox.menu
@@ -541,12 +541,13 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         """
         selected_row = self.roi_table_model.row_data(self.selected_row)
         roi_name = self.roi_table_model.get_element(self.selected_row, 0)
+        roi_object = self.spectrum_widget.roi_dict.pop(roi_name)
         if selected_row:
             self.roi_table_model.remove_row(self.selected_row)
             self.presenter.do_remove_roi(roi_name)
             self.spectrum_widget.spectrum_data_dict.pop(roi_name)
             self.spectrum_widget.spectrum.removeItem(roi_name)
-            self.presenter.handle_roi_moved()
+            self.presenter.handle_roi_moved(roi_object)
             self.selected_row = 0
             self.tableView.selectRow(0)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -541,9 +541,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         """
         selected_row = self.roi_table_model.row_data(self.selected_row)
         roi_name = self.roi_table_model.get_element(self.selected_row, 0)
-        roi_object = self.spectrum_widget.roi_dict.pop(roi_name, None)
-        if roi_object is None:
-            return
+        roi_object = self.spectrum_widget.roi_dict[roi_name]
         if selected_row:
             self.roi_table_model.remove_row(self.selected_row)
             self.presenter.do_remove_roi(roi_name)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -545,8 +545,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         if selected_row:
             self.roi_table_model.remove_row(self.selected_row)
             self.presenter.do_remove_roi(roi_name)
-            self.spectrum_widget.spectrum_data_dict.pop(roi_name, None)
-            self.spectrum_widget.spectrum.removeItem(roi_name)
+            self.spectrum_widget.spectrum_data_dict.pop(roi_name)
             self.presenter.handle_roi_moved(roi_object)
             self.selected_row = 0
             self.tableView.selectRow(0)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -541,16 +541,17 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         """
         selected_row = self.roi_table_model.row_data(self.selected_row)
         roi_name = self.roi_table_model.get_element(self.selected_row, 0)
-        roi_object = self.spectrum_widget.roi_dict.pop(roi_name)
+        roi_object = self.spectrum_widget.roi_dict.pop(roi_name, None)
+        if roi_object is None:
+            return
         if selected_row:
             self.roi_table_model.remove_row(self.selected_row)
             self.presenter.do_remove_roi(roi_name)
-            self.spectrum_widget.spectrum_data_dict.pop(roi_name)
+            self.spectrum_widget.spectrum_data_dict.pop(roi_name, None)
             self.spectrum_widget.spectrum.removeItem(roi_name)
             self.presenter.handle_roi_moved(roi_object)
             self.selected_row = 0
             self.tableView.selectRow(0)
-
         if self.roi_table_model.rowCount() == 0:
             self.removeBtn.setEnabled(False)
             self.disable_roi_properties()


### PR DESCRIPTION
## Issue Closes #2486

### Description

- Fixed an issue where moving an ROI did not update the spectrum plot unless the ROI was selected first.
- `roi_changed` signal now correctly emits the `SpectrumROI` object instead of an `ROI` or string.
- Updated `handle_roi_moved` to process only the moved ROI for efficiency.
- Ensured `remove_roi` correctly retrieves and passes the `SpectrumROI` object to the presenter.

### Developer Testing 

- I have verified unit tests pass locally: `python -m pytest -vs`
- Manually tested by:
  - Adding an ROI and moving it.
  - Checking that the spectrum updates immediately without needing selection.
  - Removing an ROI and verifying spectrum updates correctly.

### Acceptance Criteria and Reviewer Testing

- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Adding a new ROI updates the spectrum on resize.
- [ ] Moving an existing ROI updates the spectrum in real-time.
- [ ] Removing an ROI updates the spectrum correctly.

### Documentation and Additional Notes

