### PR TITLE
DO NOT REVIEW 2378 Part Three: Return of the ROIFormWidget Class - Represent ROI: Export Tabs, Action Buttons, Table & Properties

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -25,6 +25,40 @@ if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
     from uuid import UUID
 
+    class ROIFormWidget(QGroupBox):
+        """
+        A class to represent the export tabs and ROI action buttons in the spectrum viewer window.
+        """
+
+        # TODO: table_view: ROITableWidget - uncomment when ROITableWidget is implemented
+        # TODO: roi_properties_widget: ROIPropertiesTableWidget - uncomment when ROIPropertiesTableWidget is implemented
+
+        def __init__(self,
+                     table_view: RemovableRowTableView,
+                     roiPropertiesTableWidget: QTableWidget,
+                     roiPropertiesGroupBox: QGroupBox,
+                     exportTabs=None,
+                     add_btn: QPushButton = None,
+                     remove_btn: QPushButton = None,
+                     export_btn: QPushButton = None,
+                     export_button_rits: QPushButton = None,
+                     parent=None):
+            super().__init__(parent)
+            if parent is not None:
+                layout = parent.layout()
+                if layout is not None:
+                    layout.addWidget(self)
+            # TODO: Uncomment when ROITableWidget and ROIPropertiesTableWidget are implemented
+            # self.table_view = ROITableWidget(table_view)
+            # self.roi_properties_widget = ROIPropertiesTableWidget(parent,
+            #                                                       roiPropertiesTableWidget,
+            #                                                       roiPropertiesGroupBox)
+            self.exportTabs = exportTabs
+            self.add_btn = add_btn
+            self.remove_btn = remove_btn
+            self.export_btn = export_btn
+            self.export_button_rits = export_button_rits
+
 
 class SpectrumViewerWindowView(BaseMainWindowView):
     tableView: RemovableRowTableView
@@ -67,6 +101,17 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         icon_path = finder.ROOT_PATH + "/gui/ui/images/exclamation-triangle-red.png"
         self.normalise_error_icon_pixmap = QPixmap(icon_path)
+
+        # TODO: Uncomment when ROITableWidget and ROIPropertiesTableWidget are implemented
+        # self.roi_form_widget = ROIFormWidget(table_view=self.roiTableView,
+        #                                      roiPropertiesTableWidget=self.roiPropertiesTableWidget,
+        #                                      roiPropertiesGroupBox=self.roiPropertiesGroupBox,
+        #                                      exportTabs=self.exportTabs,
+        #                                      add_btn=self.addBtn,
+        #                                      remove_btn=self.removeBtn,
+        #                                      export_btn=self.exportButton,
+        #                                      export_button_rits=self.exportButtonRITS,
+        #                                      parent=self)
 
         self.selected_row: int = 0
         self.last_clicked_roi = ""


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Contributes to: #2378 

### Description

<!-- Add a description of the changes made. -->

The proposed changes moves `ROITableWidget`, `ROIPropertiesTableWidget`, ROI export tabs and ROI action buttons into the class ROIFormWidget which will eventually act as the main interface for all these components when called within `SpectrumViewerWindowView`. This change is in preparation for extraction of the related xml GUI code out of `spectrum_viewer.ui` and into `mantidimaging/gui/widgets/spectrum_widgets/ROIFORMWidget.ui` and `ROIFormWidget` into `mantidimaging/gui/widgets/spectrum_widgets/ROIFORMWidget.py`

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- I have manually tested the Spectrum Viewer ROI table and properties remain up to date when:
  - Creating new ROIs
  - Renaming ROIs
  - Removing ROIs
  - Selecting an ROI with the intention to rename, then selecting another ROI
  - Swapping tabs between ROI and Image tabs
  - Toggling ROI visibility for various ROIs
  - Toggling ROI visibility and swapping between Image and ROI tab views.

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] ROI Properties table values always display the selected ROI
- [ ]  ROI table state remains up to date/in-sync with state of ROIs when adding, renaming and removing ROIs.
- [ ] The Selected ROI can only be a visible ROI
- [ ] No change in functional behaviour is introduced when compared to main branch.

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

Release notes are not needed as they will be added as part of the final PR completing the work described by #2378 

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

