### PR TITLE
Added Spectrum Viewer Tests

### DIFF
--- a/mantidimaging/eyes_tests/spectrum_viewer_test.py
+++ b/mantidimaging/eyes_tests/spectrum_viewer_test.py
@@ -40,3 +40,11 @@ class SpectrumViewerWindowTest(BaseEyesTest):
         self.imaging.spectrum_viewer.spectrum_widget.roi_dict["roi_1"].setSize(2, 2)
         self.imaging.spectrum_viewer.spectrum_widget.roi_dict["roi_1"].setPos(5, 5)
         self.check_target(widget=self.imaging.spectrum_viewer)
+
+    def test_spectrum_viewer_scatter_plot(self):
+        self._generate_spectrum_dataset()
+        self.imaging.show_spectrum_viewer_window()
+        for action in self.imaging.spectrum_viewer.spectrum.spectrum.join_choice_group.actions():
+            if action.text() == 'Points':
+                action.trigger()
+        self.check_target(widget=self.imaging.spectrum_viewer)

--- a/mantidimaging/gui/test/gui_system_spectrum_test.py
+++ b/mantidimaging/gui/test/gui_system_spectrum_test.py
@@ -8,8 +8,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtTest import QTest
 from PyQt5.QtGui import QColor
 from parameterized import parameterized
-from pyqtgraph import mkPen
-from pyqtgraph.graphicsItems.PlotItem import PlotItem
+from pyqtgraph.graphicsItems.PlotDataItem import PlotDataItem
 
 from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHOW_DELAY, SHORT_DELAY
 from mantidimaging.gui.windows.spectrum_viewer.model import SpecType, SensibleROI
@@ -188,17 +187,19 @@ class TestGuiSpectrumViewer(GuiSystemBase):
             if action.text() == 'Points':
                 action.trigger()
         QTest.qWait(SHORT_DELAY)
-        self.assertEqual(self.spectrum_window.spectrum.spectrum.items[-1].opts['symbol'], 'o')
-        self.assertEqual(self.spectrum_window.spectrum.spectrum.items[-1].opts['pen'].color().getRgb(),
-                         mkPen(None).color().getRgb())
+        for item in self.spectrum_window.spectrum.spectrum.items:
+            if isinstance(item, PlotDataItem):
+                self.assertEqual(item.opts['symbol'], 'o')
+                self.assertEqual(item.opts['pen'].color().getRgb(), (200, 200, 200, 255))
 
     def test_add_roi_with_scatter_plot(self):
         for action in self.spectrum_window.spectrum.spectrum.join_choice_group.actions():
             if action.text() == 'Points':
                 action.trigger()
-        QTest.mouseClick(self.spectrum_window.addBtn, Qt.MouseButton.LeftButton)
+        initial_items = len(self.spectrum_window.spectrum.spectrum.items)
+        QTest.mouseClick(self.spectrum_window.roi_form.addBtn, Qt.MouseButton.LeftButton)
         for item in self.spectrum_window.spectrum.spectrum.items:
-            if isinstance(item, PlotItem):
+            if isinstance(item, PlotDataItem):
                 self.assertEqual(item.opts['symbol'], 'o')
-                self.assertEqual(item.opts['pen'].color().getRgb(), mkPen(None).color().getRgb())
-        self.assertEqual(len(self.spectrum_window.spectrum.spectrum.items), 3)
+                self.assertEqual(item.opts['pen'].color().getRgb(), (200, 200, 200, 255))
+        self.assertEqual(len(self.spectrum_window.spectrum.spectrum.items), initial_items + 1)

--- a/mantidimaging/gui/test/gui_system_spectrum_test.py
+++ b/mantidimaging/gui/test/gui_system_spectrum_test.py
@@ -188,7 +188,6 @@ class TestGuiSpectrumViewer(GuiSystemBase):
             if action.text() == 'Points':
                 action.trigger()
         QTest.qWait(SHORT_DELAY)
-        self.assertEqual(self.spectrum_window.spectrum.spectrum.join_plot, False)
         self.assertEqual(self.spectrum_window.spectrum.spectrum.items[-1].opts['symbol'], 'o')
         self.assertEqual(self.spectrum_window.spectrum.spectrum.items[-1].opts['pen'].color().getRgb(),
                          mkPen(None).color().getRgb())
@@ -198,7 +197,6 @@ class TestGuiSpectrumViewer(GuiSystemBase):
             if action.text() == 'Points':
                 action.trigger()
         QTest.mouseClick(self.spectrum_window.addBtn, Qt.MouseButton.LeftButton)
-        self.assertEqual(self.spectrum_window.spectrum.spectrum.join_plot, False)
         for item in self.spectrum_window.spectrum.spectrum.items:
             if isinstance(item, PlotItem):
                 self.assertEqual(item.opts['symbol'], 'o')

--- a/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
@@ -13,7 +13,7 @@ from pyqtgraph import Point
 
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowView, SpectrumViewerWindowPresenter
-from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumWidget, SpectrumPlotWidget
+from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumWidget, SpectrumPlotWidget, MIPlotItem
 from mantidimaging.test_helpers import mock_versions, start_qapplication
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumROI
@@ -175,3 +175,28 @@ class SpectrumWidgetTest(unittest.TestCase):
 
         with self.assertRaises(KeyError):
             self.spectrum_widget.rename_roi("roi_1", "roi_2")
+
+
+@start_qapplication
+class MIPlotItemTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.spectrum_plot = MIPlotItem()
+        self.x_data = np.random.default_rng().random(10)
+        self.y_data = np.random.default_rng().random(10)
+        self.colour = (10, 50, 200, 255)
+
+    def test_WHEN_plotting_original_pen_set(self):
+        self.spectrum_plot.plot(self.x_data, self.y_data, pen=self.colour)
+        self.assertEqual(self.spectrum_plot.items[-1].original_pen, self.colour)
+
+    @parameterized.expand([("Line", (10, 50, 200, 255), None), ("Points", None, 'o')])
+    def test_WHEN_plot_mode_set_THEN_data_plotted_correctly(self, joined_choice, pen_expected, symbol_expected):
+        self.spectrum_plot.join_choice_group.checkedAction().text = mock.Mock()
+        self.spectrum_plot.join_choice_group.checkedAction().text.return_value = joined_choice
+        self.spectrum_plot.plot(self.x_data, self.y_data, pen=self.colour)
+        self.spectrum_plot.items[-1].setPen = mock.Mock()
+        self.spectrum_plot.items[-1].setSymbol = mock.Mock()
+        self.spectrum_plot.set_join_plot()
+        self.spectrum_plot.items[-1].setPen.assert_called_once_with(pen_expected)
+        self.spectrum_plot.items[-1].setSymbol.assert_called_once_with(symbol_expected)


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2525

### Description

Unit, System, and Eyes tests have been added to reflect the changed in the Spectrum Viewer related to the scatter plot option.

### Developer Testing 

- I have verified unit tests pass locally: `python -m pytest -vs`
- `make check`
- `make test-system`
- `make test-screenshots`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Check that all tests pass as above

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->


- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) 

