### PR TITLE
Use np.nanmin/max to handle NaN values in fitting ROI positioning

### DIFF
--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -63,8 +63,8 @@ class FittingDisplayWidget(QWidget):
 
     def set_default_region(self, x_data: np.ndarray, y_data: np.ndarray) -> None:
         """Position the ROI centrally over the plotted data."""
-        x_min, x_max = float(np.min(x_data)), float(np.max(x_data))
-        y_min, y_max = float(np.min(y_data)), float(np.max(y_data))
+        x_min, x_max = float(np.nanmin(x_data)), float(np.nanmax(x_data))
+        y_min, y_max = float(np.nanmin(y_data)), float(np.nanmax(y_data))
         x_span = max((x_max - x_min) * 0.25, 20.0)
         y_span = max((y_max - y_min) * 0.5, 10.0)
         x_start = (x_min + x_max - x_span) / 2


### PR DESCRIPTION
## Issue Closes #2556

### Description

Replace np.min/max with np.nanmin/max in set_default_region to properly handle NaN values in the input data when positioning the fitting ROI. This makes the ROI positioning more robust when working with datasets that contain missing or invalid values.

### Developer Testing
- I have verified unit tests pass locally: `python -m pytest -vs`
- Tested with sample data containing NaN values to verify ROI positioning works correctly
- Verified existing behavior remains unchanged for data without NaNs
- Checked that ROI dimensions and positioning constraints are still respected

### Acceptance Criteria and Reviewer Testing
- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Load a dataset with NaN values and verify the fitting ROI positions correctly
- [x] Confirm the ROI can still be:
    - [ ] Moved manually after initial positioning
    - [ ] Resized using the corner handles
    - [ ] Updated via `set_selected_fit_region`

- [x] Verify ROI positioning is consistent with these cases:
    - [ ] Data containing all valid numbers
    - [ ] Data with some NaN values
    - [ ] Data with NaN values at the edges

- [x] Check that minimum size constraints (x_span ≥ 20.0, y_span ≥ 10.0) are still enforced
- [x] Verify y_start remains non-negative as per the original implementation

