### PR TITLE
Add Resizable ROI to Fitting Spectrum Plot 

### DIFF
--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -27,8 +27,6 @@ class FittingDisplayWidget(QWidget):
         self.spectrum_plot.spectrum.addItem(self.fitting_region)
 
     def update_plot(self, x_data: np.ndarray, y_data: np.ndarray, label: str = "ROI") -> None:
-        if x_data is None or x_data.size == 0:
-            return
         self.spectrum_plot.spectrum.clear()
         self.spectrum_plot.spectrum.plot(x_data, y_data, name=label, pen=(255, 255, 0))
         self.spectrum_plot.spectrum.addItem(self.fitting_region)

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -2,6 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 import numpy as np
 from PyQt5.QtWidgets import QWidget, QVBoxLayout
+from pyqtgraph import RectROI, mkPen
 from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumPlotWidget
 
 
@@ -13,14 +14,53 @@ class FittingDisplayWidget(QWidget):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
 
-        self.layout: QVBoxLayout = QVBoxLayout(self)
-        self.spectrum_plot: SpectrumPlotWidget = SpectrumPlotWidget()
+        self.layout = QVBoxLayout(self)
+        self.spectrum_plot = SpectrumPlotWidget()
         self.layout.addWidget(self.spectrum_plot)
 
+        self.fitting_region = RectROI([0, 0], [1, 1], pen=mkPen((255, 0, 0), width=2), movable=True)
+        self.fitting_region.setZValue(10)
+        self.fitting_region.addScaleHandle([1, 1], [0, 0])
+        self.fitting_region.addScaleHandle([0, 0], [1, 1])
+        self.fitting_region.addScaleHandle([0, 1], [1, 0])
+        self.fitting_region.addScaleHandle([1, 0], [0, 1])
+        self.spectrum_plot.spectrum.addItem(self.fitting_region)
+
     def update_plot(self, x_data: np.ndarray, y_data: np.ndarray, label: str = "ROI") -> None:
+        if x_data is None or x_data.size == 0:
+            return
         self.spectrum_plot.spectrum.clear()
         self.spectrum_plot.spectrum.plot(x_data, y_data, name=label, pen=(255, 255, 0))
+        self.spectrum_plot.spectrum.addItem(self.fitting_region)
+        self.set_default_region(x_data, y_data)
 
     def update_labels(self, wavelength_range: tuple[float, float] | None = None) -> None:
-        if wavelength_range is not None and len(wavelength_range) == 2:
+        """Update wavelength range label below the plot, if available."""
+        if wavelength_range is not None:
             self.spectrum_plot.set_wavelength_range_label(*wavelength_range)
+
+    def set_default_region(self, x_data: np.ndarray, y_data: np.ndarray) -> None:
+        """Position the ROI centrally over the plotted data."""
+        x_min, x_max = float(np.min(x_data)), float(np.max(x_data))
+        y_min, y_max = float(np.min(y_data)), float(np.max(y_data))
+        x_span = max((x_max - x_min) * 0.25, 20.0)
+        y_span = max((y_max - y_min) * 0.5, 10.0)
+        x_start = (x_min + x_max - x_span) / 2
+        y_start = max((y_min + y_max - y_span) / 2, 0.0)
+
+        self.fitting_region.setPos((x_start, y_start))
+        self.fitting_region.setSize((x_span, y_span))
+
+    def set_selected_fit_region(self, region: tuple[float, float]) -> None:
+        """Set the horizontal (X-axis) range of the ROI."""
+        x_start, x_end = region
+        width = x_end - x_start
+        y_pos = self.fitting_region.pos().y()
+        height = self.fitting_region.size().y()
+        self.fitting_region.setPos((x_start, y_pos))
+        self.fitting_region.setSize((width, height))
+
+    def get_selected_fit_region(self) -> tuple[float, float]:
+        pos = self.fitting_region.pos()
+        size = self.fitting_region.size()
+        return float(pos.x()), float(pos.x() + size.x())

--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_selection_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_selection_widget.py
@@ -47,6 +47,7 @@ class ROISelectionWidget(QtWidgets.QGroupBox):
         elif filtered_rois:
             self.roiDropdown.setCurrentIndex(0)
             self._on_selection_changed()
+            self._on_selection_changed()
         self.roiDropdown.blockSignals(False)
 
     def set_selected_roi(self, roi_name: str) -> None:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -215,20 +215,22 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             self.view.table_view.select_roi(roi.name)
             self.view.set_roi_properties()
 
-    def update_fitting_spectrum(self, roi_name: str) -> None:
-        """Fetches the spectrum data for the selected ROI and updates the view."""
+    def update_fitting_spectrum(self, roi_name: str, reset_region: bool = False) -> None:
+        """
+        Fetches the spectrum data for the selected ROI and updates the fitting display plot.
+        """
         if roi_name not in self.view.spectrum_widget.roi_dict:
             return
         roi = self.view.spectrum_widget.get_roi(roi_name)
         spectrum_data = self.model.get_spectrum(roi, self.spectrum_mode)
         tof_data = self.model.tof_data
-        if tof_data is None:
+        if tof_data is None or tof_data.size == 0:
             return
         self.view.fittingDisplayWidget.update_plot(tof_data, spectrum_data, label=roi_name)
-        wavelength_range = None
-        if isinstance(tof_data, list | np.ndarray) and len(tof_data) > 0:
-            wavelength_range = (min(tof_data), max(tof_data))
+        wavelength_range = float(np.min(tof_data)), float(np.max(tof_data))
         self.view.fittingDisplayWidget.update_labels(wavelength_range=wavelength_range)
+        if reset_region:
+            self.view.fittingDisplayWidget.set_default_region(tof_data, spectrum_data)
 
     def redraw_spectrum(self, name: str) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -224,7 +224,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         roi = self.view.spectrum_widget.get_roi(roi_name)
         spectrum_data = self.model.get_spectrum(roi, self.spectrum_mode)
         tof_data = self.model.tof_data
-        if tof_data is None or tof_data.size == 0:
+        if tof_data is None:
             return
         self.view.fittingDisplayWidget.update_plot(tof_data, spectrum_data, label=roi_name)
         wavelength_range = float(np.min(tof_data)), float(np.max(tof_data))

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -177,6 +177,12 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
             self.set_roi_properties()
 
+    def get_fitting_region(self) -> tuple[float, float]:
+        return self.fittingDisplayWidget.get_selected_fit_region()
+
+    def set_fitting_region(self, region: tuple[float, float]) -> None:
+        self.fittingDisplayWidget.set_selected_fit_region(region)
+
     def _configure_dropdown(self, selector: DatasetSelectorWidgetView) -> None:
         selector.presenter.show_stacks = True
         selector.subscribe_to_main_window(self.main_window)


### PR DESCRIPTION
## Issue
Closes #2388

### Description

This PR adds a default, resizable ROI (Region of Interest) to the Fitting tab of the Spectrum Viewer Window.

- A red rectangular `RectROI` is added to the spectrum plot on first use.
- The ROI is fully draggable and resizable (both axes), allowing users to specify fitting bounds.
- The region persists during spectrum updates and no longer disappears when the ROI is moved.
- The default fitting region is centered within the spectrum data range and auto-sized.
- Region can be programmatically retrieved and updated via:
  - `get_selected_fit_region()`
  - `set_selected_fit_region(...)`

This enhancement prepares the groundwork for interactive fitting using user-defined ranges and aligns with the goal of modular, widget-based design outlined in the issue.

### Developer Testing 

- I have verified unit tests pass locally: `python -m pytest -vs`
- Manually tested the following:
  - ROI is visible on initial load
  - ROI remains when ROI is moved or spectrum updates
  - The red box can be resized and repositioned
  - `set_selected_fit_region` and `get_selected_fit_region` work as expected

### Acceptance Criteria and Reviewer Testing

- [x] ROI appears by default on the fitting plot
- [x] ROI remains visible after ROI move
- [x] ROI can be resized and dragged
- [x] Plot and ROI sync with ROI selection and spectrum updates
- [x] Code adheres to widget-based modular design principles

### Documentation and Additional Notes

- [ ] Sphinx documentation not required for internal widget usage
- [ ] No release note needed unless tied to a user-facing release milestone

This change builds toward interactive, Bragg-edge-based spectrum fitting by enabling precise fitting region control in the GUI.
