### PR TITLE
Fix units for set_centre_of_rotation() call

### DIFF
--- a/mantidimaging/core/data/geometry.py
+++ b/mantidimaging/core/data/geometry.py
@@ -49,4 +49,4 @@ class Geometry(AcquisitionGeometry):
         """
         offset: float = (cor.value - self.config.panel.num_pixels[0] / 2) * self.config.panel.pixel_size[0]
 
-        self.set_centre_of_rotation(offset=offset, angle=-tilt)
+        self.set_centre_of_rotation(offset=offset, angle=-tilt, angle_units='degree')

--- a/mantidimaging/core/data/test/geometry_test.py
+++ b/mantidimaging/core/data/test/geometry_test.py
@@ -80,7 +80,7 @@ class GeometryTest(unittest.TestCase):
         geo.set_geometry_from_cor_tilt(cor, tilt)
 
         self.assertEqual(geo.get_centre_of_rotation()["offset"][0], expected_offset)
-        self.assertTrue(np.isclose(geo.get_centre_of_rotation()["angle"][0], expected_angle))
+        self.assertTrue(np.isclose(geo.get_centre_of_rotation(angle_units='degree')["angle"][0], expected_angle))
 
     @parameterized.expand([("default_units", ScalarCoR(256.0), 0.0, 0.0, 0.0),
                            ("positive_offset_angle", ScalarCoR(266.0), 1.0, 10.0, -1.0),
@@ -97,7 +97,7 @@ class GeometryTest(unittest.TestCase):
         geo.set_geometry_from_cor_tilt(cor, tilt)
 
         self.assertEqual(geo.get_centre_of_rotation()["offset"][0], expected_offset)
-        self.assertTrue(np.isclose(geo.get_centre_of_rotation()["angle"][0], expected_angle))
+        self.assertTrue(np.isclose(geo.get_centre_of_rotation(angle_units='degree')["angle"][0], expected_angle))
 
     @parameterized.expand([("default_units", ScalarCoR(4.0), 0.0, 0.0, 0.0),
                            ("positive_offset_angle", ScalarCoR(5.0), 1.0, 1.0, -1.0),
@@ -114,4 +114,4 @@ class GeometryTest(unittest.TestCase):
         geo.set_geometry_from_cor_tilt(cor, tilt)
 
         self.assertEqual(geo.get_centre_of_rotation()["offset"][0], expected_offset)
-        self.assertTrue(np.isclose(geo.get_centre_of_rotation()["angle"][0], expected_angle))
+        self.assertTrue(np.isclose(geo.get_centre_of_rotation(angle_units='degree')["angle"][0], expected_angle))


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2621 

### Description
When call `self.set_centre_of_rotation()` pass the angle units explicitly. This prevents the angle being interpreted as radians.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`


### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Follow the steps on #2621, and confirm that the reconstruction with CIL matches FBP

### Documentation and Additional Notes

Fix for recent regression, so release note not needed

