### PR TITLE
FLASHPR: Fix removeBtn, missed change from PR2530

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -498,7 +498,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.presenter.handle_roi_moved(roi_object)
 
         if self.table_view.roi_table_model.rowCount() == 0:
-            self.removeBtn.setEnabled(False)
+            self.roi_form.removeBtn.setEnabled(False)
             self.disable_roi_properties()
         else:
             self.set_roi_properties()


### PR DESCRIPTION
### Description
Quick fix up for a missing change in #2530

`removeBtn` is now in the `ROIFormWidget`

This fix prevents and error when removing the last ROI in the spectrum viewer.

### Developer Testing 


<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- ...

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Check that it is possible to remove all the ROIs from the spectrum viewer without an error message

### Documentation and Additional Notes
Not needed