### PR TITLE
Add Format and Area Dropdowns to Export Tab

### DIFF
--- a/mantidimaging/gui/widgets/spectrum_widgets/export_settings_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_settings_widget.py
@@ -3,7 +3,7 @@
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel, QComboBox
 
 
-class ExportDropdownWidget(QWidget):
+class FitExportFormWidget(QWidget):
     """
     Export Format and Export Area dropdowns.
     """

--- a/mantidimaging/gui/widgets/spectrum_widgets/export_settings_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_settings_widget.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel, QComboBox
+
+
+class ExportDropdownWidget(QWidget):
+    """
+    Export Format and Export Area dropdowns.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        layout = QVBoxLayout(self)
+        self.formatDropdown = QComboBox()
+        self.formatDropdown.addItems(["CSV", "Nexus", "RITS"])
+        self.areaDropdown = QComboBox()
+        self.areaDropdown.addItem("All")
+
+        layout.addWidget(QLabel("Export Format"))
+        layout.addWidget(self.formatDropdown)
+        layout.addWidget(QLabel("Export Area"))
+        layout.addWidget(self.areaDropdown)
+        layout.addStretch()
+
+    def set_roi_names(self, roi_names: list[str]) -> None:
+        """Update ROI dropdown list dynamically."""
+        current = self.areaDropdown.currentText()
+        self.areaDropdown.blockSignals(True)
+        self.areaDropdown.clear()
+        self.areaDropdown.addItem("All")
+        self.areaDropdown.addItems(roi_names)
+        if current in roi_names:
+            self.areaDropdown.setCurrentText(current)
+        self.areaDropdown.blockSignals(False)
+
+    def selected_format(self) -> str:
+        return self.formatDropdown.currentText()
+
+    def selected_area(self) -> str:
+        return self.areaDropdown.currentText()

--- a/mantidimaging/gui/widgets/spectrum_widgets/export_settings_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_settings_widget.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel, QComboBox
 
 

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -56,6 +56,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.model = SpectrumViewerWindowModel(self)
         self.export_mode = ExportMode.ROI_MODE
         self.main_window.stack_changed.connect(self.handle_stack_modified)
+        self.selected_export_format = "CSV"
+        self.selected_export_area = "All"
 
     def handle_stack_modified(self) -> None:
         """
@@ -330,6 +332,14 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                 path = path.with_suffix(".dat")
             roi = self.view.spectrum_widget.get_roi(ROI_RITS)
             self.model.save_single_rits_spectrum(path, error_mode, roi)
+
+    def handle_export_format_change(self, fmt: str) -> None:
+        self.selected_export_format = fmt
+        LOG.debug(f"Selected export format changed to: {fmt}")
+
+    def handle_export_area_change(self, area: str) -> None:
+        self.selected_export_area = area
+        LOG.debug(f"Selected export area changed to: {area}")
 
     def _async_save_done(self, task: TaskWorkerThread) -> None:
         if task.error is not None:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -56,8 +56,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.model = SpectrumViewerWindowModel(self)
         self.export_mode = ExportMode.ROI_MODE
         self.main_window.stack_changed.connect(self.handle_stack_modified)
-        self.selected_export_format = "CSV"
-        self.selected_export_area = "All"
 
     def handle_stack_modified(self) -> None:
         """
@@ -332,14 +330,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                 path = path.with_suffix(".dat")
             roi = self.view.spectrum_widget.get_roi(ROI_RITS)
             self.model.save_single_rits_spectrum(path, error_mode, roi)
-
-    def handle_export_format_change(self, fmt: str) -> None:
-        self.selected_export_format = fmt
-        LOG.debug(f"Selected export format changed to: {fmt}")
-
-    def handle_export_area_change(self, area: str) -> None:
-        self.selected_export_area = area
-        LOG.debug(f"Selected export area changed to: {area}")
 
     def _async_save_done(self, task: TaskWorkerThread) -> None:
         if task.error is not None:

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -20,7 +20,7 @@ from mantidimaging.gui.widgets.spectrum_widgets.tof_properties import Experiment
 from mantidimaging.gui.widgets.spectrum_widgets.roi_selection_widget import ROISelectionWidget
 from mantidimaging.gui.widgets.spectrum_widgets.fitting_display_widget import FittingDisplayWidget
 from mantidimaging.gui.widgets.spectrum_widgets.fitting_param_form_widget import FittingParamFormWidget
-from mantidimaging.gui.widgets.spectrum_widgets.export_settings_widget import ExportDropdownWidget
+from mantidimaging.gui.widgets.spectrum_widgets.export_settings_widget import FitExportFormWidget
 
 import numpy as np
 
@@ -75,11 +75,8 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.scalable_roi_widget = FittingParamFormWidget()
         self.fittingFormLayout.layout().addWidget(self.scalable_roi_widget)
 
-        self.exportSettingsWidget = ExportDropdownWidget()
+        self.exportSettingsWidget = FitExportFormWidget()
         self.exportFormLayout.layout().addWidget(self.exportSettingsWidget)
-
-        self.exportSettingsWidget.formatDropdown.currentTextChanged.connect(self.presenter.handle_export_format_change)
-        self.exportSettingsWidget.areaDropdown.currentTextChanged.connect(self.presenter.handle_export_area_change)
 
         self.spectrum_widget.roi_clicked.connect(self.presenter.handle_roi_clicked)
         self.spectrum_widget.roi_changed.connect(self.presenter.handle_roi_moved)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -20,6 +20,7 @@ from mantidimaging.gui.widgets.spectrum_widgets.tof_properties import Experiment
 from mantidimaging.gui.widgets.spectrum_widgets.roi_selection_widget import ROISelectionWidget
 from mantidimaging.gui.widgets.spectrum_widgets.fitting_display_widget import FittingDisplayWidget
 from mantidimaging.gui.widgets.spectrum_widgets.fitting_param_form_widget import FittingParamFormWidget
+from mantidimaging.gui.widgets.spectrum_widgets.export_settings_widget import ExportDropdownWidget
 
 import numpy as np
 
@@ -61,7 +62,6 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.spectrum_widget = SpectrumWidget(main_window)
         self.spectrum = self.spectrum_widget.spectrum_plot_widget
         self.imageLayout.addWidget(self.spectrum_widget)
-        self.exportLayout.addWidget(QLabel("export"))
 
         self.spectrum.range_changed.connect(self.presenter.handle_range_slide_moved)
 
@@ -74,6 +74,12 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         self.scalable_roi_widget = FittingParamFormWidget()
         self.fittingFormLayout.layout().addWidget(self.scalable_roi_widget)
+
+        self.exportSettingsWidget = ExportDropdownWidget()
+        self.exportFormLayout.layout().addWidget(self.exportSettingsWidget)
+
+        self.exportSettingsWidget.formatDropdown.currentTextChanged.connect(self.presenter.handle_export_format_change)
+        self.exportSettingsWidget.areaDropdown.currentTextChanged.connect(self.presenter.handle_export_area_change)
 
         self.spectrum_widget.roi_clicked.connect(self.presenter.handle_roi_clicked)
         self.spectrum_widget.roi_changed.connect(self.presenter.handle_roi_moved)
@@ -291,6 +297,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         """ Updates the ROI dropdown menu with the available ROIs. """
         roi_names = self.presenter.get_roi_names()
         self.roiSelectionWidget.update_roi_list(roi_names)
+        self.exportSettingsWidget.set_roi_names(roi_names)
 
     def shuttercount_norm_enabled(self) -> bool:
         return self.normalise_ShutterCount_CheckBox.isChecked()


### PR DESCRIPTION
Issue
Closes #2394

Description

This PR implements a cleaner Export Window user interface by adding two stacked dropdown menus to the left panel of the Export tab:
- Export Format: allows selection between "CSV", "Nexus", and "RITS".
- Export Area: allows selection between "All" and available ROIs (ROI_1, ROI_2, etc.).

Developer Testing

- [x] I have verified unit tests pass locally: `python -m pytest -vs`
- [x] Manual testing: UI displays the dropdowns properly in the Export tab
- [x] Manual testing: Dropdown selections correctly trigger signal updates to presenter

Acceptance Criteria and Reviewer Testing

- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Export Format defaults to "CSV"
- [ ] Export Area defaults to "All"
- [ ] Export Area dynamically updates when ROIs are added or removed
- [ ] Selecting a format/area triggers correct signal updates


Documentation and Additional Notes

- No release notes update required (internal UI cleanup).
- No changes needed for Sphinx documentation.
- No screenshot testing changes necessary (minor UI addition only).

