### PR TITLE
Update links to correct webpage

### DIFF
--- a/mantidimaging/core/net/help_pages.py
+++ b/mantidimaging/core/net/help_pages.py
@@ -10,7 +10,7 @@ SECTION_USER_GUIDE = f"{DOCS_BASE}/user_guide/"
 
 
 def open_user_operation_docs(operation_name: str) -> None:
-    page_url = "operations/index"
+    page_url = "explanations/operations/index"
     section = operation_name.lower().replace(" ", "-")
     open_help_webpage(SECTION_USER_GUIDE, page_url, section)
 

--- a/mantidimaging/core/net/test/help_pages_test.py
+++ b/mantidimaging/core/net/test/help_pages_test.py
@@ -14,7 +14,7 @@ class HelpPagesTest(unittest.TestCase):
     @mock.patch("mantidimaging.core.net.help_pages.open_help_webpage")
     def test_open_user_operation_docs(self, open_func: mock.Mock):
         open_user_operation_docs("Crop Coordinates")
-        open_func.assert_called_with(SECTION_USER_GUIDE, "operations/index", "crop-coordinates")
+        open_func.assert_called_with(SECTION_USER_GUIDE, "explanations/operations/index", "crop-coordinates")
 
     @mock.patch("mantidimaging.core.net.help_pages.QDesktopServices.openUrl")
     def test_open_help_webpage(self, open_url: mock.Mock):

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -192,8 +192,9 @@ class ReconstructWindowView(BaseMainWindowView):
         self.stochasticCheckBox.stateChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
         self.subsetsSpinBox.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
         self.regPercentSpinBox.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
-        self.reconHelpButton.clicked.connect(lambda: self.open_help_webpage("reconstructions/index"))
-        self.corHelpButton.clicked.connect(lambda: self.open_help_webpage("reconstructions/center_of_rotation"))
+        self.reconHelpButton.clicked.connect(lambda: self.open_help_webpage("explanations/reconstructions/index"))
+        self.corHelpButton.clicked.connect(
+            lambda: self.open_help_webpage("explanations/reconstructions/center_of_rotation"))
 
         self.stochasticCheckBox.stateChanged.connect(self.subsetsSpinBox.setEnabled)
         self.stochasticCheckBox.stateChanged.connect(self.subsetsLabel.setEnabled)


### PR DESCRIPTION
Operations and Recon

<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2502

### Description

Clicking these buttons gave a 404 not found error:

Operations window `?` button
Recon window `Open Reconstruction Help Page` button
Recon window `?` button

The operations window has a `?` button that links to descriptions of each operation. These currently give a 404 not found error.

E.g. the button links to
https://mantidproject.github.io/mantidimaging/user_guide/operations/index.html#median when it should now be https://mantidproject.github.io/mantidimaging/user_guide/explanations/operations/index.html#median

Clicking the "Open Reconstruction Help Page" button in the Reconstruction window's Reconstruct tab opens the link in the browser, however a 404 page error is displayed as the link is invalid.

Invalid link: https://mantidproject.github.io/mantidimaging/user_guide/reconstructions/index.html
Working link: https://mantidproject.github.io/mantidimaging/user_guide/explanations/reconstructions/index.html

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- [x] I have verified buttons open correct webpages

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Browser opens correct page



