### PR TITLE
(spectrum-viewer): add detailed logging for ROI actions and fitting

### DIFF
--- a/mantidimaging/gui/widgets/spectrum_widgets/export_data_table_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_data_table_widget.py
@@ -1,10 +1,13 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
+from logging import getLogger
 
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QTableView, QHeaderView, QAbstractItemView
 from PyQt5.QtGui import QStandardItemModel, QStandardItem
 from PyQt5.QtCore import Qt
+
+LOG = getLogger(__name__)
 
 
 class ExportDataTableWidget(QWidget):
@@ -66,6 +69,8 @@ class ExportDataTableWidget(QWidget):
         else:
             self.model.appendRow(items)
 
+        LOG.info("Export table updated: ROI=%s, Params=%s, Status=%s", roi_name, params, status)
+
     def _find_row_by_roi_name(self, roi_name: str) -> int | None:
         """
         Find the row index for a given ROI name. Returns None if not found.
@@ -80,3 +85,4 @@ class ExportDataTableWidget(QWidget):
         Remove all rows from the table.
         """
         self.model.removeRows(0, self.model.rowCount())
+        LOG.info("Export table cleared")

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -13,6 +13,9 @@ from pyqtgraph import RectROI, mkPen, ImageItem, PlotDataItem, ROI
 from mantidimaging.gui.windows.spectrum_viewer.model import allowed_modes
 from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumPlotWidget, SpectrumROI
 from mantidimaging.core.fitting.fitting_functions import FittingRegion
+from logging import getLogger
+
+LOG = getLogger(__name__)
 
 
 class FittingDisplayWidget(QWidget):
@@ -64,6 +67,7 @@ class FittingDisplayWidget(QWidget):
         self.spectrum_plot.spectrum.plot(x_data, y_data, name=label, pen=(255, 255, 0))
         self.spectrum_plot.spectrum.addItem(self.fitting_region)
         self.set_default_region(x_data, y_data)
+        LOG.debug("Spectrum plot updated: label=%s, points=%d", label, len(x_data))
 
     def update_image(self, image: np.ndarray | None) -> None:
         if image is not None:
@@ -114,6 +118,7 @@ class FittingDisplayWidget(QWidget):
         height = self.fitting_region.size().y()
         self.fitting_region.setPos((x_start, y_pos))
         self.fitting_region.setSize((width, height))
+        LOG.info("Fit region set: x_start=%.3f, x_end=%.3f", x_start, x_end)
 
     def get_selected_fit_region(self) -> FittingRegion:
         pos = self.fitting_region.pos()
@@ -154,6 +159,7 @@ class FittingDisplayWidget(QWidget):
             self._current_fit_line = None
         self._current_fit_line = self.spectrum_plot.spectrum.plot(x_data, y_data, name=label, pen=color)
         self._showing_initial_fit = initial
+        LOG.debug("Fit line displayed: label=%s, initial=%s, points=%d", label, initial, len(x_data))
 
     def is_initial_fit_visible(self) -> bool:
         return self._showing_initial_fit

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -67,7 +67,9 @@ class FittingDisplayWidget(QWidget):
         self.spectrum_plot.spectrum.plot(x_data, y_data, name=label, pen=(255, 255, 0))
         self.spectrum_plot.spectrum.addItem(self.fitting_region)
         self.set_default_region(x_data, y_data)
-        LOG.debug("Spectrum plot updated: label=%s, points=%d", label, len(x_data))
+        if not getattr(self, "_log_emitted", False):
+            LOG.debug("Spectrum plot updated: label=%s, points=%d", label, len(x_data))
+        self._log_emitted = True
 
     def update_image(self, image: np.ndarray | None) -> None:
         if image is not None:

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_param_form_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_param_form_widget.py
@@ -2,12 +2,15 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from typing import TYPE_CHECKING
+from logging import getLogger
 
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QSizePolicy, QPushButton
 from PyQt5.QtGui import QDoubleValidator
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowPresenter
+
+LOG = getLogger(__name__)
 
 
 class FittingParamFormWidget(QWidget):
@@ -68,11 +71,13 @@ class FittingParamFormWidget(QWidget):
         for name, value in values.items():
             row = self._rows[name]
             row[2].setText(f"{value:f}")
+            LOG.debug("Final fit parameter values updated: %s", values)
 
     def set_fitted_parameter_values(self, values: dict[str, float]) -> None:
         for name, value in values.items():
             row = self._rows[name]
             row[3].setText(f"{value:f}")
+            LOG.debug("Final fit parameter values updated: %s", values)
 
     def get_initial_param_values(self) -> list[float]:
         params = [float(row[2].text()) for row in self._rows.values()]
@@ -91,3 +96,4 @@ class FittingParamFormWidget(QWidget):
                 widget.setParent(None)
             self.params_layout.layout().removeItem(row_layout)
         self._rows.clear()
+        LOG.debug("Parameter form rows cleared")

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_param_form_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_param_form_widget.py
@@ -41,6 +41,7 @@ class FittingParamFormWidget(QWidget):
         self.run_fit_button = QPushButton("Run fit")
         self.layout().addWidget(self.run_fit_button)
         self.run_fit_button.clicked.connect(self.presenter.run_region_fit)
+        self._param_values_logged = False
 
     def set_parameters(self, params: list[str]) -> None:
         """
@@ -71,13 +72,16 @@ class FittingParamFormWidget(QWidget):
         for name, value in values.items():
             row = self._rows[name]
             row[2].setText(f"{value:f}")
-            LOG.debug("Final fit parameter values updated: %s", values)
+
+        if not self._param_values_logged:
+            LOG.info("Final fit parameter values updated: %s", values)
+            self._param_values_logged = True
 
     def set_fitted_parameter_values(self, values: dict[str, float]) -> None:
         for name, value in values.items():
             row = self._rows[name]
             row[3].setText(f"{value:f}")
-            LOG.debug("Final fit parameter values updated: %s", values)
+        LOG.debug("Final fit parameter values updated: %s", values)
 
     def get_initial_param_values(self) -> list[float]:
         params = [float(row[2].text()) for row in self._rows.values()]

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_selection_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_selection_widget.py
@@ -7,12 +7,14 @@ from mantidimaging.core.fitting import fitting_functions
 from PyQt5 import QtWidgets, QtCore
 
 from mantidimaging.core.fitting.fitting_functions import BaseFittingFunction
+from logging import getLogger
+
+LOG = getLogger(__name__)
 
 
 class FitSelectionWidget(QtWidgets.QGroupBox):
     """
     A custom Qt widget for selecting an Fitting Model.
-
     Attributes:
         fitDropdown: A dropdown menu for selecting fits.
         func_dict: A dictionary for storing fitting functions available in the viewer.
@@ -45,6 +47,7 @@ class FitSelectionWidget(QtWidgets.QGroupBox):
         """ Handle dropdown selection change and emit signal. """
         selected_fit = self.fitDropdown.currentText()
         self.selectionChanged.emit(self.func_dict[selected_fit])
+        LOG.info("Fit function selected: %s", self.fitDropdown.currentText())
 
     def set_available_fitting_functions(self) -> None:
         """ Update the dropdown and trigger selection change if needed. """

--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_selection_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_selection_widget.py
@@ -3,12 +3,14 @@
 
 from mantidimaging.gui.windows.spectrum_viewer.model import ROI_RITS
 from PyQt5 import QtWidgets, QtCore
+from logging import getLogger
+
+LOG = getLogger(__name__)
 
 
 class ROISelectionWidget(QtWidgets.QGroupBox):
     """
     A custom Qt widget for selecting an ROI.
-
     Attributes:
         roiDropdown: A dropdown menu for selecting ROIs.
         selectionChanged: Signal emitted when the ROI selection changes.
@@ -34,6 +36,7 @@ class ROISelectionWidget(QtWidgets.QGroupBox):
         selected_roi = self.roiDropdown.currentText()
         if selected_roi != self.previous_selection:
             self.previous_selection = selected_roi
+            LOG.info("ROI selected: %s", selected_roi)
             self.selectionChanged.emit(selected_roi)
 
     def update_roi_list(self, roi_names: list[str]) -> None:
@@ -50,6 +53,7 @@ class ROISelectionWidget(QtWidgets.QGroupBox):
             self._on_selection_changed()
             self._on_selection_changed()
         self.roiDropdown.blockSignals(False)
+        LOG.debug("ROI dropdown updated: %s", filtered_rois)
 
     def set_selected_roi(self, roi_name: str) -> None:
         """ Set the dropdown selection to the given ROI name. """

--- a/mantidimaging/gui/widgets/spectrum_widgets/tof_properties.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/tof_properties.py
@@ -2,6 +2,9 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 
 from PyQt5 import QtCore, QtWidgets
+from logging import getLogger
+
+LOG = getLogger(__name__)
 
 
 class ExperimentSetupFormWidget(QtWidgets.QGroupBox):
@@ -75,6 +78,7 @@ class ExperimentSetupFormWidget(QtWidgets.QGroupBox):
     @flight_path.setter
     def flight_path(self, value: float) -> None:
         self.flightPathSpinBox.setValue(value)
+        LOG.debug("Flight path set to: %.3f m", value)
 
     @property
     def time_delay(self) -> float:
@@ -83,6 +87,7 @@ class ExperimentSetupFormWidget(QtWidgets.QGroupBox):
     @time_delay.setter
     def time_delay(self, value: float):
         self.timeDelaySpinBox.setValue(value)
+        LOG.debug("Time delay set to: %.3f µs", value)
 
     def connect_value_changed(self, handler: QtCore.pyqtSlot):
         self.flightPathSpinBox.valueChanged.connect(handler)

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -2,6 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+from logging import getLogger
 from typing import TYPE_CHECKING
 
 from PyQt5.QtCore import pyqtSignal, Qt, QSignalBlocker, QEvent
@@ -27,6 +28,8 @@ from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401   # pragma: no cover
+
+LOG = getLogger(__name__)
 
 
 class SpectrumROI(ROI):
@@ -201,6 +204,8 @@ class SpectrumWidget(QWidget):
         self.roi_dict[name].sigClicked.connect(self.roi_clicked.emit)
         self.image.vb.addItem(self.roi_dict[name])
         self.roi_dict[name].hoverPen = mkPen(self.roi_dict[name].colour, width=3)
+        LOG.debug("ROI created: name=%s, coords=(Left: %d, Right: %d, Top: %d, Bottom: %d)", name, roi.left, roi.right,
+                  roi.top, roi.bottom)
 
     def adjust_roi(self, new_roi: SensibleROI, roi_name: str) -> None:
         """
@@ -209,6 +214,8 @@ class SpectrumWidget(QWidget):
         @param roi_name: The name of the existing ROI.
         """
         self.roi_dict[roi_name].adjust_spec_roi(new_roi)
+        LOG.debug("ROI adjusted: name=%s, new coords=(Left: %d, Right: %d, Top: %d, Bottom: %d)", roi_name,
+                  new_roi.left, new_roi.right, new_roi.top, new_roi.bottom)
 
     def get_roi(self, roi_name: str) -> SensibleROI:
         """
@@ -239,6 +246,7 @@ class SpectrumWidget(QWidget):
 
         self.image.vb.removeItem(self.roi_dict[roi_name])
         del self.roi_dict[roi_name]
+        LOG.info("ROI deleted: name=%s", roi_name)
 
     def rename_roi(self, old_name: str, new_name: str) -> None:
         """
@@ -258,6 +266,8 @@ class SpectrumWidget(QWidget):
         self.roi_dict[new_name] = self.roi_dict.pop(old_name)
         self.spectrum_data_dict[new_name] = self.spectrum_data_dict.pop(old_name)
         self.roi_dict[new_name].name = new_name
+
+        LOG.info(f"ROI renamed: from={old_name} to={new_name}")
 
     def _emit_roi_changed(self):
         sender_roi = self.sender()
@@ -341,6 +351,7 @@ class SpectrumPlotWidget(GraphicsLayoutWidget):
         tof_range = self.get_tof_range()
         self.set_tof_range_label(tof_range[0], tof_range[1])
         self.range_changed.emit(tof_range)
+        LOG.info("Projection range changed: TOF=%.2f to %.2f", tof_range[0], tof_range[1])
 
     def add_range(self, range_min: int | float, range_max: int | float) -> None:
         with QSignalBlocker(self.range_control):

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -11,6 +11,7 @@ from pyqtgraph import mkPen
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import (QCheckBox, QVBoxLayout, QFileDialog, QLabel, QGroupBox, QActionGroup, QAction)
 from PyQt5.QtCore import QModelIndex
+from logging import getLogger
 
 from mantidimaging.core.utility import finder
 from mantidimaging.gui.mvp_base import BaseMainWindowView
@@ -34,6 +35,8 @@ if TYPE_CHECKING:
     from mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget import ROIFormWidget, ROITableWidget
     from mantidimaging.core.fitting.fitting_functions import FittingRegion
     from uuid import UUID
+
+LOG = getLogger(__name__)
 
 
 class SpectrumViewerWindowView(BaseMainWindowView):
@@ -175,6 +178,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     def handle_change_tab(self, tab_index: int):
         self.imageTabs.setCurrentIndex(tab_index)
         self.presenter.update_unit_labels_and_menus()
+        LOG.debug("Tab changed: index=%d", tab_index)
 
     def sync_unit_menus(self, unit_name: str) -> None:
         """Sync the checked unit in both the image and fitting tab unit menus."""
@@ -239,6 +243,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.fittingSpectrumPlot.spectrum.clear()
 
         if spectrum_data is not None and len(spectrum_data) > 0:
+            LOG.info("Fitting plot updated: ROI=%s, points=%d", roi_name, len(spectrum_data))
             yellow_pen = mkPen(color=(255, 255, 0), width=2)
             self.fittingSpectrumPlot.spectrum.plot(self.presenter.model.tof_data,
                                                    spectrum_data,
@@ -325,6 +330,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         roi_names = self.presenter.get_roi_names()
         self.roiSelectionWidget.update_roi_list(roi_names)
         self.exportSettingsWidget.set_roi_names(roi_names)
+        LOG.debug("ROI dropdown updated in view")
 
     def handle_fitting_roi_changed(self) -> None:
         self.show_visible_spectrums()
@@ -340,6 +346,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.presenter.do_add_roi()
         self.roi_form.roi_properties_widget.enable_roi_spinboxes(True)
         self.set_roi_properties()
+        LOG.debug("New ROI creation triggered by user")
 
     def handle_table_click(self, index: QModelIndex) -> None:
         if index.isValid() and index.column() == 1:
@@ -391,6 +398,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         Clear the selected ROI in the table view
         """
         roi_name = self.table_view.get_roi_name_by_row(self.table_view.selected_row)
+        LOG.debug("ROI removed by user: %s", roi_name)
 
         self.table_view.remove_row(self.table_view.selected_row)
         self.presenter.do_remove_roi(roi_name)


### PR DESCRIPTION
## Issue Closes 
#2626 (sub-issue)

### Description

Added structured logging to Spectrum Viewer for key user interactions:
- ROI creation, movement, renaming, and deletion
- Fitting functions used, parameters, and fit completion


### Developer Testing 

- I have verified unit tests pass locally: `python -m pytest -vs`
- Manually tested logging during typical ROI and fitting workflows

### Acceptance Criteria and Reviewer Testing

- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Verify ROI interactions (add, move, delete, rename) emit meaningful logs
- [ ] Verify fitting logs contain function and parameter info
- [ ] No unexpected warnings or redundant logging seen in output

### Documentation and Additional Notes

<!-- - [ ] Release Notes have been updated -->
<!-- - [ ] Sphinx documentation has been updated -->
<!-- - [ ] Screenshot tests have been updated -->
