### PR TITLE
Added the Overlap Corrections script to MI Operations

### DIFF
--- a/docs/release_notes/next/feature-2545-overlap-correction-operation
+++ b/docs/release_notes/next/feature-2545-overlap-correction-operation
@@ -1,0 +1,1 @@
+#2545: the overlap correction script has been migrated into the operations window in MI

--- a/mantidimaging/core/operations/overlap_correction/__init__.py
+++ b/mantidimaging/core/operations/overlap_correction/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from .overlap_correction import OverlapCorrection  # noqa:F401
+
+FILTER_CLASS = OverlapCorrection

--- a/mantidimaging/core/operations/overlap_correction/overlap_correction.py
+++ b/mantidimaging/core/operations/overlap_correction/overlap_correction.py
@@ -21,12 +21,24 @@ if TYPE_CHECKING:
 
 
 class OverlapCorrection(BaseFilter):
+    """
+    Overlap correction is a post-experimental data correction performed when the input fluxes are periodic,
+    accurately restoring the input flux up to a very large fraction of pixels (up to ~90%) occupied by the end of the
+    acquisition shutter which leads to large distortions of measured timing characteristics of the input flux.
+
+    Intended to be used on: Projections
+
+    When: As a pre-processing step, to correct the observed spectrum and clarify its characteristics.
+    """
     filter_name = "Overlap Correction"
     link_histograms = True
     allow_for_180_projection = False
 
     @staticmethod
     def filter_func(images: ImageStack, progress=None) -> ImageStack:
+        """
+        :return: The ImageStack object which has been corrected using the supplied shutter information.
+        """
         if images.shutter_count_file:
             shutters_dir = images.shutter_count_file.source_file.parent
             shutter_breaks = OverlapCorrection.get_shutters_breaks(shutters_dir)

--- a/mantidimaging/core/operations/overlap_correction/overlap_correction.py
+++ b/mantidimaging/core/operations/overlap_correction/overlap_correction.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+from dataclasses import dataclass
+
+from functools import partial
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
+
+import numpy
+import numpy as np
+
+from mantidimaging.core.operations.base_filter import BaseFilter
+from mantidimaging.core.parallel import utility as pu, shared as ps
+
+if TYPE_CHECKING:
+    from mantidimaging.core.data import ImageStack
+    from mantidimaging.gui.mvp_base import BaseMainWindowView
+    from PyQt5.QtWidgets import QFormLayout, QWidget
+
+
+class OverlapCorrection(BaseFilter):
+    filter_name = "Overlap Correction"
+    link_histograms = True
+    allow_for_180_projection = False
+
+    @staticmethod
+    def filter_func(images: ImageStack, progress=None) -> ImageStack:
+        shutter_breaks = [(0, 0, 0)]
+        if images.shutter_count_file:
+            shutters_dir = images.shutter_count_file.source_file.parent
+            shutters = get_shutters(shutters_dir)
+            shutter_breaks = [(shutter.start_index, shutter.end_index, shutter.count) for shutter in shutters]
+        params = {'shutter_breaks': shutter_breaks}
+        output = pu.create_array(images.data.shape, images.dtype)
+        ps.run_compute_func(OverlapCorrection._compute_overlap_correction, images.data.shape[0],
+                            [images.shared_array, output], params, progress)
+        images.shared_array = output
+        return images
+
+    @staticmethod
+    def _compute_overlap_correction(i: int, arrays: list[np.ndarray], params: dict[str, np.ndarray]):
+        array = arrays[0]
+        output = arrays[1]
+        for sb in params['shutter_breaks']:
+            if i == sb[0] or i == sb[1]:
+                output[i] = array[i]
+            elif sb[0] < i < sb[1]:
+                ss = sb[0]
+                counts = sb[2]
+                prob_occupied = numpy.sum(array[ss:i], axis=0) / counts
+                output[i] = array[i] / (1 - prob_occupied)
+
+    @staticmethod
+    def register_gui(form: QFormLayout, on_change: Callable, view: BaseMainWindowView) -> dict[str, QWidget]:
+        return {}
+
+    @staticmethod
+    def execute_wrapper(*args) -> partial:
+        return partial(OverlapCorrection.filter_func)
+
+    @staticmethod
+    def validate_execute_kwargs(kwargs: dict[str, Any]) -> bool:
+        return True
+
+
+@dataclass
+class ShutterInfo:
+    number: int
+    count: int
+    start_time: float = 0
+    end_time: float = 0
+    start_index: int = 0
+    end_index: int = 0
+
+
+def get_shutters(data_dir: Path) -> list[ShutterInfo]:
+    shuter_count_file = sorted(data_dir.glob("*ShutterCount.txt"))[0]
+    shutter_times_file = sorted(data_dir.glob("*ShutterTimes.txt"))[0]
+    spectra_file = sorted(data_dir.glob("*Spectra.txt"))[0]
+
+    shuter_count = numpy.loadtxt(shuter_count_file, dtype=int)
+    shutter_times = numpy.loadtxt(shutter_times_file)
+    spectra = numpy.loadtxt(spectra_file)
+
+    shutters = []
+    prev_time = 0.0
+    for number, count in shuter_count:
+        if count == 0:
+            break
+
+        this_shutter = ShutterInfo(number, count)
+        delay = shutter_times[number, 1]
+        duration = shutter_times[number, 2]
+
+        this_shutter.start_time = prev_time + delay
+        this_shutter.end_time = this_shutter.start_time + duration
+        prev_time = this_shutter.end_time
+        this_shutter.start_index = int(numpy.searchsorted(spectra[:, 0], this_shutter.start_time))
+        this_shutter.end_index = int(numpy.searchsorted(spectra[:, 0], this_shutter.end_time))
+        shutters.append(this_shutter)
+        print(this_shutter)
+
+    return shutters

--- a/mantidimaging/core/operations/overlap_correction/test/__init__.py
+++ b/mantidimaging/core/operations/overlap_correction/test/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/core/operations/overlap_correction/test/overlap_correction_test.py
+++ b/mantidimaging/core/operations/overlap_correction/test/overlap_correction_test.py
@@ -9,17 +9,8 @@ from unittest import mock
 
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.operations.overlap_correction import OverlapCorrection
+from mantidimaging.core.operations.overlap_correction.overlap_correction import ShutterInfo
 from mantidimaging.test_helpers.start_qapplication import start_multiprocessing_pool
-
-
-@dataclass
-class ShutterInfo:
-    number: int
-    count: int
-    start_time: float = 0
-    end_time: float = 0
-    start_index: int = 0
-    end_index: int = 0
 
 
 @start_multiprocessing_pool
@@ -51,7 +42,6 @@ class OverlapCorrectionTest(unittest.TestCase):
             ShutterInfo(1, 230, start_index=2, end_index=4),
             ShutterInfo(2, 235, start_index=4, end_index=10)
         ]
-        #get_shutters_mock.return_value = ((0, 2, 102), (2, 4, 230), (4, 10, 235))
 
         original = images.copy()
         images = OverlapCorrection.filter_func(images)

--- a/mantidimaging/core/operations/overlap_correction/test/overlap_correction_test.py
+++ b/mantidimaging/core/operations/overlap_correction/test/overlap_correction_test.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import unittest
-from dataclasses import dataclass
 from functools import partial
 from unittest import mock
 

--- a/mantidimaging/core/operations/overlap_correction/test/overlap_correction_test.py
+++ b/mantidimaging/core/operations/overlap_correction/test/overlap_correction_test.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+import unittest
+from functools import partial
+from unittest import mock
+
+import mantidimaging.test_helpers.unit_test_helper as th
+from mantidimaging.core.operations.overlap_correction import OverlapCorrection
+from mantidimaging.test_helpers.start_qapplication import start_multiprocessing_pool
+
+
+@start_multiprocessing_pool
+class OverlapCorrectionTest(unittest.TestCase):
+
+    def test_WHEN_no_shutter_file_THEN_exception(self):
+        images = th.generate_images()
+        images._shutter_count_file = None
+
+        self.assertRaises(RuntimeError, OverlapCorrection.filter_func, images)
+
+    def test_executed_par(self):
+        self.do_execute(True)
+
+    def test_executed_seq(self):
+        self.do_execute(False)
+
+    @mock.patch(
+        'mantidimaging.core.operations.overlap_correction.overlap_correction.OverlapCorrection.get_shutters_breaks')
+    def do_execute(self, in_parallel, get_shutters_breaks_mock):
+        # only works on square images
+        if in_parallel:
+            images = th.generate_images_for_parallel((15, 15, 15))
+        else:
+            images = th.generate_images((10, 10, 10))
+
+        images._shutter_count_file = mock.Mock()
+        # images.shutter_count_file.source_file.parent = mock.Mock(return_value='')
+        get_shutters_breaks_mock.return_value = ((0, 2, 102), (2, 4, 230), (4, 10, 235))
+
+        original = images.copy()
+        images = OverlapCorrection.filter_func(images)
+
+        get_shutters_breaks_mock.assert_called_once()
+        th.assert_not_equals(original.data, images.data)
+
+    def test_register_gui(self):
+        assert OverlapCorrection.register_gui(None, None, None) == {}
+
+    def test_execute_wrapper(self):
+        wrapper = OverlapCorrection.execute_wrapper()
+        assert wrapper is not None
+        assert isinstance(wrapper, partial)
+
+    def test_validate_execute_kwargs(self):
+        assert OverlapCorrection.validate_execute_kwargs({}) is True

--- a/mantidimaging/core/operations/test/operations_test.py
+++ b/mantidimaging/core/operations/test/operations_test.py
@@ -13,21 +13,12 @@ from mantidimaging.core.operations.loader import load_filter_packages
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.utility.data_containers import Counts
 from mantidimaging.core.gpu import utility as gpu
+from mantidimaging.core.operations.overlap_correction.overlap_correction import ShutterInfo
 
 if TYPE_CHECKING:
     from mantidimaging.core.operations.loader import BaseFilterClass
 
 GPU_NOT_AVAIL = not gpu.gpu_available()
-
-
-@dataclass
-class ShutterInfo:
-    number: int
-    count: int
-    start_time: float = 0
-    end_time: float = 0
-    start_index: int = 0
-    end_index: int = 0
 
 
 def get_filter_func_args():

--- a/mantidimaging/core/operations/test/operations_test.py
+++ b/mantidimaging/core/operations/test/operations_test.py
@@ -12,6 +12,7 @@ from mantidimaging.core.operations.loader import load_filter_packages
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.utility.data_containers import Counts
 from mantidimaging.core.gpu import utility as gpu
+from overlap_correction import ShutterInfo
 
 if TYPE_CHECKING:
     from mantidimaging.core.operations.loader import BaseFilterClass
@@ -60,7 +61,11 @@ class OperationsTest(unittest.TestCase):
                 counts = Counts(numpy.ones(images.num_images))
                 images._log_file = mock.Mock(counts=lambda counts=counts: counts)
             if filter_name == "Overlap Correction":
-                filter.get_shutters_breaks = mock.Mock(return_value=((0, 1), (1, 2)))
+                filter.get_shutters = mock.Mock()
+                filter.get_shutters.return_value = [
+                    ShutterInfo(0, 102, start_index=0, end_index=1),
+                    ShutterInfo(1, 230, start_index=1, end_index=2)
+                ]
                 images._shutter_count_file = mock.Mock()
 
             returned = filter.filter_func(images, **filter_args)

--- a/mantidimaging/core/operations/test/operations_test.py
+++ b/mantidimaging/core/operations/test/operations_test.py
@@ -59,6 +59,9 @@ class OperationsTest(unittest.TestCase):
             if filter_name == "Monitor Normalisation":
                 counts = Counts(numpy.ones(images.num_images))
                 images._log_file = mock.Mock(counts=lambda counts=counts: counts)
+            if filter_name == "Overlap Correction":
+                filter.get_shutters_breaks = mock.Mock(return_value=((0, 1), (1, 2)))
+                images._shutter_count_file = mock.Mock()
 
             returned = filter.filter_func(images, **filter_args)
             self.assertEqual(id(images), id(returned))

--- a/mantidimaging/core/operations/test/operations_test.py
+++ b/mantidimaging/core/operations/test/operations_test.py
@@ -2,7 +2,6 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 import unittest
 from unittest import mock

--- a/mantidimaging/core/operations/test/operations_test.py
+++ b/mantidimaging/core/operations/test/operations_test.py
@@ -2,6 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 import unittest
 from unittest import mock
@@ -12,12 +13,21 @@ from mantidimaging.core.operations.loader import load_filter_packages
 import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.utility.data_containers import Counts
 from mantidimaging.core.gpu import utility as gpu
-from overlap_correction import ShutterInfo
 
 if TYPE_CHECKING:
     from mantidimaging.core.operations.loader import BaseFilterClass
 
 GPU_NOT_AVAIL = not gpu.gpu_available()
+
+
+@dataclass
+class ShutterInfo:
+    number: int
+    count: int
+    start_time: float = 0
+    end_time: float = 0
+    start_index: int = 0
+    end_index: int = 0
 
 
 def get_filter_func_args():

--- a/mantidimaging/gui/windows/operations/test/model_test.py
+++ b/mantidimaging/gui/windows/operations/test/model_test.py
@@ -187,9 +187,9 @@ class FiltersWindowModelTest(unittest.TestCase):
         self.assertEqual([
             'Crop Coordinates', 'Flat-fielding', 'Remove Outliers', 'ROI Normalisation', "-----------------",
             'Arithmetic', 'Circular Mask', 'Clip Values', 'Divide', 'Gaussian', 'Median', 'Monitor Normalisation',
-            'NaN Removal', 'Rebin', 'Rescale', 'Ring Removal', 'Rotate Stack', "-----------------",
-            'Remove all stripes', 'Remove dead stripes', 'Remove large stripes', 'Remove stripes with filtering',
-            'Remove stripes with sorting and fitting'
+            'NaN Removal', 'Overlap Correction', 'Rebin', 'Rescale', 'Ring Removal', 'Rotate Stack',
+            "-----------------", 'Remove all stripes', 'Remove dead stripes', 'Remove large stripes',
+            'Remove stripes with filtering', 'Remove stripes with sorting and fitting'
         ], filter_names)
 
 


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2545 

### Description

The standalone Overlap Correction script which IMAT have been using has now been migrated into the MI Operations. In order to use the Overlap Correction operation, a ShutterCount.txt file must be loaded along with the imagestack, i.e. the iron dataset. The operation will search for the ShutterTimes and Spectra files in the same directory.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Load in a dataset which has Shutter information files (i.e. MCP_Fe_Calibration)
- [ ] Open the Operations Window and select `Overlap Correction`  (You may need to run `Remove NaNs` first or crop the edges!)
- [ ] Apply the operation to the Stack.
- [ ] When finished, open the Spectrum Viewer and check that the Spectrum is correct. (see below)

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->
  - [ ] 

### Results from Standalone `overlap_correction.py`
![image](https://github.com/user-attachments/assets/e2ae772d-d665-4819-a572-f625ffcd1053)

### Results after MI Overlap Correction Operation 
![image](https://github.com/user-attachments/assets/92fafac8-0fe0-457c-a1b1-bf2ce29c9766)


