### PR TITLE
Spectrum Viewer: Spinbox limits are dynamically updated when ROI is moved

### DIFF
--- a/docs/release_notes/next/fix-2698-spectrum-spinboxes-update-limits
+++ b/docs/release_notes/next/fix-2698-spectrum-spinboxes-update-limits
@@ -1,0 +1,1 @@
+#2698: The Spectrum ROI spinboxes limits are updated when ROIs are moved by the user. The size parameters are now updated correctly.

--- a/mantidimaging/eyes_tests/spectrum_viewer_test.py
+++ b/mantidimaging/eyes_tests/spectrum_viewer_test.py
@@ -44,7 +44,7 @@ class SpectrumViewerWindowTest(BaseEyesTest):
         self.imaging.spectrum_viewer.normaliseCheckBox.setChecked(True)
         self.imaging.spectrum_viewer.normaliseStackSelector.try_to_select_relevant_stack("Open Beam Stack")
         self.imaging.spectrum_viewer.set_new_roi()
-        self.imaging.spectrum_viewer.spectrum_widget.roi_dict["roi_1"].setSize(2, 2)
+        self.imaging.spectrum_viewer.spectrum_widget.roi_dict["roi_1"].setSize((2, 2))
         self.imaging.spectrum_viewer.spectrum_widget.roi_dict["roi_1"].setPos(5, 5)
         wait_until(lambda: not np.isnan(self.imaging.spectrum_viewer.spectrum_widget.spectrum_data_dict["roi_1"]).any(),
                    max_retry=600)

--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
@@ -137,6 +137,13 @@ class ROIPropertiesTableWidget(BaseWidget):
         self.spin_top.setMaximum(shape[0])
         self.spin_bottom.setMaximum(shape[0])
 
+    def update_roi_limits(self, roi: SensibleROI) -> None:
+        self.set_roi_values(roi)
+        self.spin_left.setMaximum(roi.right - 1)
+        self.spin_right.setMinimum(roi.left + 1)
+        self.spin_top.setMaximum(roi.bottom - 1)
+        self.spin_bottom.setMinimum(roi.top + 1)
+
     def to_roi(self) -> SensibleROI:
         new_roi = SensibleROI(left=self.spin_left.value(),
                               right=self.spin_right.value(),

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -229,6 +229,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def handle_notify_roi_moved(self, roi: SpectrumROI) -> None:
         self.changed_roi = roi
+        self.view.roi_form.roi_properties_widget.update_roi_limits(roi.as_sensible_roi())
         run_thread_check = not bool(self.roi_to_process_queue)
         self.roi_to_process_queue[self.changed_roi.name] = self.changed_roi
         spectrum = self.view.spectrum_widget.spectrum_data_dict[roi.name]


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2698 and #2701

### Description

When an ROI is adjusted via mouse movements or via the spinboxes, the limits on the ROI spinboxes are set to prevent a zero size ROI. This also fixes an issue where the spinboxes where not updating the ROIs size labels properly.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`


### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Open Spectrum viewer with data
- [x] Attempt to create a zero-size ROI via dragging and via spinboxes
- [x] Verify that the ROI is restricted to a 1x1 pixel and will not go any smaller
- [x] When moving the ROI via mouse or spinboxes, check that the spinbox values and the Size labels update correctly.

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [ ] Release Notes have been updated
- [ ] Screenshot tests have edited


