### PR TITLE
Use TaskWorkerThread which has exception checking

### DIFF
--- a/docs/release_notes/next/fix-2690-exception-worker-thread
+++ b/docs/release_notes/next/fix-2690-exception-worker-thread
@@ -1,0 +1,1 @@
+#2690: Handle exception in the spectrum viewer worker thread


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2690 

### Description

Use TaskWorkerThread to run the spectrum calculations, it can capture the exception so that it can be pickup back in the main thread. This means that we get clean error meessages when exceptions happen in the worker thread.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- Tested with adding a raise into `get_spectrum()` as described on the issue

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Follow steps to trigger on the issue

### Documentation and Additional Notes



- [ ] Release Notes have been updated
