### PR TITLE
Change `Apply to all stacks` to `Apply to dataset`

### DIFF
--- a/docs/release_notes/next/dev-2552-apply-to-dataset
+++ b/docs/release_notes/next/dev-2552-apply-to-dataset
@@ -1,0 +1,1 @@
+#2552: Replaced "Apply to all stacks" button with "Apply to Dataset", which only applies the operation to the selected dataset.

--- a/mantidimaging/gui/ui/filters_window.ui
+++ b/mantidimaging/gui/ui/filters_window.ui
@@ -308,7 +308,7 @@
             <item>
              <widget class="QPushButton" name="applyToAllButton">
               <property name="text">
-               <string>Apply to ALL stacks</string>
+               <string>Apply to Dataset</string>
               </property>
              </widget>
             </item>

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -77,22 +77,27 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         assert_called_once_with(apply_filter_mock, expected_apply_to,
                                 partial(self.presenter._post_filter, expected_apply_to))
 
-    @mock.patch("mantidimaging.gui.windows.operations.presenter.operation_in_progress")
-    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.do_apply_filter')
-    def test_apply_filter_to_all(self, apply_filter_mock: mock.Mock, _):
+    @mock.patch("mantidimaging.gui.utility.common.operation_in_progress")
+    @mock.patch("mantidimaging.gui.windows.operations.presenter.FiltersWindowModel.do_apply_filter")
+    def test_apply_filter_to_dataset(self, apply_filter_mock: mock.Mock, _):
         self.view.ask_confirmation.return_value = False
-        self.presenter.do_apply_filter_to_all()
-
+        self.presenter.stack = mock.Mock()
+        self.presenter.do_apply_filter_to_dataset()
         self.view.ask_confirmation.assert_called_once()
 
         self.view.ask_confirmation.reset_mock()
         self.view.ask_confirmation.return_value = True
-        mock_stacks = [mock.Mock(), mock.Mock()]
-        self.presenter._main_window = mock.Mock()
-        self.presenter._main_window.get_all_stacks = mock.Mock()
-        self.presenter._main_window.get_all_stacks.return_value = mock_stacks
 
-        self.presenter.do_apply_filter_to_all()
+        mock_stack = mock.Mock()
+        self.presenter.stack = mock_stack
+        self.presenter._main_window = mock.Mock()
+        self.presenter._main_window.get_dataset_id_from_stack_uuid.return_value = "dataset_id"
+        mock_dataset = mock.Mock()
+        mock_stacks = [mock.Mock(), mock.Mock()]
+        mock_dataset.all = mock_stacks
+        self.presenter._main_window.get_dataset.return_value = mock_dataset
+
+        self.presenter.do_apply_filter_to_dataset()
 
         assert_called_once_with(apply_filter_mock, mock_stacks, partial(self.presenter._post_filter, mock_stacks))
 


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #1329 

### Description
Updated the functionality of the previous `Apply to all stacks` button to only apply to the current selected dataset instead of all stacks open.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`


### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Verify that the filters were only applied to the currently selected dataset


