### PR TITLE
2378 Part One: A New ROI Properties Table Class

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumROI
     from mantidimaging.core.data import ImageStack
     from uuid import UUID
-    from PyQt5.QtWidgets import QAction, QSpinBox
+    from PyQt5.QtWidgets import QAction
 
 LOG = getLogger(__name__)
 
@@ -438,7 +438,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                     self.check_action(action, False)
 
     def do_adjust_roi(self) -> None:
-        new_roi = self.convert_spinbox_roi_to_SensibleROI(self.view.roiPropertiesSpinBoxes)
+        new_roi = self.view.roi_properties_widget.as_roi()
         self.view.spectrum_widget.adjust_roi(new_roi, self.view.current_roi_name)
 
     def handle_storing_current_roi_name_on_tab_change(self) -> None:
@@ -458,8 +458,3 @@ class SpectrumViewerWindowPresenter(BasePresenter):
     @staticmethod
     def check_action(action: QAction, param: bool) -> None:
         action.setChecked(param)
-
-    def convert_spinbox_roi_to_SensibleROI(self, spinboxes: dict[str, QSpinBox]) -> SensibleROI:
-        roi_iter_order = ["Left", "Top", "Right", "Bottom"]
-        new_points = [spinboxes[prop].value() for prop in roi_iter_order]
-        return SensibleROI.from_list(new_points)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -185,7 +185,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.spectrum_widget.spectrum_plot_widget.add_range(*self.model.tof_plot_range)
         self.view.spectrum_widget.spectrum_plot_widget.set_image_index_range_label(*self.model.tof_range)
         self.view.auto_range_image()
-        if self.view.get_roi_properties_spinboxes():
+        if self.view.roi_properties_widget.roiPropertiesSpinBoxes:
             self.view.set_roi_properties()
 
     def handle_range_slide_moved(self, tof_range: tuple[float, float] | tuple[int, int]) -> None:

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -394,8 +394,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.check_action.assert_has_calls(calls)
 
     def test_WHEN_roi_changed_via_spinboxes_THEN_roi_adjusted(self):
-        self.presenter.view.roiPropertiesSpinBoxes = mock.Mock()
-        self.presenter.convert_spinbox_roi_to_SensibleROI = mock.Mock(return_value=SensibleROI(10, 10, 20, 30))
+        self.view.roi_properties_widget.as_roi = mock.Mock(return_value=SensibleROI(10, 10, 20, 30))
         self.view.current_roi_name = "roi_1"
         self.presenter.do_adjust_roi()
         self.view.spectrum_widget.adjust_roi.assert_called_once_with(SensibleROI(10, 10, 20, 30), "roi_1")

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from unittest import mock
 
 import numpy as np
-from PyQt5.QtWidgets import QPushButton, QActionGroup, QGroupBox, QAction, QCheckBox, QTabWidget
+from PyQt5.QtWidgets import QPushButton, QActionGroup, QGroupBox, QAction, QCheckBox, QTabWidget, QWidget, QSpinBox
 from parameterized import parameterized
 
 from mantidimaging.core.data.dataset import Dataset
@@ -31,6 +31,13 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
             self.main_window = MainWindowView()
         self.view = mock.create_autospec(SpectrumViewerWindowView, instance=True)
         self.view.current_dataset_id = uuid.uuid4()
+        self.view.roi_properties_widget = mock.create_autospec(QWidget, instance=True)
+        self.view.roi_properties_widget.roiPropertiesSpinBoxes = {
+            "Top": mock.create_autospec(QSpinBox, instance=True),
+            "Bottom": mock.create_autospec(QSpinBox, instance=True),
+            "Left": mock.create_autospec(QSpinBox, instance=True),
+            "Right": mock.create_autospec(QSpinBox, instance=True)
+        }
         mock_spectrum_roi_dict = mock.create_autospec(dict, instance=True)
         self.view.spectrum_widget = mock.create_autospec(SpectrumWidget, roi_dict=mock_spectrum_roi_dict, instance=True)
         self.view.spectrum_widget.spectrum_plot_widget = mock.create_autospec(SpectrumPlotWidget,

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -34,15 +34,20 @@ class ROIPropertiesTableWidget(QWidget):
     the ROI properties table widget to its own class.
     """
 
+    roiPropertiesTableWidget: QTableWidget
+    roiPropertiesGroupBox: QGroupBox
+    roiPropertiesSpinBoxes: dict[str, QSpinBox]
+    roiPropertiesLabels: dict[str, QLabel]
+
     def __init__(self, parent=None, roiPropertiesTableWidget=QTableWidget, roiPropertiesGroupBox=QGroupBox):
         super().__init__(parent)
         self.roi_table_properties = ["Top", "Bottom", "Left", "Right"]
         self.roi_table_properties_secondary = ["Width", "Height"]
 
-        self.roiPropertiesTableWidget: QTableWidget = roiPropertiesTableWidget
-        self.roiPropertiesGroupBox: QGroupBox = roiPropertiesGroupBox
-        self.roiPropertiesSpinBoxes: dict[str, QSpinBox] = {}
-        self.roiPropertiesLabels: dict[str, QLabel] = {}
+        self.roiPropertiesTableWidget = roiPropertiesTableWidget
+        self.roiPropertiesGroupBox = roiPropertiesGroupBox
+        self.roiPropertiesSpinBoxes = {}
+        self.roiPropertiesLabels = {}
         self.initialize_roi_properties()
         self.initialize_roi_properties_labels()
 

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -49,9 +49,6 @@ class ROIPropertiesTableWidget(QWidget):
         self.roiPropertiesSpinBoxes = {}
         self.roiPropertiesLabels = {}
         self.initialize_roi_properties()
-        self.initialize_roi_properties_labels()
-
-        self.initialise_roi_properties_table()
 
     def initialize_roi_properties(self) -> None:
         self.roiPropertiesSpinBoxes["Left"] = QSpinBox()
@@ -59,23 +56,22 @@ class ROIPropertiesTableWidget(QWidget):
         self.roiPropertiesSpinBoxes["Top"] = QSpinBox()
         self.roiPropertiesSpinBoxes["Bottom"] = QSpinBox()
 
-    def initialize_roi_properties_labels(self) -> None:
+        # set up the labels
         self.roiPropertiesLabels["Width"] = QLabel()
         self.roiPropertiesLabels["Height"] = QLabel()
 
-    def set_roi_spinbox_ranges(self) -> None:
+        # set spinbox ranges
         self.roiPropertiesSpinBoxes["Left"].setMaximum(self.roiPropertiesSpinBoxes["Right"].value() - 1)
         self.roiPropertiesSpinBoxes["Right"].setMinimum(self.roiPropertiesSpinBoxes["Left"].value() + 1)
         self.roiPropertiesSpinBoxes["Top"].setMaximum(self.roiPropertiesSpinBoxes["Bottom"].value() - 1)
         self.roiPropertiesSpinBoxes["Bottom"].setMinimum(self.roiPropertiesSpinBoxes["Top"].value() + 1)
 
-    def initialise_roi_properties_table(self) -> None:
+        # set up table
         self.roiPropertiesTableWidget.setColumnCount(3)
         self.roiPropertiesTableWidget.setRowCount(3)
         self.roiPropertiesTableWidget.setColumnWidth(0, 80)
         self.roiPropertiesTableWidget.setColumnWidth(1, 50)
         self.roiPropertiesTableWidget.setColumnWidth(2, 50)
-
         self.roiPropertiesTableWidget.horizontalHeader().hide()
         self.roiPropertiesTableWidget.verticalHeader().hide()
         self.roiPropertiesTableWidget.setShowGrid(False)
@@ -605,7 +601,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         for row, pos in enumerate(current_roi):
             with QSignalBlocker(self.roi_properties_widget.roiPropertiesSpinBoxes[roi_iter_order[row]]):
                 self.roi_properties_widget.roiPropertiesSpinBoxes[roi_iter_order[row]].setValue(pos)
-        self.roi_properties_widget.set_roi_spinbox_ranges()
         self.presenter.redraw_spectrum(self.current_roi_name)
         self.roi_properties_widget.roiPropertiesLabels["Width"].setText(str(current_roi.width))
         self.roi_properties_widget.roiPropertiesLabels["Height"].setText(str(current_roi.height))

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -12,6 +12,7 @@ from PyQt5.QtWidgets import QCheckBox, QVBoxLayout, QFileDialog, QPushButton, QL
 from PyQt5.QtCore import QSignalBlocker, Qt, QModelIndex
 
 from mantidimaging.core.utility import finder
+from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
 from .model import ROI_RITS, allowed_modes
@@ -117,6 +118,11 @@ class ROIPropertiesTableWidget(QWidget):
                 spinbox.setDisabled(True)
         for _, label in self.roiPropertiesLabels.items():
             label.setText("0")
+
+    def as_roi(self):
+        roi_iter_order = ["Left", "Top", "Right", "Bottom"]
+        new_points = [self.roiPropertiesSpinBoxes[prop].value() for prop in roi_iter_order]
+        return SensibleROI.from_list(new_points)
 
 
 class SpectrumViewerWindowView(BaseMainWindowView):


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Contributes to: #2378 

### Description

<!-- Add a description of the changes made. -->
The proposed changes moves the ROI Table Properties out of `SpectrumViewerWindowView` and into the class: `ROIPropertiesTableWidget` in preparation for extracting the related `xml` GUI code out of `spectrum_viewer.ui` and into `mantidimaging/gui/widgets/spectrum_widgets/ROIFORMWidget.ui` and `ROIPropertiesTableWidget` into `mantidimaging/gui/widgets/spectrum_widgets/ROIFORMWidget.py` 

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- I have manually tested the Spectrum Viewer ROI properties remain up to date when:
  - Creating new ROIs
  - Renaming ROIs
  - Removing ROIs
  - Selecting an ROI with the intention to rename, then selecting another ROI
  - Swapping tabs between ROI and Image tabs
  - Toggling ROI visibility for various ROIs
  - Toggling ROI visibility and swapping between Image and ROI tab views.

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] ROI Properties table values always display the selected ROI
- [x] The Selected ROI can only be a visible ROI
- [x] No change in functional behaviour is introduced when compared to main branch.

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

Release notes are not needed as they will be added as part of the final PR completing the work described by #2378 

GUI change due to chance bug fix. Correct width and height now shown in screenshot
- [x] Screenshot tests have been updated
  - [x] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info)
