### PR TITLE
Add start_qapplication to MIPlotItemTest

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/spectrum_test.py
@@ -177,6 +177,7 @@ class SpectrumWidgetTest(unittest.TestCase):
             self.spectrum_widget.rename_roi("roi_1", "roi_2")
 
 
+@start_qapplication
 class MIPlotItemTest(unittest.TestCase):
 
     def setUp(self) -> None:


### PR DESCRIPTION
Needed because the test creates QObjects (a QPixmap)

<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2576 

### Description

Add start_qapplication to MIPlotItemTest to prevent intermittent failures in the tests.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Unit tests pass locally: `python -m pytest -vs`


### Documentation and Additional Notes

Not needed.