### PR TITLE
Scale image dynamically in fitting display widget

### DIFF
--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -2,6 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 import numpy as np
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QGraphicsItem
+from PyQt5.QtGui import QTransform
 from PyQt5 import QtCore
 from pyqtgraph import RectROI, mkPen, ImageItem, PlotDataItem, ROI
 
@@ -32,9 +33,9 @@ class FittingDisplayWidget(QWidget):
         self.image_item = ImageItem()
         self.image_item.setFlag(QGraphicsItem.ItemIsMovable, True)
         self.image_item.setFlag(QGraphicsItem.ItemIsSelectable, True)
+        self.image_item.setImage(np.zeros((200, 200)), autoLevels=True)
         self.image_item.setParentItem(self.spectrum_plot.spectrum)
         self.image_item.setZValue(20)
-        self.image_item.setScale(0.2)
         self.image_item.setPos(self.spectrum_plot.width() - 150, 10)
 
         self.image_preview_roi = ROI([0, 0], [10, 10], pen=mkPen((0, 255, 0), width=2))
@@ -57,6 +58,10 @@ class FittingDisplayWidget(QWidget):
     def update_image(self, image: np.ndarray | None) -> None:
         if image is not None:
             self.image_item.setImage(image, autoLevels=True)
+            height, width = image.shape
+            scale_x = 200 / width
+            scale_y = 200 / height
+            self.image_item.setTransform(QTransform().scale(scale_x, scale_y))
 
     def update_labels(self, wavelength_range: tuple[float, float] | None = None) -> None:
         """Update wavelength range label below the plot, if available."""


### PR DESCRIPTION

Closes #2564

---

### Description

This update improves the visual consistency of the thumbnail image display (`ImageItem`) in the `FittingDisplayWidget`. Previously, the image scaling was static and unreliable across different input image sizes. This PR:

- Introduces dynamic scaling using `QTransform` to enforce a fixed 200×200 pixel display.
- Replaces hardcoded `setScale` values with scaling factors based on the image's actual dimensions.
- Positions the thumbnail in the top-left corner for improved layout stability.

---

### Developer Testing 

- [x] Verified consistent 200x200 display size for a variety of image inputs.
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Manual UI testing for interaction and resizing behavior.

---

### Acceptance Criteria and Reviewer Testing

- [ ] Confirm the thumbnail image maintains a consistent 200x200 size regardless of input resolution.
- [ ] Ensure the image remains correctly positioned in the top-left.
- [ ] Verify that unit tests pass: `python -m pytest -vs`
- [ ] Confirm no regressions in ROI preview functionality.

---

### Documentation and Additional Notes

<!-- Uncomment and update relevant items as needed -->
<!-- 
- [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] Before merge for developer: Resolve the change on Applitools by creating a new baseline for test and verify that the tests pass.
  - [ ] After merge for reviewer: Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] After merge for reviewer: Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info)
-->

