### PR TITLE
Spectrum Viewer: Santisteban fits Bragg Edge extremes using ydata percentiles

### DIFF
--- a/docs/release_notes/next/fix-2642-Santisteban-fitting-crash
+++ b/docs/release_notes/next/fix-2642-Santisteban-fitting-crash
@@ -1,0 +1,1 @@
+#2642: While using the Santisteban fit, the window will not crash if a bad fit is found or a poor ROI is chosen. The user receives a warning if a poor ROI is used.


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2642
### Description

When performing the left and right side fittings, lower and upper percentiles of the ydata within the ROI are used to consistently produce the same fit for a given Bragg Edge. Extending the horizontal width of the ROI now decides how much of the ydata before and after the Edge is used in the statistics to find the fitting of the additional parameters.
This method now produces better and consistent fits, even for sparser/lower resolution data.

For poorly chosen ROIs, the use is warned to resize the ROI via a custom exception, therefore preventing crashes/infinite loops.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] follow steps in linked error and make sure that no errors occur and that a fit is always given (good or bad!)

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [ ] Release Notes have been updated


