### PR TITLE
2603 tof data type revision

### DIFF
--- a/mantidimaging/core/utility/unit_conversion.py
+++ b/mantidimaging/core/utility/unit_conversion.py
@@ -42,7 +42,10 @@ class UnitConversion:
 
     def check_data(self) -> None:
         try:
-            self.velocity = self.target_to_camera_dist / (self.tof_data_to_convert + self.data_offset)
+            tof_with_offset = self.tof_data_to_convert + self.data_offset
+            if np.any(tof_with_offset == 0):
+                raise ValueError("Time-of-flight (with offset) contains zero(s), which is likely invalid.")
+            self.velocity = self.target_to_camera_dist / tof_with_offset
         except AttributeError as exc:
             raise TypeError("No data to convert") from exc
 

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -182,7 +182,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.setup_roi_properties_spinboxes()
 
     def reset_units_menu(self) -> None:
-        if self.model.tof_data is None:
+        if self.model.tof_data.size == 0:
             self.view.tof_mode_select_group.setEnabled(False)
             self.view.experimentSetupGroupBox.setEnabled(False)
             self.model.tof_mode = ToFUnitMode.IMAGE_NUMBER
@@ -249,7 +249,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         if self.model.tof_mode == ToFUnitMode.IMAGE_NUMBER:
             self.model.tof_range = (int(tof_range[0]), int(tof_range[1]))
         else:
-            assert self.model.tof_data is not None
             image_index_min = np.abs(self.model.tof_data - tof_range[0]).argmin()
             image_index_max = np.abs(self.model.tof_data - tof_range[1]).argmin()
             self.model.tof_range = tuple(sorted((image_index_min, image_index_max)))
@@ -328,7 +327,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             return
         roi = self.view.spectrum_widget.get_roi(roi_name)
         tof_data = self.model.tof_data
-        if tof_data is None:
+        if tof_data.size == 0:
             return
 
         image = (self.model.get_normalized_averaged_image()
@@ -578,7 +577,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.view.exportDataTableWidget.update_roi_data(roi_name=roi_name, params=init_params, status="Initial")
 
     def _plot_initial_fit(self) -> None:
-        assert self.model.tof_data is not None
         init_params = self.view.scalable_roi_widget.get_initial_param_values()
         xvals = self.model.tof_data
         init_fit = self.model.fitting_engine.model.evaluate(xvals, init_params)
@@ -596,7 +594,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         Otherwise, re-runs the fit with the updated parameters, updates the fitted parameter values,
         and displays the new fit result.
         """
-        assert self.model.tof_data is not None
         if self.view.fittingDisplayWidget.is_initial_fit_visible():
             self._plot_initial_fit()
         else:
@@ -615,7 +612,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         Retrieves current TOF data and the initial parameter values from the view
         and evaluates the fitting model using these parameters to generate the initial fit curve.
         """
-        assert self.model.tof_data is not None
         xvals = self.model.tof_data
         init_params = self.view.scalable_roi_widget.get_initial_param_values()
         init_fit = self.model.fitting_engine.model.evaluate(xvals, init_params)
@@ -626,7 +622,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                                                      initial=True)
 
     def run_region_fit(self) -> None:
-        assert self.model.tof_data is not None
         result = self.fit_single_region(self.fitting_spectrum, self.view.get_fitting_region(), self.model.tof_data,
                                         self.view.scalable_roi_widget.get_initial_param_values())
 
@@ -656,7 +651,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             self.view.exportDataTableWidget.update_roi_data(roi_name=roi_name, params=result, status="Fitted")
 
     def show_fit(self, params: list[float]) -> None:
-        assert self.model.tof_data is not None
         xvals = self.model.tof_data
         fit = self.model.fitting_engine.model.evaluate(xvals, params)
         self.view.fittingDisplayWidget.show_fit_line(xvals, fit, color=(0, 128, 255), label="fit", initial=False)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -406,20 +406,26 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         self.model.remove_all_roi()
         self.assertEqual(self.model._roi_id_counter, 0)
 
-    def test_WHEN_no_stack_tof_THEN_time_of_flight_none(self):
+    def test_WHEN_no_stack_tof_THEN_time_of_flight_empty(self):
         # No Stack
         self.model.set_stack(None)
-        self.assertIsNone(self.model.get_stack_time_of_flight())
+        result = self.model.get_stack_time_of_flight()
+        self.assertIsInstance(result, np.ndarray)
+        self.assertEqual(result.size, 0)
 
         # No Log
         stack, _ = self._set_sample_stack()
-        self.assertIsNone(self.model.get_stack_time_of_flight())
+        result = self.model.get_stack_time_of_flight()
+        self.assertIsInstance(result, np.ndarray)
+        self.assertEqual(result.size, 0)
 
         # Log but not tof
         mock_log = mock.create_autospec(InstrumentLog, source_file="foo.txt", instance=True)
         mock_log.get_column.side_effect = KeyError()
         stack.log_file = mock_log
-        self.assertIsNone(self.model.get_stack_time_of_flight())
+        result = self.model.get_stack_time_of_flight()
+        self.assertIsInstance(result, np.ndarray)
+        self.assertEqual(result.size, 0)
 
     def test_WHEN_stack_tof_THEN_tof_correct(self):
         stack, _ = self._set_sample_stack(with_tof=True)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -47,7 +47,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         stack = ImageStack(np.ones([10, 11, 12]) * spectrum.reshape((10, 1, 1)))
         if with_tof:
             mock_inst_log = mock.create_autospec(InstrumentLog, source_file="", instance=True)
-            mock_inst_log.get_column.return_value = np.arange(0, 10) * 0.1
+            mock_inst_log.get_column.return_value = (np.arange(0, 10) + 1) * 0.1
             stack.log_file = mock_inst_log
         if with_shuttercount:
             mock_shuttercounts = mock.create_autospec(ShutterCount, source_file="", instance=True)
@@ -236,8 +236,8 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
 
         mock_path.open.assert_called_once_with("w")
         self.assertIn("0.0\t0.0\t0.0", mock_stream.captured[0])
-        self.assertIn("100000.0\t0.75\t0.25", mock_stream.captured[1])
-        self.assertIn("200000.0\t1.5\t0.5", mock_stream.captured[2])
+        self.assertIn("200000.0\t0.75\t0.25", mock_stream.captured[1])
+        self.assertIn("300000.00000000006\t1.5\t0.5", mock_stream.captured[2])
         self.assertTrue(mock_stream.is_closed)
 
     def test_save_rits_roi_dat(self):
@@ -252,8 +252,8 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
             self.model.save_rits_roi(mock_path, ErrorMode.STANDARD_DEVIATION, roi)
         mock_path.open.assert_called_once_with("w")
         self.assertIn("0.0\t0.0\t0.0", mock_stream.captured[0])
-        self.assertIn("100000.0\t0.75\t0.25", mock_stream.captured[1])
-        self.assertIn("200000.0\t1.5\t0.5", mock_stream.captured[2])
+        self.assertIn("200000.0\t0.75\t0.25", mock_stream.captured[1])
+        self.assertIn("300000.00000000006\t1.5\t0.5", mock_stream.captured[2])
         self.assertTrue(mock_stream.is_closed)
 
     @parameterized.expand([
@@ -372,9 +372,10 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         self.assertIn("# ToF_index,Wavelength,ToF,Energy,all,all_open,all_norm,roi,roi_open,roi_norm",
                       mock_stream.captured[0])
         self.assertIn("# Index,Angstrom,Microseconds,MeV,Counts,Counts,Counts", mock_stream.captured[1])
-        self.assertIn("0.0,0.0,0.0,inf,0.0,2.0,0.0,0.0,2.0,0.0", mock_stream.captured[2])
+        self.assertIn("0.0,7.064346392065392,100000.0,2.9271405738026552,0.0,2.0,0.0,0.0,2.0,0.0",
+                      mock_stream.captured[2])
         self.assertIn(
-            "1.0,7.064346392065392,100000.0,2.9271405738026552,1.4166666666666667,2.0,0.7083333333333334,1.4166666666666667,2.0,0.7083333333333334",
+            "1.0,14.128692784130784,200000.0,1.4635702869013276,1.4166666666666667,2.0,0.7083333333333334,1.4166666666666667,2.0,0.7083333333333334",
             mock_stream.captured[3])
         self.assertTrue(mock_stream.is_closed)
 
@@ -432,7 +433,7 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
 
         tof_result = self.model.get_stack_time_of_flight()
         self.assertIsInstance(tof_result, np.ndarray)
-        npt.assert_array_equal(tof_result, np.arange(0, 10) * 0.1)
+        npt.assert_array_equal(tof_result, (np.arange(0, 10) + 1) * 0.1)
 
     def test_error_modes(self):
         self.assertEqual(ErrorMode.get_by_value("Standard Deviation"), ErrorMode.STANDARD_DEVIATION)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -303,7 +303,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.assertEqual(self.presenter.model.tof_mode, expected_mode)
 
     @parameterized.expand([
-        (None, ToFUnitMode.IMAGE_NUMBER),
+        (np.array([]), ToFUnitMode.IMAGE_NUMBER),
         (np.arange(1, 10), ToFUnitMode.WAVELENGTH),
     ])
     @mock.patch("mantidimaging.gui.windows.spectrum_viewer.model.SpectrumViewerWindowModel.get_stack_time_of_flight")
@@ -318,9 +318,10 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.assertEqual(self.presenter.model.tof_mode, expected_tof_mode)
 
     @parameterized.expand([
-        (None, "Image Index", ToFUnitMode.IMAGE_NUMBER, np.arange(1, 10), [False, True], ToFUnitMode.WAVELENGTH),
-        (np.arange(1, 10), "Wavelength", ToFUnitMode.WAVELENGTH, None, [True, False], ToFUnitMode.IMAGE_NUMBER),
-        (None, "Image Index", ToFUnitMode.IMAGE_NUMBER, None, [False, False], ToFUnitMode.IMAGE_NUMBER),
+        (np.array([]), "Image Index", ToFUnitMode.IMAGE_NUMBER, np.arange(1, 10), [False,
+                                                                                   True], ToFUnitMode.WAVELENGTH),
+        (np.arange(1, 10), "Wavelength", ToFUnitMode.WAVELENGTH, np.array([]), [True, False], ToFUnitMode.IMAGE_NUMBER),
+        (np.array([]), "Image Index", ToFUnitMode.IMAGE_NUMBER, np.array([]), [False, False], ToFUnitMode.IMAGE_NUMBER),
         (np.arange(1, 10), "Wavelength", ToFUnitMode.WAVELENGTH, np.arange(2, 20), [True,
                                                                                     True], ToFUnitMode.WAVELENGTH),
         (np.arange(1, 10), "Energy", ToFUnitMode.ENERGY, np.arange(2, 20), [True, True], ToFUnitMode.ENERGY),

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -99,7 +99,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             action.triggered.connect(self.presenter.handle_tof_unit_change_via_menu)
             if mode == "Image Index":
                 action.setChecked(True)
-        if self.presenter.model.tof_data is None:
+        if self.presenter.model.tof_data.size == 0:
             self.tof_mode_select_group.setEnabled(False)
 
         self.current_dataset_id: UUID | None = None


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2603 

### Description

<!-- Add a description of the changes made. -->
Refactor `tof_data` type from `tof_data: np.ndarray | None = np.array([])` to `tof_data: np.ndarray = np.array([])` to avoid the need to `assert self.model.tof_data is not None` going forward as `tof_data` will likely increase in use as the spectrum viewer is further developed. 
This change included changes to any references to `tof_data` in `model.py`, `presenter.py`, `view.py`, associated tests and added protection against `RuntimeWarning: divide by zero encountered in divide` by refactoring `check_data`.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- I have inspected the spectrum viewer to ensure all referenced to `tof_data` including indirect references are updated to handle empty arrays instead of None.
- Tested basic workflows within the spectrum viewer

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Check all direct and indirect references to `tof_data` are treated as `np.array([])` and not `None`
- [ ] Test a variety of workflows within the spectrum viewer with a ToF dataset.

### Documentation and Additional Notes

Documentation not needed as this change is not user facing. 

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

