### PR TITLE
Fix COR line

### DIFF
--- a/docs/release_notes/next/fix-2542-fix-cor-tilt-display
+++ b/docs/release_notes/next/fix-2542-fix-cor-tilt-display
@@ -1,0 +1,1 @@
+#2542: Correctly update core and tilt table and line when changed

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -111,9 +111,9 @@ class ReconImagesView(GraphicsLayoutWidget):
 
     def reset_slice_and_tilt(self, slice_index) -> None:
         self.slice_line.setPos(slice_index)
-        self.hide_tilt()
+        self.hide_cor_line()
 
-    def hide_tilt(self) -> None:
+    def hide_cor_line(self) -> None:
         """
         Hides the tilt line. This stops infinite zooming out loop that messes up the image view
         (the line likes to be unbound when the degree isn't a multiple o 90 - and the tilt never is)
@@ -122,7 +122,7 @@ class ReconImagesView(GraphicsLayoutWidget):
         if self.tilt_line.scene() is not None:
             self.imageview_projection.viewbox.removeItem(self.tilt_line)
 
-    def set_tilt(self, tilt: Degrees, pos: float) -> None:
+    def show_cor_line(self, tilt: Degrees, pos: float) -> None:
         if not isnan(tilt.value):  # is isnan it means there is no tilt, i.e. the line is vertical
             self.tilt_line.setPos((pos, 0))
             self.tilt_line.setAngle(90 + tilt.value)

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -63,16 +63,12 @@ class ReconImagesView(GraphicsLayoutWidget):
     def slice_line_moved(self) -> None:
         self.slice_changed(int(self.slice_line.value()))
 
-    def update_projection(self, image_data: np.ndarray, preview_slice_index: int, tilt_angle: Degrees | None) -> None:
+    def update_projection(self, image_data: np.ndarray, preview_slice_index: int) -> None:
         self.imageview_projection.clear()
         self.imageview_projection.setImage(image_data)
         self.imageview_projection.histogram.imageChanged(autoLevel=True, autoRange=True)
         self.slice_line.setPos(preview_slice_index)
         self.slice_line.setBounds([0, int(self.imageview_projection.image_item.height()) - 1])
-        if tilt_angle:
-            self.set_tilt(tilt_angle, image_data.shape[1] // 2)
-        else:
-            self.hide_tilt()
         set_histogram_log_scale(self.imageview_projection.histogram)
 
     def update_sinogram(self, image) -> None:
@@ -126,11 +122,9 @@ class ReconImagesView(GraphicsLayoutWidget):
         if self.tilt_line.scene() is not None:
             self.imageview_projection.viewbox.removeItem(self.tilt_line)
 
-    def set_tilt(self, tilt: Degrees, pos: int | None = None) -> None:
+    def set_tilt(self, tilt: Degrees, pos: float) -> None:
         if not isnan(tilt.value):  # is isnan it means there is no tilt, i.e. the line is vertical
-            if pos is not None:
-                self.tilt_line.setAngle(90)
-                self.tilt_line.setPos(pos)
+            self.tilt_line.setPos((pos, 0))
             self.tilt_line.setAngle(90 + tilt.value)
         self.imageview_projection.viewbox.addItem(self.tilt_line)
 

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -27,7 +27,7 @@ class ReconImagesView(GraphicsLayoutWidget):
 
         self.slice_line = InfiniteLine(pos=1024, angle=0, movable=True)
         self.imageview_projection.viewbox.addItem(self.slice_line)
-        self.tilt_line = InfiniteLine(pos=1024, angle=90, pen=(255, 0, 0, 255), movable=True)
+        self.tilt_line = InfiniteLine(pos=1024, angle=90, pen=(255, 0, 0, 255), movable=False)
         self.recon_line_profile = LineProfilePlot(self.imageview_recon)
 
         self.addItem(self.imageview_projection, 0, 0)

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -184,7 +184,7 @@ class ReconstructWindowPresenter(BasePresenter):
             self.view.reset_projection_preview()
             return
         img_data = images.projection(self.model.preview_projection_idx)
-        self.view.update_projection(img_data, self.model.preview_slice_idx, self.model.tilt_angle)
+        self.view.update_projection(img_data, self.model.preview_slice_idx)
 
     def handle_stack_changed(self) -> None:
         if self.view.isVisible():

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -116,12 +116,12 @@ class ReconstructWindowViewTest(unittest.TestCase):
         tilt = Degrees(tilt_val)
         slope = Slope(slope_val)
 
-        with mock.patch.object(self.image_view, "set_tilt") as set_tilt:
+        with mock.patch.object(self.image_view, "show_cor_line") as show_cor_line:
             self.view.set_results(cor, tilt, slope)
             self.assertEqual(self.view.rotation_centre, cor_val)
             self.assertEqual(self.view.tilt, tilt_val)
             self.assertEqual(self.view.slope, slope_val)
-            set_tilt.assert_called_once_with(tilt, cor_val)
+            show_cor_line.assert_called_once_with(tilt, cor_val)
 
     def test_preview_image_on_button_press(self):
         event_mock = mock.Mock()
@@ -276,7 +276,7 @@ class ReconstructWindowViewTest(unittest.TestCase):
 
     def test_hide_tilt(self):
         self.view.hide_tilt()
-        self.image_view.hide_tilt.assert_called_once()
+        self.image_view.hide_cor_line.assert_called_once()
 
     def test_set_filters_for_recon_tool(self):
         filters = ["abc" for _ in range(3)]

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -121,7 +121,7 @@ class ReconstructWindowViewTest(unittest.TestCase):
             self.assertEqual(self.view.rotation_centre, cor_val)
             self.assertEqual(self.view.tilt, tilt_val)
             self.assertEqual(self.view.slope, slope_val)
-            set_tilt.assert_called_once_with(tilt)
+            set_tilt.assert_called_once_with(tilt, cor_val)
 
     def test_preview_image_on_button_press(self):
         event_mock = mock.Mock()
@@ -143,13 +143,12 @@ class ReconstructWindowViewTest(unittest.TestCase):
     def test_update_projection(self, _):
         image_data = mock.Mock()
         preview_slice_idx = 13
-        tilt_angle = Degrees(30)
 
         self.view.previewSliceIndex = preview_slice_index_mock = mock.Mock()
-        self.view.update_projection(image_data, preview_slice_idx, tilt_angle)
+        self.view.update_projection(image_data, preview_slice_idx)
 
         preview_slice_index_mock.setValue.assert_called_once_with(preview_slice_idx)
-        self.image_view.update_projection.assert_called_once_with(image_data, preview_slice_idx, tilt_angle)
+        self.image_view.update_projection.assert_called_once_with(image_data, preview_slice_idx)
 
     def test_update_sinogram(self):
         image_data = mock.Mock()

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -264,7 +264,7 @@ class ReconstructWindowView(BaseMainWindowView):
         self.rotation_centre = cor.value
         self.tilt = tilt.value
         self.slope = slope.value
-        self.image_view.set_tilt(tilt)
+        self.image_view.set_tilt(tilt, cor.value)
 
     def preview_image_on_button_press(self, event) -> None:
         """
@@ -276,7 +276,7 @@ class ReconstructWindowView(BaseMainWindowView):
         if event.button == 1 and event.ydata is not None:
             self.presenter.set_preview_slice_idx(int(event.ydata))
 
-    def update_projection(self, image_data, preview_slice_index: int, tilt_angle: Degrees | None) -> None:
+    def update_projection(self, image_data, preview_slice_index: int) -> None:
         """
         Updates the preview projection image and associated annotations.
 
@@ -293,7 +293,7 @@ class ReconstructWindowView(BaseMainWindowView):
         with QSignalBlocker(self.previewSliceIndex):
             self.previewSliceIndex.setValue(preview_slice_index)
 
-        self.image_view.update_projection(image_data, preview_slice_index, tilt_angle)
+        self.image_view.update_projection(image_data, preview_slice_index)
 
     def update_sinogram(self, image_data) -> None:
         self.image_view.update_sinogram(image_data)

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -264,7 +264,7 @@ class ReconstructWindowView(BaseMainWindowView):
         self.rotation_centre = cor.value
         self.tilt = tilt.value
         self.slope = slope.value
-        self.image_view.set_tilt(tilt, cor.value)
+        self.image_view.show_cor_line(tilt, cor.value)
 
     def preview_image_on_button_press(self, event) -> None:
         """
@@ -483,7 +483,7 @@ class ReconstructWindowView(BaseMainWindowView):
         return None
 
     def hide_tilt(self) -> None:
-        self.image_view.hide_tilt()
+        self.image_view.hide_cor_line()
 
     def set_filters_for_recon_tool(self, filters: list[str]) -> None:
         self.filterName.clear()


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2542

### Description

Make `set_tilt()` (now `show_cor_line()`) set the position as well.
Remove unnecessary drawing in `update_projection()`
Rename some methods
Stop line being movable (There is no code to handle moves)
Update tests


### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- ...

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Try a range of position and tilt values and check that the line behaves as expected

### Documentation and Additional Notes


- [x] Release Notes have been updated
