### PR TITLE
Make Jenks and Otsu robust against NaNs in the image 

### DIFF
--- a/docs/release_notes/next/fix-2532-jenks-nan-safe
+++ b/docs/release_notes/next/fix-2532-jenks-nan-safe
@@ -1,0 +1,1 @@
+#2532: Make Jenks and Otsu robust against NaNs in the image

--- a/mantidimaging/gui/widgets/palette_changer/presenter.py
+++ b/mantidimaging/gui/widgets/palette_changer/presenter.py
@@ -78,14 +78,16 @@ class PaletteChangerPresenter(BasePresenter):
         """
         Determine the Otsu threshold tick point.
         """
-        vals = filters.threshold_multiotsu(self.image, classes=self.view.num_materials)
+        data = np.where(np.isnan(self.flattened_image), 0, self.flattened_image)
+        vals = filters.threshold_multiotsu(data, classes=self.view.num_materials)
         return self._normalise_tick_values(vals.tolist())
 
     def _generate_jenks_tick_points(self) -> list[float]:
         """
         Determine the Jenks tick points.
         """
-        breaks = jenks_breaks(self.flattened_image, self.view.num_materials)
+        data = np.where(np.isnan(self.flattened_image), 0, self.flattened_image)
+        breaks = jenks_breaks(data, self.view.num_materials)
         return self._normalise_tick_values(list(breaks)[1:-1])
 
     def _normalise_tick_values(self, breaks: list[float]) -> list[float]:
@@ -93,9 +95,9 @@ class PaletteChangerPresenter(BasePresenter):
         Scale the collection of break values so that they range from 0 to 1. This is done because addTick expects an
         x value in this range.
         """
-        min_val = self.image.min()
-        max_val = self.image.max()
-        val_range = np.ptp(self.image)
+        min_val = np.nanmin(self.image)
+        max_val = np.nanmax(self.image)
+        val_range = max_val - min_val
         breaks = [min_val] + breaks + [max_val]
         return [(break_x - min_val) / val_range for break_x in breaks]
 


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2532 

### Description

Ignore NaN when passing values to Jenks and Otsu. This it just used for making the output colours better distributed, so there is no need to force the user to do NAN removal first.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- Tested with the Fe dataset which has NaNs along the edges

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Open the Fe ToF dataset in the spectrum viewer
- [x] Right click on the histogram colour back and select auto
- [x] Select Jenks or Otsu and press ok

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [x] Release Notes have been updated
