### PR TITLE
Live Viewer Intensity Plot recalculates when images modified

### DIFF
--- a/docs/release_notes/next/fix-2490-live-viewer-modified-intensity
+++ b/docs/release_notes/next/fix-2490-live-viewer-modified-intensity
@@ -1,0 +1,1 @@
+#2490: The Live Viewer Intensity plot now updates correctly when images are modified, i.e. deleted or multiple added files

--- a/mantidimaging/eyes_tests/live_viewer_window_test.py
+++ b/mantidimaging/eyes_tests/live_viewer_window_test.py
@@ -6,9 +6,12 @@ from typing import TYPE_CHECKING
 from unittest import mock
 import numpy as np
 import os
+
+from PyQt5.QtTest import QTest
+
 from mantidimaging.core.operations.loader import load_filter_packages
 from mantidimaging.gui.windows.live_viewer.model import Image_Data
-from mantidimaging.gui.windows.live_viewer.presenter import ImageLoadFailError
+from mantidimaging.gui.windows.live_viewer.presenter import ImageLoadFailError, IMAGE_lIST_UPDATE_TIME
 from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
 from pathlib import Path
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
@@ -66,6 +69,7 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
         mock_load_image.return_value = self._generate_image()
         self.imaging.show_live_viewer(self.live_directory)
         self.imaging.live_viewer_list[-1].presenter.model._handle_image_changed_in_list(image_list)
+        QTest.qWait(int(IMAGE_lIST_UPDATE_TIME * 1.5))
         self.check_target(widget=self.imaging.live_viewer_list[-1])
 
     @mock.patch('mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowPresenter.load_image_from_path')
@@ -88,5 +92,6 @@ class LiveViewerWindowTest(FakeFSTestCase, BaseEyesTest):
         mock_load_image.return_value = self._generate_image()
         self.imaging.show_live_viewer(self.live_directory)
         self.imaging.live_viewer_list[-1].presenter.model._handle_image_changed_in_list(image_list)
+        QTest.qWait(int(IMAGE_lIST_UPDATE_TIME * 1.5))
         self.imaging.live_viewer_list[-1].rotate_angles_group.actions()[1].trigger()
         self.check_target(widget=self.imaging.live_viewer_list[-1])

--- a/mantidimaging/gui/test/gui_system_liveviewer_test.py
+++ b/mantidimaging/gui/test/gui_system_liveviewer_test.py
@@ -37,6 +37,7 @@ class TestGuiLiveViewer(GuiSystemBase):
 
     def test_open_close_intensity_profile(self):
         self.assertEqual(self.live_viewer_window.splitter.sizes()[1], 0)
+        QTest.qWait(SHORT_DELAY * 4)
         self.live_viewer_window.intensity_action.trigger()
         QTest.qWait(SHORT_DELAY)
         QTest.qWait(SHOW_DELAY)
@@ -49,6 +50,7 @@ class TestGuiLiveViewer(GuiSystemBase):
         QTest.qWait(SHOW_DELAY)
 
     def test_roi_resized(self):
+        QTest.qWait(SHORT_DELAY * 4)
         self.live_viewer_window.intensity_action.trigger()
         QTest.qWait(SHORT_DELAY)
         wait_until(lambda: not np.isnan(self.live_viewer_window.presenter.model.mean).any(), max_retry=600)

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -179,11 +179,11 @@ class LiveViewerWindowModel:
         :param image_files: list of image files
         """
         self.images = image_files
-        self.presenter.update_image_list(self.images)
+        self.presenter.notify_update_image_list()
 
     def handle_image_modified(self, image_path: Path) -> None:
         self.presenter.update_image_modified(image_path)
-        self.presenter.update_image_list(self.images)
+        self.presenter.notify_update_image_list()
 
     def close(self) -> None:
         """Close the model."""

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -183,7 +183,6 @@ class LiveViewerWindowModel:
 
     def handle_image_modified(self, image_path: Path) -> None:
         self.presenter.update_image_modified(image_path)
-        self.presenter.notify_update_image_list()
 
     def close(self) -> None:
         """Close the model."""
@@ -192,7 +191,7 @@ class LiveViewerWindowModel:
             self.image_watcher = None
         self.presenter = None  # type: ignore # Model instance to be destroyed -type can be inconsistent
 
-    def add_mean(self, image_data_obj: Image_Data, image_array: np.ndarray | None) -> None:
+    def add_mean(self, image_path: Path, image_array: np.ndarray | None) -> None:
         if image_array is None:
             mean_to_add = np.nan
             mean_readable = 0
@@ -203,9 +202,12 @@ class LiveViewerWindowModel:
         else:
             mean_to_add = np.mean(image_array)
             mean_readable = 1
-        self.mean_paths[image_data_obj.image_path] = (mean_to_add, mean_readable)
-        self.mean = np.array(list(dict(sorted(self.mean_paths.items())).values()))[:, 0]
-        self.mean_readable = np.array(list(dict(sorted(self.mean_paths.items())).values()))[:, 1]
+        self.update_mean_dict(image_path, mean_to_add, mean_readable)
+
+    def update_mean_dict(self, image_path: Path, mean_to_add: float, mean_readable: int) -> None:
+        self.mean_paths[image_path] = (mean_to_add, mean_readable)
+        self.mean = np.array(list(self.mean_paths.values()))[:, 0]
+        self.mean_readable = np.array(list(self.mean_paths.values()))[:, 1]
 
     def clear_mean_partial(self) -> None:
         self.mean_paths = dict.fromkeys(self.mean_paths, (np.nan, 1))

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
 
 logger = getLogger(__name__)
 
+IMAGE_lIST_UPDATE_TIME = 100
+
 
 class Worker(QObject):
     finished = pyqtSignal()
@@ -128,7 +130,7 @@ class LiveViewerWindowPresenter(BasePresenter):
             self.view.set_load_as_dataset_enabled(True)
 
     def notify_update_image_list(self) -> None:
-        self.update_image_list_timer.start(100)
+        self.update_image_list_timer.start(IMAGE_lIST_UPDATE_TIME)
 
     def select_image(self, index: int) -> None:
         if not self.model.images:

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -67,6 +67,10 @@ class LiveViewerWindowPresenter(BasePresenter):
         self.handle_roi_change_timer.setSingleShot(True)
         self.handle_roi_change_timer.timeout.connect(self.handle_roi_moved)
 
+        self.update_image_list_timer = QTimer()
+        self.update_image_list_timer.setSingleShot(True)
+        self.update_image_list_timer.timeout.connect(self.update_image_list)
+
         self.model.image_cache.use_loading_function(self.load_image_from_path)
 
     def close(self) -> None:
@@ -91,11 +95,14 @@ class LiveViewerWindowPresenter(BasePresenter):
         self.view.live_viewer.z_slider.set_range(0, 1)
         self.view.live_viewer.show_error(None)
 
-    def update_image_list(self, images_list: list[Image_Data]) -> None:
+    def update_image_list(self) -> None:
         """Update the image in the view."""
+        images_list = self.model.images
         if not images_list:
             self.handle_deleted()
             self.view.set_load_as_dataset_enabled(False)
+            self.model.clear_mean_partial()
+            self.update_intensity_with_mean()
         else:
             if self.view.intensity_action.isChecked():
                 if not self.view.live_viewer.roi_object:
@@ -120,6 +127,8 @@ class LiveViewerWindowPresenter(BasePresenter):
             self.view.set_image_index(len(images_list) - 1)
             self.view.set_load_as_dataset_enabled(True)
 
+    def notify_update_image_list(self) -> None:
+        self.update_image_list_timer.start(100)
 
     def select_image(self, index: int) -> None:
         if not self.model.images:

--- a/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
@@ -52,6 +52,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.model.mean = []
         self.model.image_cache = mock.Mock()
         self.model.add_mean = mock.Mock()
+        self.model.images = image_list
         self.presenter.roi_moving = True
         self.view.live_viewer = mock.Mock()
         self.view.intensity_profile = mock.Mock()
@@ -60,7 +61,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.view.intensity_action.isChecked = mock.Mock()
         self.view.intensity_action.isChecked.return_value = False
         with mock.patch.object(self.presenter, "handle_deleted"):
-            self.presenter.update_image_list(image_list)
+            self.presenter.update_image_list()
 
         self.view.set_load_as_dataset_enabled.assert_called_once_with(action_enabled)
 


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2490

### Description

The Live Viewer now keeps track of the Updated Image List and compares it to the new Image List when changes are made in the directory. This allows the LV to detect if more than one image has appeared at a time, or if any number of images have been deleted and recalculate the mean if this has happened. The `update_image_list()` method in the `presenter` is now put on a QTimer as when a large number of images are deleted or changed, it can take long enough that `update_image_list()` could be triggered multiple times in short succession which lead to peoples with the QThreads.

### Developer Testing 

`make check`
`make test-system`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Open the LV with some images in the directory
- [ ] Add and delete images of various quantities in the directory and check that the Intensity Plot updates accordingly.

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [ ] Release Notes have been updated


