### PR TITLE
Live Viewer eyes tests run independently 

### DIFF
--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -22,6 +22,8 @@ import mantidimaging.core.parallel.utility as pu
 from mantidimaging.core.io.filenames import FilenameGroup
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
+import matplotlib.pyplot  # noqa: F401 - need to import before FakeFileSystem, see Issue #2480
+
 # APPLITOOLS_BATCH_ID will be set by Github actions to the commit SHA, or a random UUID for individual developer
 # execution
 


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2480

### Description

`Matplotlib` is explicitly imported before any tests are run.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- verify that `make test-screenshots` and:
- ```-mkdir ${TEST_RESULT_DIR}
	APPLITOOLS_API_KEY=local APPLITOOLS_IMAGE_DIR=${TEST_RESULT_DIR} ${XVFBRUN} pytest -p no:xdist -p no:randomly -p no:cov mantidimaging/eyes_tests/live_viewer_window_test.py -vs --run-eyes-tests
	@echo "Screenshots writen to" ${TEST_RESULT_DIR}``` 
both run successfully

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Repeat steps above

### Documentation and Additional Notes

Not needed
