### PR TITLE
 Add Resizable ROI to Fitting Spectrum Plot

### DIFF
--- a/mantidimaging/gui/ui/roi_form_widget.ui
+++ b/mantidimaging/gui/ui/roi_form_widget.ui
@@ -214,12 +214,12 @@
   <customwidget>
    <class>ROITableWidget</class>
    <extends>QTableView</extends>
-   <header>mantidimaging.gui.windows.spectrum_viewer.view</header>
+   <header>mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget</header>
   </customwidget>
   <customwidget>
    <class>ROIPropertiesTableWidget</class>
    <extends>QWidget</extends>
-   <header>mantidimaging.gui.windows.spectrum_viewer.view</header>
+   <header>mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -2,6 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 import numpy as np
 from PyQt5.QtWidgets import QWidget, QVBoxLayout
+from pyqtgraph import RectROI, mkPen
 from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumPlotWidget
 
 
@@ -13,14 +14,53 @@ class FittingDisplayWidget(QWidget):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
 
-        self.layout: QVBoxLayout = QVBoxLayout(self)
-        self.spectrum_plot: SpectrumPlotWidget = SpectrumPlotWidget()
+        self.layout = QVBoxLayout(self)
+        self.spectrum_plot = SpectrumPlotWidget()
         self.layout.addWidget(self.spectrum_plot)
 
+        self.fitting_region = RectROI([0, 0], [1, 1], pen=mkPen((255, 0, 0), width=2), movable=True)
+        self.fitting_region.setZValue(10)
+        self.fitting_region.addScaleHandle([1, 1], [0, 0])
+        self.fitting_region.addScaleHandle([0, 0], [1, 1])
+        self.fitting_region.addScaleHandle([0, 1], [1, 0])
+        self.fitting_region.addScaleHandle([1, 0], [0, 1])
+        self.spectrum_plot.spectrum.addItem(self.fitting_region)
+
     def update_plot(self, x_data: np.ndarray, y_data: np.ndarray, label: str = "ROI") -> None:
+        if x_data is None or x_data.size == 0:
+            return
         self.spectrum_plot.spectrum.clear()
         self.spectrum_plot.spectrum.plot(x_data, y_data, name=label, pen=(255, 255, 0))
+        self.spectrum_plot.spectrum.addItem(self.fitting_region)
+        self.set_default_region(x_data, y_data)
 
     def update_labels(self, wavelength_range: tuple[float, float] | None = None) -> None:
-        if wavelength_range is not None and len(wavelength_range) == 2:
+        """Update wavelength range label below the plot, if available."""
+        if wavelength_range is not None:
             self.spectrum_plot.set_wavelength_range_label(*wavelength_range)
+
+    def set_default_region(self, x_data: np.ndarray, y_data: np.ndarray) -> None:
+        """Position the ROI centrally over the plotted data."""
+        x_min, x_max = float(np.min(x_data)), float(np.max(x_data))
+        y_min, y_max = float(np.min(y_data)), float(np.max(y_data))
+        x_span = max((x_max - x_min) * 0.25, 20.0)
+        y_span = max((y_max - y_min) * 0.5, 10.0)
+        x_start = (x_min + x_max - x_span) / 2
+        y_start = max((y_min + y_max - y_span) / 2, 0.0)
+
+        self.fitting_region.setPos((x_start, y_start))
+        self.fitting_region.setSize((x_span, y_span))
+
+    def set_selected_fit_region(self, region: tuple[float, float]) -> None:
+        """Set the horizontal (X-axis) range of the ROI."""
+        x_start, x_end = region
+        width = x_end - x_start
+        y_pos = self.fitting_region.pos().y()
+        height = self.fitting_region.size().y()
+        self.fitting_region.setPos((x_start, y_pos))
+        self.fitting_region.setSize((width, height))
+
+    def get_selected_fit_region(self) -> tuple[float, float]:
+        pos = self.fitting_region.pos()
+        size = self.fitting_region.size()
+        return float(pos.x()), float(pos.x() + size.x())

--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
@@ -2,16 +2,24 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from PyQt5.QtCore import pyqtSignal, QSignalBlocker, QModelIndex
+from PyQt5.QtWidgets import QAbstractItemView, QHeaderView
+
+from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.mvp_base import BaseWidget
+from mantidimaging.gui.widgets import RemovableRowTableView
+from mantidimaging.gui.windows.spectrum_viewer.roi_table_model import TableModel
 
 if TYPE_CHECKING:
-    from PyQt5.QtWidgets import QTabWidget, QComboBox, QPushButton
-    from mantidimaging.gui.windows.spectrum_viewer.view import ROIPropertiesTableWidget, ROITableWidget
+    from PyQt5.QtWidgets import QTabWidget, QComboBox, QPushButton, QSpinBox, QLabel, QGroupBox
 
 
 class ROIFormWidget(BaseWidget):
+    """
+    Collection of widgets for adding, removing and adjusting ROIs in the spectrum viewer
+    """
     exportTabs: QTabWidget
     roi_properties_widget: ROIPropertiesTableWidget
     table_view: ROITableWidget
@@ -20,6 +28,9 @@ class ROIFormWidget(BaseWidget):
     removeBtn: QPushButton
     exportButton: QPushButton
     exportButtonRITS: QPushButton
+    transmission_error_mode_combobox: QComboBox
+    bin_size_spinBox: QSpinBox
+    bin_step_spinBox: QSpinBox
 
     def __init__(self, parent=None):
         super().__init__(parent, ui_file='gui/ui/roi_form_widget.ui')
@@ -37,3 +48,167 @@ class ROIFormWidget(BaseWidget):
         self.bin_size_spinBox.setHidden(hide_binning)
         self.bin_step_label.setHidden(hide_binning)
         self.bin_step_spinBox.setHidden(hide_binning)
+
+
+class ROIPropertiesTableWidget(BaseWidget):
+    """
+    Widget for manually adjusting the current selected ROI
+    """
+    spin_left: QSpinBox
+    spin_right: QSpinBox
+    spin_top: QSpinBox
+    spin_bottom: QSpinBox
+    label_height: QLabel
+    label_width: QLabel
+    group_box: QGroupBox
+
+    roi_changed = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent, ui_file='gui/ui/roi_properties_table_widget.ui')
+
+        self.spin_boxes = [self.spin_left, self.spin_right, self.spin_top, self.spin_bottom]
+
+        for spin_box in self.spin_boxes:
+            spin_box.valueChanged.connect(self.roi_changed.emit)
+
+    def set_roi_name(self, name: str) -> None:
+        self.group_box.setTitle(f"Roi Properties: {name}")
+
+    def set_roi_values(self, roi: SensibleROI) -> None:
+        with QSignalBlocker(self):
+            self.spin_left.setValue(roi.left)
+            self.spin_right.setValue(roi.right)
+            self.spin_top.setValue(roi.top)
+            self.spin_bottom.setValue(roi.bottom)
+            self.label_width.setText(str(roi.width))
+            self.label_height.setText(str(roi.height))
+
+    def set_roi_limits(self, shape: tuple[int, ...]) -> None:
+        self.spin_left.setMaximum(shape[1])
+        self.spin_right.setMaximum(shape[1])
+        self.spin_top.setMaximum(shape[0])
+        self.spin_bottom.setMaximum(shape[0])
+
+    def to_roi(self) -> SensibleROI:
+        new_roi = SensibleROI(left=self.spin_left.value(),
+                              right=self.spin_right.value(),
+                              top=self.spin_top.value(),
+                              bottom=self.spin_bottom.value())
+        return new_roi
+
+    def enable_roi_spinboxes(self, enable: bool) -> None:
+        for spin_box in self.spin_boxes:
+            spin_box.setEnabled(enable)
+        if not enable:
+            self.set_roi_values(SensibleROI(0, 0, 0, 0))
+
+
+class ROITableWidget(RemovableRowTableView):
+    """
+    A class to represent the ROI table widget in the spectrum viewer window.
+    """
+    ElementType = str | tuple[int, int, int] | bool
+    RowType = list[ElementType]
+    selected_row: int
+
+    selection_changed = pyqtSignal()
+    name_changed = pyqtSignal(str, str)
+    visibility_changed = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.selected_row = 0
+
+        # Point table
+        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.setAlternatingRowColors(True)
+
+        # Initialise model
+        self.roi_table_model = TableModel()
+        self.setModel(self.roi_table_model)
+
+        # Configure up the table view
+        self.setVisible(True)
+        header = self.horizontalHeader()
+        header.setSectionResizeMode(0, QHeaderView.Stretch)
+        header.setSectionResizeMode(1, QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(2, QHeaderView.ResizeToContents)
+
+        self.selectionModel().currentRowChanged.connect(self.on_row_change)
+        self.roi_table_model.name_changed.connect(self.name_changed.emit)
+        self.roi_table_model.visibility_changed.connect(self.visibility_changed.emit)
+
+    def on_row_change(self, item: QModelIndex, _: Any) -> None:
+        self.selected_row = item.row()
+        self.selection_changed.emit()
+
+    def get_roi_names(self) -> list[str]:
+        return self.roi_table_model.roi_names()
+
+    def get_roi_name_by_row(self, row: int) -> str:
+        """
+        Retrieve the name an ROI by its row index.
+        """
+        return self.roi_table_model.get_element(row, 0)
+
+    @property
+    def current_roi_name(self) -> str:
+        return self.get_roi_name_by_row(self.selected_row)
+
+    def get_roi_visibility_by_row(self, row: int) -> bool:
+        """
+        Retrieve the visibility status of an ROI by its row index.
+        """
+        return self.roi_table_model.get_element(row, 2)
+
+    def row_count(self) -> int:
+        """
+        Returns the number of rows in the ROI table model.
+        """
+        return self.roi_table_model.rowCount()
+
+    def find_row_for_roi(self, roi_name: str) -> int | None:
+        """
+        Returns row index for ROI name, or None if not found.
+        """
+        for row in range(self.roi_table_model.rowCount()):
+            if self.roi_table_model.index(row, 0).data() == roi_name:
+                return row
+        return None
+
+    def update_roi_color(self, roi_name: str, new_color: tuple[int, int, int, int]) -> None:
+        """
+        Finds ROI by name in table and updates it's colour (R, G, B) format.
+        """
+        row = self.find_row_for_roi(roi_name)
+        if row is not None:
+            self.roi_table_model.update_color(row, new_color)
+
+    def add_row(self, name: str, colour: tuple[int, int, int, int], roi_names: list[str]) -> None:
+        """
+        Add a new row to the ROI table
+        """
+        self.roi_table_model.appendNewRow(name, colour, True)
+        self.selected_row = self.roi_table_model.rowCount() - 1
+        self.selectRow(self.selected_row)
+
+    def remove_row(self, row: int) -> None:
+        """
+        Remove a row from the ROI table
+        """
+        self.roi_table_model.remove_row(row)
+        self.selectRow(0)
+
+    def clear_table(self) -> None:
+        """
+        Clears the ROI table in the spectrum viewer.
+        """
+        self.roi_table_model.clear_table()
+
+    def select_roi(self, roi_name: str) -> None:
+        selected_row = self.find_row_for_roi(roi_name)
+        assert selected_row is not None
+        self.selectRow(selected_row)

--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_selection_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_selection_widget.py
@@ -47,6 +47,7 @@ class ROISelectionWidget(QtWidgets.QGroupBox):
         elif filtered_rois:
             self.roiDropdown.setCurrentIndex(0)
             self._on_selection_changed()
+            self._on_selection_changed()
         self.roiDropdown.blockSignals(False)
 
     def set_selected_roi(self, roi_name: str) -> None:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -215,20 +215,22 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             self.view.table_view.select_roi(roi.name)
             self.view.set_roi_properties()
 
-    def update_fitting_spectrum(self, roi_name: str) -> None:
-        """Fetches the spectrum data for the selected ROI and updates the view."""
+    def update_fitting_spectrum(self, roi_name: str, reset_region: bool = False) -> None:
+        """
+        Fetches the spectrum data for the selected ROI and updates the fitting display plot.
+        """
         if roi_name not in self.view.spectrum_widget.roi_dict:
             return
         roi = self.view.spectrum_widget.get_roi(roi_name)
         spectrum_data = self.model.get_spectrum(roi, self.spectrum_mode)
         tof_data = self.model.tof_data
-        if tof_data is None:
+        if tof_data is None or tof_data.size == 0:
             return
         self.view.fittingDisplayWidget.update_plot(tof_data, spectrum_data, label=roi_name)
-        wavelength_range = None
-        if isinstance(tof_data, list | np.ndarray) and len(tof_data) > 0:
-            wavelength_range = (min(tof_data), max(tof_data))
+        wavelength_range = float(np.min(tof_data)), float(np.max(tof_data))
         self.view.fittingDisplayWidget.update_labels(wavelength_range=wavelength_range)
+        if reset_region:
+            self.view.fittingDisplayWidget.set_default_region(tof_data, spectrum_data)
 
     def redraw_spectrum(self, name: str) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -438,7 +438,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                     self.check_action(action, False)
 
     def do_adjust_roi(self) -> None:
-        new_roi = self.view.roi_form.roi_properties_widget.as_roi()
+        new_roi = self.view.roi_form.roi_properties_widget.to_roi()
         roi_name = self.view.table_view.current_roi_name
         self.view.spectrum_widget.adjust_roi(new_roi, roi_name)
         self.handle_roi_moved(self.view.spectrum_widget.roi_dict[roi_name])

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -12,13 +12,13 @@ from parameterized import parameterized
 
 from mantidimaging.core.data.dataset import Dataset
 from mantidimaging.core.utility.sensible_roi import SensibleROI
-from mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget import ROIFormWidget
+from mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget import ROIFormWidget, ROIPropertiesTableWidget, \
+    ROITableWidget
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowView, SpectrumViewerWindowPresenter
 from mantidimaging.gui.windows.spectrum_viewer.model import ErrorMode, ToFUnitMode, ROI_RITS, SpecType
 from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumWidget, SpectrumPlotWidget, SpectrumROI
 from mantidimaging.gui.widgets.spectrum_widgets.tof_properties import ExperimentSetupFormWidget
-from mantidimaging.gui.windows.spectrum_viewer.view import ROITableWidget, ROIPropertiesTableWidget
 from mantidimaging.test_helpers import start_qapplication
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 
@@ -371,7 +371,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.check_action.assert_has_calls(calls)
 
     def test_WHEN_roi_changed_via_spinboxes_THEN_roi_adjusted(self):
-        self.view.roi_form.roi_properties_widget.as_roi = mock.Mock(return_value=SensibleROI(10, 10, 20, 30))
+        self.view.roi_form.roi_properties_widget.to_roi = mock.Mock(return_value=SensibleROI(10, 10, 20, 30))
         type(self.view.table_view).current_roi_name = mock.PropertyMock(return_value="roi_1")
         self.presenter.do_adjust_roi()
         self.view.spectrum_widget.adjust_roi.assert_called_once_with(SensibleROI(10, 10, 20, 30), "roi_1")

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -296,7 +296,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         Set a new ROI on the image
         """
         self.presenter.do_add_roi()
-        self.roi_form.roi_properties_widget.enable_widgets(True)
+        self.roi_form.roi_properties_widget.enable_roi_spinboxes(True)
         self.set_roi_properties()
 
     def handle_table_click(self, index: QModelIndex) -> None:
@@ -392,11 +392,11 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         current_roi = self.presenter.view.spectrum_widget.get_roi(roi_name)
         self.roi_form.roi_properties_widget.set_roi_name(roi_name)
         self.roi_form.roi_properties_widget.set_roi_values(current_roi)
-        self.roi_form.roi_properties_widget.enable_widgets(True)
+        self.roi_form.roi_properties_widget.enable_roi_spinboxes(True)
 
     def disable_roi_properties(self) -> None:
         self.roi_form.roi_properties_widget.set_roi_name("None selected")
-        self.roi_form.roi_properties_widget.enable_widgets(False)
+        self.roi_form.roi_properties_widget.enable_roi_spinboxes(False)
 
     def setup_roi_properties_spinboxes(self) -> None:
         assert self.spectrum_widget.image.image_data is not None

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -177,6 +177,12 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
             self.set_roi_properties()
 
+    def get_fitting_region(self) -> tuple[float, float]:
+        return self.fittingDisplayWidget.get_selected_fit_region()
+
+    def set_fitting_region(self, region: tuple[float, float]) -> None:
+        self.fittingDisplayWidget.set_selected_fit_region(region)
+
     def _configure_dropdown(self, selector: DatasetSelectorWidgetView) -> None:
         selector.presenter.show_stacks = True
         selector.subscribe_to_main_window(self.main_window)
@@ -290,7 +296,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         Set a new ROI on the image
         """
         self.presenter.do_add_roi()
-        self.roi_form.roi_properties_widget.enable_roi_spinboxes(True)
+        self.roi_form.roi_properties_widget.enable_widgets(True)
         self.set_roi_properties()
 
     def handle_table_click(self, index: QModelIndex) -> None:
@@ -386,11 +392,11 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         current_roi = self.presenter.view.spectrum_widget.get_roi(roi_name)
         self.roi_form.roi_properties_widget.set_roi_name(roi_name)
         self.roi_form.roi_properties_widget.set_roi_values(current_roi)
-        self.roi_form.roi_properties_widget.enable_roi_spinboxes(True)
+        self.roi_form.roi_properties_widget.enable_widgets(True)
 
     def disable_roi_properties(self) -> None:
         self.roi_form.roi_properties_widget.set_roi_name("None selected")
-        self.roi_form.roi_properties_widget.enable_roi_spinboxes(False)
+        self.roi_form.roi_properties_widget.enable_widgets(False)
 
     def setup_roi_properties_spinboxes(self) -> None:
         assert self.spectrum_widget.image.image_data is not None

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -3,23 +3,19 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from pyqtgraph import mkPen
 from PyQt5.QtGui import QPixmap
-from PyQt5.QtWidgets import (QCheckBox, QVBoxLayout, QFileDialog, QLabel, QAbstractItemView, QHeaderView, QComboBox,
-                             QSpinBox, QGroupBox, QActionGroup, QAction)
-from PyQt5.QtCore import QSignalBlocker, QModelIndex, pyqtSignal
+from PyQt5.QtWidgets import (QCheckBox, QVBoxLayout, QFileDialog, QLabel, QGroupBox, QActionGroup, QAction)
+from PyQt5.QtCore import QModelIndex
 
 from mantidimaging.core.utility import finder
-from mantidimaging.core.utility.sensible_roi import SensibleROI
-from mantidimaging.gui.mvp_base import BaseMainWindowView, BaseWidget
+from mantidimaging.gui.mvp_base import BaseMainWindowView
 from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
 from .model import ROI_RITS, allowed_modes
 from .presenter import SpectrumViewerWindowPresenter, ExportMode
-from mantidimaging.gui.widgets import RemovableRowTableView
 from .spectrum_widget import SpectrumWidget
-from mantidimaging.gui.windows.spectrum_viewer.roi_table_model import TableModel
 from mantidimaging.gui.widgets.spectrum_widgets.tof_properties import ExperimentSetupFormWidget
 from mantidimaging.gui.widgets.spectrum_widgets.roi_selection_widget import ROISelectionWidget
 from mantidimaging.gui.widgets.spectrum_widgets.fitting_display_widget import FittingDisplayWidget
@@ -28,169 +24,8 @@ import numpy as np
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
-    from mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget import ROIFormWidget
+    from mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget import ROIFormWidget, ROITableWidget
     from uuid import UUID
-
-
-class ROIPropertiesTableWidget(BaseWidget):
-    spin_left: QSpinBox
-    spin_right: QSpinBox
-    spin_top: QSpinBox
-    spin_bottom: QSpinBox
-    label_height: QLabel
-    label_width: QLabel
-    group_box: QGroupBox
-
-    roi_changed = pyqtSignal()
-
-    def __init__(self, parent=None):
-        super().__init__(parent, ui_file='gui/ui/roi_properties_table_widget.ui')
-
-        self.spin_boxes = [self.spin_left, self.spin_right, self.spin_top, self.spin_bottom]
-
-        for spin_box in self.spin_boxes:
-            spin_box.valueChanged.connect(self.roi_changed.emit)
-
-    def set_roi_name(self, name: str) -> None:
-        self.group_box.setTitle(f"Roi Properties: {name}")
-
-    def set_roi_values(self, roi: SensibleROI) -> None:
-        with QSignalBlocker(self):
-            self.spin_left.setValue(roi.left)
-            self.spin_right.setValue(roi.right)
-            self.spin_top.setValue(roi.top)
-            self.spin_bottom.setValue(roi.bottom)
-            self.label_width.setText(str(roi.width))
-            self.label_height.setText(str(roi.height))
-
-    def set_roi_limits(self, shape: tuple[int, ...]) -> None:
-        self.spin_left.setMaximum(shape[1])
-        self.spin_right.setMaximum(shape[1])
-        self.spin_top.setMaximum(shape[0])
-        self.spin_bottom.setMaximum(shape[0])
-
-    def as_roi(self) -> SensibleROI:
-        new_roi = SensibleROI(left=self.spin_left.value(),
-                              right=self.spin_right.value(),
-                              top=self.spin_top.value(),
-                              bottom=self.spin_bottom.value())
-        return new_roi
-
-    def enable_widgets(self, enable: bool) -> None:
-        for spin_box in self.spin_boxes:
-            spin_box.setEnabled(enable)
-        if not enable:
-            self.set_roi_values(SensibleROI(0, 0, 0, 0))
-
-
-class ROITableWidget(RemovableRowTableView):
-    """
-    A class to represent the ROI table widget in the spectrum viewer window.
-    """
-    ElementType = str | tuple[int, int, int] | bool
-    RowType = list[ElementType]
-    selected_row: int
-
-    selection_changed = pyqtSignal()
-    name_changed = pyqtSignal(str, str)
-    visibility_changed = pyqtSignal()
-
-    def __init__(self, parent=None):
-        super().__init__(parent)
-
-        self.selected_row = 0
-
-        # Point table
-        self.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.setSelectionMode(QAbstractItemView.SingleSelection)
-        self.setAlternatingRowColors(True)
-
-        # Initialise model
-        self.roi_table_model = TableModel()
-        self.setModel(self.roi_table_model)
-
-        # Configure up the table view
-        self.setVisible(True)
-        header = self.horizontalHeader()
-        header.setSectionResizeMode(0, QHeaderView.Stretch)
-        header.setSectionResizeMode(1, QHeaderView.ResizeToContents)
-        header.setSectionResizeMode(2, QHeaderView.ResizeToContents)
-
-        self.selectionModel().currentRowChanged.connect(self.on_row_change)
-        self.roi_table_model.name_changed.connect(self.name_changed.emit)
-        self.roi_table_model.visibility_changed.connect(self.visibility_changed.emit)
-
-    def on_row_change(self, item: QModelIndex, _: Any) -> None:
-        self.selected_row = item.row()
-        self.selection_changed.emit()
-
-    def get_roi_names(self) -> list[str]:
-        return self.roi_table_model.roi_names()
-
-    def get_roi_name_by_row(self, row: int) -> str:
-        """
-        Retrieve the name an ROI by its row index.
-        """
-        return self.roi_table_model.get_element(row, 0)
-
-    @property
-    def current_roi_name(self) -> str:
-        return self.get_roi_name_by_row(self.selected_row)
-
-    def get_roi_visibility_by_row(self, row: int) -> bool:
-        """
-        Retrieve the visibility status of an ROI by its row index.
-        """
-        return self.roi_table_model.get_element(row, 2)
-
-    def row_count(self) -> int:
-        """
-        Returns the number of rows in the ROI table model.
-        """
-        return self.roi_table_model.rowCount()
-
-    def find_row_for_roi(self, roi_name: str) -> int | None:
-        """
-        Returns row index for ROI name, or None if not found.
-        """
-        for row in range(self.roi_table_model.rowCount()):
-            if self.roi_table_model.index(row, 0).data() == roi_name:
-                return row
-        return None
-
-    def update_roi_color(self, roi_name: str, new_color: tuple[int, int, int, int]) -> None:
-        """
-        Finds ROI by name in table and updates it's colour (R, G, B) format.
-        """
-        row = self.find_row_for_roi(roi_name)
-        if row is not None:
-            self.roi_table_model.update_color(row, new_color)
-
-    def add_row(self, name: str, colour: tuple[int, int, int, int], roi_names: list[str]) -> None:
-        """
-        Add a new row to the ROI table
-        """
-        self.roi_table_model.appendNewRow(name, colour, True)
-        self.selected_row = self.roi_table_model.rowCount() - 1
-        self.selectRow(self.selected_row)
-
-    def remove_row(self, row: int) -> None:
-        """
-        Remove a row from the ROI table
-        """
-        self.roi_table_model.remove_row(row)
-        self.selectRow(0)
-
-    def clear_table(self) -> None:
-        """
-        Clears the ROI table in the spectrum viewer.
-        """
-        self.roi_table_model.clear_table()
-
-    def select_roi(self, roi_name: str) -> None:
-        selected_row = self.find_row_for_roi(roi_name)
-        assert selected_row is not None
-        self.selectRow(selected_row)
 
 
 class SpectrumViewerWindowView(BaseMainWindowView):
@@ -206,9 +41,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     shuttercountErrorIcon: QLabel
     normalise_error_issue: str = ""
     shuttercount_error_issue: str = ""
-    transmission_error_mode_combobox: QComboBox
-    bin_size_spinBox: QSpinBox
-    bin_step_spinBox: QSpinBox
 
     spectrum_widget: SpectrumWidget
     experimentSetupGroupBox: QGroupBox
@@ -458,7 +290,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         Set a new ROI on the image
         """
         self.presenter.do_add_roi()
-        self.roi_form.roi_properties_widget.enable_widgets(True)
+        self.roi_form.roi_properties_widget.enable_roi_spinboxes(True)
         self.set_roi_properties()
 
     def handle_table_click(self, index: QModelIndex) -> None:
@@ -522,7 +354,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
     @property
     def transmission_error_mode(self) -> str:
-        return self.transmission_error_mode_combobox.currentText()
+        return self.roi_form.transmission_error_mode_combobox.currentText()
 
     @property
     def image_output_mode(self) -> str:
@@ -530,11 +362,11 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
     @property
     def bin_size(self) -> int:
-        return self.bin_size_spinBox.value()
+        return self.roi_form.bin_size_spinBox.value()
 
     @property
     def bin_step(self) -> int:
-        return self.bin_step_spinBox.value()
+        return self.roi_form.bin_step_spinBox.value()
 
     @property
     def tof_units_mode(self) -> str:
@@ -554,11 +386,11 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         current_roi = self.presenter.view.spectrum_widget.get_roi(roi_name)
         self.roi_form.roi_properties_widget.set_roi_name(roi_name)
         self.roi_form.roi_properties_widget.set_roi_values(current_roi)
-        self.roi_form.roi_properties_widget.enable_widgets(True)
+        self.roi_form.roi_properties_widget.enable_roi_spinboxes(True)
 
     def disable_roi_properties(self) -> None:
         self.roi_form.roi_properties_widget.set_roi_name("None selected")
-        self.roi_form.roi_properties_widget.enable_widgets(False)
+        self.roi_form.roi_properties_widget.enable_roi_spinboxes(False)
 
     def setup_roi_properties_spinboxes(self) -> None:
         assert self.spectrum_widget.image.image_data is not None


### PR DESCRIPTION
## Issue
Closes #2388

### Description

This PR adds a default, resizable ROI (Region of Interest) to the Fitting tab of the Spectrum Viewer Window.

- A red rectangular `RectROI` is added to the spectrum plot on first use.
- The ROI is fully draggable and resizable (both axes), allowing users to specify fitting bounds.
- The region persists during spectrum updates and no longer disappears when the ROI is moved.
- The default fitting region is centered within the spectrum data range and auto-sized.
- Region can be programmatically retrieved and updated via:
  - `get_selected_fit_region()`
  - `set_selected_fit_region(...)`

This enhancement prepares the groundwork for interactive fitting using user-defined ranges and aligns with the goal of modular, widget-based design outlined in the issue.

### Developer Testing 

- I have verified unit tests pass locally: `python -m pytest -vs`
- Manually tested the following:
  - ROI is visible on initial load
  - ROI remains when ROI is moved or spectrum updates
  - The red box can be resized and repositioned
  - `set_selected_fit_region` and `get_selected_fit_region` work as expected

### Acceptance Criteria and Reviewer Testing

- [ ] ROI appears by default on the fitting plot
- [ ] ROI remains visible after ROI move
- [ ] ROI can be resized and dragged
- [ ] Plot and ROI sync with ROI selection and spectrum updates
- [ ] Code adheres to widget-based modular design principles

### Documentation and Additional Notes

- [ ] Sphinx documentation not required for internal widget usage
- [ ] No release note needed unless tied to a user-facing release milestone

This change builds toward interactive, Bragg-edge-based spectrum fitting by enabling precise fitting region control in the GUI.
