### PR TITLE
Flash PR Make coverall failures non fatal

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -138,6 +138,7 @@ jobs:
         timeout-minutes: 15
 
       - name: Coveralls
+        continue-on-error: true
         shell: bash -l {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This prevents issues with the coveralls API causing jobs to fail

Currently the Coveralls service is down. This allows us to continue work. In general the API being down should not be blocking our PRs.

Check

- [ ] on the conda test https://github.com/mantidproject/mantidimaging/actions/runs/13309358911/job/37167761075 . If you open the coveralls log, it the 405 error, but the workflow is still counting as a pass.