### PR TITLE
2588 edit fitting init params

### DIFF
--- a/docs/release_notes/next/feature-2588-enable-user-editable-initial-fitting-parameters
+++ b/docs/release_notes/next/feature-2588-enable-user-editable-initial-fitting-parameters
@@ -1,0 +1,1 @@
+#2588: Enable user-editable initial fitting parameters within the spectrum viewer fitting tab

--- a/mantidimaging/gui/widgets/spectrum_widgets/export_data_table_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_data_table_widget.py
@@ -13,7 +13,7 @@ class ExportDataTableWidget(QWidget):
     For integration with the fitting/export tab in the spectrum viewer.
     """
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None) -> None:
         super().__init__(parent)
 
         layout = QVBoxLayout(self)

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_param_form_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_param_form_widget.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QSizePolicy, QPushButton
+from PyQt5.QtGui import QDoubleValidator
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowPresenter
@@ -50,9 +51,9 @@ class FittingParamFormWidget(QWidget):
             row_label = QLabel(str(label))
             initial_edit = QLineEdit(str(0.0))
             final_edit = QLineEdit(str(0.0))
-
-            for widget in (initial_edit, final_edit):
-                widget.setReadOnly(True)
+            initial_edit.setReadOnly(False)
+            final_edit.setReadOnly(True)
+            initial_edit.setValidator(QDoubleValidator())
 
             row_layout.addWidget(row_label, 1)
             row_layout.addWidget(initial_edit, 2)
@@ -60,6 +61,8 @@ class FittingParamFormWidget(QWidget):
 
             self.params_layout.addLayout(row_layout)
             self._rows[label] = (row_layout, row_label, initial_edit, final_edit)
+
+            initial_edit.editingFinished.connect(self.presenter.on_initial_params_edited)
 
     def set_parameter_values(self, values: dict[str, float]) -> None:
         for name, value in values.items():
@@ -73,6 +76,10 @@ class FittingParamFormWidget(QWidget):
 
     def get_initial_param_values(self) -> list[float]:
         params = [float(row[2].text()) for row in self._rows.values()]
+        return params
+
+    def get_fitted_param_values(self) -> list[float]:
+        params = [float(row[3].text()) for row in self._rows.values()]
         return params
 
     def clear_rows(self) -> None:

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -91,7 +91,7 @@ class SpectrumViewerWindowModel:
     tof_range: tuple[int, int] = (0, 0)
     tof_plot_range: tuple[float, float] | tuple[int, int] = (0, 0)
     tof_mode: ToFUnitMode = ToFUnitMode.WAVELENGTH
-    tof_data: np.ndarray | None = None
+    tof_data: np.ndarray | None = np.array([])
     spectrum_cache: dict[tuple, np.ndarray] = {}
 
     def __init__(self, presenter: SpectrumViewerWindowPresenter):

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -577,6 +577,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.exportDataTableWidget.update_roi_data(roi_name=roi_name, params=init_params, status="Initial")
 
     def _plot_initial_fit(self) -> None:
+        assert self.model.tof_data is not None
         init_params = self.view.scalable_roi_widget.get_initial_param_values()
         xvals = self.model.tof_data
         init_fit = self.model.fitting_engine.model.evaluate(xvals, init_params)
@@ -594,6 +595,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         Otherwise, re-runs the fit with the updated parameters, updates the fitted parameter values,
         and displays the new fit result.
         """
+        assert self.model.tof_data is not None
         if self.view.fittingDisplayWidget.is_initial_fit_visible():
             self._plot_initial_fit()
         else:
@@ -612,6 +614,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         Retrieves current TOF data and the initial parameter values from the view
         and evaluates the fitting model using these parameters to generate the initial fit curve.
         """
+        assert self.model.tof_data is not None
         xvals = self.model.tof_data
         init_params = self.view.scalable_roi_widget.get_initial_param_values()
         init_fit = self.model.fitting_engine.model.evaluate(xvals, init_params)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -52,6 +52,9 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view.experimentSetupGroupBox = mock.create_autospec(QGroupBox, instance=True)
         self.view.experimentSetupFormWidget = mock.Mock(spec=ExperimentSetupFormWidget)
         self.view.experimentSetupFormWidget.time_delay = 0.0
+        self.view.fittingDisplayWidget = mock.Mock()
+        self.view.scalable_roi_widget = mock.Mock()
+        self.view.roiSelectionWidget = mock.Mock()
         self.presenter = SpectrumViewerWindowPresenter(self.view, self.main_window)
 
     def test_get_dataset_id_for_stack_no_stack_id(self):
@@ -427,3 +430,83 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.presenter.handle_enable_normalised(norm_enabled)
         self.assertEqual(self.presenter.spectrum_mode, spec_type)
         self.view.display_normalise_error.assert_called_once()
+
+    def test_show_initial_fit_calls_correct_plot_method(self):
+        self.view.scalable_roi_widget.get_initial_param_values = mock.Mock(return_value=[1.0, 2.0, 3.0, 4.0])
+        self.presenter.model.tof_data = np.array([1, 2, 3])
+        self.presenter.model.fitting_engine.model.evaluate = mock.Mock(return_value=np.array([10, 20, 30]))
+        self.view.fittingDisplayWidget.show_fit_line = mock.Mock()
+
+        self.presenter.show_initial_fit()
+
+        self.view.fittingDisplayWidget.show_fit_line.assert_called_once()
+        args, kwargs = self.view.fittingDisplayWidget.show_fit_line.call_args
+        np.testing.assert_array_equal(args[0], np.array([1, 2, 3]))
+        np.testing.assert_array_equal(args[1], np.array([10, 20, 30]))
+        assert kwargs["color"] == (128, 128, 128)
+        assert kwargs["label"] == "initial"
+        assert kwargs["initial"] is True
+        self.view.fittingDisplayWidget.show_fit_line.reset_mock()
+
+    @parameterized.expand([
+        (True, True, False),  # (is_initial_fit_visible, expect_plot_initial, expect_show_fit)
+        (False, False, True),
+    ])
+    def test_on_initial_params_edited_updates_plot_correctly(self, is_initial_fit_visible, expect_plot_initial,
+                                                             expect_show_fit):
+        self.presenter._plot_initial_fit = mock.Mock()
+        self.view.fittingDisplayWidget.show_fit_line = mock.Mock()
+        self.view.scalable_roi_widget.get_initial_param_values = mock.Mock(return_value=[1.0, 2.0, 3.0, 4.0])
+        self.view.roiSelectionWidget.current_roi_name = "roi"
+        self.view.spectrum_widget.get_roi = mock.Mock(return_value="mock_roi")
+        self.presenter.model.get_spectrum = mock.Mock(return_value=np.array([1, 2, 3]))
+        self.presenter.model.tof_data = np.array([1, 2, 3])
+        self.presenter.model.fitting_engine.find_best_fit = mock.Mock(return_value={
+            "mu": 1.0,
+            "sigma": 2.0,
+            "h": 3.0,
+            "a": 4.0
+        })
+        self.view.scalable_roi_widget.set_fitted_parameter_values = mock.Mock()
+        self.view.fittingDisplayWidget.is_initial_fit_visible.return_value = is_initial_fit_visible
+
+        self.presenter.on_initial_params_edited()
+
+        if expect_plot_initial:
+            self.presenter._plot_initial_fit.assert_called_once()
+            self.view.fittingDisplayWidget.show_fit_line.assert_not_called()
+            self.view.scalable_roi_widget.set_fitted_parameter_values.assert_not_called()
+        if expect_show_fit:
+            self.presenter._plot_initial_fit.assert_not_called()
+            self.view.fittingDisplayWidget.show_fit_line.assert_called_once()
+            args, kwargs = self.view.fittingDisplayWidget.show_fit_line.call_args
+            np.testing.assert_array_equal(args[0], np.array([1, 2, 3]))
+            assert kwargs["color"] == (0, 128, 255)
+            assert kwargs["label"] == "fit"
+            assert kwargs["initial"] is False
+            self.view.scalable_roi_widget.set_fitted_parameter_values.assert_called_once_with({
+                "mu": 1.0,
+                "sigma": 2.0,
+                "h": 3.0,
+                "a": 4.0
+            })
+
+    @parameterized.expand([
+        ([1.0, 2.0], [10, 20, 30], [100, 200, 300]),
+        ([0.5, 1.5], [5, 15, 25], [50, 150, 250]),
+    ])
+    def test_show_fit_calls_show_fit_line_with_expected_args(self, fitted_params, xvals, fit):
+        xvals = np.array(xvals)
+        fit = np.array(fit)
+        self.presenter.model.tof_data = xvals
+        self.presenter.model.fitting_engine.model.evaluate = mock.Mock(return_value=fit)
+        self.view.fittingDisplayWidget.show_fit_line = mock.Mock()
+
+        self.presenter.show_fit(fitted_params)
+
+        self.presenter.model.fitting_engine.model.evaluate.assert_called_once_with(xvals, fitted_params)
+        self.view.fittingDisplayWidget.show_fit_line.assert_called_once_with(xvals,
+                                                                             fit,
+                                                                             color=(0, 128, 255),
+                                                                             label="fit",
+                                                                             initial=False)


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2588 

### Description

<!-- Add a description of the changes made. -->
* Enable user editing of initial fitting parameters
* Update "From ROI" plot on user-edited initial fitting param change
* Update "Run fit" plot on user-edited initial param change
* Add a validation to initial fitting params to ensure they are doubles and prevent character input.
* Minor refactor to centralise how initial fit and fitted curve plots are toggled to only show one plot at any given time.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- Manually tested:
  - Editing initial fitting parameters is possible
  - Only floats can be entered by a user into the initial fitting parameters
  - Validating user-edited initial fitting parameters update fit from ROI
  - Validating user-edited initial fitting parameters update final fit
  - Validated only one plot visible at any time

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Unit tests pass locally: `python -m pytest -vs`
- [x]  Editing initial fitting parameters is possible
- [x] Only floats can be entered by a user into the initial fitting parameters
- [x] User-edited initial input params can be outside of original fitting region i.e. outside the ROI bounds
- [x] User-edited initial fitting parameters update fit from ROI
- [x] User-edited initial fitting parameters update final fit
- [x] Only one plot visible at any time

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [x] Release Notes have been updated
<!--
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

