### PR TITLE
Add spectrum plot to fitting tab

### DIFF
--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from collections.abc import Sequence
+import numpy as np
 from PyQt5.QtWidgets import QWidget, QVBoxLayout
 from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumPlotWidget
 
@@ -9,17 +11,20 @@ class FittingDisplayWidget(QWidget):
     Widget for displaying fitting-related spectrum plot using the reusable SpectrumPlotWidget.
     """
 
-    def __init__(self, parent=None):
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
 
-        self.layout = QVBoxLayout(self)
-        self.spectrum_plot = SpectrumPlotWidget()
+        self.layout: QVBoxLayout = QVBoxLayout(self)
+        self.spectrum_plot: SpectrumPlotWidget = SpectrumPlotWidget()
         self.layout.addWidget(self.spectrum_plot)
 
-    def update_plot(self, x_data, y_data, label="ROI"):
+    def update_plot(self,
+                    x_data: Sequence[float] | np.ndarray,
+                    y_data: Sequence[float] | np.ndarray,
+                    label: str = "ROI") -> None:
         self.spectrum_plot.spectrum.clear()
         self.spectrum_plot.spectrum.plot(x_data, y_data, name=label, pen=(255, 255, 0))
 
-    def update_labels(self, wavelength_range=None):
+    def update_labels(self, wavelength_range: tuple[float, float] | None = None) -> None:
         if wavelength_range is not None and len(wavelength_range) == 2:
             self.spectrum_plot.set_wavelength_range_label(*wavelength_range)

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from PyQt5.QtWidgets import QWidget, QVBoxLayout
+from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumPlotWidget
+
+
+class FittingDisplayWidget(QWidget):
+    """
+    Widget for displaying fitting-related spectrum plot using the reusable SpectrumPlotWidget.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.layout = QVBoxLayout(self)
+        self.spectrum_plot = SpectrumPlotWidget()
+        self.layout.addWidget(self.spectrum_plot)
+
+    def update_plot(self, x_data, y_data, label="ROI"):
+        self.spectrum_plot.spectrum.clear()
+        self.spectrum_plot.spectrum.plot(x_data, y_data, name=label, pen=(255, 255, 0))
+
+    def update_labels(self, tof_range, image_range, wavelength_range=None):
+        self.spectrum_plot.set_tof_range_label(*tof_range)
+        self.spectrum_plot.set_image_index_range_label(*image_range)
+        if wavelength_range is not None and len(wavelength_range) == 2:
+            self.spectrum_plot.set_wavelength_range_label(*wavelength_range)

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -20,8 +20,6 @@ class FittingDisplayWidget(QWidget):
         self.spectrum_plot.spectrum.clear()
         self.spectrum_plot.spectrum.plot(x_data, y_data, name=label, pen=(255, 255, 0))
 
-    def update_labels(self, tof_range, image_range, wavelength_range=None):
-        self.spectrum_plot.set_tof_range_label(*tof_range)
-        self.spectrum_plot.set_image_index_range_label(*image_range)
+    def update_labels(self, wavelength_range=None):
         if wavelength_range is not None and len(wavelength_range) == 2:
             self.spectrum_plot.set_wavelength_range_label(*wavelength_range)

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
-from collections.abc import Sequence
 import numpy as np
 from PyQt5.QtWidgets import QWidget, QVBoxLayout
 from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumPlotWidget
@@ -18,10 +17,7 @@ class FittingDisplayWidget(QWidget):
         self.spectrum_plot: SpectrumPlotWidget = SpectrumPlotWidget()
         self.layout.addWidget(self.spectrum_plot)
 
-    def update_plot(self,
-                    x_data: Sequence[float] | np.ndarray,
-                    y_data: Sequence[float] | np.ndarray,
-                    label: str = "ROI") -> None:
+    def update_plot(self, x_data: np.ndarray, y_data: np.ndarray, label: str = "ROI") -> None:
         self.spectrum_plot.spectrum.clear()
         self.spectrum_plot.spectrum.plot(x_data, y_data, name=label, pen=(255, 255, 0))
 

--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_selection_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_selection_widget.py
@@ -46,6 +46,7 @@ class ROISelectionWidget(QtWidgets.QGroupBox):
             self.roiDropdown.setCurrentText(current_selection)
         elif filtered_rois:
             self.roiDropdown.setCurrentIndex(0)
+            self._on_selection_changed()
         self.roiDropdown.blockSignals(False)
 
     def set_selected_roi(self, roi_name: str) -> None:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -225,9 +225,10 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         if tof_data is None:
             return
         self.view.fittingDisplayWidget.update_plot(tof_data, spectrum_data, label=roi_name)
-        self.view.fittingDisplayWidget.update_labels(tof_range=self.model.tof_plot_range,
-                                                     image_range=self.model.tof_range,
-                                                     wavelength_range=(min(tof_data), max(tof_data)))
+        wavelength_range = None
+        if isinstance(tof_data, list | np.ndarray) and len(tof_data) > 0:
+            wavelength_range = (min(tof_data), max(tof_data))
+        self.view.fittingDisplayWidget.update_labels(wavelength_range=wavelength_range)
 
     def redraw_spectrum(self, name: str) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -215,6 +215,20 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             self.view.table_view.select_roi(roi.name)
             self.view.set_roi_properties()
 
+    def update_fitting_spectrum(self, roi_name: str) -> None:
+        """Fetches the spectrum data for the selected ROI and updates the view."""
+        if roi_name not in self.view.spectrum_widget.roi_dict:
+            return
+        roi = self.view.spectrum_widget.get_roi(roi_name)
+        spectrum_data = self.model.get_spectrum(roi, self.spectrum_mode)
+        tof_data = self.model.tof_data
+        if tof_data is None:
+            return
+        self.view.fittingDisplayWidget.update_plot(tof_data, spectrum_data, label=roi_name)
+        self.view.fittingDisplayWidget.update_labels(tof_range=self.model.tof_plot_range,
+                                                     image_range=self.model.tof_range,
+                                                     wavelength_range=(min(tof_data), max(tof_data)))
+
     def redraw_spectrum(self, name: str) -> None:
         """
         Redraw the spectrum with the given name

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -342,6 +342,12 @@ class SpectrumPlotWidget(GraphicsLayoutWidget):
     def set_tof_axis_label(self, tof_axis_label: str) -> None:
         self.spectrum.setLabel('bottom', text=tof_axis_label)
 
+    def set_wavelength_range_label(self, range_min: float, range_max: float) -> None:
+        if not hasattr(self, "_wavelength_range_label"):
+            self.nextRow()
+            self._wavelength_range_label = self.addLabel()
+        self._wavelength_range_label.setText(f"Neutron Wavelength (Å)\nRange: {range_min:.3f} - {range_max:.3f}")
+
 
 class SpectrumProjectionWidget(GraphicsLayoutWidget):
     image: MIMiniImageView

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from pyqtgraph import mkPen
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import (QCheckBox, QVBoxLayout, QFileDialog, QLabel, QAbstractItemView, QHeaderView, QComboBox,
                              QSpinBox, QGroupBox, QActionGroup, QAction)
@@ -21,6 +22,8 @@ from .spectrum_widget import SpectrumWidget
 from mantidimaging.gui.windows.spectrum_viewer.roi_table_model import TableModel
 from mantidimaging.gui.widgets.spectrum_widgets.tof_properties import ExperimentSetupFormWidget
 from mantidimaging.gui.widgets.spectrum_widgets.roi_selection_widget import ROISelectionWidget
+from mantidimaging.gui.widgets.spectrum_widgets.fitting_display_widget import FittingDisplayWidget
+
 import numpy as np
 
 if TYPE_CHECKING:
@@ -225,13 +228,16 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.spectrum_widget = SpectrumWidget(main_window)
         self.spectrum = self.spectrum_widget.spectrum_plot_widget
         self.imageLayout.addWidget(self.spectrum_widget)
-        self.fittingLayout.addWidget(QLabel("fitting"))
         self.exportLayout.addWidget(QLabel("export"))
 
         self.spectrum.range_changed.connect(self.presenter.handle_range_slide_moved)
 
         self.roiSelectionWidget = ROISelectionWidget(self)
         self.fittingFormLayout.layout().addWidget(self.roiSelectionWidget)
+
+        self.fittingDisplayWidget = FittingDisplayWidget()
+        self.fittingLayout.addWidget(self.fittingDisplayWidget)
+        self.roiSelectionWidget.selectionChanged.connect(self.presenter.update_fitting_spectrum)
 
         self.spectrum_widget.roi_clicked.connect(self.presenter.handle_roi_clicked)
         self.spectrum_widget.roi_changed.connect(self.presenter.handle_roi_moved)
@@ -355,6 +361,17 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             return Path(path)
         else:
             return None
+
+    def update_fitting_plot(self, roi_name: str, spectrum_data: np.ndarray) -> None:
+        """Updates the spectrum plot in the Fitting Window with a yellow line."""
+        self.fittingSpectrumPlot.spectrum.clear()
+
+        if spectrum_data is not None and len(spectrum_data) > 0:
+            yellow_pen = mkPen(color=(255, 255, 0), width=2)
+            self.fittingSpectrumPlot.spectrum.plot(self.presenter.model.tof_data,
+                                                   spectrum_data,
+                                                   pen=yellow_pen,
+                                                   name=roi_name)
 
     def get_rits_export_directory(self) -> Path | None:
         """


### PR DESCRIPTION
## Issue Closes #2387

### Description

Adds a spectrum line plot to the Fitting Window, including:
- Yellow ROI spectrum line
- Dynamic labels: Neutron Wavelength (Å), ToF Range, Image Index Range

### Developer Testing 

- Verified unit tests pass: `python -m pytest -vs`
- Manually tested ROI selection, plot rendering, and label updates

### Acceptance Criteria

- [ ] Yellow line appears on ROI plot
- [ ] First ROI plots successfully
- [ ] Switching ROIs updates the plot
- [ ] Wavelength, ToF Range, and Image Index Range shown below the plot
