### PR TITLE
Overlap Correction calculation replicates CubeRead

### DIFF
--- a/mantidimaging/core/operations/overlap_correction/overlap_correction.py
+++ b/mantidimaging/core/operations/overlap_correction/overlap_correction.py
@@ -118,11 +118,16 @@ def execute_single(data, shutters, progress=None):
     progress.set_estimated_steps(len(shutters) + 1)
     prob_occupied = numpy.zeros_like(data, dtype=numpy.float32)
 
+    shutter_check = [True] + [shutters[i - 1].end_index == shutters[i].start_index for i in range(1, len(shutters))]
+
     with progress:
-        for shutter in shutters:
-            progress.update(1, msg=f"Using shutter: {shutter.start_index} - {shutter.end_index}")
-            ss, se = shutter.start_index, shutter.end_index
-            prob_occupied[ss + 1:se] = numpy.cumsum(data[ss:se - 1], axis=0) / shutter.count
+        for shutter_num in range(0, len(shutters)):
+            ss, se = shutters[shutter_num].start_index, shutters[shutter_num].end_index
+            progress.update(1, msg=f"Using shutter: {ss} - {se}")
+            if shutter_check[shutter_num]:
+                prob_occupied[ss + 1:se] = numpy.cumsum(data[ss:se - 1], axis=0) / shutters[shutter_num].count
+            else:
+                prob_occupied[ss:se] = numpy.cumsum(data[ss - 1:se - 1], axis=0) / shutters[shutter_num].count
 
         output = data / (1 - prob_occupied)
 


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2589

### Description

The previous equations used have been modified to give a result with agrees with the program CubeRead which the IMAT scientists use to calculate the Overlap Correction. MI now checks with there is an overlap with the previous shutter and if so, includes the last "frame" of the previous shutter as this is where we regain the efficiency of the camera.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Load in a dataset which has a `spectrum.txt` and a `ShutterCount.txt` file and run the Overlap Correction in the Operations window
- [ ] Open the corrected dataset in the Spectrum Viewer and optionally export the spectrum
- [ ] Load the dataset in [CubeRead](\\isis\shares\IMAT-Imaging\Software\AST_NewOverlap) e.g.
```
- C:\Users\ddb29996\TPX_CubeRead\OverlapCorrection>TPX_CubeRead.exe C:\Users\ddb29996\MI_testing_Overlap\Uncorrected_Raw\Flat1\IMAT00033082_Amentum_Zr_PH80_000_00000.fits
```
- [ ] Load the CubeRead corrected dataset into MI and go to the Spectrum Viewer.
- [ ] Compare the CubeRead and MI corrected datasets in the Spectrum Viewer or plot the exported spectrums in Excel.

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

 - [ ] Release Notes have been updated

# Comparison for Fe Powder dataset

![image](https://github.com/user-attachments/assets/c46d95e0-024f-432c-93d2-93461d8ecf15)

# Comparison for the Zr dataset

![image](https://github.com/user-attachments/assets/51f4c6db-690f-4161-a7bc-92b7397479da)


