### PR TITLE
add image view to spectrum plot

### DIFF
--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -1,8 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 import numpy as np
-from PyQt5.QtWidgets import QWidget, QVBoxLayout
-from PyQt5.QtWidgets import QGraphicsItem
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QGraphicsItem
 from pyqtgraph import RectROI, mkPen, ImageItem
 from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumPlotWidget
 
@@ -27,16 +26,14 @@ class FittingDisplayWidget(QWidget):
         self.fitting_region.addScaleHandle([1, 0], [0, 1])
         self.spectrum_plot.spectrum.addItem(self.fitting_region)
 
-        self.floating_image_item = ImageItem()
-        self.floating_image_item.setFlag(QGraphicsItem.ItemIsMovable, True)
-        self.floating_image_item.setFlag(QGraphicsItem.ItemIsSelectable, True)
-        self.floating_image_item.setZValue(20)
-        self.floating_image_item.setPos(400, 10)
-        self.spectrum_plot.spectrum.addItem(self.floating_image_item)
-
-    def update_image(self, image: np.ndarray | None) -> None:
-        if image is not None:
-            self.floating_image_item.setImage(image, autoLevels=True)
+        self.image_item = ImageItem()
+        self.image_item.setFlag(QGraphicsItem.ItemIsMovable, True)
+        self.image_item.setFlag(QGraphicsItem.ItemIsSelectable, True)
+        self.image_item.setFlag(QGraphicsItem.ItemIgnoresTransformations, True)
+        self.image_item.setScale(0.2)
+        self.spectrum_plot.spectrum.vb.addItem(self.image_item)
+        self.image_item.setZValue(20)
+        self.image_item.setPos(1000, 16500)
 
     def update_plot(self,
                     x_data: np.ndarray,
@@ -48,6 +45,10 @@ class FittingDisplayWidget(QWidget):
         self.spectrum_plot.spectrum.addItem(self.fitting_region)
         self.set_default_region(x_data, y_data)
         self.update_image(image)
+
+    def update_image(self, image: np.ndarray | None) -> None:
+        if image is not None:
+            self.image_item.setImage(image, autoLevels=True)
 
     def update_labels(self, wavelength_range: tuple[float, float] | None = None) -> None:
         """Update wavelength range label below the plot, if available."""

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -3,9 +3,8 @@
 import numpy as np
 from PyQt5.QtWidgets import QWidget, QVBoxLayout
 from PyQt5.QtWidgets import QGraphicsItem
-from pyqtgraph import RectROI, mkPen
-from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumPlotWidget, CustomViewBox
-from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
+from pyqtgraph import RectROI, mkPen, ImageItem
+from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumPlotWidget
 
 
 class FittingDisplayWidget(QWidget):
@@ -28,14 +27,16 @@ class FittingDisplayWidget(QWidget):
         self.fitting_region.addScaleHandle([1, 0], [0, 1])
         self.spectrum_plot.spectrum.addItem(self.fitting_region)
 
-        self.image_view = MIMiniImageView(name="FloatingSampleImage", view_box_type=CustomViewBox)
-        self.image_view.hist.hide()
-        self.image_view.details.hide()
-        self.image_view.setFlag(QGraphicsItem.ItemIsMovable, True)
-        self.image_view.setFlag(QGraphicsItem.ItemIsSelectable, True)
-        self.image_view.setParentItem(self.spectrum_plot.spectrum)
-        self.image_view.setZValue(20)
-        self.image_view.setPos(400, 10)
+        self.floating_image_item = ImageItem()
+        self.floating_image_item.setFlag(QGraphicsItem.ItemIsMovable, True)
+        self.floating_image_item.setFlag(QGraphicsItem.ItemIsSelectable, True)
+        self.floating_image_item.setZValue(20)
+        self.floating_image_item.setPos(400, 10)
+        self.spectrum_plot.spectrum.addItem(self.floating_image_item)
+
+    def update_image(self, image: np.ndarray | None) -> None:
+        if image is not None:
+            self.floating_image_item.setImage(image, autoLevels=True)
 
     def update_plot(self,
                     x_data: np.ndarray,
@@ -47,10 +48,6 @@ class FittingDisplayWidget(QWidget):
         self.spectrum_plot.spectrum.addItem(self.fitting_region)
         self.set_default_region(x_data, y_data)
         self.update_image(image)
-
-    def update_image(self, image: np.ndarray | None) -> None:
-        if image is not None:
-            self.image_view.setImage(image, autoLevels=True)
 
     def update_labels(self, wavelength_range: tuple[float, float] | None = None) -> None:
         """Update wavelength range label below the plot, if available."""

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -31,6 +31,7 @@ class FittingDisplayWidget(QWidget):
         self.image_item.setFlag(QGraphicsItem.ItemIsSelectable, True)
         self.image_item.setParentItem(self.spectrum_plot.spectrum)
         self.image_item.setZValue(20)
+        self.image_item.setScale(0.2)
         self.image_item.setPos(self.spectrum_plot.width() - 150, 10)
 
     def update_plot(self,

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -29,11 +29,9 @@ class FittingDisplayWidget(QWidget):
         self.image_item = ImageItem()
         self.image_item.setFlag(QGraphicsItem.ItemIsMovable, True)
         self.image_item.setFlag(QGraphicsItem.ItemIsSelectable, True)
-        self.image_item.setFlag(QGraphicsItem.ItemIgnoresTransformations, True)
-        self.image_item.setScale(0.2)
-        self.spectrum_plot.spectrum.vb.addItem(self.image_item)
+        self.image_item.setParentItem(self.spectrum_plot.spectrum)
         self.image_item.setZValue(20)
-        self.image_item.setPos(1000, 16500)
+        self.image_item.setPos(self.spectrum_plot.width() - 150, 10)
 
     def update_plot(self,
                     x_data: np.ndarray,

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -2,8 +2,10 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 import numpy as np
 from PyQt5.QtWidgets import QWidget, QVBoxLayout
+from PyQt5.QtWidgets import QGraphicsItem
 from pyqtgraph import RectROI, mkPen
-from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumPlotWidget
+from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumPlotWidget, CustomViewBox
+from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
 
 
 class FittingDisplayWidget(QWidget):
@@ -26,11 +28,29 @@ class FittingDisplayWidget(QWidget):
         self.fitting_region.addScaleHandle([1, 0], [0, 1])
         self.spectrum_plot.spectrum.addItem(self.fitting_region)
 
-    def update_plot(self, x_data: np.ndarray, y_data: np.ndarray, label: str = "ROI") -> None:
+        self.image_view = MIMiniImageView(name="FloatingSampleImage", view_box_type=CustomViewBox)
+        self.image_view.hist.hide()
+        self.image_view.details.hide()
+        self.image_view.setFlag(QGraphicsItem.ItemIsMovable, True)
+        self.image_view.setFlag(QGraphicsItem.ItemIsSelectable, True)
+        self.image_view.setParentItem(self.spectrum_plot.spectrum)
+        self.image_view.setZValue(20)
+        self.image_view.setPos(400, 10)
+
+    def update_plot(self,
+                    x_data: np.ndarray,
+                    y_data: np.ndarray,
+                    label: str = "ROI",
+                    image: np.ndarray | None = None) -> None:
         self.spectrum_plot.spectrum.clear()
         self.spectrum_plot.spectrum.plot(x_data, y_data, name=label, pen=(255, 255, 0))
         self.spectrum_plot.spectrum.addItem(self.fitting_region)
         self.set_default_region(x_data, y_data)
+        self.update_image(image)
+
+    def update_image(self, image: np.ndarray | None) -> None:
+        if image is not None:
+            self.image_view.setImage(image, autoLevels=True)
 
     def update_labels(self, wavelength_range: tuple[float, float] | None = None) -> None:
         """Update wavelength range label below the plot, if available."""

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -226,7 +226,11 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         tof_data = self.model.tof_data
         if tof_data is None:
             return
-        self.view.fittingDisplayWidget.update_plot(tof_data, spectrum_data, label=roi_name)
+
+        image = (self.model.get_normalized_averaged_image()
+                 if self.view.normalisation_enabled() else self.model.get_averaged_image())
+
+        self.view.fittingDisplayWidget.update_plot(tof_data, spectrum_data, label=roi_name, image=image)
         wavelength_range = float(np.min(tof_data)), float(np.max(tof_data))
         self.view.scalable_roi_widget.set_parameters(self.get_roi_fitting_params(roi_name))
         self.view.fittingDisplayWidget.update_labels(wavelength_range=wavelength_range)


### PR DESCRIPTION


## Issue Closes #2389

### Description
- Added a floating sample image view to FittingDisplayWidget.
- Updated presenter to pass the averaged image to the widget.

### Developer Testing 
- Verified unit tests pass locally: `python -m pytest -vs`
- Manually tested that the floating image view remains visible and draggable.

### Acceptance Criteria and Reviewer Testing
- [ ] Unit tests pass locally
- [ ] Floating image view displays only the image and remains visible when moved
