### PR TITLE
Refactor roi table widget

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -113,8 +113,6 @@ class ROITableWidget(RemovableRowTableView):
         header.setSectionResizeMode(0, QHeaderView.Stretch)
         header.setSectionResizeMode(1, QHeaderView.ResizeToContents)
         header.setSectionResizeMode(2, QHeaderView.ResizeToContents)
-        if self._roi_table_model.rowCount() > 0:
-            self.current_roi_name = self.last_clicked_roi = self._roi_table_model.roi_names()[0]
 
     @property
     def roi_table_model(self) -> TableModel:

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -575,17 +575,13 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         """
         Clear the selected ROI in the table view
         """
-
-        roi_name, selected_row, _ = self.table_view.get_row_data(self.table_view.selected_row)
-        assert isinstance(roi_name, str)
+        roi_name = self.table_view.get_roi_name_by_row(self.table_view.selected_row)
         roi_object = self.spectrum_widget.roi_dict[roi_name]
 
-        if selected_row:
-            self.table_view.remove_row(self.table_view.selected_row)
-            self.presenter.do_remove_roi(roi_name)
-            self.spectrum_widget.spectrum_data_dict.pop(roi_name)
-            self.presenter.handle_roi_moved(roi_object)
-            self.table_view.selectRow(0)
+        self.table_view.remove_row(self.table_view.selected_row)
+        self.presenter.do_remove_roi(roi_name)
+        self.spectrum_widget.spectrum_data_dict.pop(roi_name)
+        self.presenter.handle_roi_moved(roi_object)
 
         if self.table_view.roi_table_model.rowCount() == 0:
             self.removeBtn.setEnabled(False)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -103,9 +103,8 @@ class ROITableWidget(RemovableRowTableView):
         self.setAlternatingRowColors(True)
 
         # Initialise model
-        mdl = TableModel()
-        self.setModel(mdl)
-        self._roi_table_model = mdl
+        self.roi_table_model = TableModel()
+        self.setModel(self.roi_table_model)
 
         # Configure up the table view
         self.setVisible(True)
@@ -114,38 +113,33 @@ class ROITableWidget(RemovableRowTableView):
         header.setSectionResizeMode(1, QHeaderView.ResizeToContents)
         header.setSectionResizeMode(2, QHeaderView.ResizeToContents)
 
-    @property
-    def roi_table_model(self) -> TableModel:
-        """The model for the ROI table"""
-        return self._roi_table_model
-
     def get_roi_names(self) -> list[str]:
-        return self._roi_table_model.roi_names()
+        return self.roi_table_model.roi_names()
 
     def get_roi_name_by_row(self, row: int) -> str:
         """
         Retrieve the name an ROI by its row index.
         """
-        return self._roi_table_model.get_element(row, 0)
+        return self.roi_table_model.get_element(row, 0)
 
     def get_roi_visibility_by_row(self, row: int) -> bool:
         """
         Retrieve the visibility status of an ROI by its row index.
         """
-        return self._roi_table_model.get_element(row, 2)
+        return self.roi_table_model.get_element(row, 2)
 
     def row_count(self) -> int:
         """
         Returns the number of rows in the ROI table model.
         """
-        return self._roi_table_model.rowCount()
+        return self.roi_table_model.rowCount()
 
     def find_row_for_roi(self, roi_name: str) -> int | None:
         """
         Returns row index for ROI name, or None if not found.
         """
-        for row in range(self._roi_table_model.rowCount()):
-            if self._roi_table_model.index(row, 0).data() == roi_name:
+        for row in range(self.roi_table_model.rowCount()):
+            if self.roi_table_model.index(row, 0).data() == roi_name:
                 return row
         return None
 
@@ -153,7 +147,7 @@ class ROITableWidget(RemovableRowTableView):
         """
         Set the name of the ROI for a given row in the ROI table.
         """
-        self._roi_table_model.set_element(row, 0, name)
+        self.roi_table_model.set_element(row, 0, name)
 
     def set_old_table_names(self, old_table_names) -> None:
         """
@@ -171,14 +165,14 @@ class ROITableWidget(RemovableRowTableView):
         """
         row = self.find_row_for_roi(roi_name)
         if row is not None:
-            self._roi_table_model.update_color(row, new_color)
+            self.roi_table_model.update_color(row, new_color)
 
     def add_row(self, name: str, colour: tuple[int, int, int, int], roi_names: list[str]) -> None:
         """
         Add a new row to the ROI table
         """
-        self._roi_table_model.appendNewRow(name, colour, True)
-        self.selected_row = self._roi_table_model.rowCount() - 1
+        self.roi_table_model.appendNewRow(name, colour, True)
+        self.selected_row = self.roi_table_model.rowCount() - 1
         self.selectRow(self.selected_row)
         self.current_roi_name = name
         self.set_old_table_names(roi_names)
@@ -187,14 +181,14 @@ class ROITableWidget(RemovableRowTableView):
         """
         Remove a row from the ROI table
         """
-        self._roi_table_model.remove_row(row)
+        self.roi_table_model.remove_row(row)
         self.selectRow(0)
 
     def clear_table(self) -> None:
         """
         Clears the ROI table in the spectrum viewer.
         """
-        self._roi_table_model.clear_table()
+        self.roi_table_model.clear_table()
 
 
 class SpectrumViewerWindowView(BaseMainWindowView):

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -124,13 +124,6 @@ class ROITableWidget(RemovableRowTableView):
     def get_roi_names(self) -> list[str]:
         return self._roi_table_model.roi_names()
 
-    def get_row_data(self, row: int) -> RowType:
-        """
-        Get the data for a specific row in the ROI table.
-        """
-        name, data, visible = self._roi_table_model.row_data(row)
-        return [name, data, visible]
-
     def get_roi_name_by_row(self, row: int) -> str:
         """
         Retrieve the name an ROI by its row index.


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Work on #2378 

### Description

Refactor ROITableWidget

Changes
- Remove unneeded code
  - `get_row_data()`
  - Error checking in `remove_roi()`
  - Check for rows in `__init__`
- Change properties to attributes
  - `properties to attributes`
- Move `on_row_change` into class

~~Needs rebase after #2506~~

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- ...

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] In spectrum viewer
  - [x] Adding and removing ROIs
  - [x] Renaming ROIs
  - [x] Changing ROI colour
  - [x] Resizing ROI from image view or properties

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

