### PR TITLE
Flat fielding apply to all stacks histogram levels fix

### DIFF
--- a/docs/release_notes/next/fix-1952-Fix-Brightness-levels-when-applying-flat-fielding
+++ b/docs/release_notes/next/fix-1952-Fix-Brightness-levels-when-applying-flat-fielding
@@ -1,0 +1,1 @@
+#1952: Fix brightness levels when applying flat fielding

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -301,6 +301,8 @@ class FiltersWindowPresenter(BasePresenter):
                     self.init_roi_field(self.model.filter_widget_kwargs["roi_field"])
                 elif selected_filter == FLAT_FIELDING and negative_stacks:
                     self._show_negative_values_error(negative_stacks)
+
+                self.sync_histogram_levels()
             else:
                 self.view.clear_notification_dialog()
                 self.view.show_operation_cancelled(self.model.selected_filter.filter_name)
@@ -309,6 +311,11 @@ class FiltersWindowPresenter(BasePresenter):
             self._set_apply_buttons_enabled(self.prev_apply_single_state, self.prev_apply_all_state)
             self.filter_is_running = False
             self.do_update_previews()
+
+    def sync_histogram_levels(self):
+        p_low, p_high = self.view.preview_image_after.histogram.getHistogramRange()
+        self.view.preview_image_before.histogram.setHistogramRange(p_low, p_high)
+        self.view.preview_image_before.histogram.setLevels(p_low, p_high)
 
     def _do_apply_filter(self, apply_to: list[ImageStack]):
         self.filter_is_running = True

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -27,6 +27,7 @@ class FiltersWindowPresenterTest(unittest.TestCase):
     def setUp(self) -> None:
         self.main_window = mock.create_autospec(MainWindowView, instance=True)
         self.view = mock.MagicMock()
+        self.view.preview_image_after.histogram.getHistogramRange.return_value = (0, 1)
         self.presenter = FiltersWindowPresenter(self.view, self.main_window)
         self.presenter.model.filter_widget_kwargs = {"roi_field": None}
         self.view.presenter = self.presenter


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #1952 

### Description
MI defaults to locking brightness levels in the operations window, so that the effect of changes is clear. We already have some special casing for flat-fielding to set the levels in the after panel. It should also adjust the levels of the before panel, after running the flatfielding. 

Instead of running only for flat fielding,it should run for any filter

Steps To Reproduce
Run a flat field operation

Expected Behaviour
After running, the object should be visible in the before panel

<!-- Add a description of the changes made. -->

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- [x] I have verified unit tests pass locally: `python -m pytest -vs`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Works as mentioned above 


