### PR TITLE
Fitting Window: Create a Drop Down ROI Menu Widget 

### DIFF
--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_selection_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_selection_widget.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+from mantidimaging.gui.windows.spectrum_viewer.model import ROI_RITS
+from PyQt5 import QtWidgets, QtCore
+
+
+class ROISelectionWidget(QtWidgets.QGroupBox):
+    """
+    A custom Qt widget for selecting an ROI.
+    Attributes:
+        roiDropdown: A dropdown menu for selecting ROIs.
+        selectionChanged: Signal emitted when the ROI selection changes.
+    """
+
+    selectionChanged = QtCore.pyqtSignal(str)
+
+    def __init__(self, parent: QtWidgets.QWidget = None):
+        super().__init__("Select ROI", parent)
+
+        self.setFixedHeight(60)
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(10, 5, 10, 5)
+        layout.setSpacing(2)
+
+        self.roiDropdown = QtWidgets.QComboBox(self)
+        self.roiDropdown.currentIndexChanged.connect(self._on_selection_changed)
+        layout.addWidget(self.roiDropdown)
+        self.previous_selection = None
+
+    def _on_selection_changed(self) -> None:
+        """ Handle dropdown selection change and emit signal. """
+        selected_roi = self.roiDropdown.currentText()
+        if selected_roi != self.previous_selection:
+            self.previous_selection = selected_roi
+            self.selectionChanged.emit(selected_roi)
+
+    def update_roi_list(self, roi_names: list[str]) -> None:
+        """ Update the dropdown and trigger selection change if needed. """
+        current_selection = self.roiDropdown.currentText()
+        self.roiDropdown.blockSignals(True)
+        self.roiDropdown.clear()
+        filtered_rois = [name for name in roi_names if str(name) != str(ROI_RITS)]
+        self.roiDropdown.addItems(filtered_rois)
+        if current_selection in filtered_rois:
+            self.roiDropdown.setCurrentText(current_selection)
+        elif filtered_rois:
+            self.roiDropdown.setCurrentIndex(0)
+        self.roiDropdown.blockSignals(False)
+
+    def set_selected_roi(self, roi_name: str) -> None:
+        """ Set the dropdown selection to the given ROI name. """
+        index = self.roiDropdown.findText(roi_name)
+        if index != -1:
+            self.roiDropdown.setCurrentIndex(index)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -342,6 +342,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.set_spectrum(roi_name, spectrum)
         self.view.auto_range_image()
         self.do_add_roi_to_table(roi_name)
+        self.view.update_roi_dropdown()
 
     def change_roi_colour(self, roi_name: str, new_colour: tuple[int, int, int]) -> None:
         """
@@ -398,6 +399,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             self.model.remove_all_roi()
         else:
             self.view.spectrum_widget.remove_roi(roi_name)
+        self.view.update_roi_dropdown()
 
     def handle_export_tab_change(self, index: int) -> None:
         self.export_mode = ExportMode(index)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -20,6 +20,7 @@ from mantidimaging.gui.widgets import RemovableRowTableView
 from .spectrum_widget import SpectrumWidget
 from mantidimaging.gui.windows.spectrum_viewer.roi_table_model import TableModel
 from mantidimaging.gui.widgets.spectrum_widgets.tof_properties import ExperimentSetupFormWidget
+from mantidimaging.gui.widgets.spectrum_widgets.roi_selection_widget import ROISelectionWidget
 import numpy as np
 
 if TYPE_CHECKING:
@@ -263,6 +264,9 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.exportLayout.addWidget(QLabel("export"))
 
         self.spectrum.range_changed.connect(self.presenter.handle_range_slide_moved)
+
+        self.roiSelectionWidget = ROISelectionWidget(self)
+        self.fittingFormLayout.layout().addWidget(self.roiSelectionWidget)
 
         self.spectrum_widget.roi_clicked.connect(self.presenter.handle_roi_clicked)
         self.spectrum_widget.roi_changed.connect(self.presenter.handle_roi_moved)
@@ -516,6 +520,11 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         else:
             self.shuttercountErrorIcon.setPixmap(QPixmap())
             self.shuttercountErrorIcon.setToolTip("")
+
+    def update_roi_dropdown(self) -> None:
+        """ Updates the ROI dropdown menu with the available ROIs. """
+        roi_names = self.presenter.get_roi_names()
+        self.roiSelectionWidget.update_roi_list(roi_names)
 
     def shuttercount_norm_enabled(self) -> bool:
         return self.normalise_ShutterCount_CheckBox.isChecked()


### PR DESCRIPTION
## Issue Closes #2385

### Description

Implemented a **ROI Selection Widget (`ROISelectionWidget`)** to allow users to select one ROI from the ROIs created within the Fitting Window. This widget is part of the ongoing redesign of the Spectrum Viewer.

### Developer Testing 

- I have verified unit tests pass locally: `python -m pytest -vs`
- Tested the dropdown menu behavior when ROIs are added and removed.
- Ensured the dropdown updates dynamically and maintains the selected ROI if it still exists.
- Verified that **ROI_RITS is excluded** from the dropdown menu.
- Checked that the **first available ROI is selected** if the previous ROI was deleted.
- Ensured that `selectionChanged` **only emits when the actual selection changes**.

### Acceptance Criteria and Reviewer Testing

- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Verify that the dropdown updates correctly when ROIs are added or removed.
- [x] Test that the selection remains on the same ROI if it still exists after an update.
- [x] If the previous ROI is deleted, ensure the dropdown **selects the first available ROI**.
- [x] Ensure no unnecessary `selectionChanged` signals are emitted.

### Documentation and Additional Notes

- [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on Applitools by creating a new baseline for the test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes, and merge the `dev` branch into the `default` branch.
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info).

