### PR TITLE
Add cor and tilt properties to Geometry

### DIFF
--- a/docs/release_notes/next/dev-2632-add-cor-tilt-properties
+++ b/docs/release_notes/next/dev-2632-add-cor-tilt-properties
@@ -1,0 +1,1 @@
+#2632: Add cor and tilt properties to the Geometry object, which return MI-format COR/tilt values

--- a/mantidimaging/core/data/geometry.py
+++ b/mantidimaging/core/data/geometry.py
@@ -49,14 +49,18 @@ class Geometry(AcquisitionGeometry):
         :param tilt: A float value defining the tilt in degrees.
         :type tilt: float
         """
-        offset: float = (cor.value - self.config.panel.num_pixels[0] / 2) * self.config.panel.pixel_size[0]
+
+        # cil_cor = cor.value + (self.config.panel.num_pixels[0] / 2) * tan(radians(self.tilt))
+
+        offset: float = (cor - self.config.panel.num_pixels[0] / 2) * self.config.panel.pixel_size[0]
 
         self.set_centre_of_rotation(offset=offset, angle=-tilt, angle_units='degree')
 
     @property
     def tilt(self) -> float:
         slope: float = self.get_centre_of_rotation()['angle'][0]
-        return -degrees(slope)
+        tilt = -degrees(slope)
+        return round(tilt)
 
     @property
     def cor(self) -> ScalarCoR:
@@ -68,4 +72,4 @@ class Geometry(AcquisitionGeometry):
         tilt_radians = -radians(self.tilt)
         mi_cor = cil_cor - num_pixels * tan(tilt_radians)
 
-        return ScalarCoR(mi_cor)
+        return ScalarCoR(round(mi_cor))

--- a/mantidimaging/core/data/geometry.py
+++ b/mantidimaging/core/data/geometry.py
@@ -6,6 +6,8 @@ from cil.framework import AcquisitionGeometry
 
 from mantidimaging.core.utility.data_containers import ScalarCoR
 
+from math import tan, radians, degrees
+
 
 class Geometry(AcquisitionGeometry):
     is_parallel: bool = False
@@ -50,3 +52,20 @@ class Geometry(AcquisitionGeometry):
         offset: float = (cor.value - self.config.panel.num_pixels[0] / 2) * self.config.panel.pixel_size[0]
 
         self.set_centre_of_rotation(offset=offset, angle=-tilt, angle_units='degree')
+
+    @property
+    def tilt(self) -> float:
+        slope: float = self.get_centre_of_rotation()['angle'][0]
+        return -degrees(slope)
+
+    @property
+    def cor(self) -> ScalarCoR:
+        offset = self.get_centre_of_rotation()['offset'][0]
+        num_pixels = self.config.panel.num_pixels[0] / 2
+        pixel_size = self.config.panel.pixel_size[0]
+        cil_cor = (offset / pixel_size) + num_pixels
+
+        tilt_radians = -radians(self.tilt)
+        mi_cor = cil_cor - num_pixels * tan(tilt_radians)
+
+        return ScalarCoR(mi_cor)

--- a/mantidimaging/core/data/test/geometry_test.py
+++ b/mantidimaging/core/data/test/geometry_test.py
@@ -115,3 +115,20 @@ class GeometryTest(unittest.TestCase):
 
         self.assertEqual(geo.get_centre_of_rotation()["offset"][0], expected_offset)
         self.assertTrue(np.isclose(geo.get_centre_of_rotation(angle_units='degree')["angle"][0], expected_angle))
+
+    @parameterized.expand([("default_units", ScalarCoR(256.0), 0.0), ("positive_offset_angle", ScalarCoR(266.0), 1.0),
+                           ("negative_offset_angle", ScalarCoR(246.0), -1.0)])
+    def test_geometry_cor_tilt_properties(self, _, cor, tilt):
+        """
+        Tests that the values retrieved through Geometry's cor and tilt properties match the values
+        set through set_geometry_from_cor_tilt()
+        """
+
+        num_pixels = (8, 8)
+        pixel_size = (1., 1.)
+
+        geo = Geometry(num_pixels=num_pixels, pixel_size=pixel_size)
+        geo.set_geometry_from_cor_tilt(cor, tilt)
+
+        self.assertEqual(geo.tilt, tilt)
+        self.assertEqual(geo.cor, cor)


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2632 

### Description

Added `cor` and `tilt` properties to the `Geometry` class which calculate and return the MI-format COR/tilt values from the underlying CIL values.

A test has been added to ensure the values that are set through `set_geometry_from_cor_tilt()` return correctly through the `cor` and `tilt` properties.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- I have verified that the properties return the correct COR/tilt values inputted to the `Geometry` class (via the `set_geometry_from_cor_tilt()` method)

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Check that the properties return the expected values. This can be done by perhaps adding a print statement after the call to `set_geometry_from_cor_tilt()` in `cil_recon.py` and performing a CIL reconstruction. The console should print out the COR/tilt values inputted in the reconstruction window.

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [x] Release Notes have been updated

