### PR TITLE
Clean logging: memory setup and redundant startup messages

### DIFF
--- a/mantidimaging/core/parallel/manager.py
+++ b/mantidimaging/core/parallel/manager.py
@@ -2,6 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+import time
 from multiprocessing import get_context
 import os
 import uuid
@@ -28,6 +29,7 @@ pool: Pool | None = None
 
 
 def create_and_start_pool(process_count: int) -> None:
+    t0 = time.monotonic()
     context = get_context('spawn')
     global cores
     if process_count == 0:
@@ -36,6 +38,8 @@ def create_and_start_pool(process_count: int) -> None:
         cores = process_count
     global pool
     pool = context.Pool(cores, initializer=worker_setup)
+    if perf_logger.isEnabledFor(1):
+        perf_logger.info(f"Process pool started in {time.monotonic() - t0}")
 
 
 def worker_setup():

--- a/mantidimaging/core/utility/progress_reporting/progress.py
+++ b/mantidimaging/core/utility/progress_reporting/progress.py
@@ -235,13 +235,9 @@ class Progress:
         """
         Marks the task as completed.
         """
-        log = getLogger(__name__)
 
         self.update(force_continue=True, msg=self.cancel_msg if self.should_cancel else msg)
 
         if not self.should_cancel:
             self.complete = True
             self.end_step = self.current_step
-
-        # Log elapsed time and final memory usage
-        log.debug("Memory usage after execution: %s", get_memory_usage_linux_str())


### PR DESCRIPTION
## Issue  
Part of #2626

### Description  
Cleaned up logging: removed per-frame, memory, and redundant startup logs.

### Developer Testing  
- [ ] Verified unit tests pass: `python -m pytest -vs`

### Acceptance Criteria  
- [ ] Logs are minimal and relevant  
- [ ] No redundant log noise
