### PR TITLE
Fitting engine part 2

### DIFF
--- a/docs/release_notes/next/feature-2548-fitting-system
+++ b/docs/release_notes/next/feature-2548-fitting-system
@@ -1,0 +1,1 @@
+#2548: Add a fitting system for Bragg Edges in Time of Flight data

--- a/mantidimaging/core/fitting/fitting_engine.py
+++ b/mantidimaging/core/fitting/fitting_engine.py
@@ -2,6 +2,9 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+import numpy as np
+from scipy.optimize import minimize
+
 from mantidimaging.core.fitting.fitting_functions import BaseFittingFunction
 
 
@@ -15,3 +18,11 @@ class FittingEngine:
 
     def get_init_params_from_roi(self, region: tuple[float, float, float, float]) -> dict[str, float]:
         return self.model.get_init_params_from_roi(region)
+
+    def find_best_fit(self, xdata: np.ndarray, ydata: np.ndarray, initial_params: list[float]) -> dict[str, float]:
+
+        def f(params):
+            return ((self.model.evaluate(xdata, params) - ydata)**2).sum()
+
+        result = minimize(f, initial_params, method="Nelder-Mead")
+        return dict(zip(self.model.get_parameter_names(), result.x, strict=True))

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_param_form_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_param_form_widget.py
@@ -34,6 +34,10 @@ class FittingParamFormWidget(QWidget):
         self.layout().addWidget(self.from_roi_button)
         self.from_roi_button.clicked.connect(self.presenter.get_init_params_from_roi)
 
+        self.run_fit_button = QPushButton("Run fit")
+        self.layout().addWidget(self.run_fit_button)
+        self.run_fit_button.clicked.connect(self.presenter.run_region_fit)
+
     def set_parameters(self, params: list[str]) -> None:
         """
         Set parameters in the widget.
@@ -61,6 +65,11 @@ class FittingParamFormWidget(QWidget):
         for name, value in values.items():
             row = self._rows[name]
             row[2].setText(f"{value:f}")
+
+    def set_fitted_parameter_values(self, values: dict[str, float]) -> None:
+        for name, value in values.items():
+            row = self._rows[name]
+            row[3].setText(f"{value:f}")
 
     def get_initial_param_values(self) -> list[float]:
         params = [float(row[2].text()) for row in self._rows.values()]


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2567 

### Description

Add a Run fit button
Add a `FittingEngine.find_best_fit()` to run the fit with SciPy's Nelder-Mead
Hook up in the presenter to run the fit and show the result.


### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- ...

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Open a ToF dataset in the spectrum viewer
- [ ] Add a new ROI and resize it (work around #2563)
- [ ] Switch to Fitting tab and select the new ROI
- [ ] Select an edge
- [ ] Press From ROI (this should draw a step function based on the ROI position)
- [ ] Press Run Fit (this should find a good fit for the current edge)

### Documentation and Additional Notes

 - [ ] Release Notes have been updated


