### PR TITLE
Raise clear error if no parser matches, guiding user to fix missing header

### DIFF
--- a/docs/release_notes/next/feature-2648-Improve-error-when-log-file-doesn't-have-a-header
+++ b/docs/release_notes/next/feature-2648-Improve-error-when-log-file-doesn't-have-a-header
@@ -1,0 +1,1 @@
+2648: Improve error when log file doesn't have a header

--- a/mantidimaging/core/io/instrument_log.py
+++ b/mantidimaging/core/io/instrument_log.py
@@ -135,7 +135,11 @@ class InstrumentLog:
             if parser.match(self.lines, self.source_file.name):
                 self.parser = parser
                 return
-        raise NoParserFound
+        raise NoParserFound(
+            f"File format not recognised for log file: '{self.source_file.name}'. "
+            "See documentation for details of supported formats: "
+            "https://mantidproject.github.io/mantidimaging/user_docs/explanations/gui/loading_saving.html#load-log-for-stack"
+        )
 
     def parse(self) -> None:
         self.data = self.parser(self.lines).parse()


### PR DESCRIPTION
## Issue Closes #2648

### Description

Improve error handling for log files without headers. Raises a descriptive `NoParserFound` exception and shows a QMessageBox with a helpful message and link to documentation.

### Developer Testing

- Verified unit tests pass: `python -m pytest -vs`
- Manually tested with and without headers

### Acceptance Criteria and Reviewer Testing

- [ ] Unit tests pass
- [ ] Valid log file loads without error
- [ ] Missing-header log file shows helpful QMessageBox
- [x] App exits cleanly after warning

### Documentation and Additional Notes

- [ ] Release Notes have been updated

