### PR TITLE
Speedup of Spectrum Viewer startup

### DIFF
--- a/docs/release_notes/next/fix-2523-Improve-spectrum-viewer-startup
+++ b/docs/release_notes/next/fix-2523-Improve-spectrum-viewer-startup
@@ -1,0 +1,1 @@
+2523: The Spectrum Viewer configures stack and calculates spectrum after window is displayed. Spectrum is now cached.

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -210,12 +210,7 @@ class SpectrumViewerWindowModel:
         return ""
 
     def get_spectrum(self, roi: SensibleROI, mode: SpecType, normalise_with_shuttercount: bool = False) -> np.ndarray:
-        #print("=-=-=-=-=-=-=-=-=-=-=-=- get_spectrum CALLED =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-")
-        # print(*roi)
-        # print((*roi, mode, normalise_with_shuttercount))
-        # print(self.spectrum_cache.keys())
         if (*roi, mode, normalise_with_shuttercount) in self.spectrum_cache.keys():
-            #print("=-=-=-=-=-=-=-=-=-=-=-=- found in spectrum_cache =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-")
             return self.spectrum_cache[(*roi, mode, normalise_with_shuttercount)]
 
         if self._stack is None:

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -252,7 +252,7 @@ class SpectrumViewerWindowModel:
     def store_spectrum(self, roi: SensibleROI, mode: SpecType, normalise_with_shuttercount: bool, spectrum: np.ndarray):
         params = (*roi, mode, normalise_with_shuttercount)
         if len(self.spectrum_cache) >= 5:
-            self.spectrum_cache.pop(next(iter(self.spectrum_cache.keys())))
+            self.spectrum_cache.pop(list(self.spectrum_cache.keys())[1])
         self.spectrum_cache[params] = spectrum
         # print(f"{self.spectrum_cache=}")
 

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -102,13 +102,6 @@ class SpectrumViewerWindowModel:
 
         self.fitting_engine = FittingEngine(ErfStepFunction())
 
-        print("========================= Model Init ===============================")
-        # self.full_image_spectrum = self.get_spectrum(SensibleROI.from_list([0, 0, *self.get_image_shape()]),
-        #                                         self.presenter.spectrum_mode,
-        #                                         self.presenter.view.shuttercount_norm_enabled())
-
-
-
     def roi_name_generator(self) -> str:
         """
         Returns a new Unique ID for newly created ROIs
@@ -249,10 +242,14 @@ class SpectrumViewerWindowModel:
 
     def store_spectrum(self, roi: SensibleROI, mode: SpecType, normalise_with_shuttercount: bool, spectrum: np.ndarray):
         params = (*roi, mode, normalise_with_shuttercount)
-        if len(self.spectrum_cache) >= 5:
-            self.spectrum_cache.pop(list(self.spectrum_cache.keys())[1])
+        if len(self.spectrum_cache) > 99:
+            full_width, full_height = self.get_image_shape()
+            full_size = (0, 0, full_width, full_height)
+            for param_to_evict in self.spectrum_cache.keys():
+                if param_to_evict[:4] != full_size:
+                    break
+            self.spectrum_cache.pop(param_to_evict)
         self.spectrum_cache[params] = spectrum
-        # print(f"{self.spectrum_cache=}")
 
     def get_shuttercount_normalised_correction_parameter(self) -> float:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -216,6 +216,9 @@ class SpectrumViewerWindowModel:
         if self._stack is None:
             return np.array([])
 
+        if self.presenter.initial_sample_change:
+            return np.zeros(self._stack.data.shape[0])
+
         if mode == SpecType.SAMPLE:
             sample_spectrum = self.get_stack_spectrum(self._stack, roi)
             self.store_spectrum(roi, mode, normalise_with_shuttercount, sample_spectrum)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -74,6 +74,10 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             self.model.set_normalise_stack(norm_stack)
 
         self.model.set_tof_unit_mode_for_stack()
+        self.model.spectrum_cache.clear()
+        self.model.get_spectrum(SensibleROI.from_list([0, 0, *self.model.get_image_shape()]),
+                                self.spectrum_mode,
+                                self.view.shuttercount_norm_enabled())
         self.reset_units_menu()
 
         self.handle_tof_unit_change()
@@ -203,7 +207,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         Handle changes to any ROI position and size.
         """
-        print("=============== handle_roi_moved ======================")
         spectrum = self.model.get_spectrum(
             roi.as_sensible_roi(),
             self.spectrum_mode,
@@ -223,7 +226,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         if roi_name not in self.view.spectrum_widget.roi_dict:
             return
         roi = self.view.spectrum_widget.get_roi(roi_name)
-        print("============== update_fitting_spectrum =====================")
         spectrum_data = self.model.get_spectrum(roi, self.spectrum_mode)
         tof_data = self.model.tof_data
         if tof_data is None:
@@ -246,7 +248,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         Redraw the spectrum with the given name
         """
         roi = self.view.spectrum_widget.get_roi(name)
-        print("================= redraw_spectrum ====================")
         spectrum = self.model.get_spectrum(roi, self.spectrum_mode, self.view.shuttercount_norm_enabled())
         self.view.set_spectrum(name, spectrum)
 
@@ -258,7 +259,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             if not roi_widget.isVisible():
                 continue
             widget_roi = self.view.spectrum_widget.get_roi(roi_name)
-            print("========================= redraw_all_rois ===================================")
             spectrum = self.model.get_spectrum(widget_roi, self.spectrum_mode, self.view.shuttercount_norm_enabled())
             self.view.set_spectrum(roi_name, spectrum)
 
@@ -356,7 +356,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         Add a new ROI to the spectrum
         """
-        print("============== do_add_roi =====================")
         roi_name = self.model.roi_name_generator()
         if roi_name in self.view.spectrum_widget.roi_dict:
             raise ValueError(f"ROI name already exists: {roi_name}")

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -203,6 +203,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         Handle changes to any ROI position and size.
         """
+        print("=============== handle_roi_moved ======================")
         spectrum = self.model.get_spectrum(
             roi.as_sensible_roi(),
             self.spectrum_mode,
@@ -222,6 +223,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         if roi_name not in self.view.spectrum_widget.roi_dict:
             return
         roi = self.view.spectrum_widget.get_roi(roi_name)
+        print("============== update_fitting_spectrum =====================")
         spectrum_data = self.model.get_spectrum(roi, self.spectrum_mode)
         tof_data = self.model.tof_data
         if tof_data is None:
@@ -244,6 +246,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         Redraw the spectrum with the given name
         """
         roi = self.view.spectrum_widget.get_roi(name)
+        print("================= redraw_spectrum ====================")
         spectrum = self.model.get_spectrum(roi, self.spectrum_mode, self.view.shuttercount_norm_enabled())
         self.view.set_spectrum(name, spectrum)
 
@@ -255,6 +258,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             if not roi_widget.isVisible():
                 continue
             widget_roi = self.view.spectrum_widget.get_roi(roi_name)
+            print("========================= redraw_all_rois ===================================")
             spectrum = self.model.get_spectrum(widget_roi, self.spectrum_mode, self.view.shuttercount_norm_enabled())
             self.view.set_spectrum(roi_name, spectrum)
 
@@ -352,6 +356,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         Add a new ROI to the spectrum
         """
+        print("============== do_add_roi =====================")
         roi_name = self.model.roi_name_generator()
         if roi_name in self.view.spectrum_widget.roi_dict:
             raise ValueError(f"ROI name already exists: {roi_name}")

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -102,6 +102,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             self.view.current_dataset_id = None
 
         self.do_remove_roi()
+        self.model.spectrum_cache.clear()
         if uuid is None:
             self.model.set_stack(None)
             self.view.clear()
@@ -109,6 +110,9 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             return
 
         self.model.set_stack(self.main_window.get_stack(uuid))
+        self.model.get_spectrum(SensibleROI.from_list([0, 0, *self.model.get_image_shape()]),
+                                self.spectrum_mode,
+                                self.view.shuttercount_norm_enabled())
         self.model.set_tof_unit_mode_for_stack()
         self.reset_units_menu()
         self.handle_tof_unit_change()

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -47,6 +47,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
     current_stack_uuid: UUID | None = None
     current_norm_stack_uuid: UUID | None = None
     export_mode: ExportMode
+    initial_sample_change: bool = True
 
     def __init__(self, view: SpectrumViewerWindowView, main_window: MainWindowView):
         super().__init__(view)
@@ -75,14 +76,18 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
         self.model.set_tof_unit_mode_for_stack()
         self.model.spectrum_cache.clear()
-        self.model.get_spectrum(SensibleROI.from_list([0, 0, *self.model.get_image_shape()]),
-                                self.spectrum_mode,
+        self.model.get_spectrum(SensibleROI.from_list([0, 0, *self.model.get_image_shape()]), self.spectrum_mode,
                                 self.view.shuttercount_norm_enabled())
         self.reset_units_menu()
 
         self.handle_tof_unit_change()
         self.show_new_sample()
         self.redraw_all_rois()
+
+    def initial_roi_calc(self):
+        spectrum = self.model.get_spectrum(SensibleROI.from_list([0, 0, *self.model.get_image_shape()]),
+                                           self.spectrum_mode, self.view.shuttercount_norm_enabled())
+        self.view.set_spectrum("roi", spectrum)
 
     def handle_sample_change(self, uuid: UUID | None) -> None:
         """
@@ -110,8 +115,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             return
 
         self.model.set_stack(self.main_window.get_stack(uuid))
-        self.model.get_spectrum(SensibleROI.from_list([0, 0, *self.model.get_image_shape()]),
-                                self.spectrum_mode,
+        self.model.get_spectrum(SensibleROI.from_list([0, 0, *self.model.get_image_shape()]), self.spectrum_mode,
                                 self.view.shuttercount_norm_enabled())
         self.model.set_tof_unit_mode_for_stack()
         self.reset_units_menu()

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -37,6 +37,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         self.presenter = mock.create_autospec(SpectrumViewerWindowPresenter, instance=True)
         self.model = SpectrumViewerWindowModel(self.presenter)
         self.model.spectrum_cache = {}
+        self.presenter.initial_sample_change = False
 
     def tearDown(self):
         del self.model.spectrum_cache

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -36,6 +36,10 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
     def setUp(self) -> None:
         self.presenter = mock.create_autospec(SpectrumViewerWindowPresenter, instance=True)
         self.model = SpectrumViewerWindowModel(self.presenter)
+        self.model.spectrum_cache = {}
+
+    def tearDown(self):
+        del self.model.spectrum_cache
 
     def _set_sample_stack(self, with_tof=False, with_shuttercount=False):
         spectrum = np.arange(0, 10)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -111,13 +111,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.roi_form.addBtn.clicked.connect(self.set_new_roi)
         self.roi_form.removeBtn.clicked.connect(self.remove_roi)
 
-        self._configure_dropdown(self.sampleStackSelector)
-        self._configure_dropdown(self.normaliseStackSelector)
-
-        self.sampleStackSelector.select_eligible_stack()
-        self.try_to_select_relevant_normalise_stack("Flat")
-        self.presenter.handle_tof_unit_change()
-
         self.roi_form.exportButton.clicked.connect(self.presenter.handle_export_csv)
         self.roi_form.exportButtonRITS.clicked.connect(self.presenter.handle_rits_export)
 
@@ -126,8 +119,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.roi_form.roi_properties_widget.roi_changed.connect(self.presenter.do_adjust_roi)
 
         self.spectrum_widget.roi_changed.connect(self.set_roi_properties)
-
-        self.set_roi_properties()
 
         self.experimentSetupFormWidget = ExperimentSetupFormWidget(self.experimentSetupGroupBox)
         self.experimentSetupFormWidget.flight_path = 56.4
@@ -143,11 +134,21 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     def show(self) -> None:
         super().show()
         self.activateWindow()
+        self.initial_setup()
 
     def cleanup(self) -> None:
         self.sampleStackSelector.unsubscribe_from_main_window()
         self.normaliseStackSelector.unsubscribe_from_main_window()
         self.main_window.spectrum_viewer = None
+
+    def initial_setup(self) -> None:
+        self._configure_dropdown(self.sampleStackSelector)
+        self._configure_dropdown(self.normaliseStackSelector)
+        self.sampleStackSelector.select_eligible_stack()
+        self.try_to_select_relevant_normalise_stack("Flat")
+        self.presenter.handle_tof_unit_change()
+        self.set_roi_properties()
+
 
     def handle_change_tab(self, tab_index: int):
         self.imageTabs.setCurrentIndex(tab_index)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from PyQt5 import QtWidgets
 from pyqtgraph import mkPen
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import (QCheckBox, QVBoxLayout, QFileDialog, QLabel, QGroupBox, QActionGroup, QAction)
@@ -142,13 +143,16 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.main_window.spectrum_viewer = None
 
     def initial_setup(self) -> None:
+        QtWidgets.qApp.processEvents()
         self._configure_dropdown(self.sampleStackSelector)
         self._configure_dropdown(self.normaliseStackSelector)
+        QtWidgets.qApp.processEvents()
         self.sampleStackSelector.select_eligible_stack()
         self.try_to_select_relevant_normalise_stack("Flat")
         self.presenter.handle_tof_unit_change()
         self.set_roi_properties()
-
+        self.presenter.initial_sample_change = False
+        self.presenter.initial_roi_calc()
 
     def handle_change_tab(self, tab_index: int):
         self.imageTabs.setCurrentIndex(tab_index)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -28,9 +28,6 @@ if TYPE_CHECKING:
     from mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget import ROIFormWidget, ROITableWidget
     from uuid import UUID
 
-from logging import getLogger
-LOG = getLogger(__name__)
-
 
 class SpectrumViewerWindowView(BaseMainWindowView):
     sampleStackSelector: DatasetSelectorWidgetView

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -28,6 +28,9 @@ if TYPE_CHECKING:
     from mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget import ROIFormWidget, ROITableWidget
     from uuid import UUID
 
+from logging import getLogger
+LOG = getLogger(__name__)
+
 
 class SpectrumViewerWindowView(BaseMainWindowView):
     sampleStackSelector: DatasetSelectorWidgetView


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2523

### Description

To improve the performance of the Spectrum Viewer on first opening, a small cache of recently used spectrums is stored to reduce the number of unnecessary spectrum calculations. The spectrum of the images over the whole image size is permanently stored so it does not need to be recalculated when new ROIs are created.
Previously, the GUI would wait until the dropdown menus for Stack selection are configured and all details are calculated, leading to a long wait time before the Spectrum Viewer window is displayed, this is particularly a problem for large datasets. Now the GUI is forced to process and show before the stacks are configured, giving better responsiveness.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `make check`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `make check`
- [ ] To compare against current behaviour, on the `main` branch, load in a dataset and open the Spectrum Viewer. Take note of the amount of time it takes to open and display the window.
- [ ] Switch to this PR and repeat the same steps, and confirm that the window displays faster.
- [ ] Check that the Spectrum Viewer behaves as normal otherwise.

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

 - [ ] Release Notes have been updated

### Current results on main branch for (571 x 2048 x 2048) dataset

```
2025-04-28 16:40:23,991 [perf.mantidimaging.gui.mvp_base.view:L65] INFO: SpectrumViewerWindowView shown in 6.390999999999622
```

### Current results on PR branch for (571 x 2048 x 2048) dataset

```
2025-04-28 16:43:00,177 [perf.mantidimaging.gui.mvp_base.view:L65] INFO: SpectrumViewerWindowView shown in 0.6089999999967404
```
