### PR TITLE
Display Selected ROI within Image view

### DIFF
--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -3,7 +3,7 @@
 import numpy as np
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QGraphicsItem
 from pyqtgraph import RectROI, mkPen, ImageItem
-from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumPlotWidget
+from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumPlotWidget, SpectrumROI
 
 
 class FittingDisplayWidget(QWidget):
@@ -33,6 +33,11 @@ class FittingDisplayWidget(QWidget):
         self.image_item.setZValue(20)
         self.image_item.setScale(0.2)
         self.image_item.setPos(self.spectrum_plot.width() - 150, 10)
+
+        self.image_preview_roi = RectROI([0, 0], [10, 10], pen=mkPen((0, 255, 0), width=2), movable=False)
+        self.image_preview_roi.setZValue(21)
+        self.image_preview_roi.setParentItem(self.image_item)
+        self.image_preview_roi.hide()
 
     def update_plot(self,
                     x_data: np.ndarray,
@@ -79,3 +84,16 @@ class FittingDisplayWidget(QWidget):
         pos = self.fitting_region.pos()
         size = self.fitting_region.size()
         return float(pos.x()), float(pos.x() + size.x())
+
+    def show_roi_on_thumbnail_from_widget(self, roi_widget: SpectrumROI) -> None:
+        """
+        Copy ROI size and color from the main image window ROI to the thumbnail overlay.
+        """
+        pos = roi_widget.pos()
+        size = roi_widget.size()
+        color = roi_widget.colour if hasattr(roi_widget, "colour") else (0, 255, 0, 255)
+        scale = 0.2
+        self.image_preview_roi.setPos((pos.x() * scale, pos.y() * scale))
+        self.image_preview_roi.setSize((size.x() * scale, size.y() * scale))
+        self.image_preview_roi.setPen(mkPen(color, width=2))
+        self.image_preview_roi.show()

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -34,7 +34,10 @@ class FittingDisplayWidget(QWidget):
         self.image_item.setScale(0.2)
         self.image_item.setPos(self.spectrum_plot.width() - 150, 10)
 
-        self.image_preview_roi = RectROI([0, 0], [10, 10], pen=mkPen((0, 255, 0), width=2), movable=False)
+        self.image_preview_roi = RectROI([0, 0], [10, 10],
+                                         pen=mkPen((0, 255, 0), width=2),
+                                         movable=False,
+                                         rotatable=False)
         self.image_preview_roi.setZValue(21)
         self.image_preview_roi.setParentItem(self.image_item)
         self.image_preview_roi.hide()
@@ -91,9 +94,9 @@ class FittingDisplayWidget(QWidget):
         """
         pos = roi_widget.pos()
         size = roi_widget.size()
-        color = roi_widget.colour if hasattr(roi_widget, "colour") else (0, 255, 0, 255)
-        scale = 0.2
-        self.image_preview_roi.setPos((pos.x() * scale, pos.y() * scale))
-        self.image_preview_roi.setSize((size.x() * scale, size.y() * scale))
+        color = roi_widget.colour
+
+        self.image_preview_roi.setPos(pos)
+        self.image_preview_roi.setSize(size)
         self.image_preview_roi.setPen(mkPen(color, width=2))
         self.image_preview_roi.show()

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -2,7 +2,8 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 import numpy as np
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QGraphicsItem
-from pyqtgraph import RectROI, mkPen, ImageItem
+from PyQt5 import QtCore
+from pyqtgraph import RectROI, mkPen, ImageItem, ROI
 from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumPlotWidget, SpectrumROI
 
 
@@ -34,12 +35,10 @@ class FittingDisplayWidget(QWidget):
         self.image_item.setScale(0.2)
         self.image_item.setPos(self.spectrum_plot.width() - 150, 10)
 
-        self.image_preview_roi = RectROI([0, 0], [10, 10],
-                                         pen=mkPen((0, 255, 0), width=2),
-                                         movable=False,
-                                         rotatable=False)
+        self.image_preview_roi = ROI([0, 0], [10, 10], pen=mkPen((0, 255, 0), width=2))
         self.image_preview_roi.setZValue(21)
         self.image_preview_roi.setParentItem(self.image_item)
+        self.image_preview_roi.setAcceptedMouseButtons(QtCore.Qt.NoButton)  # Optional: make non-interactive
         self.image_preview_roi.hide()
 
     def update_plot(self,

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -239,7 +239,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         if reset_region:
             self.view.fittingDisplayWidget.set_default_region(tof_data, spectrum_data)
 
-
     def get_roi_fitting_params(self, roi_name: str) -> dict[str, tuple[float, float]]:
         """
         Return placeholder fitting parameters for the selected ROI.

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -232,10 +232,13 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
         self.view.fittingDisplayWidget.update_plot(tof_data, spectrum_data, label=roi_name, image=image)
         wavelength_range = float(np.min(tof_data)), float(np.max(tof_data))
+        roi_widget = self.view.spectrum_widget.roi_dict[roi_name]
+        self.view.fittingDisplayWidget.show_roi_on_thumbnail_from_widget(roi_widget)
         self.view.scalable_roi_widget.set_parameters(self.get_roi_fitting_params(roi_name))
         self.view.fittingDisplayWidget.update_labels(wavelength_range=wavelength_range)
         if reset_region:
             self.view.fittingDisplayWidget.set_default_region(tof_data, spectrum_data)
+
 
     def get_roi_fitting_params(self, roi_name: str) -> dict[str, tuple[float, float]]:
         """


### PR DESCRIPTION
## Issue Closes #2390

### Description

This PR adds support for displaying the selected Region of Interest (ROI) as an overlay on the thumbnail image in the fitting window. The ROI overlay:
- Matches the position and size of the ROI shown in the main image window
- Adopts the same color as the selected ROI
- Updates live when an ROI is selected or moved

This improves the user experience by making it easier to visually identify which part of the image the fitting corresponds to, directly from the fitting window.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- Manually tested ROI selection via the dropdown
- Verified that the thumbnail image ROI overlay matches the full image ROI
- Verified the ROI overlay updates live on ROI movement

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Select an ROI from the dropdown — a green box appears on the thumbnail image, matching the main image ROI
- [ ] Move or resize the ROI in the main image view — the thumbnail overlay updates live
- [ ] ROI color changes are reflected in the thumbnail overlay
- [ ] Thumbnail ROI remains accurate when switching datasets or tabs
