### PR TITLE
Refactor of ROIPropertiesTableWidget

### DIFF
--- a/mantidimaging/gui/mvp_base/__init__.py
+++ b/mantidimaging/gui/mvp_base/__init__.py
@@ -2,5 +2,5 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from .view import (BaseDialogView, BaseMainWindowView)  # noqa: F401
+from .view import (BaseDialogView, BaseMainWindowView, BaseWidget)  # noqa: F401
 from .presenter import BasePresenter  # noqa: F401  # noqa:F821

--- a/mantidimaging/gui/mvp_base/view.py
+++ b/mantidimaging/gui/mvp_base/view.py
@@ -7,7 +7,7 @@ from logging import getLogger
 
 from PyQt5 import QtCore
 from PyQt5.QtCore import Qt, QTimer
-from PyQt5.QtWidgets import QMainWindow, QMessageBox, QDialog, QApplication
+from PyQt5.QtWidgets import QMainWindow, QMessageBox, QDialog, QApplication, QWidget
 
 from mantidimaging.gui.utility import compile_ui
 
@@ -83,3 +83,12 @@ class BaseDialogView(QDialog):
         :param msg: Error message string
         """
         QMessageBox.critical(self, "Error", str(msg))
+
+
+class BaseWidget(QWidget):
+
+    def __init__(self, parent, ui_file=None):
+        super().__init__(parent)
+
+        if ui_file is not None:
+            compile_ui(ui_file, self)

--- a/mantidimaging/gui/ui/roi_properties_table_widget.ui
+++ b/mantidimaging/gui/ui/roi_properties_table_widget.ui
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ROIPropertiesTable</class>
+ <widget class="QWidget" name="ROIPropertiesTable">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>270</width>
+    <height>151</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="group_box">
+     <property name="title">
+      <string>ROI Properties</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="spin_left"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>y1, y2</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_1">
+        <property name="text">
+         <string>x1, x2</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QSpinBox" name="spin_right"/>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="spin_top"/>
+      </item>
+      <item row="1" column="2">
+       <widget class="QSpinBox" name="spin_bottom"/>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="label_width">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QLabel" name="label_height">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/mantidimaging/gui/ui/spectrum_viewer.ui
+++ b/mantidimaging/gui/ui/spectrum_viewer.ui
@@ -407,44 +407,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QGroupBox" name="roiPropertiesGroupBox">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>200</height>
-            </size>
-           </property>
-           <property name="title">
-            <string>ROI Properties</string>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_7">
-            <item>
-             <widget class="QTableWidget" name="roiPropertiesTableWidget">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>200</height>
-               </size>
-              </property>
-              <property name="sizeAdjustPolicy">
-               <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
+          <widget class="ROIPropertiesTableWidget" name="roi_properties_widget" native="true"/>
          </item>
          <item>
           <widget class="QWidget" name="experimentSetupGroupBox" native="true"/>
@@ -548,6 +511,12 @@
    <class>ROITableWidget</class>
    <extends>QTableView</extends>
    <header>mantidimaging.gui.windows.spectrum_viewer.view</header>
+  </customwidget>
+  <customwidget>
+   <class>ROIPropertiesTableWidget</class>
+   <extends>QWidget</extends>
+   <header>mantidimaging.gui.windows.spectrum_viewer.view</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -186,8 +186,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.spectrum_widget.spectrum_plot_widget.add_range(*self.model.tof_plot_range)
         self.view.spectrum_widget.spectrum_plot_widget.set_image_index_range_label(*self.model.tof_range)
         self.view.auto_range_image()
-        if self.view.roi_properties_widget.roiPropertiesSpinBoxes:
-            self.view.set_roi_properties()
+        self.view.set_roi_properties()
 
     def handle_range_slide_moved(self, tof_range: tuple[float, float] | tuple[int, int]) -> None:
         self.model.tof_plot_range = tof_range

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -123,6 +123,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.set_shuttercount_error()
         self.show_new_sample()
         self.view.on_visibility_change()
+        self.view.setup_roi_properties_spinboxes()
 
     def reset_units_menu(self) -> None:
         if self.model.tof_data is None:

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -78,6 +78,12 @@ class ROIPropertiesTableWidget(BaseWidget):
         new_points = [self.roiPropertiesSpinBoxes[prop].value() for prop in roi_iter_order]
         return SensibleROI.from_list(new_points)
 
+    def enable_widgets(self, enable: bool) -> None:
+        for spin_box in self.roiPropertiesSpinBoxes.values():
+            spin_box.setEnabled(enable)
+        if not enable:
+            self.set_roi_values(SensibleROI(0, 0, 0, 0))
+
 
 class ROITableWidget(RemovableRowTableView):
     """
@@ -421,9 +427,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             self.presenter.redraw_spectrum(ROI_RITS)
             self.table_view.current_roi_name = ROI_RITS
 
-            for _, spinbox in self.roi_properties_widget.roiPropertiesSpinBoxes.items():
-                spinbox.setEnabled(False)
-
             self.set_roi_properties()
 
     @property
@@ -533,9 +536,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         Set a new ROI on the image
         """
         self.presenter.do_add_roi()
-        for _, spinbox in self.roi_properties_widget.roiPropertiesSpinBoxes.items():
-            if not spinbox.isEnabled():
-                spinbox.setEnabled(True)
+        self.roi_properties_widget.enable_widgets(True)
         self.set_roi_properties()
 
     def handle_table_click(self, index: QModelIndex) -> None:
@@ -651,19 +652,12 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.roi_properties_widget.set_roi_name(self.table_view.current_roi_name)
         self.roi_properties_widget.set_roi_values(current_roi)
         self.presenter.redraw_spectrum(self.table_view.current_roi_name)
-        for spinbox in self.roi_properties_widget.roiPropertiesSpinBoxes.values():
-            spinbox.setEnabled(True)
+        self.roi_properties_widget.enable_widgets(True)
 
     def disable_roi_properties(self) -> None:
         self.roi_properties_widget.set_roi_name("None selected")
         self.table_view.last_clicked_roi = "roi"
-        for _, spinbox in self.roi_properties_widget.roiPropertiesSpinBoxes.items():
-            with QSignalBlocker(spinbox):
-                spinbox.setMinimum(0)
-                spinbox.setValue(0)
-                spinbox.setDisabled(True)
-        for _, label in self.roi_properties_widget.roiPropertiesLabels.items():
-            label.setText("0")
+        self.roi_properties_widget.enable_widgets(False)
 
     def get_roi_properties_spinboxes(self) -> dict[str, QSpinBox]:
         return self.roi_properties_widget.roiPropertiesSpinBoxes

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -58,6 +58,15 @@ class ROIPropertiesTableWidget(BaseWidget):
     def set_roi_name(self, name: str) -> None:
         self.group_box.setTitle(f"Roi Properties: {name}")
 
+    def set_roi_values(self, roi: SensibleROI) -> None:
+        with QSignalBlocker(self):
+            self.spin_left.setValue(roi.left)
+            self.spin_right.setValue(roi.right)
+            self.spin_top.setValue(roi.top)
+            self.spin_bottom.setValue(roi.bottom)
+            self.label_width.setText(str(roi.width))
+            self.label_height.setText(str(roi.height))
+
     def set_roi_limits(self, shape: tuple[int, ...]) -> None:
         self.spin_left.setMaximum(shape[1])
         self.spin_right.setMaximum(shape[1])
@@ -636,18 +645,12 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     def set_roi_properties(self) -> None:
         if self.presenter.export_mode == ExportMode.IMAGE_MODE:
             self.table_view.current_roi_name = ROI_RITS
-        if (self.table_view.current_roi_name not in self.presenter.view.spectrum_widget.roi_dict
-                or not self.roi_properties_widget.roiPropertiesSpinBoxes):
+        if self.table_view.current_roi_name not in self.presenter.view.spectrum_widget.roi_dict:
             return
         current_roi = self.presenter.view.spectrum_widget.get_roi(self.table_view.current_roi_name)
         self.roi_properties_widget.set_roi_name(self.table_view.current_roi_name)
-        roi_iter_order = ["Left", "Top", "Right", "Bottom"]
-        for row, pos in enumerate(current_roi):
-            with QSignalBlocker(self.roi_properties_widget.roiPropertiesSpinBoxes[roi_iter_order[row]]):
-                self.roi_properties_widget.roiPropertiesSpinBoxes[roi_iter_order[row]].setValue(pos)
+        self.roi_properties_widget.set_roi_values(current_roi)
         self.presenter.redraw_spectrum(self.table_view.current_roi_name)
-        self.roi_properties_widget.roiPropertiesLabels["Width"].setText(str(current_roi.width))
-        self.roi_properties_widget.roiPropertiesLabels["Height"].setText(str(current_roi.height))
         for spinbox in self.roi_properties_widget.roiPropertiesSpinBoxes.values():
             spinbox.setEnabled(True)
 

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -41,18 +41,9 @@ class ROIPropertiesTableWidget(BaseWidget):
     def __init__(self, parent=None):
         super().__init__(parent, ui_file='gui/ui/roi_properties_table_widget.ui')
 
-        self.roiPropertiesSpinBoxes = {
-            'Left': self.spin_left,
-            'Right': self.spin_right,
-            'Top': self.spin_top,
-            'Bottom': self.spin_bottom,
-        }
-        self.roiPropertiesLabels = {
-            'Width': self.label_width,
-            'Height': self.label_height,
-        }
+        self.spin_boxes = [self.spin_left, self.spin_right, self.spin_top, self.spin_bottom]
 
-        for spin_box in self.roiPropertiesSpinBoxes.values():
+        for spin_box in self.spin_boxes:
             spin_box.valueChanged.connect(self.roi_changed.emit)
 
     def set_roi_name(self, name: str) -> None:
@@ -74,12 +65,14 @@ class ROIPropertiesTableWidget(BaseWidget):
         self.spin_bottom.setMaximum(shape[0])
 
     def as_roi(self) -> SensibleROI:
-        roi_iter_order = ["Left", "Top", "Right", "Bottom"]
-        new_points = [self.roiPropertiesSpinBoxes[prop].value() for prop in roi_iter_order]
-        return SensibleROI.from_list(new_points)
+        new_roi = SensibleROI(left=self.spin_left.value(),
+                              right=self.spin_right.value(),
+                              top=self.spin_top.value(),
+                              bottom=self.spin_bottom.value())
+        return new_roi
 
     def enable_widgets(self, enable: bool) -> None:
-        for spin_box in self.roiPropertiesSpinBoxes.values():
+        for spin_box in self.spin_boxes:
             spin_box.setEnabled(enable)
         if not enable:
             self.set_roi_values(SensibleROI(0, 0, 0, 0))
@@ -320,10 +313,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.exportButtonRITS.clicked.connect(self.presenter.handle_rits_export)
 
         self.table_view.clicked.connect(self.handle_table_click)
-
-        # Roi Prop table
-        self.roi_table_properties = ["Top", "Bottom", "Left", "Right"]
-        self.roi_table_properties_secondary = ["Width", "Height"]
 
         self.roi_properties_widget.roi_changed.connect(self.presenter.do_adjust_roi)
 
@@ -658,9 +647,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.roi_properties_widget.set_roi_name("None selected")
         self.table_view.last_clicked_roi = "roi"
         self.roi_properties_widget.enable_widgets(False)
-
-    def get_roi_properties_spinboxes(self) -> dict[str, QSpinBox]:
-        return self.roi_properties_widget.roiPropertiesSpinBoxes
 
     def get_checked_menu_option(self) -> QAction:
         return self.tof_mode_select_group.checkedAction()


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Work on  #2378

Also closes #2499 (I think the issue was due to nested tables in the layout making Qt unhappy)

### Description
Now that ROIPropertiesTableWidget is split into its own class, it is easier to make some refactoring.

This PR:
Does the layout for ROIPropertiesTableWidget with a .ui file
Moves all access to internal widgets into the class, with high level access functions (e.g. `set_roi_limits()`)
Uses explicit widget names, rather than looping over keys to make any ordering difference bugs impossible

### Developer Testing 

- I have verified unit tests pass locally: `make check` and `make test-system`
- I have maunally tested

### Acceptance Criteria and Reviewer Testing

Note changes are split into commits for easier reviewing

- [x] Adding and removing ROIs
- [x] Resizing ROIs by dragging handles in the image view
- [x] Resizing ROIs using the spin boxes
- [x] switching between samples

### Documentation and Additional Notes

Does not need release notes as part of bigger work

Will have some screenshot changes

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

