### PR TITLE
Add ROI export table to spectrum viewer

### DIFF
--- a/mantidimaging/gui/widgets/spectrum_widgets/export_data_table_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_data_table_widget.py
@@ -1,6 +1,6 @@
-from PyQt5.QtWidgets import (
-    QWidget, QVBoxLayout, QTableView, QHeaderView, QAbstractItemView
-)
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QTableView, QHeaderView, QAbstractItemView)
 from PyQt5.QtGui import QStandardItemModel, QStandardItem
 from PyQt5.QtCore import Qt
 
@@ -36,7 +36,8 @@ class ExportDataTableWidget(QWidget):
             QStandardItem(roi_name),
             QStandardItem(f"{params.get('mu', 0):.3f}"),
             QStandardItem(f"{params.get('sigma', 0):.3f}"),
-            QStandardItem(status),]
+            QStandardItem(status),
+        ]
         for item in items:
             item.setTextAlignment(Qt.AlignCenter)
 

--- a/mantidimaging/gui/widgets/spectrum_widgets/export_data_table_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_data_table_widget.py
@@ -1,0 +1,56 @@
+from PyQt5.QtWidgets import (
+    QWidget, QVBoxLayout, QTableView, QHeaderView, QAbstractItemView
+)
+from PyQt5.QtGui import QStandardItemModel, QStandardItem
+from PyQt5.QtCore import Qt
+
+
+class ExportDataTableWidget(QWidget):
+    """
+    A scalable table widget to display export-relevant data for each ROI.
+    Intended for integration with the fitting/export tab in the spectrum viewer.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.table_view = QTableView(self)
+        self.model = QStandardItemModel(0, 4, self)
+        self.model.setHorizontalHeaderLabels(["ROI Name", "μ (mu)", "σ (sigma)", "Export Status"])
+        self.table_view.setModel(self.model)
+        self.table_view.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table_view.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.table_view.horizontalHeader().setStretchLastSection(True)
+        self.table_view.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.table_view.verticalHeader().setVisible(False)
+
+        layout.addWidget(self.table_view)
+
+    def update_roi_data(self, roi_name: str, params: dict[str, float], status: str = "Ready") -> None:
+        """
+        Add or update a row for the given ROI.
+        """
+        existing_row = self._find_row_by_roi_name(roi_name)
+        items = [
+            QStandardItem(roi_name),
+            QStandardItem(f"{params.get('mu', 0):.3f}"),
+            QStandardItem(f"{params.get('sigma', 0):.3f}"),
+            QStandardItem(status),]
+        for item in items:
+            item.setTextAlignment(Qt.AlignCenter)
+
+        if existing_row is not None:
+            for col, item in enumerate(items):
+                self.model.setItem(existing_row, col, item)
+        else:
+            self.model.appendRow(items)
+
+    def _find_row_by_roi_name(self, roi_name: str) -> int | None:
+        for row in range(self.model.rowCount()):
+            if self.model.item(row, 0).text() == roi_name:
+                return row
+        return None
+
+    def clear_table(self) -> None:
+        self.model.removeRows(0, self.model.rowCount())

--- a/mantidimaging/gui/widgets/spectrum_widgets/export_data_table_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_data_table_widget.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
 from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QTableView, QHeaderView, QAbstractItemView)
 from PyQt5.QtGui import QStandardItemModel, QStandardItem
 from PyQt5.QtCore import Qt

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -477,6 +477,10 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         init_params = self.model.fitting_engine.get_init_params_from_roi(fitting_region)
         self.view.scalable_roi_widget.set_parameter_values(init_params)
         self.show_initial_fit()
+        mu_val = init_params.get("mu", 0.0)
+        sigma_val = init_params.get("sigma", 0.0)
+        roi_name = self.view.table_view.current_roi_name
+        self.view.update_export_table(roi_name=roi_name, mu=mu_val, sigma=sigma_val, status="Initial")
 
     def show_initial_fit(self):
         init_params = self.view.scalable_roi_widget.get_initial_param_values()
@@ -496,6 +500,10 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         result = self.model.fitting_engine.find_best_fit(xvals, yvals, init_params)
         self.view.scalable_roi_widget.set_fitted_parameter_values(result)
         self.show_fit(list(result.values()))
+        mu_val = result.get("mu", 0.0)
+        sigma_val = result.get("sigma", 0.0)
+        roi_name = self.view.table_view.current_roi_name
+        self.view.update_export_table(roi_name=roi_name, mu=mu_val, sigma=sigma_val, status="Fitted")
 
     def show_fit(self, params: list[float]) -> None:
         assert self.model.tof_data is not None

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -22,6 +22,7 @@ from mantidimaging.gui.widgets.spectrum_widgets.roi_selection_widget import ROIS
 from mantidimaging.gui.widgets.spectrum_widgets.fitting_display_widget import FittingDisplayWidget
 from mantidimaging.gui.widgets.spectrum_widgets.fitting_param_form_widget import FittingParamFormWidget
 from mantidimaging.gui.widgets.spectrum_widgets.export_settings_widget import FitExportFormWidget
+from mantidimaging.gui.widgets.spectrum_widgets.export_data_table_widget import ExportDataTableWidget
 
 import numpy as np
 
@@ -117,6 +118,8 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         self.roi_form.exportButton.clicked.connect(self.presenter.handle_export_csv)
         self.roi_form.exportButtonRITS.clicked.connect(self.presenter.handle_rits_export)
+        self.exportDataTableWidget = ExportDataTableWidget()
+        self.exportLayout.addWidget(self.exportDataTableWidget)
 
         self.roi_form.table_view.clicked.connect(self.handle_table_click)
 
@@ -242,6 +245,9 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             return Path(path)
         else:
             return None
+
+    def update_export_table(self, roi_name: str, mu: float, sigma: float, status: str = "Ready") -> None:
+        self.exportDataTableWidget.update_roi_data(roi_name, {"mu": mu, "sigma": sigma}, status)
 
     def set_image(self, image_data: np.ndarray, autoLevels: bool = True) -> None:
         self.spectrum_widget.image.setImage(image_data, autoLevels=autoLevels)


### PR DESCRIPTION
## Summary

Introduced a new `ExportDataTableWidget` for displaying export data related to Regions of Interest (ROIs).  
Updated the presenter to populate this table with fitting parameters (`μ`, `σ`) and export statuses during both the initial parameter estimation and fitted stages.  
Integrated this widget into the spectrum viewer export tab to enhance user feedback during fitting and export workflows.

## Issue Closes

Closes #2393

## Description of Changes

- Added `ExportDataTableWidget`, a `QTableView`-based UI for showing per-ROI fitting data.
- Integrated the widget into the spectrum viewer’s export layout (`view.py`).
- Presenter updates the table in:
  - `get_init_params_from_roi()` → adds initial values with status `Initial`.
  - `run_region_fit()` → adds final values with status `Fitted`.
- New columns:
  - ROI Name
  - μ (mu)
  - σ (sigma)
  - Export Status

##  Developer Testing

- [ ] Manually verified ROI creation, parameter extraction, and fit table updates.
- [ ] Confirmed table scales with window and supports multiple ROIs.
- [ ] Unit tests pass locally: `python -m pytest -vs`

## Acceptance Criteria and Reviewer Testing

- [ ] Adding an ROI and clicking "From ROI" populates the table with initial `μ` and `σ`.
- [ ] Running "Run Fit" updates the same row with fitted values and changes status to `Fitted`.
- [ ] Table entries align with selected ROIs.
- [ ] Table widget scales correctly within the export layout.
- [ ] Unit tests pass: `python -m pytest -v

