### PR TITLE
Add fitting spectrum updates after spectrum modifications

### DIFF
--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_selection_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_selection_widget.py
@@ -23,6 +23,7 @@ class ROISelectionWidget(QtWidgets.QGroupBox):
         layout.setContentsMargins(10, 5, 10, 5)
         layout.setSpacing(2)
 
+        self.current_roi_name = None
         self.roiDropdown = QtWidgets.QComboBox(self)
         self.roiDropdown.currentIndexChanged.connect(self._on_selection_changed)
         layout.addWidget(self.roiDropdown)

--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_selection_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_selection_widget.py
@@ -23,7 +23,6 @@ class ROISelectionWidget(QtWidgets.QGroupBox):
         layout.setContentsMargins(10, 5, 10, 5)
         layout.setSpacing(2)
 
-        self.current_roi_name = None
         self.roiDropdown = QtWidgets.QComboBox(self)
         self.roiDropdown.currentIndexChanged.connect(self._on_selection_changed)
         layout.addWidget(self.roiDropdown)
@@ -56,3 +55,9 @@ class ROISelectionWidget(QtWidgets.QGroupBox):
         index = self.roiDropdown.findText(roi_name)
         if index != -1:
             self.roiDropdown.setCurrentIndex(index)
+
+    @property
+    def current_roi_name(self) -> str:
+        """Returns the currently selected ROI name from the dropdown."""
+        return self.roi_combo.currentText()
+

--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_selection_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_selection_widget.py
@@ -59,4 +59,4 @@ class ROISelectionWidget(QtWidgets.QGroupBox):
     @property
     def current_roi_name(self) -> str:
         """Returns the currently selected ROI name from the dropdown."""
-        return self.roi_combo.currentText()
+        return self.roiDropdown.currentText()

--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_selection_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_selection_widget.py
@@ -60,4 +60,3 @@ class ROISelectionWidget(QtWidgets.QGroupBox):
     def current_roi_name(self) -> str:
         """Returns the currently selected ROI name from the dropdown."""
         return self.roi_combo.currentText()
-

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -223,6 +223,9 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         )
         self.view.set_spectrum(roi.name, spectrum)
 
+        if self.view.roiSelectionWidget.current_roi_name == roi.name:
+            self.update_fitting_spectrum(roi.name)
+
     def handle_roi_clicked(self, roi: SpectrumROI) -> None:
         if not roi.name == ROI_RITS:
             self.view.table_view.select_roi(roi.name)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -88,6 +88,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         spectrum = self.model.get_spectrum(SensibleROI.from_list([0, 0, *self.model.get_image_shape()]),
                                            self.spectrum_mode, self.view.shuttercount_norm_enabled())
         self.view.set_spectrum("roi", spectrum)
+        self.update_fitting_spectrum("roi", reset_region=True)
 
     def handle_sample_change(self, uuid: UUID | None) -> None:
         """
@@ -397,6 +398,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.set_spectrum(ROI_RITS,
                                self.model.get_spectrum(roi, self.spectrum_mode, self.view.shuttercount_norm_enabled()))
         self.view.set_roi_visibility_flags(ROI_RITS, visible=False)
+        self.update_fitting_spectrum(ROI_RITS, reset_region=True)
 
     def do_add_roi_to_table(self, roi_name: str) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -370,11 +370,14 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         calls = [mock.call(menu_options[a], b) for a, b in [(0, False), (1, True), (2, False), (3, False)]]
         self.presenter.check_action.assert_has_calls(calls)
 
-    def test_WHEN_roi_changed_via_spinboxes_THEN_roi_adjusted(self):
+    @mock.patch.object(SpectrumViewerWindowPresenter, 'update_fitting_spectrum')
+    def test_WHEN_roi_changed_via_spinboxes_THEN_roi_adjusted(self, mock_update_fit):
         self.view.roi_form.roi_properties_widget.to_roi = mock.Mock(return_value=SensibleROI(10, 10, 20, 30))
         type(self.view.table_view).current_roi_name = mock.PropertyMock(return_value="roi_1")
+        self.view.roiSelectionWidget.current_roi_name = "roi_1"
         self.presenter.do_adjust_roi()
         self.view.spectrum_widget.adjust_roi.assert_called_once_with(SensibleROI(10, 10, 20, 30), "roi_1")
+        mock_update_fit.assert_called_once_with("roi_1")
 
     def test_WHEN_refresh_spectrum_plot_THEN_spectrum_plot_refreshed(self):
         self.view.spectrum_widget.spectrum = mock.MagicMock()

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -374,7 +374,12 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
     def test_WHEN_roi_changed_via_spinboxes_THEN_roi_adjusted(self, mock_update_fit):
         self.view.roi_form.roi_properties_widget.to_roi = mock.Mock(return_value=SensibleROI(10, 10, 20, 30))
         type(self.view.table_view).current_roi_name = mock.PropertyMock(return_value="roi_1")
-        self.view.roiSelectionWidget.current_roi_name = "roi_1"
+        self.view.roiSelectionWidget = mock.Mock()
+        type(self.view.roiSelectionWidget).current_roi_name = mock.PropertyMock(return_value="roi_1")
+        roi_mock = mock.Mock()
+        roi_mock.name = "roi_1"
+        roi_mock.as_sensible_roi.return_value = SensibleROI(10, 10, 20, 30)
+        self.view.spectrum_widget.roi_dict = {"roi_1": roi_mock}
         self.presenter.do_adjust_roi()
         self.view.spectrum_widget.adjust_roi.assert_called_once_with(SensibleROI(10, 10, 20, 30), "roi_1")
         mock_update_fit.assert_called_once_with("roi_1")


### PR DESCRIPTION
## Issue Closes #2563

### Description

Ensure the fitting spectrum is updated consistently when ROI spectra are set.  
This resolves potential discrepancies in the fitting display — particularly the initial roi
Now updates fitting spectrum immediately on adding initial `"roi"` or `"rits_roi"`.

### Developer Testing 

- Verified unit tests pass locally: `python -m pytest -vs`
- Confirmed fitting display updates correctly with one ROI
- Tested with both normal and RITS ROI

### Acceptance Criteria and Reviewer Testing

- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Fitting display updates immediately with first ROI
- [x] Spectrum and fit region display correctly
- [x] Normal and RITS ROIs behave consistently
- [x] No regression in ROI handling


