### PR TITLE
Fix TypeError in Minimise Error: allow numpy integer slice indices

### DIFF
--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -422,7 +422,7 @@ class ReconstructWindowPresenter(BasePresenter):
         if self.model.has_results:
             initial_cor = []
             for slc in slice_indices:
-                if isinstance(slc, (int, np.integer)):
+                if isinstance(slc, int | np.integer):
                     initial_cor.append(self.model.data_model.get_cor_from_regression(slc))
                 else:
                     raise TypeError(f"Expected int for slice index, got {type(slc)}")

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -423,7 +423,7 @@ class ReconstructWindowPresenter(BasePresenter):
             initial_cor = []
             for slc in slice_indices:
                 if isinstance(slc, int | np.integer):
-                    initial_cor.append(self.model.data_model.get_cor_from_regression(slc))
+                    initial_cor.append(self.model.data_model.get_cor_from_regression(int(slc)))
                 else:
                     raise TypeError(f"Expected int for slice index, got {type(slc)}")
         else:

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -422,7 +422,7 @@ class ReconstructWindowPresenter(BasePresenter):
         if self.model.has_results:
             initial_cor = []
             for slc in slice_indices:
-                if isinstance(slc, int):
+                if isinstance(slc, (int, np.integer)):
                     initial_cor.append(self.model.data_model.get_cor_from_regression(slc))
                 else:
                     raise TypeError(f"Expected int for slice index, got {type(slc)}")


### PR DESCRIPTION
## Issue Closes #2627

### Description

Fix TypeError in Minimise Error: accept numpy integer types as slice indices using numbers.Integral.

### Developer Testing 

Unit tests pass: python -m pytest -vs

Verified Minimise Error works after Correlate 0 and 180

Verified no regression in other COR workflows

### Acceptance Criteria and Reviewer Testing

Unit tests pass

Minimise Error works with and without Correlate

No regression in recon workflows

