### PR TITLE
2627 slice type error

### DIFF
--- a/docs/release_notes/next/fix-2627-fix-minimise-error-type-error
+++ b/docs/release_notes/next/fix-2627-fix-minimise-error-type-error
@@ -1,0 +1,1 @@
+#2627: Remove Int type check of slice in  ``_auto_find_minimisation_square_sum`` to resolve TypeError when applying minimise error in reconstruction view.

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -422,10 +422,7 @@ class ReconstructWindowPresenter(BasePresenter):
         if self.model.has_results:
             initial_cor = []
             for slc in slice_indices:
-                if isinstance(slc, int):
-                    initial_cor.append(self.model.data_model.get_cor_from_regression(slc))
-                else:
-                    raise TypeError(f"Expected int for slice index, got {type(slc)}")
+                initial_cor.append(self.model.data_model.get_cor_from_regression(slc))
         else:
             initial_cor = [self.view.rotation_centre]
 


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2627 

### Description

<!-- Add a description of the changes made. -->
Remove int type check of slice in `_auto_find_minimisation_square_sum` to resolve TypeError when applying "Minimise Error" after "Correlate 0 and 180" in the Reconstruction View.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- I have manually tested that "Minimise Error" now works as expected after applying "Correlate 0 and 180"

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ]  "Minimise Error" now works as expected after applying "Correlate 0 and 180" in the Reconstruction view with a tomography dataset

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [ ] Release Notes have been updated
<!-- - [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

