### PR TITLE
2561 update geometry parameters in imagestack

### DIFF
--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 class ImageStack:
     name: str
-    geometry: Geometry | None
+    geometry: Geometry | None = None
     _shared_array: pu.SharedArray
 
     def __init__(self,
@@ -263,7 +263,20 @@ class ImageStack:
 
     @data.setter
     def data(self, other: np.ndarray) -> None:
+        """
+        Set data array and update geometry data
+
+        :param other: numpy array
+        """
+
         self._shared_array.array = other
+
+        if self.geometry is not None:
+            pixel_size = (1.0, 1.0)
+            pixel_num_h = self.width
+            pixel_num_v = self.height
+            num_pixels = (pixel_num_h, pixel_num_v)
+            self.geometry.set_panel(num_pixels=num_pixels, pixel_size=pixel_size)
 
     @property
     def shared_array(self) -> pu.SharedArray:
@@ -327,9 +340,8 @@ class ImageStack:
 
         self._projection_angles = angles
 
-        if self.geometry is None:
-            raise ValueError("self.geometry is not set")
-        self.geometry.set_angles(angles=angles.value, angle_unit="radian")
+        if self.geometry is not None:
+            self.geometry.set_angles(angles=angles.value, angle_unit="radian")
 
     def real_projection_angles(self) -> ProjectionAngles | None:
         """

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -404,13 +404,3 @@ class ImageStack:
         Creates an AcquisitionGeometry belonging to the ImageStack.
         """
         self.geometry = Geometry(num_pixels=(self.width, self.height), pixel_size=(1., 1.))
-
-    def update_geometry(self, angles: list | np.ndarray, angle_unit: str, num_pixels: list | tuple,
-                        pixel_size: list | tuple) -> None:
-        """
-        Updates the configuration of the ImageStack's Geometry object.
-        """
-        if self.geometry is None:
-            raise ValueError("self.geometry is not set")
-        self.geometry.set_angles(angles=angles, angle_unit=angle_unit)
-        self.geometry.set_panel(num_pixels=num_pixels, pixel_size=pixel_size)

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -406,7 +406,7 @@ class ImageStack:
         """
         Updates the geometry's panel data based on its parent ImageStack's array data
         """
-        if self.geometry is not None:
+        if self.geometry is not None and self._shared_array is not None:
             pixel_size = (1.0, 1.0)
             pixel_num_h = self.width
             pixel_num_v = self.height

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -315,11 +315,21 @@ class ImageStack:
         self._shutter_count_file = value
 
     def set_projection_angles(self, angles: ProjectionAngles) -> None:
+        """
+        Set the projection angles and update geometry data
+
+        :param angles: ProjectionAngles object
+        """
+
         if len(angles.value) != self.num_images:
             raise RuntimeError("The number of angles does not match the number of images. "
                                f"Num angles {len(angles.value)} and num images {self.num_images}")
 
         self._projection_angles = angles
+
+        if self.geometry is None:
+            raise ValueError("self.geometry is not set")
+        self.geometry.set_angles(angles=angles.value, angle_unit="radian")
 
     def real_projection_angles(self) -> ProjectionAngles | None:
         """

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -270,13 +270,7 @@ class ImageStack:
         """
 
         self._shared_array.array = other
-
-        if self.geometry is not None:
-            pixel_size = (1.0, 1.0)
-            pixel_num_h = self.width
-            pixel_num_v = self.height
-            num_pixels = (pixel_num_h, pixel_num_v)
-            self.geometry.set_panel(num_pixels=num_pixels, pixel_size=pixel_size)
+        self.set_geometry_panels()
 
     @property
     def shared_array(self) -> pu.SharedArray:
@@ -285,6 +279,7 @@ class ImageStack:
     @shared_array.setter
     def shared_array(self, shared_array: pu.SharedArray) -> None:
         self._shared_array = shared_array
+        self.set_geometry_panels()
 
     @property
     def uses_shared_memory(self) -> bool:

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -404,3 +404,20 @@ class ImageStack:
         Creates an AcquisitionGeometry belonging to the ImageStack.
         """
         self.geometry = Geometry(num_pixels=(self.width, self.height), pixel_size=(1., 1.))
+        self.set_geometry_angles()
+        self.set_geometry_panels()
+
+    def set_geometry_panels(self):
+        """
+        Updates the geometry's panel data based on its parent ImageStack's array data
+        """
+        if self.geometry is not None:
+            pixel_size = (1.0, 1.0)
+            pixel_num_h = self.width
+            pixel_num_v = self.height
+            num_pixels = (pixel_num_h, pixel_num_v)
+            self.geometry.set_panel(num_pixels=num_pixels, pixel_size=pixel_size)
+
+    def set_geometry_angles(self):
+        if self.geometry is not None and self._projection_angles is not None:
+            self.geometry.set_angles(angles=self._projection_angles.value, angle_unit="radian")

--- a/mantidimaging/core/data/test/image_stack_test.py
+++ b/mantidimaging/core/data/test/image_stack_test.py
@@ -237,16 +237,23 @@ class ImageStackTest(unittest.TestCase):
         images = generate_images()
         angles = range(0, 10)
         pangles = ProjectionAngles(list(angles))
-        angle_unit = "radian"
         images.set_projection_angles(pangles)
 
         actual = images.projection_angles()
         self.assertEqual(10, len(actual.value))
         self.assertAlmostEqual(images.projection_angles().value, pangles.value, places=4)
 
-        if images.geometry is not None:
-            self.assertEqual(images.geometry.config.angles.angle_unit, angle_unit)
-            npt.assert_array_equal(images.geometry.config.angles.angle_data, np.array(angles))
+    def test_set_angles_geometry(self):
+        images = generate_images()
+        images.set_geometry()
+        angles = range(0, 10)
+        angle_unit = "radian"
+        pangles = ProjectionAngles(list(angles))
+        images.set_projection_angles(pangles)
+
+        self.assertIsNotNone(images.geometry)
+        self.assertEqual(images.geometry.config.angles.angle_unit, angle_unit)
+        npt.assert_array_equal(images.geometry.config.angles.angle_data, np.array(angles))
 
     def test_image_eq_method(self):
         data_array = np.arange(64, dtype=float).reshape([4, 4, 4])

--- a/mantidimaging/core/data/test/image_stack_test.py
+++ b/mantidimaging/core/data/test/image_stack_test.py
@@ -183,6 +183,17 @@ class ImageStackTest(unittest.TestCase):
         images.clear_proj180deg()
         self.assertIsNone(images._proj180deg)
 
+    def test_data_set(self):
+        data = generate_images().data
+        images = ImageStack(data=data)
+        images.set_geometry()
+
+        num_pixels = (512, 512)
+        pixel_size = (2., 2.)
+        images.geometry.set_panel(num_pixels=num_pixels, pixel_size=pixel_size)
+        npt.assert_array_equal(images.geometry.config.panel.num_pixels, np.array(num_pixels))
+        npt.assert_array_equal(images.geometry.config.panel.pixel_size, np.array(pixel_size))
+
     def test_data_get(self):
         images = generate_images((10, 100, 350))
         self.assertIsNotNone(images.data)
@@ -224,12 +235,18 @@ class ImageStackTest(unittest.TestCase):
 
     def test_set_projection_angles(self):
         images = generate_images()
-        pangles = ProjectionAngles(list(range(0, 10)))
+        angles = range(0, 10)
+        pangles = ProjectionAngles(list(angles))
+        angle_unit = "radian"
         images.set_projection_angles(pangles)
 
         actual = images.projection_angles()
         self.assertEqual(10, len(actual.value))
         self.assertAlmostEqual(images.projection_angles().value, pangles.value, places=4)
+
+        if images.geometry is not None:
+            self.assertEqual(images.geometry.config.angles.angle_unit, angle_unit)
+            npt.assert_array_equal(images.geometry.config.angles.angle_data, np.array(angles))
 
     def test_image_eq_method(self):
         data_array = np.arange(64, dtype=float).reshape([4, 4, 4])
@@ -241,7 +258,6 @@ class ImageStackTest(unittest.TestCase):
 
         data_array[1, 1, 1] *= 2
         self.assertNotEqual(data_images, data_array)
-
         self.assertRaises(ValueError, lambda a, b: a == b, data_images, 1.0)
 
     def test_cant_change_id(self):
@@ -337,17 +353,3 @@ class ImageStackTest(unittest.TestCase):
         pixel_size = (1., 1.)
         npt.assert_array_equal(images.geometry.config.panel.num_pixels, np.array(num_pixels))
         npt.assert_array_equal(images.geometry.config.panel.pixel_size, np.array(pixel_size))
-
-    def test_update_geometry(self):
-        data = generate_images().data
-        images = ImageStack(data=data)
-        images.set_geometry()
-        angles = range(0, 360)
-        angle_unit = "radian"
-        num_pixels = (512, 512)
-        pixel_size = (2., 2.)
-        images.update_geometry(angles=angles, angle_unit=angle_unit, num_pixels=num_pixels, pixel_size=pixel_size)
-        npt.assert_array_equal(images.geometry.config.panel.num_pixels, np.array(num_pixels))
-        npt.assert_array_equal(images.geometry.config.panel.pixel_size, np.array(pixel_size))
-        npt.assert_array_equal(images.geometry.config.angles.angle_data, np.array(angles))
-        self.assertEqual(images.geometry.config.angles.angle_unit, angle_unit)

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -379,17 +379,15 @@ class CILRecon(BaseRecon):
                 raise ValueError("recon_params.tilt is not set")
             tilt = recon_params.tilt.value
 
-            if images.geometry is None:
-                raise ValueError("images.geometry is not set")
-            images.geometry.set_geometry_from_cor_tilt(cors[pixel_num_v // 2], tilt)
-
             if images.is_sinograms:
                 data_order = DataOrder.ASTRA_AG_LABELS
             else:
                 data_order = DataOrder.TIGRE_AG_LABELS
-            images.geometry.set_labels(data_order)
 
-            ig = images.geometry.get_ImageGeometry()
+            if images.geometry is not None:
+                images.geometry.set_geometry_from_cor_tilt(cors[pixel_num_v // 2], tilt)
+                images.geometry.set_labels(data_order)
+                ig = images.geometry.get_ImageGeometry()
 
             data = CILRecon.get_data(BaseRecon.prepare_sinogram(images.data, recon_params), images.geometry,
                                      recon_params, num_subsets)

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -345,7 +345,6 @@ class CILRecon(BaseRecon):
 
         progress = Progress.ensure_instance(progress, task_name='CIL reconstruction', num_steps=num_iter + 1)
 
-        pixel_size = (1., 1.)
         pixel_num_h = images.width
         pixel_num_v = images.height
 
@@ -382,11 +381,6 @@ class CILRecon(BaseRecon):
 
             if images.geometry is None:
                 raise ValueError("images.geometry is not set")
-            angles = images.projection_angles(recon_params.max_projection_angle).value
-            images.update_geometry(angles=angles,
-                                   angle_unit="radian",
-                                   num_pixels=(pixel_num_h, pixel_num_v),
-                                   pixel_size=pixel_size)
             images.geometry.set_geometry_from_cor_tilt(cors[pixel_num_v // 2], tilt)
 
             if images.is_sinograms:

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -384,10 +384,12 @@ class CILRecon(BaseRecon):
             else:
                 data_order = DataOrder.TIGRE_AG_LABELS
 
-            if images.geometry is not None:
-                images.geometry.set_geometry_from_cor_tilt(cors[pixel_num_v // 2], tilt)
-                images.geometry.set_labels(data_order)
-                ig = images.geometry.get_ImageGeometry()
+            if images.geometry is None:
+                raise ValueError("images.geometry is not set")
+
+            images.geometry.set_geometry_from_cor_tilt(cors[pixel_num_v // 2], tilt)
+            images.geometry.set_labels(data_order)
+            ig = images.geometry.get_ImageGeometry()
 
             data = CILRecon.get_data(BaseRecon.prepare_sinogram(images.data, recon_params), images.geometry,
                                      recon_params, num_subsets)


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2561

### Description

<!-- Add a description of the changes made. -->

The `ImageStack`'s `update_geometry()` method has been removed. Instead, all changes to the panel data or projection angles are directly set from the `data()` and `set_projection_angles()` setter functions, to keep the `geometry` object in sync all the time, rather than just after the call to `CILRecon`.

Not all `ImageStack` instances hold a geometry object (only the sample `ImageStack` does), however, the previous call to `update_geometry()` meant that all `ImageStack`'s would get a `geometry` object instantiated. With that removed, a check to ensure `geometry` isn't `None` has been added.

The `test_update_geometry()` function has also been removed, its functionality split into the existing `test_set_projection_angles()` and `test_data_set()` pytest functions.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- I have gone through a full reconstruction workflow to ensure functionality remains the same

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

