### PR TITLE
Catch errors in Fit All and show in export table

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -17,12 +17,12 @@ from mantidimaging.gui.dialogs.async_task import start_async_task_view, TaskWork
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.windows.spectrum_viewer.model import SpectrumViewerWindowModel, SpecType, ROI_RITS, ErrorMode, \
     ToFUnitMode, allowed_modes
+from mantidimaging.core.fitting.fitting_functions import FittingRegion, BadFittingRoiError
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.spectrum_viewer.view import SpectrumViewerWindowView  # pragma: no cover
     from mantidimaging.gui.windows.main.view import MainWindowView  # pragma: no cover
     from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumROI
-    from mantidimaging.core.fitting.fitting_functions import FittingRegion
     from mantidimaging.core.data import ImageStack
     from uuid import UUID
     from PyQt5.QtWidgets import QAction
@@ -673,9 +673,15 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             roi = roi_widget.as_sensible_roi()
             spectrum = self.model.get_spectrum(roi, self.spectrum_mode, self.view.shuttercount_norm_enabled())
             fitting_region = self.view.get_fitting_region()
+            try:
+                result = self.fit_single_region(spectrum, fitting_region, self.model.tof_data, init_params)
+                status = "Fitted"
+            except (ValueError, BadFittingRoiError) as e:
+                LOG.warning(f"Failed to find fit for {roi_name}: {e}")
+                result = {param_name: 0 for param_name in self.model.fitting_engine.get_parameter_names()}
+                status = "Failed"
 
-            result = self.fit_single_region(spectrum, fitting_region, self.model.tof_data, init_params)
-            self.view.exportDataTableWidget.update_roi_data(roi_name=roi_name, params=result, status="Fitted")
+            self.view.exportDataTableWidget.update_roi_data(roi_name=roi_name, params=result, status=status)
             LOG.info("Fit completed for ROI=%s, params=%s", roi_name, result)
 
     def show_fit(self, params: list[float]) -> None:


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2700

### Description

When looping ROIs in Fit All catch exceptions and display "failed" in the export table.

This is needed because otherwise there is just an error pop and its not clear that the data in the table is not an up to date fit.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- ...

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] ...

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

