### PR TITLE
Move widgets into roi_form_widget.py

### DIFF
--- a/mantidimaging/gui/ui/roi_form_widget.ui
+++ b/mantidimaging/gui/ui/roi_form_widget.ui
@@ -219,7 +219,7 @@
   <customwidget>
    <class>ROIPropertiesTableWidget</class>
    <extends>QWidget</extends>
-   <header>mantidimaging.gui.windows.spectrum_viewer.view</header>
+   <header>mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/mantidimaging/gui/ui/roi_form_widget.ui
+++ b/mantidimaging/gui/ui/roi_form_widget.ui
@@ -214,7 +214,7 @@
   <customwidget>
    <class>ROITableWidget</class>
    <extends>QTableView</extends>
-   <header>mantidimaging.gui.windows.spectrum_viewer.view</header>
+   <header>mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget</header>
   </customwidget>
   <customwidget>
    <class>ROIPropertiesTableWidget</class>

--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
@@ -17,6 +17,9 @@ if TYPE_CHECKING:
 
 
 class ROIFormWidget(BaseWidget):
+    """
+    Collection of widgets for adding, removing and adjusting ROIs in the spectrum viewer
+    """
     exportTabs: QTabWidget
     roi_properties_widget: ROIPropertiesTableWidget
     table_view: ROITableWidget
@@ -48,6 +51,9 @@ class ROIFormWidget(BaseWidget):
 
 
 class ROIPropertiesTableWidget(BaseWidget):
+    """
+    Widget for manually adjusting the current selected ROI
+    """
     spin_left: QSpinBox
     spin_right: QSpinBox
     spin_top: QSpinBox

--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
@@ -25,6 +25,9 @@ class ROIFormWidget(BaseWidget):
     removeBtn: QPushButton
     exportButton: QPushButton
     exportButtonRITS: QPushButton
+    transmission_error_mode_combobox: QComboBox
+    bin_size_spinBox: QSpinBox
+    bin_step_spinBox: QSpinBox
 
     def __init__(self, parent=None):
         super().__init__(parent, ui_file='gui/ui/roi_form_widget.ui')

--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
@@ -2,16 +2,18 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from PyQt5.QtCore import pyqtSignal, QSignalBlocker
+from PyQt5.QtCore import pyqtSignal, QSignalBlocker, QModelIndex
+from PyQt5.QtWidgets import QAbstractItemView, QHeaderView
 
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.mvp_base import BaseWidget
+from mantidimaging.gui.widgets import RemovableRowTableView
+from mantidimaging.gui.windows.spectrum_viewer.roi_table_model import TableModel
 
 if TYPE_CHECKING:
     from PyQt5.QtWidgets import QTabWidget, QComboBox, QPushButton, QSpinBox, QLabel, QGroupBox
-    from mantidimaging.gui.windows.spectrum_viewer.view import ROITableWidget
 
 
 class ROIFormWidget(BaseWidget):
@@ -91,3 +93,113 @@ class ROIPropertiesTableWidget(BaseWidget):
             spin_box.setEnabled(enable)
         if not enable:
             self.set_roi_values(SensibleROI(0, 0, 0, 0))
+
+
+class ROITableWidget(RemovableRowTableView):
+    """
+    A class to represent the ROI table widget in the spectrum viewer window.
+    """
+    ElementType = str | tuple[int, int, int] | bool
+    RowType = list[ElementType]
+    selected_row: int
+
+    selection_changed = pyqtSignal()
+    name_changed = pyqtSignal(str, str)
+    visibility_changed = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.selected_row = 0
+
+        # Point table
+        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.setAlternatingRowColors(True)
+
+        # Initialise model
+        self.roi_table_model = TableModel()
+        self.setModel(self.roi_table_model)
+
+        # Configure up the table view
+        self.setVisible(True)
+        header = self.horizontalHeader()
+        header.setSectionResizeMode(0, QHeaderView.Stretch)
+        header.setSectionResizeMode(1, QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(2, QHeaderView.ResizeToContents)
+
+        self.selectionModel().currentRowChanged.connect(self.on_row_change)
+        self.roi_table_model.name_changed.connect(self.name_changed.emit)
+        self.roi_table_model.visibility_changed.connect(self.visibility_changed.emit)
+
+    def on_row_change(self, item: QModelIndex, _: Any) -> None:
+        self.selected_row = item.row()
+        self.selection_changed.emit()
+
+    def get_roi_names(self) -> list[str]:
+        return self.roi_table_model.roi_names()
+
+    def get_roi_name_by_row(self, row: int) -> str:
+        """
+        Retrieve the name an ROI by its row index.
+        """
+        return self.roi_table_model.get_element(row, 0)
+
+    @property
+    def current_roi_name(self) -> str:
+        return self.get_roi_name_by_row(self.selected_row)
+
+    def get_roi_visibility_by_row(self, row: int) -> bool:
+        """
+        Retrieve the visibility status of an ROI by its row index.
+        """
+        return self.roi_table_model.get_element(row, 2)
+
+    def row_count(self) -> int:
+        """
+        Returns the number of rows in the ROI table model.
+        """
+        return self.roi_table_model.rowCount()
+
+    def find_row_for_roi(self, roi_name: str) -> int | None:
+        """
+        Returns row index for ROI name, or None if not found.
+        """
+        for row in range(self.roi_table_model.rowCount()):
+            if self.roi_table_model.index(row, 0).data() == roi_name:
+                return row
+        return None
+
+    def update_roi_color(self, roi_name: str, new_color: tuple[int, int, int, int]) -> None:
+        """
+        Finds ROI by name in table and updates it's colour (R, G, B) format.
+        """
+        row = self.find_row_for_roi(roi_name)
+        if row is not None:
+            self.roi_table_model.update_color(row, new_color)
+
+    def add_row(self, name: str, colour: tuple[int, int, int, int], roi_names: list[str]) -> None:
+        """
+        Add a new row to the ROI table
+        """
+        self.roi_table_model.appendNewRow(name, colour, True)
+        self.selected_row = self.roi_table_model.rowCount() - 1
+        self.selectRow(self.selected_row)
+
+    def remove_row(self, row: int) -> None:
+        """
+        Remove a row from the ROI table
+        """
+        self.roi_table_model.remove_row(row)
+        self.selectRow(0)
+
+    def clear_table(self) -> None:
+        """
+        Clears the ROI table in the spectrum viewer.
+        """
+        self.roi_table_model.clear_table()
+
+    def select_roi(self, roi_name: str) -> None:
+        selected_row = self.find_row_for_roi(roi_name)
+        assert selected_row is not None
+        self.selectRow(selected_row)

--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from PyQt5.QtCore import pyqtSignal, QSignalBlocker
+
+from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.mvp_base import BaseWidget
 
 if TYPE_CHECKING:
-    from PyQt5.QtWidgets import QTabWidget, QComboBox, QPushButton
-    from mantidimaging.gui.windows.spectrum_viewer.view import ROIPropertiesTableWidget, ROITableWidget
+    from PyQt5.QtWidgets import QTabWidget, QComboBox, QPushButton, QSpinBox, QLabel, QGroupBox
+    from mantidimaging.gui.windows.spectrum_viewer.view import ROITableWidget
 
 
 class ROIFormWidget(BaseWidget):
@@ -37,3 +40,54 @@ class ROIFormWidget(BaseWidget):
         self.bin_size_spinBox.setHidden(hide_binning)
         self.bin_step_label.setHidden(hide_binning)
         self.bin_step_spinBox.setHidden(hide_binning)
+
+
+class ROIPropertiesTableWidget(BaseWidget):
+    spin_left: QSpinBox
+    spin_right: QSpinBox
+    spin_top: QSpinBox
+    spin_bottom: QSpinBox
+    label_height: QLabel
+    label_width: QLabel
+    group_box: QGroupBox
+
+    roi_changed = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent, ui_file='gui/ui/roi_properties_table_widget.ui')
+
+        self.spin_boxes = [self.spin_left, self.spin_right, self.spin_top, self.spin_bottom]
+
+        for spin_box in self.spin_boxes:
+            spin_box.valueChanged.connect(self.roi_changed.emit)
+
+    def set_roi_name(self, name: str) -> None:
+        self.group_box.setTitle(f"Roi Properties: {name}")
+
+    def set_roi_values(self, roi: SensibleROI) -> None:
+        with QSignalBlocker(self):
+            self.spin_left.setValue(roi.left)
+            self.spin_right.setValue(roi.right)
+            self.spin_top.setValue(roi.top)
+            self.spin_bottom.setValue(roi.bottom)
+            self.label_width.setText(str(roi.width))
+            self.label_height.setText(str(roi.height))
+
+    def set_roi_limits(self, shape: tuple[int, ...]) -> None:
+        self.spin_left.setMaximum(shape[1])
+        self.spin_right.setMaximum(shape[1])
+        self.spin_top.setMaximum(shape[0])
+        self.spin_bottom.setMaximum(shape[0])
+
+    def as_roi(self) -> SensibleROI:
+        new_roi = SensibleROI(left=self.spin_left.value(),
+                              right=self.spin_right.value(),
+                              top=self.spin_top.value(),
+                              bottom=self.spin_bottom.value())
+        return new_roi
+
+    def enable_widgets(self, enable: bool) -> None:
+        for spin_box in self.spin_boxes:
+            spin_box.setEnabled(enable)
+        if not enable:
+            self.set_roi_values(SensibleROI(0, 0, 0, 0))

--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
@@ -90,7 +90,7 @@ class ROIPropertiesTableWidget(BaseWidget):
         self.spin_top.setMaximum(shape[0])
         self.spin_bottom.setMaximum(shape[0])
 
-    def as_roi(self) -> SensibleROI:
+    def to_roi(self) -> SensibleROI:
         new_roi = SensibleROI(left=self.spin_left.value(),
                               right=self.spin_right.value(),
                               top=self.spin_top.value(),

--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
@@ -97,7 +97,7 @@ class ROIPropertiesTableWidget(BaseWidget):
                               bottom=self.spin_bottom.value())
         return new_roi
 
-    def enable_widgets(self, enable: bool) -> None:
+    def enable_roi_spinboxes(self, enable: bool) -> None:
         for spin_box in self.spin_boxes:
             spin_box.setEnabled(enable)
         if not enable:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -423,7 +423,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                     self.check_action(action, False)
 
     def do_adjust_roi(self) -> None:
-        new_roi = self.view.roi_form.roi_properties_widget.as_roi()
+        new_roi = self.view.roi_form.roi_properties_widget.to_roi()
         roi_name = self.view.table_view.current_roi_name
         self.view.spectrum_widget.adjust_roi(new_roi, roi_name)
         self.handle_roi_moved(self.view.spectrum_widget.roi_dict[roi_name])

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -12,13 +12,13 @@ from parameterized import parameterized
 
 from mantidimaging.core.data.dataset import Dataset
 from mantidimaging.core.utility.sensible_roi import SensibleROI
-from mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget import ROIFormWidget
+from mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget import ROIFormWidget, ROIPropertiesTableWidget
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowView, SpectrumViewerWindowPresenter
 from mantidimaging.gui.windows.spectrum_viewer.model import ErrorMode, ToFUnitMode, ROI_RITS, SpecType
 from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumWidget, SpectrumPlotWidget, SpectrumROI
 from mantidimaging.gui.widgets.spectrum_widgets.tof_properties import ExperimentSetupFormWidget
-from mantidimaging.gui.windows.spectrum_viewer.view import ROITableWidget, ROIPropertiesTableWidget
+from mantidimaging.gui.windows.spectrum_viewer.view import ROITableWidget
 from mantidimaging.test_helpers import start_qapplication
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -371,7 +371,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.check_action.assert_has_calls(calls)
 
     def test_WHEN_roi_changed_via_spinboxes_THEN_roi_adjusted(self):
-        self.view.roi_form.roi_properties_widget.as_roi = mock.Mock(return_value=SensibleROI(10, 10, 20, 30))
+        self.view.roi_form.roi_properties_widget.to_roi = mock.Mock(return_value=SensibleROI(10, 10, 20, 30))
         type(self.view.table_view).current_roi_name = mock.PropertyMock(return_value="roi_1")
         self.presenter.do_adjust_roi()
         self.view.spectrum_widget.adjust_roi.assert_called_once_with(SensibleROI(10, 10, 20, 30), "roi_1")

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -12,13 +12,13 @@ from parameterized import parameterized
 
 from mantidimaging.core.data.dataset import Dataset
 from mantidimaging.core.utility.sensible_roi import SensibleROI
-from mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget import ROIFormWidget, ROIPropertiesTableWidget
+from mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget import ROIFormWidget, ROIPropertiesTableWidget, \
+    ROITableWidget
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowView, SpectrumViewerWindowPresenter
 from mantidimaging.gui.windows.spectrum_viewer.model import ErrorMode, ToFUnitMode, ROI_RITS, SpecType
 from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumWidget, SpectrumPlotWidget, SpectrumROI
 from mantidimaging.gui.widgets.spectrum_widgets.tof_properties import ExperimentSetupFormWidget
-from mantidimaging.gui.windows.spectrum_viewer.view import ROITableWidget
 from mantidimaging.test_helpers import start_qapplication
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -3,139 +3,27 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from PyQt5.QtGui import QPixmap
-from PyQt5.QtWidgets import (QCheckBox, QVBoxLayout, QFileDialog, QLabel, QAbstractItemView, QHeaderView, QComboBox,
-                             QSpinBox, QGroupBox, QActionGroup, QAction)
-from PyQt5.QtCore import QModelIndex, pyqtSignal
+from PyQt5.QtWidgets import (QCheckBox, QVBoxLayout, QFileDialog, QLabel, QComboBox, QSpinBox, QGroupBox, QActionGroup,
+                             QAction)
+from PyQt5.QtCore import QModelIndex
 
 from mantidimaging.core.utility import finder
 from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
 from .model import ROI_RITS, allowed_modes
 from .presenter import SpectrumViewerWindowPresenter, ExportMode
-from mantidimaging.gui.widgets import RemovableRowTableView
 from .spectrum_widget import SpectrumWidget
-from mantidimaging.gui.windows.spectrum_viewer.roi_table_model import TableModel
 from mantidimaging.gui.widgets.spectrum_widgets.tof_properties import ExperimentSetupFormWidget
 from mantidimaging.gui.widgets.spectrum_widgets.roi_selection_widget import ROISelectionWidget
 import numpy as np
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
-    from mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget import ROIFormWidget
+    from mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget import ROIFormWidget, ROITableWidget
     from uuid import UUID
-
-
-class ROITableWidget(RemovableRowTableView):
-    """
-    A class to represent the ROI table widget in the spectrum viewer window.
-    """
-    ElementType = str | tuple[int, int, int] | bool
-    RowType = list[ElementType]
-    selected_row: int
-
-    selection_changed = pyqtSignal()
-    name_changed = pyqtSignal(str, str)
-    visibility_changed = pyqtSignal()
-
-    def __init__(self, parent=None):
-        super().__init__(parent)
-
-        self.selected_row = 0
-
-        # Point table
-        self.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.setSelectionMode(QAbstractItemView.SingleSelection)
-        self.setAlternatingRowColors(True)
-
-        # Initialise model
-        self.roi_table_model = TableModel()
-        self.setModel(self.roi_table_model)
-
-        # Configure up the table view
-        self.setVisible(True)
-        header = self.horizontalHeader()
-        header.setSectionResizeMode(0, QHeaderView.Stretch)
-        header.setSectionResizeMode(1, QHeaderView.ResizeToContents)
-        header.setSectionResizeMode(2, QHeaderView.ResizeToContents)
-
-        self.selectionModel().currentRowChanged.connect(self.on_row_change)
-        self.roi_table_model.name_changed.connect(self.name_changed.emit)
-        self.roi_table_model.visibility_changed.connect(self.visibility_changed.emit)
-
-    def on_row_change(self, item: QModelIndex, _: Any) -> None:
-        self.selected_row = item.row()
-        self.selection_changed.emit()
-
-    def get_roi_names(self) -> list[str]:
-        return self.roi_table_model.roi_names()
-
-    def get_roi_name_by_row(self, row: int) -> str:
-        """
-        Retrieve the name an ROI by its row index.
-        """
-        return self.roi_table_model.get_element(row, 0)
-
-    @property
-    def current_roi_name(self) -> str:
-        return self.get_roi_name_by_row(self.selected_row)
-
-    def get_roi_visibility_by_row(self, row: int) -> bool:
-        """
-        Retrieve the visibility status of an ROI by its row index.
-        """
-        return self.roi_table_model.get_element(row, 2)
-
-    def row_count(self) -> int:
-        """
-        Returns the number of rows in the ROI table model.
-        """
-        return self.roi_table_model.rowCount()
-
-    def find_row_for_roi(self, roi_name: str) -> int | None:
-        """
-        Returns row index for ROI name, or None if not found.
-        """
-        for row in range(self.roi_table_model.rowCount()):
-            if self.roi_table_model.index(row, 0).data() == roi_name:
-                return row
-        return None
-
-    def update_roi_color(self, roi_name: str, new_color: tuple[int, int, int, int]) -> None:
-        """
-        Finds ROI by name in table and updates it's colour (R, G, B) format.
-        """
-        row = self.find_row_for_roi(roi_name)
-        if row is not None:
-            self.roi_table_model.update_color(row, new_color)
-
-    def add_row(self, name: str, colour: tuple[int, int, int, int], roi_names: list[str]) -> None:
-        """
-        Add a new row to the ROI table
-        """
-        self.roi_table_model.appendNewRow(name, colour, True)
-        self.selected_row = self.roi_table_model.rowCount() - 1
-        self.selectRow(self.selected_row)
-
-    def remove_row(self, row: int) -> None:
-        """
-        Remove a row from the ROI table
-        """
-        self.roi_table_model.remove_row(row)
-        self.selectRow(0)
-
-    def clear_table(self) -> None:
-        """
-        Clears the ROI table in the spectrum viewer.
-        """
-        self.roi_table_model.clear_table()
-
-    def select_roi(self, roi_name: str) -> None:
-        selected_row = self.find_row_for_roi(roi_name)
-        assert selected_row is not None
-        self.selectRow(selected_row)
 
 
 class SpectrumViewerWindowView(BaseMainWindowView):

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -273,7 +273,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         Set a new ROI on the image
         """
         self.presenter.do_add_roi()
-        self.roi_form.roi_properties_widget.enable_widgets(True)
+        self.roi_form.roi_properties_widget.enable_roi_spinboxes(True)
         self.set_roi_properties()
 
     def handle_table_click(self, index: QModelIndex) -> None:
@@ -369,11 +369,11 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         current_roi = self.presenter.view.spectrum_widget.get_roi(roi_name)
         self.roi_form.roi_properties_widget.set_roi_name(roi_name)
         self.roi_form.roi_properties_widget.set_roi_values(current_roi)
-        self.roi_form.roi_properties_widget.enable_widgets(True)
+        self.roi_form.roi_properties_widget.enable_roi_spinboxes(True)
 
     def disable_roi_properties(self) -> None:
         self.roi_form.roi_properties_widget.set_roi_name("None selected")
-        self.roi_form.roi_properties_widget.enable_widgets(False)
+        self.roi_form.roi_properties_widget.enable_roi_spinboxes(False)
 
     def setup_roi_properties_spinboxes(self) -> None:
         assert self.spectrum_widget.image.image_data is not None

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -8,11 +8,10 @@ from typing import TYPE_CHECKING, Any
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import (QCheckBox, QVBoxLayout, QFileDialog, QLabel, QAbstractItemView, QHeaderView, QComboBox,
                              QSpinBox, QGroupBox, QActionGroup, QAction)
-from PyQt5.QtCore import QSignalBlocker, QModelIndex, pyqtSignal
+from PyQt5.QtCore import QModelIndex, pyqtSignal
 
 from mantidimaging.core.utility import finder
-from mantidimaging.core.utility.sensible_roi import SensibleROI
-from mantidimaging.gui.mvp_base import BaseMainWindowView, BaseWidget
+from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
 from .model import ROI_RITS, allowed_modes
 from .presenter import SpectrumViewerWindowPresenter, ExportMode
@@ -27,57 +26,6 @@ if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
     from mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget import ROIFormWidget
     from uuid import UUID
-
-
-class ROIPropertiesTableWidget(BaseWidget):
-    spin_left: QSpinBox
-    spin_right: QSpinBox
-    spin_top: QSpinBox
-    spin_bottom: QSpinBox
-    label_height: QLabel
-    label_width: QLabel
-    group_box: QGroupBox
-
-    roi_changed = pyqtSignal()
-
-    def __init__(self, parent=None):
-        super().__init__(parent, ui_file='gui/ui/roi_properties_table_widget.ui')
-
-        self.spin_boxes = [self.spin_left, self.spin_right, self.spin_top, self.spin_bottom]
-
-        for spin_box in self.spin_boxes:
-            spin_box.valueChanged.connect(self.roi_changed.emit)
-
-    def set_roi_name(self, name: str) -> None:
-        self.group_box.setTitle(f"Roi Properties: {name}")
-
-    def set_roi_values(self, roi: SensibleROI) -> None:
-        with QSignalBlocker(self):
-            self.spin_left.setValue(roi.left)
-            self.spin_right.setValue(roi.right)
-            self.spin_top.setValue(roi.top)
-            self.spin_bottom.setValue(roi.bottom)
-            self.label_width.setText(str(roi.width))
-            self.label_height.setText(str(roi.height))
-
-    def set_roi_limits(self, shape: tuple[int, ...]) -> None:
-        self.spin_left.setMaximum(shape[1])
-        self.spin_right.setMaximum(shape[1])
-        self.spin_top.setMaximum(shape[0])
-        self.spin_bottom.setMaximum(shape[0])
-
-    def as_roi(self) -> SensibleROI:
-        new_roi = SensibleROI(left=self.spin_left.value(),
-                              right=self.spin_right.value(),
-                              top=self.spin_top.value(),
-                              bottom=self.spin_bottom.value())
-        return new_roi
-
-    def enable_widgets(self, enable: bool) -> None:
-        for spin_box in self.spin_boxes:
-            spin_box.setEnabled(enable)
-        if not enable:
-            self.set_roi_values(SensibleROI(0, 0, 0, 0))
 
 
 class ROITableWidget(RemovableRowTableView):

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -6,8 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from PyQt5.QtGui import QPixmap
-from PyQt5.QtWidgets import (QCheckBox, QVBoxLayout, QFileDialog, QLabel, QComboBox, QSpinBox, QGroupBox, QActionGroup,
-                             QAction)
+from PyQt5.QtWidgets import (QCheckBox, QVBoxLayout, QFileDialog, QLabel, QGroupBox, QActionGroup, QAction)
 from PyQt5.QtCore import QModelIndex
 
 from mantidimaging.core.utility import finder
@@ -39,9 +38,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     shuttercountErrorIcon: QLabel
     normalise_error_issue: str = ""
     shuttercount_error_issue: str = ""
-    transmission_error_mode_combobox: QComboBox
-    bin_size_spinBox: QSpinBox
-    bin_step_spinBox: QSpinBox
 
     spectrum_widget: SpectrumWidget
     experimentSetupGroupBox: QGroupBox
@@ -341,7 +337,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
     @property
     def transmission_error_mode(self) -> str:
-        return self.transmission_error_mode_combobox.currentText()
+        return self.roi_form.transmission_error_mode_combobox.currentText()
 
     @property
     def image_output_mode(self) -> str:
@@ -349,11 +345,11 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
     @property
     def bin_size(self) -> int:
-        return self.bin_size_spinBox.value()
+        return self.roi_form.bin_size_spinBox.value()
 
     @property
     def bin_step(self) -> int:
-        return self.bin_step_spinBox.value()
+        return self.roi_form.bin_step_spinBox.value()
 
     @property
     def tof_units_mode(self) -> str:


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2378

### Description

Move `ROIPropertiesTableWidget` and `ROITableWidget` into `spectrum_widgets/roi_form_widget.py`

Updates imports and tests for the new locations.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- Check the spectrum viewer launches and still works

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Check that basic functions in the spectrum viewer work

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

