### PR TITLE
Fix COR/Tilt display not updating after manual refinement

### DIFF
--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -321,6 +321,7 @@ class ReconstructWindowPresenter(BasePresenter):
             self.model.data_model.set_cor_at_slice(slice_idx, new_cor.value)
             self.model.last_cor = new_cor
             # Update reconstruction preview with new COR
+            self.view.set_results(*self.model.get_results())
             self.set_preview_slice_idx(slice_idx)
 
     def _do_refine_iterations(self) -> None:


### PR DESCRIPTION
## Issue  
Closes #2531

### Description  
Fixes top COR/Tilt display not updating after manual refinement. Presenter now updates the view using set_results().

### Developer Testing  
- Verified unit tests pass: `python -m pytest -vs`
- Manually tested COR refinement updates display

### Acceptance Criteria  
- [ ] COR/Tilt display updates after manual refinement
- [ ] Reconstruction uses correct COR
- [ ] No crashes or errors


