### PR TITLE
 Improve type annotation in mantidimaging.core.rotation

### DIFF
--- a/mantidimaging/core/rotation/data_model.py
+++ b/mantidimaging/core/rotation/data_model.py
@@ -24,22 +24,22 @@ class CorTiltDataModel:
     _cached_cor: float | None
     _points: list[Point]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._points = []
         self._cached_gradient = None
         self._cached_cor = None
 
-    def populate_slice_indices(self, begin, end, count, cor=0.0):
+    def populate_slice_indices(self, begin, end, count, cor=0.0) -> None:
         self.clear_results()
 
         self._points = [Point(int(idx), cor) for idx in np.linspace(begin, end, count, dtype=int)]
         LOG.debug(f'Populated slice indices: {self.slices}')
 
-    def linear_regression(self):
+    def linear_regression(self) -> None:
         LOG.debug(f'Running linear regression with {self.num_points} points')
         self._cached_gradient, self._cached_cor, *_ = sp.stats.linregress(self.slices, self.cors)
 
-    def add_point(self, idx=None, slice_idx=0, cor=0.0):
+    def add_point(self, idx: int | None = None, slice_idx: int = 0, cor: float = 0.0) -> None:
         self.clear_results()
 
         if idx is None:
@@ -47,7 +47,12 @@ class CorTiltDataModel:
         else:
             self._points.insert(idx, Point(slice_idx, cor))
 
-    def set_point(self, idx, slice_idx: int | None = None, cor: float | None = None, reset_results=True):
+    def set_point(self,
+                  idx: int,
+                  slice_idx: int | None = None,
+                  cor: float | None = None,
+                  reset_results: bool = True) -> None:
+
         if reset_results:
             self.clear_results()
 
@@ -58,39 +63,39 @@ class CorTiltDataModel:
             if cor is not None:
                 self._points[idx] = Point(self._points[idx].slice_index, float(cor))
 
-    def _get_data_idx_from_slice_idx(self, slice_idx) -> int:
+    def _get_data_idx_from_slice_idx(self, slice_idx: int) -> int:
         for i, p in enumerate(self._points):
             if p.slice_index == slice_idx:
                 return i
         raise ValueError(f"Slice {slice_idx} that is not in COR table")
 
-    def set_cor_at_slice(self, slice_idx: int, cor: float):
+    def set_cor_at_slice(self, slice_idx: int, cor: float) -> None:
         data_idx = self._get_data_idx_from_slice_idx(slice_idx)
         self.set_point(data_idx, cor=cor)
 
-    def remove_point(self, idx):
+    def remove_point(self, idx: int) -> None:
         self.clear_results()
         del self._points[idx]
 
-    def clear_points(self):
+    def clear_points(self) -> None:
         self._points = []
         self.clear_results()
 
-    def clear_results(self):
+    def clear_results(self) -> None:
         self._cached_gradient = None
         self._cached_cor = None
 
-    def point(self, idx):
+    def point(self, idx: int) -> Point | None:
         return self._points[idx] if idx < self.num_points else None
 
-    def sort_points(self):
+    def sort_points(self) -> None:
         self._points.sort(key=lambda p: p.slice_index)
 
-    def get_cor_from_regression(self, slice_idx) -> float:
+    def get_cor_from_regression(self, slice_idx: int) -> float:
         cor = (self.gradient.value * slice_idx) + self.cor.value
         return cor
 
-    def get_all_cors_from_regression(self, image_height) -> list[ScalarCoR]:
+    def get_all_cors_from_regression(self, image_height: int) -> list[ScalarCoR]:
         """
 
         :param image_height: How many cors will be generated,
@@ -104,11 +109,11 @@ class CorTiltDataModel:
         return cors
 
     @property
-    def slices(self):
+    def slices(self) -> list[int]:
         return [p.slice_index for p in self._points]
 
     @property
-    def cors(self):
+    def cors(self) -> list[float]:
         return [float(p.cor) for p in self._points]
 
     @property
@@ -152,7 +157,7 @@ class CorTiltDataModel:
             const.COR_TILT_ROTATION_CENTRES: self.cors
         }
 
-    def set_precalculated(self, cor: ScalarCoR, tilt: Degrees):
+    def set_precalculated(self, cor: ScalarCoR, tilt: Degrees) -> None:
         self._cached_cor = cor.value
         # reverse the tilt calculation to get the slope of the regression back
         self._cached_gradient = -np.tan(np.deg2rad(tilt.value))

--- a/mantidimaging/core/rotation/polyfit_correlation.py
+++ b/mantidimaging/core/rotation/polyfit_correlation.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from logging import getLogger
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -68,7 +68,7 @@ def find_center(images: ImageStack, progress: Progress) -> tuple[ScalarCoR, Degr
     return ScalarCoR(images.h_middle + -offset), theta
 
 
-def compute_correlation_error(index: int, arrays: list[Any], params: dict[str, Any]) -> None:
+def compute_correlation_error(index: int, arrays: list[np.ndarray], params: dict[str, int]) -> None:
     min_correlation_error = arrays[0]
     shared_projections = arrays[1]
     shared_search_range = arrays[2]
@@ -87,7 +87,7 @@ def _find_shift(images: ImageStack, search_range: range, min_correlation_error: 
     # just in case that happens - get the first minimum one, should be close enough
     for row in range(images.height):
         min_arg_positions = min_correlation_error[row].argmin()
-        min_arg = min_arg_positions if isinstance(min_arg_positions, np.int64) else min_arg_positions[0]
+        min_arg = int(min_arg_positions)
         # And we get which search range is at that index
         # that is the number that we then pass into polyfit
         shift[row] = search_range[min_arg]

--- a/mantidimaging/core/rotation/polyfit_correlation.py
+++ b/mantidimaging/core/rotation/polyfit_correlation.py
@@ -17,8 +17,7 @@ if TYPE_CHECKING:
 LOG = getLogger(__name__)
 
 
-def do_calculate_correlation_err(store: NDArray[np.float32], search_index: int,
-                                 p0_and_180: tuple[NDArray[np.float32], NDArray[np.float32]], image_width: int) -> None:
+def do_calculate_correlation_err(store, search_index: int, p0_and_180, image_width: int) -> None:
     """
     Calculates squared sum error in the difference between the projection at 0 degrees, and the one at 180 degrees
     """
@@ -30,9 +29,9 @@ def find_center(images: ImageStack, progress: Progress) -> tuple[ScalarCoR, Degr
         raise ValueError("images and images.proj180deg cannot be None")
 
     # Assume the ROI is the full image, i.e. the slices are ALL rows of the image
-    slices: NDArray[np.int_] = np.arange(images.height)
+    slices = np.arange(images.height)
     shift = pu.create_array((images.height, ), dtype=np.float32)
-    search_range: range = get_search_range(images.width)
+    search_range = get_search_range(images.width)
     min_correlation_error = pu.create_array((len(search_range), images.height), dtype=np.float32)
     shared_search_range = pu.create_array((len(search_range), ), dtype=np.int32)
     shared_search_range.array[:] = np.asarray(search_range, dtype=np.int32)
@@ -43,7 +42,7 @@ def find_center(images: ImageStack, progress: Progress) -> tuple[ScalarCoR, Degr
     shared_projections.array[1][:] = np.fliplr(images.proj180deg.data[0])
 
     # Prepare parameters for the compute function
-    params: dict[str, int] = {'image_width': images.width}
+    params = {'image_width': images.width}
     ps.run_compute_func(compute_correlation_error,
                         len(search_range), [min_correlation_error, shared_projections, shared_search_range],
                         params,
@@ -67,7 +66,7 @@ def compute_correlation_error(index: int, arrays: list[NDArray[np.float32]], par
     min_correlation_error = arrays[0]
     shared_projections = arrays[1]
     shared_search_range = arrays[2]
-    image_width: int = params['image_width']
+    image_width = params['image_width']
 
     search_index = int(shared_search_range[index])
     do_calculate_correlation_err(min_correlation_error[index], search_index,
@@ -90,7 +89,7 @@ def _find_shift(images: ImageStack, search_range: range, min_correlation_error: 
 
 
 def get_search_range(width: int) -> range:
-    tmin: int = -width // 2
-    tmax: int = width - width // 2
+    tmin = -width // 2
+    tmax = width - width // 2
     search_range = range(tmin, tmax + 1)
     return search_range

--- a/mantidimaging/core/rotation/polyfit_correlation.py
+++ b/mantidimaging/core/rotation/polyfit_correlation.py
@@ -5,6 +5,7 @@ from logging import getLogger
 from typing import TYPE_CHECKING
 
 import numpy as np
+from numpy.typing import NDArray
 
 from mantidimaging.core.parallel import utility as pu, shared as ps
 from mantidimaging.core.utility.data_containers import Degrees, ScalarCoR
@@ -16,8 +17,8 @@ if TYPE_CHECKING:
 LOG = getLogger(__name__)
 
 
-def do_calculate_correlation_err(store: np.ndarray, search_index: int, p0_and_180: tuple[np.ndarray, np.ndarray],
-                                 image_width: int) -> None:
+def do_calculate_correlation_err(store: NDArray[np.float32], search_index: int,
+                                 p0_and_180: tuple[NDArray[np.float32], NDArray[np.float32]], image_width: int) -> None:
     """
     Calculates squared sum error in the difference between the projection at 0 degrees, and the one at 180 degrees
     """
@@ -29,9 +30,9 @@ def find_center(images: ImageStack, progress: Progress) -> tuple[ScalarCoR, Degr
         raise ValueError("images and images.proj180deg cannot be None")
 
     # Assume the ROI is the full image, i.e. the slices are ALL rows of the image
-    slices = np.arange(images.height)
+    slices: NDArray[np.int_] = np.arange(images.height)
     shift = pu.create_array((images.height, ), dtype=np.float32)
-    search_range = get_search_range(images.width)
+    search_range: range = get_search_range(images.width)
     min_correlation_error = pu.create_array((len(search_range), images.height), dtype=np.float32)
     shared_search_range = pu.create_array((len(search_range), ), dtype=np.int32)
     shared_search_range.array[:] = np.asarray(search_range, dtype=np.int32)
@@ -42,61 +43,54 @@ def find_center(images: ImageStack, progress: Progress) -> tuple[ScalarCoR, Degr
     shared_projections.array[1][:] = np.fliplr(images.proj180deg.data[0])
 
     # Prepare parameters for the compute function
-    params = {
-        'image_width': images.width,
-    }
+    params: dict[str, int] = {'image_width': images.width}
     ps.run_compute_func(compute_correlation_error,
                         len(search_range), [min_correlation_error, shared_projections, shared_search_range],
                         params,
                         progress=progress)
 
-    # Originally the output of do_search is stored in dimensions
-    # corresponding to (search_range, square sum). This is awkward to navigate
-    # we transpose store to make the array hold (square sum, search range)
-    # so that each store[row] accesses the information for the row's square sum across all search ranges
     _find_shift(images, search_range, min_correlation_error.array, shift.array)
 
     par = np.polyfit(slices, shift.array, deg=1)
-    m = par[0]
-    q = par[1]
+    m = float(par[0])
+    q = float(par[1])
     LOG.debug(f"m={m}, q={q}")
 
     theta = Degrees(np.rad2deg(np.arctan(0.5 * m)))
-    offset = np.round(m * images.height * 0.5 + q) * 0.5
+    offset = float(np.round(m * images.height * 0.5 + q) * 0.5)
     LOG.info(f"found offset: {-offset} and tilt {theta}")
 
     return ScalarCoR(images.h_middle + -offset), theta
 
 
-def compute_correlation_error(index: int, arrays: list[np.ndarray], params: dict[str, int]) -> None:
+def compute_correlation_error(index: int, arrays: list[NDArray[np.float32]], params: dict[str, int]) -> None:
     min_correlation_error = arrays[0]
     shared_projections = arrays[1]
     shared_search_range = arrays[2]
-    image_width = params['image_width']
+    image_width: int = params['image_width']
 
-    search_index = shared_search_range[index]
+    search_index = int(shared_search_range[index])
     do_calculate_correlation_err(min_correlation_error[index], search_index,
                                  (shared_projections[0], shared_projections[1]), image_width)
 
 
-def _find_shift(images: ImageStack, search_range: range, min_correlation_error: np.ndarray,
-                shift: np.ndarray) -> np.ndarray:
+def _find_shift(images: ImageStack, search_range: range, min_correlation_error: NDArray[np.float32],
+                shift: NDArray[np.float32]) -> NDArray[np.float32]:
     # Then we just find the index of the minimum one (minimum error)
     min_correlation_error = np.transpose(min_correlation_error)
     # argmin returns a list of where the minimum argument is found
     # just in case that happens - get the first minimum one, should be close enough
     for row in range(images.height):
-        min_arg_positions = min_correlation_error[row].argmin()
-        min_arg = int(min_arg_positions)
+        min_arg_positions = int(min_correlation_error[row].argmin())
         # And we get which search range is at that index
         # that is the number that we then pass into polyfit
-        shift[row] = search_range[min_arg]
+        shift[row] = search_range[min_arg_positions]
 
     return shift
 
 
 def get_search_range(width: int) -> range:
-    tmin = -width // 2
-    tmax = width - width // 2
+    tmin: int = -width // 2
+    tmax: int = width - width // 2
     search_range = range(tmin, tmax + 1)
     return search_range

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -215,7 +215,7 @@ class ReconstructWindowModel:
     def is_current_stack(self, uuid: uuid.UUID) -> bool:
         return self.stack_id == uuid
 
-    def get_slice_indices(self, num_cors: int) -> tuple[int, np.ndarray | tuple[np.ndarray, float | None]]:
+    def get_slice_indices(self, num_cors: int) -> tuple[int, np.ndarray]:
         # used to crop off 20% off the top and bottom, which is usually noise/empty
         remove_a_bit = self.images.height * 0.2
         slices = np.linspace(remove_a_bit, self.images.height - remove_a_bit, num=num_cors, dtype=np.int32)

--- a/mantidimaging/gui/windows/recon/point_table_model.py
+++ b/mantidimaging/gui/windows/recon/point_table_model.py
@@ -113,7 +113,7 @@ class CorTiltPointQtModel(QAbstractTableModel, CorTiltDataModel):
 
         return True
 
-    def insertRows(self, row, count, parent=None, slice_idx: int | None = None, cor: float | None = None) -> None:
+    def insertRows(self, row, count, parent, slice_idx: int, cor: float) -> None:
         self.beginInsertRows(parent if parent is not None else QModelIndex(), row, row + count - 1)
 
         for _ in range(count):
@@ -141,7 +141,7 @@ class CorTiltPointQtModel(QAbstractTableModel, CorTiltDataModel):
         self.endRemoveRows()
 
     def appendNewRow(self, row: int, slice_idx: int, cor: float = 0.0) -> None:
-        self.insertRows(row, 1, slice_idx=slice_idx, cor=cor)
+        self.insertRows(row, 1, None, slice_idx=slice_idx, cor=cor)
         self.set_point(row, slice_idx, cor)
         self.sort_points()
 

--- a/mantidimaging/gui/windows/recon/point_table_model.py
+++ b/mantidimaging/gui/windows/recon/point_table_model.py
@@ -117,7 +117,7 @@ class CorTiltPointQtModel(QAbstractTableModel, CorTiltDataModel):
         self.beginInsertRows(parent if parent is not None else QModelIndex(), row, row + count - 1)
 
         for _ in range(count):
-            self.add_point(row, slice_idx, cor)
+            self.add_point(row, slice_idx if slice_idx is not None else 0, cor if cor is not None else 0.0)
 
         self.endInsertRows()
 

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -421,7 +421,10 @@ class ReconstructWindowPresenter(BasePresenter):
         if self.model.has_results:
             initial_cor = []
             for slc in slice_indices:
-                initial_cor.append(self.model.data_model.get_cor_from_regression(slc))
+                if isinstance(slc, int):
+                    initial_cor.append(self.model.data_model.get_cor_from_regression(slc))
+                else:
+                    raise TypeError(f"Expected int for slice index, got {type(slc)}")
         else:
             initial_cor = [self.view.rotation_centre]
 


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2550

### Description
<!--StartFragment--><h3 dir="auto" style="box-sizing: border-box; margin-top: 0px !important; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(240, 246, 252); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Current Behaviour</h3><markdown-accessiblity-table data-catalyst="" style="box-sizing: border-box; display: block; color: rgb(240, 246, 252); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
module | score | lines
-- | -- | --
mantidimaging.core.rotation.data_model | 4.12% imprecise | 165 LOC
mantidimaging.core.rotation.polyfit_correlation | 18.75% imprecise | 102 LOC

</markdown-accessiblity-table><h3 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(240, 246, 252); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><!--EndFragment-->
</body>
</html>

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- ...

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] ...

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

