### PR TITLE
2378 Part Two: The ROI Table Strikes Back ...Into A Class

### DIFF
--- a/mantidimaging/gui/test/gui_system_spectrum_test.py
+++ b/mantidimaging/gui/test/gui_system_spectrum_test.py
@@ -40,36 +40,36 @@ class TestGuiSpectrumViewer(GuiSystemBase):
     def test_spectrum_window_opens_with_data_in_default_state(self) -> None:
         self.assertFalse(self.spectrum_window.normaliseCheckBox.isChecked())
         self.assertFalse(self.spectrum_window.normalise_ShutterCount_CheckBox.isEnabled())
-        self.assertEqual(self.spectrum_window.roi_table_model.rowCount(), 1)
-        self.assertEqual(self.spectrum_window.roi_table_model.columnCount(), 3)
+        self.assertEqual(self.spectrum_window.table_view.roi_table_model.rowCount(), 1)
+        self.assertEqual(self.spectrum_window.table_view.roi_table_model.columnCount(), 3)
         self.assertTrue(self.spectrum_window.addBtn.isEnabled())
         self.assertTrue(self.spectrum_window.removeBtn.isEnabled())
         self.assertTrue(self.spectrum_window.exportButton.isEnabled())
-        self.assertIn('roi', self.spectrum_window.roi_table_model.roi_names())
+        self.assertIn('roi', self.spectrum_window.table_view.roi_table_model.roi_names())
         self.assertIn('roi', self.spectrum_window.spectrum_widget.roi_dict)
         QTest.qWait(SHOW_DELAY)
 
     def test_add_roi(self) -> None:
         for i in range(1, 4):
-            initial_roi_count = self.spectrum_window.roi_table_model.rowCount()
+            initial_roi_count = self.spectrum_window.table_view.roi_table_model.rowCount()
             QTest.mouseClick(self.spectrum_window.addBtn, Qt.MouseButton.LeftButton)
             QTest.qWait(SHORT_DELAY)
-            final_roi_count = self.spectrum_window.roi_table_model.rowCount()
+            final_roi_count = self.spectrum_window.table_view.roi_table_model.rowCount()
             self.assertEqual(final_roi_count, initial_roi_count + 1)
-            self.assertIn(f'roi_{i}', self.spectrum_window.roi_table_model.roi_names())
+            self.assertIn(f'roi_{i}', self.spectrum_window.table_view.roi_table_model.roi_names())
             self.assertIn(f'roi_{i}', self.spectrum_window.spectrum_widget.roi_dict)
 
     def test_remove_roi(self) -> None:
         QTest.mouseClick(self.spectrum_window.addBtn, Qt.MouseButton.LeftButton)
         QTest.qWait(SHORT_DELAY)
-        initial_roi_count = self.spectrum_window.roi_table_model.rowCount()
+        initial_roi_count = self.spectrum_window.table_view.roi_table_model.rowCount()
 
         QTest.mouseClick(self.spectrum_window.removeBtn, Qt.MouseButton.LeftButton)
         QTest.qWait(SHORT_DELAY)
-        final_roi_count = self.spectrum_window.roi_table_model.rowCount()
+        final_roi_count = self.spectrum_window.table_view.roi_table_model.rowCount()
 
         self.assertEqual(final_roi_count, initial_roi_count - 1)
-        self.assertNotIn(f'roi_{initial_roi_count - 1}', self.spectrum_window.roi_table_model.roi_names())
+        self.assertNotIn(f'roi_{initial_roi_count - 1}', self.spectrum_window.table_view.roi_table_model.roi_names())
         self.assertNotIn(f'roi_{initial_roi_count - 1}', self.spectrum_window.spectrum_widget.roi_dict)
 
     def test_change_roi_color(self):
@@ -96,7 +96,7 @@ class TestGuiSpectrumViewer(GuiSystemBase):
         old_name = 'roi_1'
         new_name = 'roi_renamed'
 
-        table_model = self.spectrum_window.roi_table_model
+        table_model = self.spectrum_window.table_view.roi_table_model
         row = table_model.roi_names().index(old_name)
 
         table_model.set_element(row, 0, new_name)

--- a/mantidimaging/gui/ui/spectrum_viewer.ui
+++ b/mantidimaging/gui/ui/spectrum_viewer.ui
@@ -238,7 +238,7 @@
                </property>
                <layout class="QVBoxLayout" name="verticalLayout_5">
                 <item>
-                 <widget class="RemovableRowTableView" name="roiTableView">
+                 <widget class="ROITableWidget" name="table_view">
                   <attribute name="horizontalHeaderHighlightSections">
                    <bool>true</bool>
                   </attribute>
@@ -545,9 +545,9 @@
    <header>mantidimaging.gui.widgets.dataset_selector</header>
   </customwidget>
   <customwidget>
-   <class>RemovableRowTableView</class>
+   <class>ROITableWidget</class>
    <extends>QTableView</extends>
-   <header>mantidimaging.gui.widgets</header>
+   <header>mantidimaging.gui.windows.spectrum_viewer.view</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/mantidimaging/gui/ui/spectrum_viewer.ui
+++ b/mantidimaging/gui/ui/spectrum_viewer.ui
@@ -238,7 +238,7 @@
                </property>
                <layout class="QVBoxLayout" name="verticalLayout_5">
                 <item>
-                 <widget class="RemovableRowTableView" name="tableView">
+                 <widget class="RemovableRowTableView" name="roiTableView">
                   <attribute name="horizontalHeaderHighlightSections">
                    <bool>true</bool>
                   </attribute>

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -215,8 +215,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def handle_roi_clicked(self, roi: SpectrumROI) -> None:
         if not roi.name == ROI_RITS:
-            self.view.current_roi_name = roi.name
-            self.view.last_clicked_roi = roi.name
+            self.view.table_view.current_roi_name = roi.name
+            self.view.table_view.last_clicked_roi = roi.name
             self.view.set_roi_properties()
 
     def redraw_spectrum(self, name: str) -> None:
@@ -352,7 +352,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         if roi_name in self.view.spectrum_widget.roi_dict:
             self.view.spectrum_widget.roi_dict[roi_name].colour = new_colour
-        self.view.update_roi_color(roi_name, new_colour)
+        self.view.table_view.update_roi_color(roi_name, new_colour)
         self.view.on_visibility_change()
 
     def add_rits_roi(self) -> None:
@@ -394,7 +394,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             for name in list(self.get_roi_names()):
                 self.view.spectrum_widget.remove_roi(name)
             self.view.spectrum_widget.roi_dict.clear()
-            self.view.roi_table_model.clear_table()
+            self.view.table_view.roi_table_model.clear_table()
             self.model.remove_all_roi()
         else:
             self.view.spectrum_widget.remove_roi(roi_name)
@@ -437,21 +437,21 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def do_adjust_roi(self) -> None:
         new_roi = self.view.roi_properties_widget.as_roi()
-        self.view.spectrum_widget.adjust_roi(new_roi, self.view.current_roi_name)
+        self.view.spectrum_widget.adjust_roi(new_roi, self.view.table_view.current_roi_name)
 
     def handle_storing_current_roi_name_on_tab_change(self) -> None:
-        old_table_names = self.view.old_table_names
-        old_current_roi_name = self.view.current_roi_name
-        old_last_clicked_roi = self.view.last_clicked_roi
+        old_table_names = self.view.table_view.old_table_names
+        old_current_roi_name = self.view.table_view.current_roi_name
+        old_last_clicked_roi = self.view.table_view.last_clicked_roi
         if self.export_mode == ExportMode.ROI_MODE:
             if old_current_roi_name == ROI_RITS and old_last_clicked_roi in old_table_names:
-                self.view.current_roi_name = old_last_clicked_roi
+                self.view.table_view.current_roi_name = old_last_clicked_roi
             else:
-                self.view.last_clicked_roi = old_current_roi_name
+                self.view.table_view.last_clicked_roi = old_current_roi_name
         elif self.export_mode == ExportMode.IMAGE_MODE:
             if (old_current_roi_name != ROI_RITS and old_current_roi_name in old_table_names
                     and old_last_clicked_roi != old_current_roi_name):
-                self.view.last_clicked_roi = old_current_roi_name
+                self.view.table_view.last_clicked_roi = old_current_roi_name
 
     @staticmethod
     def check_action(action: QAction, param: bool) -> None:

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -138,10 +138,6 @@ class ROITableWidget(RemovableRowTableView):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        if parent is not None:
-            layout = parent.layout()
-            if layout is not None:
-                layout.addWidget(self)
 
         self.old_table_names = []
         self.selected_row = 0
@@ -258,7 +254,7 @@ class ROITableWidget(RemovableRowTableView):
 
 
 class SpectrumViewerWindowView(BaseMainWindowView):
-    roiTableView: RemovableRowTableView
+    table_view: ROITableWidget
     sampleStackSelector: DatasetSelectorWidgetView
     normaliseStackSelector: DatasetSelectorWidgetView
 
@@ -306,7 +302,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
                                                               self.roiPropertiesGroupBox)
 
         self.old_table_names: list[str] = []
-        self.table_view = ROITableWidget(self.roiTableView)
 
         self.roiPropertiesSpinBoxes: dict[str, QSpinBox] = {}
         self.roiPropertiesLabels: dict[str, QLabel] = {}
@@ -653,7 +648,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             self.presenter.do_remove_roi(roi_name)
             self.spectrum_widget.spectrum_data_dict.pop(roi_name)
             self.presenter.handle_roi_moved(roi_object)
-            self.roiTableView.selectRow(0)
+            self.table_view.selectRow(0)
 
         if self.table_view.roi_table_model.rowCount() == 0:
             self.removeBtn.setEnabled(False)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -126,7 +126,7 @@ class ROIPropertiesTableWidget(QWidget):
 
 
 class SpectrumViewerWindowView(BaseMainWindowView):
-    tableView: RemovableRowTableView
+    roiTableView: RemovableRowTableView
     sampleStackSelector: DatasetSelectorWidgetView
     normaliseStackSelector: DatasetSelectorWidgetView
 
@@ -237,10 +237,10 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.exportButtonRITS.clicked.connect(self.presenter.handle_rits_export)
 
         # Point table
-        self.tableView.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.tableView.setSelectionMode(QAbstractItemView.SingleSelection)
-        self.tableView.setAlternatingRowColors(True)
-        self.tableView.clicked.connect(self.handle_table_click)
+        self.roiTableView.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.roiTableView.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.roiTableView.setAlternatingRowColors(True)
+        self.roiTableView.clicked.connect(self.handle_table_click)
 
         # Roi Prop table
         self.roi_table_properties = ["Top", "Bottom", "Left", "Right"]
@@ -270,7 +270,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             self.current_roi_name = self.roi_table_model.get_element(item.row(), 0)
             self.set_roi_properties()
 
-        self.tableView.selectionModel().currentRowChanged.connect(on_row_change)
+        self.roiTableView.selectionModel().currentRowChanged.connect(on_row_change)
 
         def on_data_in_table_change() -> None:
             """
@@ -298,7 +298,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             return
 
         self.roi_table_model.dataChanged.connect(on_data_in_table_change)
-        header = self.tableView.horizontalHeader()
+        header = self.roiTableView.horizontalHeader()
         header.setSectionResizeMode(0, QHeaderView.Stretch)
         header.setSectionResizeMode(1, QHeaderView.ResizeToContents)
         header.setSectionResizeMode(2, QHeaderView.ResizeToContents)
@@ -351,10 +351,10 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
     @property
     def roi_table_model(self) -> TableModel:
-        if self.tableView.model() is None:
+        if self.roiTableView.model() is None:
             mdl = TableModel()
-            self.tableView.setModel(mdl)
-        return self.tableView.model()
+            self.roiTableView.setModel(mdl)
+        return self.roiTableView.model()
 
     @property
     def current_dataset_id(self) -> UUID | None:
@@ -530,7 +530,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         """
         self.roi_table_model.appendNewRow(name, colour, True)
         self.selected_row = self.roi_table_model.rowCount() - 1
-        self.tableView.selectRow(self.selected_row)
+        self.roiTableView.selectRow(self.selected_row)
         self.current_roi_name = name
         self.removeBtn.setEnabled(True)
         self.set_old_table_names()
@@ -548,7 +548,8 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             self.spectrum_widget.spectrum_data_dict.pop(roi_name)
             self.presenter.handle_roi_moved(roi_object)
             self.selected_row = 0
-            self.tableView.selectRow(0)
+            self.roiTableView.selectRow(0)
+
         if self.roi_table_model.rowCount() == 0:
             self.removeBtn.setEnabled(False)
             self.disable_roi_properties()

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -125,6 +125,138 @@ class ROIPropertiesTableWidget(QWidget):
         return SensibleROI.from_list(new_points)
 
 
+class ROITableWidget(RemovableRowTableView):
+    """
+    A class to represent the ROI table widget in the spectrum viewer window.
+    """
+    ElementType = str | tuple[int, int, int] | bool
+    RowType = list[ElementType]
+    old_table_names: list[str]
+    selected_row: int
+    last_clicked_roi: str
+    current_roi_name: str
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        if parent is not None:
+            layout = parent.layout()
+            if layout is not None:
+                layout.addWidget(self)
+
+        self.old_table_names = []
+        self.selected_row = 0
+        self.last_clicked_roi = ""
+        self.current_roi_name = ""
+
+        # Point table
+        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.setAlternatingRowColors(True)
+
+        # Initialise model
+        mdl = TableModel()
+        self.setModel(mdl)
+        self._roi_table_model = mdl
+
+        # Configure up the table view
+        self.setVisible(True)
+        header = self.horizontalHeader()
+        header.setSectionResizeMode(0, QHeaderView.Stretch)
+        header.setSectionResizeMode(1, QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(2, QHeaderView.ResizeToContents)
+        if self._roi_table_model.rowCount() > 0:
+            self.current_roi_name = self.last_clicked_roi = self._roi_table_model.roi_names()[0]
+
+    @property
+    def roi_table_model(self) -> TableModel:
+        """The model for the ROI table"""
+        return self._roi_table_model
+
+    def get_roi_names(self) -> list[str]:
+        return self._roi_table_model.roi_names()
+
+    def get_row_data(self, row: int) -> RowType:
+        """
+        Get the data for a specific row in the ROI table.
+        """
+        name, data, visible = self._roi_table_model.row_data(row)
+        return [name, data, visible]
+
+    def get_roi_name_by_row(self, row: int) -> str:
+        """
+        Retrieve the name an ROI by its row index.
+        """
+        return self._roi_table_model.get_element(row, 0)
+
+    def get_roi_visibility_by_row(self, row: int) -> bool:
+        """
+        Retrieve the visibility status of an ROI by its row index.
+        """
+        return self._roi_table_model.get_element(row, 2)
+
+    def row_count(self) -> int:
+        """
+        Returns the number of rows in the ROI table model.
+        """
+        return self._roi_table_model.rowCount()
+
+    def find_row_for_roi(self, roi_name: str) -> int | None:
+        """
+        Returns row index for ROI name, or None if not found.
+        """
+        for row in range(self._roi_table_model.rowCount()):
+            if self._roi_table_model.index(row, 0).data() == roi_name:
+                return row
+        return None
+
+    def set_roi_name_by_row(self, row: int, name: str) -> None:
+        """
+        Set the name of the ROI for a given row in the ROI table.
+        """
+        self._roi_table_model.set_element(row, 0, name)
+
+    def set_old_table_names(self, old_table_names) -> None:
+        """
+        Updates the list of old table names by removing specific entries if they exist.
+        """
+        self.old_table_names = old_table_names
+        if 'all' in self.old_table_names:
+            self.old_table_names.remove('all')
+        if 'rits_roi' in self.old_table_names:
+            self.old_table_names.remove('rits_roi')
+
+    def update_roi_color(self, roi_name: str, new_color: tuple[int, int, int]) -> None:
+        """
+        Finds ROI by name in table and updates it's colour (R, G, B) format.
+        """
+        row = self.find_row_for_roi(roi_name)
+        if row is not None:
+            self._roi_table_model.update_color(row, new_color)
+
+    def add_row(self, name: str, colour: tuple[int, int, int], roi_names: list[str]) -> None:
+        """
+        Add a new row to the ROI table
+        """
+        self._roi_table_model.appendNewRow(name, colour, True)
+        self.selected_row = self._roi_table_model.rowCount() - 1
+        self.selectRow(self.selected_row)
+        self.current_roi_name = name
+        self.set_old_table_names(roi_names)
+
+    def remove_row(self, row: int) -> None:
+        """
+        Remove a row from the ROI table
+        """
+        self._roi_table_model.remove_row(row)
+        self.selectRow(0)
+
+    def clear_table(self) -> None:
+        """
+        Clears the ROI table in the spectrum viewer.
+        """
+        self._roi_table_model.clear_table()
+
+
 class SpectrumViewerWindowView(BaseMainWindowView):
     roiTableView: RemovableRowTableView
     sampleStackSelector: DatasetSelectorWidgetView
@@ -151,8 +283,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     roiPropertiesGroupBox: QGroupBox
     roi_properties_widget: ROIPropertiesTableWidget
 
-    last_clicked_roi: str
-
     spectrum_widget: SpectrumWidget
 
     number_roi_properties_procced: int = 0
@@ -176,6 +306,10 @@ class SpectrumViewerWindowView(BaseMainWindowView):
                                                               self.roiPropertiesGroupBox)
 
         self.old_table_names: list[str] = []
+        self.table_view = ROITableWidget(self.roiTableView)
+
+        self.roiPropertiesSpinBoxes: dict[str, QSpinBox] = {}
+        self.roiPropertiesLabels: dict[str, QLabel] = {}
 
         self.presenter = SpectrumViewerWindowPresenter(self, main_window)
 
@@ -236,11 +370,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.exportButton.clicked.connect(self.presenter.handle_export_csv)
         self.exportButtonRITS.clicked.connect(self.presenter.handle_rits_export)
 
-        # Point table
-        self.roiTableView.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.roiTableView.setSelectionMode(QAbstractItemView.SingleSelection)
-        self.roiTableView.setAlternatingRowColors(True)
-        self.roiTableView.clicked.connect(self.handle_table_click)
+        self.table_view.clicked.connect(self.handle_table_click)
 
         # Roi Prop table
         self.roi_table_properties = ["Top", "Bottom", "Left", "Right"]
@@ -251,8 +381,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         self.spectrum_widget.roi_changed.connect(self.set_roi_properties)
 
-        _ = self.roi_table_model  # Initialise model
-        self.current_roi_name = self.last_clicked_roi = self.roi_table_model.roi_names()[0]
+        self.current_roi_name = self.last_clicked_roi = self.table_view.roi_table_model.roi_names()[0]
         self.set_roi_properties()
 
         self.experimentSetupFormWidget = ExperimentSetupFormWidget(self.experimentSetupGroupBox)
@@ -266,11 +395,11 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
             @param item: item in table
             """
-            self.selected_row = item.row()
-            self.current_roi_name = self.roi_table_model.get_element(item.row(), 0)
+            self.table_view.selected_row = item.row()
+            self.table_view.current_roi_name = self.table_view.get_roi_name_by_row(item.row())
             self.set_roi_properties()
 
-        self.roiTableView.selectionModel().currentRowChanged.connect(on_row_change)
+        self.table_view.selectionModel().currentRowChanged.connect(on_row_change)
 
         def on_data_in_table_change() -> None:
             """
@@ -278,30 +407,33 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             If the ROI name has changed, update the ROI name in the spectrum widget.
             If the visibility of an ROI has changed, update the visibility of the ROI in the spectrum widget.
             """
-            entered_name = self.roi_table_model.get_element(self.selected_row, 0)
-            if entered_name.lower() not in ["", " ", "all"] and entered_name != self.current_roi_name:
+            entered_name = self.table_view.get_roi_name_by_row(self.table_view.selected_row).strip()
+            if not entered_name:
+                self.table_view.set_roi_name_by_row(self.table_view.selected_row, self.table_view.current_roi_name)
+                self.table_view.last_clicked_roi = self.table_view.current_roi_name
+                self.table_view.set_old_table_names(self.presenter.get_roi_names())
+                return
+            if entered_name.lower() not in ["", " ", "all"] and entered_name != self.table_view.current_roi_name:
                 if entered_name in self.presenter.get_roi_names():
-                    entered_name = self.old_table_names[self.selected_row]
-                    self.roi_table_model.set_element(self.selected_row, 0, self.old_table_names[self.selected_row])
-                    self.current_roi_name = entered_name
-                    self.last_clicked_roi = self.current_roi_name
+                    entered_name = self.table_view.old_table_names[self.table_view.selected_row]
+                    self.table_view.roi_table_model.set_element(
+                        self.table_view.selected_row, 0, self.table_view.old_table_names[self.table_view.selected_row])
+                    self.table_view.current_roi_name = entered_name
+                    self.table_view.last_clicked_roi = self.table_view.current_roi_name
                 else:
-                    self.presenter.rename_roi(self.current_roi_name, entered_name)
-                    self.current_roi_name = entered_name
-                    self.last_clicked_roi = self.current_roi_name
+                    self.presenter.rename_roi(self.table_view.current_roi_name, entered_name)
+                    self.table_view.current_roi_name = entered_name
+                    self.table_view.last_clicked_roi = self.table_view.current_roi_name
                     self.set_roi_properties()
             else:
-                self.roi_table_model.set_element(self.selected_row, 0, self.old_table_names[self.selected_row])
+                self.table_view.roi_table_model.set_element(
+                    self.table_view.selected_row, 0, self.table_view.old_table_names[self.table_view.selected_row])
 
-            self.set_old_table_names()
+            self.table_view.set_old_table_names(self.presenter.get_roi_names())
             self.on_visibility_change()
             return
 
-        self.roi_table_model.dataChanged.connect(on_data_in_table_change)
-        header = self.roiTableView.horizontalHeader()
-        header.setSectionResizeMode(0, QHeaderView.Stretch)
-        header.setSectionResizeMode(1, QHeaderView.ResizeToContents)
-        header.setSectionResizeMode(2, QHeaderView.ResizeToContents)
+        self.table_view.roi_table_model.dataChanged.connect(on_data_in_table_change)
 
         self.formTabs.currentChanged.connect(self.handle_change_tab)
 
@@ -323,38 +455,34 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         """
 
         self.presenter.handle_storing_current_roi_name_on_tab_change()
-
         if self.presenter.export_mode == ExportMode.ROI_MODE:
             self.set_roi_visibility_flags(ROI_RITS, visible=False)
 
-            if self.roi_table_model.rowCount() == 0:
+            if self.table_view.row_count() == 0:
                 self.disable_roi_properties()
             else:
                 self.set_roi_properties()
 
-            for roi_name, _, roi_visible in self.roi_table_model:
+            for row in range(self.table_view.row_count()):
+                roi_name = self.table_view.get_roi_name_by_row(row)
+                roi_visible = self.table_view.get_roi_visibility_by_row(row)
                 self.set_roi_visibility_flags(roi_name, visible=roi_visible)
                 if roi_visible:
                     self.presenter.redraw_spectrum(roi_name)
 
         elif self.presenter.export_mode == ExportMode.IMAGE_MODE:
-            for roi_name, _, _ in self.roi_table_model:
+            for row in range(self.table_view.row_count()):
+                roi_name = self.table_view.get_roi_name_by_row(row)
                 self.set_roi_visibility_flags(roi_name, visible=False)
 
             self.set_roi_visibility_flags(ROI_RITS, visible=True)
             self.presenter.redraw_spectrum(ROI_RITS)
-            self.current_roi_name = ROI_RITS
+            self.table_view.current_roi_name = ROI_RITS
 
-            for _, spinbox in self.roi_properties_widget.roiPropertiesSpinBoxes.items():
-                spinbox.setEnabled(True)
+            for _, spinbox in self.roiPropertiesSpinBoxes.items():
+                spinbox.setEnabled(False)
+
             self.set_roi_properties()
-
-    @property
-    def roi_table_model(self) -> TableModel:
-        if self.roiTableView.model() is None:
-            mdl = TableModel()
-            self.roiTableView.setModel(mdl)
-        return self.roiTableView.model()
 
     @property
     def current_dataset_id(self) -> UUID | None:
@@ -470,33 +598,12 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
     def handle_table_click(self, index: QModelIndex) -> None:
         if index.isValid() and index.column() == 1:
-            roi_name = self.roi_table_model.index(index.row(), 0).data()
+            roi_name = self.table_view.get_roi_name_by_row(index.row())
             self.set_spectum_roi_color(roi_name)
 
     def set_spectum_roi_color(self, roi_name: str) -> None:
         spectrum_roi = self.spectrum_widget.roi_dict[roi_name]
         spectrum_roi.change_color_action.trigger()
-
-    def update_roi_color(self, roi_name: str, new_color: tuple[int, int, int]) -> None:
-        """
-        Finds ROI by name in table and updates colour.
-        @param roi_name: Name of the ROI to update.
-        @param new_color: The new color for the ROI in (R, G, B) format.
-        """
-        row = self.find_row_for_roi(roi_name)
-        if row is not None:
-            self.roi_table_model.update_color(row, new_color)
-
-    def find_row_for_roi(self, roi_name: str) -> int | None:
-        """
-        Returns row index for ROI name, or None if not found.
-        @param roi_name: Name ROI find.
-        @return: Row index ROI or None.
-        """
-        for row in range(self.roi_table_model.rowCount()):
-            if self.roi_table_model.index(row, 0).data() == roi_name:
-                return row
-        return None
 
     def set_roi_visibility_flags(self, roi_name: str, visible: bool) -> None:
         """
@@ -528,41 +635,39 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         @param name: The name of the ROI
         @param colour: The colour of the ROI
         """
-        self.roi_table_model.appendNewRow(name, colour, True)
-        self.selected_row = self.roi_table_model.rowCount() - 1
-        self.roiTableView.selectRow(self.selected_row)
+        self.table_view.add_row(name, colour, self.presenter.get_roi_names())
         self.current_roi_name = name
         self.removeBtn.setEnabled(True)
-        self.set_old_table_names()
 
     def remove_roi(self) -> None:
         """
         Clear the selected ROI in the table view
         """
-        selected_row = self.roi_table_model.row_data(self.selected_row)
-        roi_name = self.roi_table_model.get_element(self.selected_row, 0)
+
+        roi_name, selected_row, _ = self.table_view.get_row_data(self.table_view.selected_row)
+        assert isinstance(roi_name, str)
         roi_object = self.spectrum_widget.roi_dict[roi_name]
+
         if selected_row:
-            self.roi_table_model.remove_row(self.selected_row)
+            self.table_view.remove_row(self.table_view.selected_row)
             self.presenter.do_remove_roi(roi_name)
             self.spectrum_widget.spectrum_data_dict.pop(roi_name)
             self.presenter.handle_roi_moved(roi_object)
-            self.selected_row = 0
             self.roiTableView.selectRow(0)
 
-        if self.roi_table_model.rowCount() == 0:
+        if self.table_view.roi_table_model.rowCount() == 0:
             self.removeBtn.setEnabled(False)
             self.disable_roi_properties()
         else:
-            self.set_old_table_names()
-            self.current_roi_name = self.roi_table_model.get_element(self.selected_row, 0)
+            self.table_view.set_old_table_names(self.presenter.get_roi_names())
+            self.table_view.current_roi_name = self.table_view.get_roi_name_by_row(self.table_view.selected_row)
             self.set_roi_properties()
 
     def clear_all_rois(self) -> None:
         """
         Clear all ROIs from the table view
         """
-        self.roi_table_model.clear_table()
+        self.table_view.roi_table_model.clear_table()
         self.spectrum_widget.spectrum_data_dict = {}
         self.spectrum_widget.spectrum.clearPlots()
         self.removeBtn.setEnabled(False)
@@ -597,32 +702,49 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
     def set_roi_properties(self) -> None:
         if self.presenter.export_mode == ExportMode.IMAGE_MODE:
-            self.current_roi_name = ROI_RITS
-        if (self.current_roi_name not in self.presenter.view.spectrum_widget.roi_dict
+            self.table_view.current_roi_name = ROI_RITS
+        if (self.table_view.current_roi_name not in self.presenter.view.spectrum_widget.roi_dict
                 or not self.roi_properties_widget.roiPropertiesSpinBoxes):
             return
-        current_roi = self.presenter.view.spectrum_widget.get_roi(self.current_roi_name)
-        self.roi_properties_widget.roiPropertiesGroupBox.setTitle(f"Roi Properties: {self.current_roi_name}")
+        current_roi = self.presenter.view.spectrum_widget.get_roi(self.table_view.current_roi_name)
+        self.roi_properties_widget.roiPropertiesGroupBox.setTitle(f"Roi Properties: {self.table_view.current_roi_name}")
         roi_iter_order = ["Left", "Top", "Right", "Bottom"]
         for row, pos in enumerate(current_roi):
             with QSignalBlocker(self.roi_properties_widget.roiPropertiesSpinBoxes[roi_iter_order[row]]):
                 self.roi_properties_widget.roiPropertiesSpinBoxes[roi_iter_order[row]].setValue(pos)
-        self.presenter.redraw_spectrum(self.current_roi_name)
+        self.presenter.redraw_spectrum(self.table_view.current_roi_name)
         self.roi_properties_widget.roiPropertiesLabels["Width"].setText(str(current_roi.width))
         self.roi_properties_widget.roiPropertiesLabels["Height"].setText(str(current_roi.height))
         for spinbox in self.roi_properties_widget.roiPropertiesSpinBoxes.values():
             spinbox.setEnabled(True)
 
     def disable_roi_properties(self) -> None:
-        self.last_clicked_roi = "roi"
-        self.roi_properties_widget.disable_roi_properties()
+        self.roiPropertiesGroupBox.setTitle("Roi Properties: None selected")
+        self.table_view.last_clicked_roi = "roi"
+        for _, spinbox in self.roiPropertiesSpinBoxes.items():
+            with QSignalBlocker(spinbox):
+                spinbox.setMinimum(0)
+                spinbox.setValue(0)
+                spinbox.setDisabled(True)
+        for _, label in self.roiPropertiesLabels.items():
+            label.setText("0")
+
+    def get_roi_properties_spinboxes(self) -> dict[str, QSpinBox]:
+        return self.roiPropertiesSpinBoxes
 
     def get_checked_menu_option(self) -> QAction:
         return self.tof_mode_select_group.checkedAction()
 
-    def set_old_table_names(self) -> None:
-        self.old_table_names = self.presenter.get_roi_names()
-        if 'all' in self.old_table_names:
-            self.old_table_names.remove('all')
-        if 'rits_roi' in self.old_table_names:
-            self.old_table_names.remove('rits_roi')
+    def setup_roi_properties_spinboxes(self) -> None:
+        assert self.spectrum_widget.image.image_data is not None
+        for prop in self.roi_table_properties:
+            spin_box = QSpinBox()
+            if prop == "Top" or prop == "Bottom":
+                spin_box.setMaximum(self.spectrum_widget.image.image_data.shape[0])
+            if prop == "Left" or prop == "Right":
+                spin_box.setMaximum(self.spectrum_widget.image.image_data.shape[1])
+            spin_box.valueChanged.connect(self.presenter.do_adjust_roi)
+            self.roiPropertiesSpinBoxes[prop] = spin_box
+        for prop in self.roi_table_properties_secondary:
+            label = QLabel()
+            self.roiPropertiesLabels[prop] = label


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Contributes to: #2378 

### Description

<!-- Add a description of the changes made. -->
The proposed changes renames `tableView` in the `.ui` to `roiTableView` which should help to reduce any confusion between `roiTableView` and `roiPropertiesGroupBox` whose purposes are commonly muddled up.

The proposed changes also  moves the ROI Table out of `SpectrumViewerWindowView` and into the class: `ROITableWidget` in preparation for extracting the related `xml` GUI code out of `spectrum_viewer.ui` and into `mantidimaging/gui/widgets/spectrum_widgets/ROIFORMWidget.ui` and `ROITableWidget` into `mantidimaging/gui/widgets/spectrum_widgets/ROIFORMWidget.py`

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- I have manually tested the Spectrum Viewer ROI table state remains up to date when:
  - Creating new ROIs
  - Renaming ROIs
  - Removing ROIs
  - Selecting an ROI with the intention to rename, then selecting another ROI
  - Swapping tabs between ROI and Image tabs
  - Toggling ROI visibility for various ROIs
  - Toggling ROI visibility and swapping between Image and ROI tab views.

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] ROI table state remains up to date/in-sync with state of ROIs when adding, renaming and removing ROIs.
- [x] The Selected ROI can only be a visible ROI
- [x] No change in functional behaviour is introduced when compared to main branch.

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

Release notes are not needed as they will be added as part of the final PR completing the work described by #2378 

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

