### PR TITLE
Refactor roi table widget part 2

### DIFF
--- a/mantidimaging/gui/test/gui_system_spectrum_test.py
+++ b/mantidimaging/gui/test/gui_system_spectrum_test.py
@@ -7,6 +7,7 @@ from unittest import mock
 from PyQt5.QtCore import Qt
 from PyQt5.QtTest import QTest
 from PyQt5.QtGui import QColor
+from parameterized import parameterized
 
 from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHOW_DELAY, SHORT_DELAY
 from mantidimaging.gui.windows.spectrum_viewer.model import SpecType, SensibleROI
@@ -106,6 +107,26 @@ class TestGuiSpectrumViewer(GuiSystemBase):
 
         self.assertNotIn(old_name, self.spectrum_window.spectrum_widget.roi_dict)
         self.assertIn(new_name, self.spectrum_window.spectrum_widget.roi_dict)
+
+    @parameterized.expand([' ', 'roi_1', 'all'])
+    def test_no_rename_for_bad_roi_name(self, new_name: str):
+        QTest.mouseClick(self.spectrum_window.addBtn, Qt.MouseButton.LeftButton)
+        QTest.mouseClick(self.spectrum_window.addBtn, Qt.MouseButton.LeftButton)
+        QTest.qWait(SHORT_DELAY)
+
+        old_name = 'roi_2'
+        rois_before = list(self.spectrum_window.spectrum_widget.roi_dict.keys())
+
+        table_model = self.spectrum_window.table_view.roi_table_model
+        row = table_model.roi_names().index(old_name)
+
+        table_view = self.spectrum_window.table_view
+        table_view.edit(table_model.index(row, 0))
+        QTest.keyClicks(table_view.keyboardGrabber(), new_name)
+        QTest.keyClick(table_view.keyboardGrabber(), Qt.Key_Enter)
+
+        rois_after = list(self.spectrum_window.spectrum_widget.roi_dict.keys())
+        self.assertListEqual(rois_before, rois_after)
 
     def test_adjust_roi(self):
         QTest.mouseClick(self.spectrum_window.addBtn, Qt.MouseButton.LeftButton)

--- a/mantidimaging/gui/test/gui_system_spectrum_test.py
+++ b/mantidimaging/gui/test/gui_system_spectrum_test.py
@@ -99,8 +99,10 @@ class TestGuiSpectrumViewer(GuiSystemBase):
         table_model = self.spectrum_window.table_view.roi_table_model
         row = table_model.roi_names().index(old_name)
 
-        table_model.set_element(row, 0, new_name)
-        table_model.dataChanged.emit(table_model.index(row, 0), table_model.index(row, 0))
+        table_view = self.spectrum_window.table_view
+        table_view.edit(table_model.index(row, 0))
+        QTest.keyClicks(table_view.keyboardGrabber(), new_name)
+        QTest.keyClick(table_view.keyboardGrabber(), Qt.Key_Enter)
 
         self.assertNotIn(old_name, self.spectrum_window.spectrum_widget.roi_dict)
         self.assertIn(new_name, self.spectrum_window.spectrum_widget.roi_dict)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -215,7 +215,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def handle_roi_clicked(self, roi: SpectrumROI) -> None:
         if not roi.name == ROI_RITS:
-            self.view.table_view.current_roi_name = roi.name
+            self.view.table_view.select_roi(roi.name)
             self.view.set_roi_properties()
 
     def redraw_spectrum(self, name: str) -> None:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -216,7 +216,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
     def handle_roi_clicked(self, roi: SpectrumROI) -> None:
         if not roi.name == ROI_RITS:
             self.view.table_view.current_roi_name = roi.name
-            self.view.table_view.last_clicked_roi = roi.name
             self.view.set_roi_properties()
 
     def redraw_spectrum(self, name: str) -> None:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -374,15 +374,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         roi_colour = self.view.spectrum_widget.roi_dict[roi_name].colour
         self.view.add_roi_table_row(roi_name, roi_colour)
 
-    def rename_roi(self, old_name: str, new_name: str) -> None:
-        """
-        Rename a given ROI from the table by ROI name
-
-        @param old_name: Name of the ROI to rename
-        @param new_name: New name of the ROI
-        """
-        self.view.spectrum_widget.rename_roi(old_name, new_name)
-
     def do_remove_roi(self, roi_name: str | None = None) -> None:
         """
         Remove a given ROI from the table by ROI name or all ROIs from

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -430,20 +430,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         new_roi = self.view.roi_properties_widget.as_roi()
         self.view.spectrum_widget.adjust_roi(new_roi, self.view.table_view.current_roi_name)
 
-    def handle_storing_current_roi_name_on_tab_change(self) -> None:
-        old_table_names = self.view.table_view.old_table_names
-        old_current_roi_name = self.view.table_view.current_roi_name
-        old_last_clicked_roi = self.view.table_view.last_clicked_roi
-        if self.export_mode == ExportMode.ROI_MODE:
-            if old_current_roi_name == ROI_RITS and old_last_clicked_roi in old_table_names:
-                self.view.table_view.current_roi_name = old_last_clicked_roi
-            else:
-                self.view.table_view.last_clicked_roi = old_current_roi_name
-        elif self.export_mode == ExportMode.IMAGE_MODE:
-            if (old_current_roi_name != ROI_RITS and old_current_roi_name in old_table_names
-                    and old_last_clicked_roi != old_current_roi_name):
-                self.view.table_view.last_clicked_roi = old_current_roi_name
-
     @staticmethod
     def check_action(action: QAction, param: bool) -> None:
         action.setChecked(param)

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -107,9 +107,7 @@ class SpectrumWidget(QWidget):
     """
     image: MIMiniImageView
     spectrum: PlotItem
-
     range_control: LinearRegionItem
-    last_clicked_roi: str
 
     range_changed = pyqtSignal(object)
     roi_clicked = pyqtSignal(object)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -295,21 +295,6 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.assertEqual(self.view.table_view.last_clicked_roi, "NOT_RITS_ROI")
         self.view.set_roi_properties.assert_not_called()
 
-    def test_WHEN_ROI_renamed_THEN_roi_renamed(self):
-        rois = ["all", "roi", "roi_1"]
-        self.view.spectrum_widget.rois = {roi: mock.Mock() for roi in rois}
-        self.view.spectrum_widget.rename_roi = mock.Mock()
-        self.presenter.rename_roi("roi_1", "new_name")
-
-        self.view.spectrum_widget.rename_roi.assert_called_once_with("roi_1", "new_name")
-
-    def test_WHEN_invalid_ROI_renamed_THEN_error_raised(self):
-        rois = ["all", "roi", "roi_1"]
-        self.view.spectrum_widget.roi_dict = {roi: mock.Mock() for roi in rois}
-        self.view.spectrum_widget.rename_roi = mock.Mock(side_effect=KeyError("Invalid ROI"))
-        with self.assertRaises(KeyError):
-            self.presenter.rename_roi("invalid_roi", "new_name")
-
     def test_WHEN_do_remove_roi_called_with_no_arguments_THEN_all_rois_removed(self):
         rois = ["all", "roi", "roi_1", "roi_2"]
         self.view.spectrum_widget.roi_dict = {roi: mock.Mock() for roi in rois}

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -283,15 +283,13 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     def test_WHEN_roi_clicked_THEN_roi_updated(self):
         roi = SpectrumROI("themightyroi", SensibleROI())
         self.presenter.handle_roi_clicked(roi)
-        self.assertEqual(self.view.table_view.last_clicked_roi, "themightyroi")
         self.view.set_roi_properties.assert_called_once()
 
     def test_WHEN_rits_roi_clicked_THEN_rois_not_updated(self):
-        self.view.table_view.current_roi_name = self.view.table_view.last_clicked_roi = "NOT_RITS_ROI"
+        self.view.table_view.current_roi_name = "NOT_RITS_ROI"
         roi = SpectrumROI(ROI_RITS, SensibleROI())
         self.presenter.handle_roi_clicked(roi)
         self.assertEqual(self.view.table_view.current_roi_name, "NOT_RITS_ROI")
-        self.assertEqual(self.view.table_view.last_clicked_roi, "NOT_RITS_ROI")
         self.view.set_roi_properties.assert_not_called()
 
     def test_WHEN_do_remove_roi_called_with_no_arguments_THEN_all_rois_removed(self):
@@ -410,17 +408,13 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view.set_spectrum.assert_has_calls([mock.call(roi, mock.ANY) for roi in rois], any_order=True)
 
     @parameterized.expand([("roi", "roi_clicked", "roi_clicked"), ("roi", ROI_RITS, "roi")])
-    def test_WHEN_roi_clicked_THEN_current_and_last_clicked_roi_updated_correctly(self, old_roi, clicked_roi,
-                                                                                  expected_roi):
+    def test_WHEN_roi_clicked_THEN_current_roi_updated_correctly(self, old_roi, clicked_roi, expected_roi):
         self.view.table_view.current_roi_name = old_roi
-        self.view.table_view.last_clicked_roi = old_roi
         self.presenter.handle_roi_clicked(SpectrumROI(clicked_roi, SensibleROI(), pos=(0, 0)))
         self.assertEqual(self.view.table_view.current_roi_name, expected_roi)
-        self.assertEqual(self.view.table_view.last_clicked_roi, expected_roi)
 
     def test_WHEN_roi_clicked_THEN_roi_properties_set(self):
         self.view.table_view.current_roi_name = ""
-        self.view.table_view.last_clicked_roi = ""
         self.presenter.handle_roi_clicked(SpectrumROI("roi_clicked", SensibleROI(), pos=(0, 0)))
         self.view.set_roi_properties.assert_called_once()
 

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -18,7 +18,6 @@ from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowView, SpectrumViewerWindowPresenter
 from mantidimaging.gui.windows.spectrum_viewer.model import ErrorMode, ToFUnitMode, ROI_RITS, SpecType
-from mantidimaging.gui.windows.spectrum_viewer.presenter import ExportMode
 from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumWidget, SpectrumPlotWidget, SpectrumROI
 from mantidimaging.gui.widgets.spectrum_widgets.tof_properties import ExperimentSetupFormWidget
 from mantidimaging.test_helpers import mock_versions, start_qapplication
@@ -388,19 +387,6 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view.table_view.current_roi_name = "roi_1"
         self.presenter.do_adjust_roi()
         self.view.spectrum_widget.adjust_roi.assert_called_once_with(SensibleROI(10, 10, 20, 30), "roi_1")
-
-    @parameterized.expand([(["roi_1", "roi_2", "roi_3"], "roi_2", "roi_2", ExportMode.IMAGE_MODE, "roi_2"),
-                           (["roi_1", "roi_3"], "roi_3", "roi_2", ExportMode.IMAGE_MODE, "roi_3"),
-                           (["roi_1", "roi_2", "roi_3"], ROI_RITS, "roi_2", ExportMode.ROI_MODE, "roi_2")])
-    def test_WHEN_change_tab_THEN_current_roi_correct(self, old_table_names, current_roi_name, last_clicked_roi,
-                                                      export_mode, expected_roi):
-        self.view.table_view.old_table_names = old_table_names
-        self.view.table_view.current_roi_name = current_roi_name
-        self.view.table_view.last_clicked_roi = last_clicked_roi
-        self.presenter.export_mode = export_mode
-        self.presenter.handle_storing_current_roi_name_on_tab_change()
-        self.assertEqual(self.view.table_view.current_roi_name, expected_roi)
-        self.assertEqual(self.view.table_view.last_clicked_roi, expected_roi)
 
     def test_WHEN_refresh_spectrum_plot_THEN_spectrum_plot_refreshed(self):
         self.view.spectrum_widget.spectrum = mock.MagicMock()

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -85,7 +85,6 @@ class ROITableWidget(RemovableRowTableView):
     ElementType = str | tuple[int, int, int] | bool
     RowType = list[ElementType]
     selected_row: int
-    last_clicked_roi: str
     current_roi_name: str
 
     selection_changed = pyqtSignal()
@@ -96,7 +95,6 @@ class ROITableWidget(RemovableRowTableView):
         super().__init__(parent)
 
         self.selected_row = 0
-        self.last_clicked_roi = ""
         self.current_roi_name = ""
 
         # Point table
@@ -237,7 +235,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.normalise_error_icon_pixmap = QPixmap(icon_path)
 
         self.selected_row: int = 0
-        self.last_clicked_roi = ""
         self.current_roi_name: str = ""
 
         self.presenter = SpectrumViewerWindowPresenter(self, main_window)
@@ -305,7 +302,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         self.spectrum_widget.roi_changed.connect(self.set_roi_properties)
 
-        self.current_roi_name = self.last_clicked_roi = self.table_view.roi_table_model.roi_names()[0]
+        self.current_roi_name = self.table_view.roi_table_model.roi_names()[0]
         self.set_roi_properties()
 
         self.experimentSetupFormWidget = ExperimentSetupFormWidget(self.experimentSetupGroupBox)
@@ -584,7 +581,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
     def disable_roi_properties(self) -> None:
         self.roi_properties_widget.set_roi_name("None selected")
-        self.table_view.last_clicked_roi = "roi"
         self.roi_properties_widget.enable_widgets(False)
 
     def get_checked_menu_option(self) -> QAction:

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -84,7 +84,6 @@ class ROITableWidget(RemovableRowTableView):
     """
     ElementType = str | tuple[int, int, int] | bool
     RowType = list[ElementType]
-    old_table_names: list[str]
     selected_row: int
     last_clicked_roi: str
     current_roi_name: str
@@ -96,7 +95,6 @@ class ROITableWidget(RemovableRowTableView):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        self.old_table_names = []
         self.selected_row = 0
         self.last_clicked_roi = ""
         self.current_roi_name = ""
@@ -163,16 +161,6 @@ class ROITableWidget(RemovableRowTableView):
         """
         self.roi_table_model.set_element(row, 0, name)
 
-    def set_old_table_names(self, old_table_names) -> None:
-        """
-        Updates the list of old table names by removing specific entries if they exist.
-        """
-        self.old_table_names = old_table_names
-        if 'all' in self.old_table_names:
-            self.old_table_names.remove('all')
-        if 'rits_roi' in self.old_table_names:
-            self.old_table_names.remove('rits_roi')
-
     def update_roi_color(self, roi_name: str, new_color: tuple[int, int, int, int]) -> None:
         """
         Finds ROI by name in table and updates it's colour (R, G, B) format.
@@ -189,7 +177,6 @@ class ROITableWidget(RemovableRowTableView):
         self.selected_row = self.roi_table_model.rowCount() - 1
         self.selectRow(self.selected_row)
         self.current_roi_name = name
-        self.set_old_table_names(roi_names)
 
     def remove_row(self, row: int) -> None:
         """
@@ -252,8 +239,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.selected_row: int = 0
         self.last_clicked_roi = ""
         self.current_roi_name: str = ""
-
-        self.old_table_names: list[str] = []
 
         self.presenter = SpectrumViewerWindowPresenter(self, main_window)
 
@@ -351,7 +336,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         When the visibility of an ROI is changed, update the visibility of the ROI in the spectrum widget
         """
 
-        self.presenter.handle_storing_current_roi_name_on_tab_change()
         if self.presenter.export_mode == ExportMode.ROI_MODE:
             self.set_roi_visibility_flags(ROI_RITS, visible=False)
 
@@ -547,7 +531,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             self.removeBtn.setEnabled(False)
             self.disable_roi_properties()
         else:
-            self.table_view.set_old_table_names(self.presenter.get_roi_names())
             self.table_view.current_roi_name = self.table_view.get_roi_name_by_row(self.table_view.selected_row)
             self.set_roi_properties()
 


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Work on #2378 

### Description

Further refactoring. The main change is to remove `on_data_in_table_change()` from `SpectrumViewerWindowView` and put the required logic for handling renames into `TableModel`. Here it has access to the before and after name, so the logic simplifies.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `make check` and `make test-system`
- I have manually tested

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] In spectrum viewer
  - [ ] Adding and removing ROIs
  - [ ] Renaming ROIs
  - [ ] Changing ROI colour
  - [ ] Resizing ROI from image view or properties

### Documentation and Additional Notes

Not needed