### PR TITLE
Avoid forcing a redraw on ROI row selection change

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -404,8 +404,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.handle_tof_unit_change()
 
     def refresh_spectrum_plot(self) -> None:
-        self.view.spectrum_widget.spectrum.clearPlots()
-        self.view.spectrum_widget.spectrum.update()
         self.view.show_visible_spectrums()
         self.view.spectrum_widget.spectrum_plot_widget.add_range(*self.model.tof_plot_range)
         self.view.spectrum_widget.spectrum_plot_widget.set_image_index_range_label(*self.model.tof_range)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -211,7 +211,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             self.view.shuttercount_norm_enabled(),
         )
         self.view.set_spectrum(roi.name, spectrum)
-        self.view.spectrum_widget.spectrum.update()
 
     def handle_roi_clicked(self, roi: SpectrumROI) -> None:
         if not roi.name == ROI_RITS:
@@ -425,7 +424,9 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def do_adjust_roi(self) -> None:
         new_roi = self.view.roi_properties_widget.as_roi()
-        self.view.spectrum_widget.adjust_roi(new_roi, self.view.table_view.current_roi_name)
+        roi_name = self.view.table_view.current_roi_name
+        self.view.spectrum_widget.adjust_roi(new_roi, roi_name)
+        self.handle_roi_moved(self.view.spectrum_widget.roi_dict[roi_name])
 
     @staticmethod
     def check_action(action: QAction, param: bool) -> None:

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -83,8 +83,9 @@ class SpectrumROI(ROI):
             handle.setVisible(visible)
 
     def adjust_spec_roi(self, roi: SensibleROI) -> None:
-        self.setPos((roi.left, roi.top))
-        self.setSize((roi.width, roi.height))
+        with QSignalBlocker(self):
+            self.setPos((roi.left, roi.top))
+            self.setSize((roi.width, roi.height))
 
     def as_sensible_roi(self) -> SensibleROI:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -388,8 +388,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         roi may not exist in the spectrum widget yet depending on when method is called
         """
         self.spectrum_widget.spectrum_data_dict[name] = spectrum_data
-        self.spectrum_widget.spectrum.clearPlots()
-
         self.show_visible_spectrums()
 
     def clear(self) -> None:
@@ -460,21 +458,20 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         @param visible: Whether the ROI is visible.
         """
         self.spectrum_widget.set_roi_visibility_flags(roi_name, visible=visible)
-
-        if not visible:
-            self.spectrum_widget.spectrum_data_dict[roi_name] = None
-
-        self.spectrum_widget.spectrum.clearPlots()
-        self.spectrum_widget.spectrum.update()
         self.show_visible_spectrums()
 
     def show_visible_spectrums(self) -> None:
-        for key, value in self.spectrum_widget.spectrum_data_dict.items():
-            if value is not None and key in self.spectrum_widget.roi_dict:
-                self.spectrum_widget.spectrum.plot(self.presenter.model.tof_data,
-                                                   value,
-                                                   name=key,
-                                                   pen=self.spectrum_widget.roi_dict[key].colour)
+        self.spectrum_widget.spectrum.clearPlots()
+
+        for roi_name, spectrum_data in self.spectrum_widget.spectrum_data_dict.items():
+            if roi_name not in self.spectrum_widget.roi_dict:
+                continue
+            if not self.spectrum_widget.roi_dict[roi_name].isVisible():
+                continue
+            self.spectrum_widget.spectrum.plot(self.presenter.model.tof_data,
+                                               spectrum_data,
+                                               name=roi_name,
+                                               pen=self.spectrum_widget.roi_dict[roi_name].colour)
 
     def add_roi_table_row(self, name: str, colour: tuple[int, int, int, int]) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -541,7 +541,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         current_roi = self.presenter.view.spectrum_widget.get_roi(roi_name)
         self.roi_properties_widget.set_roi_name(roi_name)
         self.roi_properties_widget.set_roi_values(current_roi)
-        self.presenter.redraw_spectrum(roi_name)
         self.roi_properties_widget.enable_widgets(True)
 
     def disable_roi_properties(self) -> None:


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2508 

### Description

Avoid forcing a redraw on ROI row selection change

This also reduces some unneeded replots during opening the window. This reduces the time to open the spectrum viewer with the 2kx2k flower dataset from
`INFO: SpectrumViewerWindowView shown in 15.486498130019754`
to
`INFO: SpectrumViewerWindowView shown in 10.640741370036267`

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- ...

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Follow steps on issue

### Documentation and Additional Notes

Not needed because its fixing a recent regression