### PR TITLE
Spectrum ROI Table is now cleared on sample stack change

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -151,6 +151,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             self.view.current_dataset_id = None
 
         self.do_remove_roi()
+        self.view.table_view.clear_table()
         self.model.spectrum_cache.clear()
         if uuid is None:
             self.model.set_stack(None)


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2587

### Description

The ROI table in the spectrum viewer is now properly reset when the sample stack is changed.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Load data and open Spectrum Viewer
- [x] Add multiple ROIs and then change sample stack, check that the ROI Table is reset so that only a single roi exists named "roi", with no errors.

### Documentation and Additional Notes

Not needed

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

