### PR TITLE
Spectrum Viewer ROI plots smoothly

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from logging import getLogger
 
 import numpy as np
-from PyQt5.QtCore import QSignalBlocker
+from PyQt5.QtCore import QSignalBlocker, QTimer
 
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.dialogs.async_task import start_async_task_view, TaskWorkerThread
@@ -47,6 +47,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
     current_stack_uuid: UUID | None = None
     current_norm_stack_uuid: UUID | None = None
     export_mode: ExportMode
+    changed_roi: SpectrumROI
 
     def __init__(self, view: SpectrumViewerWindowView, main_window: MainWindowView):
         super().__init__(view)
@@ -56,6 +57,10 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.model = SpectrumViewerWindowModel(self)
         self.export_mode = ExportMode.ROI_MODE
         self.main_window.stack_changed.connect(self.handle_stack_modified)
+
+        self.handle_roi_change_timer = QTimer()
+        self.handle_roi_change_timer.setSingleShot(True)
+        self.handle_roi_change_timer.timeout.connect(self.handle_roi_moved)
 
     def handle_stack_modified(self) -> None:
         """
@@ -201,16 +206,21 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.spectrum_widget.spectrum_plot_widget.set_tof_range_label(*self.model.tof_plot_range)
         self.update_displayed_image(autoLevels=False)
 
-    def handle_roi_moved(self, roi: SpectrumROI) -> None:
+    def handle_notify_roi_moved(self, roi: SpectrumROI) -> None:
+        self.changed_roi = roi
+        if not self.handle_roi_change_timer.isActive():
+            self.handle_roi_change_timer.start(10)
+
+    def handle_roi_moved(self) -> None:
         """
         Handle changes to any ROI position and size.
         """
         spectrum = self.model.get_spectrum(
-            roi.as_sensible_roi(),
+            self.changed_roi.as_sensible_roi(),
             self.spectrum_mode,
             self.view.shuttercount_norm_enabled(),
         )
-        self.view.set_spectrum(roi.name, spectrum)
+        self.view.set_spectrum(self.changed_roi.name, spectrum)
         self.view.spectrum_widget.spectrum.update()
 
     def handle_roi_clicked(self, roi: SpectrumROI) -> None:

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -112,6 +112,7 @@ class SpectrumWidget(QWidget):
     range_changed = pyqtSignal(object)
     roi_clicked = pyqtSignal(object)
     roi_changed = pyqtSignal(object)
+    roi_changing = pyqtSignal(object)
     roiColorChangeRequested = pyqtSignal(str, tuple)
 
     spectrum_plot_widget: SpectrumPlotWidget
@@ -187,6 +188,7 @@ class SpectrumWidget(QWidget):
         self.roi_dict[name] = roi_object
         self.max_roi_size = roi_object.size()
         self.roi_dict[name].sigRegionChangeFinished.connect(self._emit_roi_changed)
+        self.roi_dict[name].sigRegionChanged.connect(self._emit_roi_changing)
         self.roi_dict[name].sigClicked.connect(self.roi_clicked.emit)
         self.image.vb.addItem(self.roi_dict[name])
         self.roi_dict[name].hoverPen = mkPen(self.roi_dict[name].colour, width=3)
@@ -251,6 +253,10 @@ class SpectrumWidget(QWidget):
     def _emit_roi_changed(self):
         sender_roi = self.sender()
         self.roi_changed.emit(sender_roi)
+
+    def _emit_roi_changing(self):
+        sender_roi = self.sender()
+        self.roi_changing.emit(sender_roi)
 
 
 class CustomViewBox(ViewBox):

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -239,7 +239,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.fittingFormLayout.layout().addWidget(self.roiSelectionWidget)
 
         self.spectrum_widget.roi_clicked.connect(self.presenter.handle_roi_clicked)
-        self.spectrum_widget.roi_changed.connect(self.presenter.handle_roi_moved)
+        self.spectrum_widget.roi_changing.connect(self.presenter.handle_notify_roi_moved)
         self.spectrum_widget.roiColorChangeRequested.connect(self.presenter.change_roi_colour)
 
         self.spectrum_right_click_menu = self.spectrum.spectrum_viewbox.menu
@@ -500,12 +500,11 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         Clear the selected ROI in the table view
         """
         roi_name = self.table_view.get_roi_name_by_row(self.table_view.selected_row)
-        roi_object = self.spectrum_widget.roi_dict[roi_name]
 
         self.table_view.remove_row(self.table_view.selected_row)
         self.presenter.do_remove_roi(roi_name)
         self.spectrum_widget.spectrum_data_dict.pop(roi_name)
-        self.presenter.handle_roi_moved(roi_object)
+        self.set_spectrum(roi_name, np.empty(0))
 
         if self.table_view.roi_table_model.rowCount() == 0:
             self.removeBtn.setEnabled(False)


### PR DESCRIPTION

<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2471

### Description

Similar to recent changes in the Live Viewer [PR#2457](https://github.com/mantidproject/mantidimaging/pull/2457), The ROI signals have been modified so multiple triggers very close together are captured by a QTimer, which then starts a Spectrum calculation via QThread. This allows rapid and smooth movement of the ROIs with no slowdown of the GUI due to the Spectrum bring calculated in the same thread.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- System tests pass `make test-system`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Open Spectrum Viewer and add several ROIs, move and resize the ROIs and check that the spectrum updates correctly with no slowdown or unresponsiveness of the GUI.
- [ ] Resize the ROIs using the ROI Properties table and check that the spectrum updates
- [ ] When ROIs are deleted, the associated spectrum is also deleted with no errors.

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [ ] Release Notes have been updated


