### PR TITLE
Add screenshot tests for spectrum viewer tabs

### DIFF
--- a/mantidimaging/eyes_tests/spectrum_viewer_test.py
+++ b/mantidimaging/eyes_tests/spectrum_viewer_test.py
@@ -57,3 +57,30 @@ class SpectrumViewerWindowTest(BaseEyesTest):
             if action.text() == 'Points':
                 action.trigger()
         self.check_target(widget=self.imaging.spectrum_viewer)
+
+    def test_spectrum_viewer_fitting_tab(self):
+        self._generate_spectrum_dataset()
+        self.imaging.show_spectrum_viewer_window()
+        self.imaging.spectrum_viewer.formTabs.setCurrentIndex(1)
+        self.check_target(widget=self.imaging.spectrum_viewer)
+
+    def test_spectrum_viewer_export_tab(self):
+        self._generate_spectrum_dataset()
+        self.imaging.show_spectrum_viewer_window()
+        self.imaging.spectrum_viewer.formTabs.setCurrentIndex(2)
+        self.check_target(widget=self.imaging.spectrum_viewer)
+
+    def test_spectrum_viewer_initial_fit_from_roi(self):
+        self._generate_spectrum_dataset()
+        self.imaging.show_spectrum_viewer_window()
+        self.imaging.spectrum_viewer.formTabs.setCurrentIndex(1)
+        self.imaging.spectrum_viewer.scalable_roi_widget.from_roi_button.click()
+        self.check_target(widget=self.imaging.spectrum_viewer)
+
+    def test_spectrum_viewer_run_fit(self):
+        self._generate_spectrum_dataset()
+        self.imaging.show_spectrum_viewer_window()
+        self.imaging.spectrum_viewer.formTabs.setCurrentIndex(1)
+        self.imaging.spectrum_viewer.scalable_roi_widget.from_roi_button.click()
+        self.imaging.spectrum_viewer.scalable_roi_widget.run_fit_button.click()
+        self.check_target(widget=self.imaging.spectrum_viewer)


### PR DESCRIPTION
## Issue  
Closes #2634  

### Description  
Adds screenshot tests for the Spectrum Viewer tabs, including ROI view, Fitting tab, and Export Table tab.

### Developer Testing  
- [x] Verified screenshot tests run and pass locally  
- [x] Confirmed tab switching and ROI setup render correctly before snapshot  

### Acceptance Criteria & Reviewer Testing  
- [x] Run `python -m pytest -vs` and confirm all tests pass  
- [x] Screenshots correctly show all three tabs populated  
- [ ] New baseline approved in Applitools  

### Documentation and Additional Notes  
- [x] Screenshot tests have been updated
  - [x] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [x] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [x] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) 
