### PR TITLE
Add "Save as Image" Feature to Spectrum Viewer 

### DIFF
--- a/docs/release_notes/next/fix-2503-Save as image in spectrum viewer
+++ b/docs/release_notes/next/fix-2503-Save as image in spectrum viewer
@@ -1,0 +1,1 @@
+2503: save the currently displayed image to a tiff file in spectrum viewer

--- a/mantidimaging/gui/widgets/mi_mini_image_view/test/view_test.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/test/view_test.py
@@ -2,8 +2,10 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-import numpy as np
 import unittest
+from unittest.mock import patch
+import numpy as np
+from PyQt5.QtWidgets import QFileDialog
 
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
@@ -13,8 +15,10 @@ from mantidimaging.test_helpers import start_qapplication
 @start_qapplication
 class MIMiniImageViewTest(unittest.TestCase):
 
-    def setUp(self) -> None:
+    def setUp(self):
         self.view = MIMiniImageView()
+        self.test_file = "/tmp/test_output.tif"
+        self.test_png = "/tmp/test_output.png"
 
     def tearDown(self):
         self.view.cleanup()
@@ -26,3 +30,23 @@ class MIMiniImageViewTest(unittest.TestCase):
         self.view.setImage(image.data)
         np.testing.assert_array_equal(self.view.im.getLevels().round(5),
                                       np.array(self.view.levels).round(5), 'Brightness levels not set correctly')
+
+    def test_save_raw_image_saves_correct_data(self):
+        image = generate_images(seed=2023, shape=(10, 10))
+        self.view.setImage(image.data)
+
+        with patch("mantidimaging.gui.widgets.mi_mini_image_view.view.tifffile.imwrite") as mock_write:
+            with patch.object(QFileDialog, 'getSaveFileName', return_value=(self.test_file, "")):
+                self.view.save_raw_image()
+        mock_write.assert_called_once()
+        saved_path, saved_data = mock_write.call_args[0]
+        self.assertEqual(saved_path, self.test_file)
+        np.testing.assert_array_equal(saved_data, image.data)
+
+    def test_save_displayed_image_saves_correct_data(self):
+        image = generate_images(seed=2023, shape=(10, 10))
+        self.view.setImage(image.data)
+        with patch.object(QFileDialog, 'getSaveFileName', return_value=(self.test_png, "")), \
+             patch('PyQt5.QtGui.QImage.save', return_value=True) as mock_save:
+            self.view.save_displayed_image()
+            mock_save.assert_called_once()

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -349,6 +349,7 @@ class SpectrumProjectionWidget(GraphicsLayoutWidget):
         self.image = MIMiniImageView(name="Projection", view_box_type=CustomViewBox)
         self.addItem(self.image, 0, 0)
         self.ci.layout.setRowStretchFactor(0, 3)
+        self.image.add_save_image_action()
 
         nan_check_menu = [("Crop Coordinates", lambda: main_window.presenter.show_operation("Crop Coordinates")),
                           ("NaN Removal", lambda: main_window.presenter.show_operation("NaN Removal"))]

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -228,7 +228,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         self.spectrum_widget = SpectrumWidget(main_window)
         self.spectrum = self.spectrum_widget.spectrum_plot_widget
-
         self.imageLayout.addWidget(self.spectrum_widget)
         self.fittingLayout.addWidget(QLabel("fitting"))
         self.exportLayout.addWidget(QLabel("export"))


### PR DESCRIPTION
## Issue  
Closes #2503  

### Description  
This PR implements the ability to **save the currently displayed image in the Spectrum Viewer** with the following features:  
- **Save Raw Image**: Saves the image array exactly as stored in `MIMiniImageView.image_data()`.  
- **Save Displayed Image**: Saves the **LUT-mapped, scaled, and color-adjusted** version as seen in the UI.  
