### PR TITLE
2709 Reconstruction Window: Add widget annotations to view

### DIFF
--- a/mantidimaging/eyes_tests/reconstruct_window_test.py
+++ b/mantidimaging/eyes_tests/reconstruct_window_test.py
@@ -76,4 +76,4 @@ class ReconstructionWindowTest(BaseEyesTest):
         self.imaging.recon.image_view.imageview_recon.setImage(np.zeros((512, 512)))
         self.imaging.recon.changeColourPaletteButton.click()
 
-        self.check_target(widget=self.imaging.recon.change_colour_palette_dialog)
+        self.check_target(widget=self.imaging.recon.changeColourPaletteDialog)

--- a/mantidimaging/gui/test/gui_system_reconstruction_test.py
+++ b/mantidimaging/gui/test/gui_system_reconstruction_test.py
@@ -53,9 +53,9 @@ class TestGuiSystemReconstruction(GuiSystemBase):
         self.assertEqual(self.recon_window.tilt, expected_initial_tilt)
 
         for _ in range(5):
-            QTest.mouseClick(self.recon_window.correlateBtn, Qt.MouseButton.LeftButton)
+            QTest.mouseClick(self.recon_window.correlateButton, Qt.MouseButton.LeftButton)
             QTest.qWait(SHORT_DELAY)
-            wait_until(lambda: self.recon_window.correlateBtn.isEnabled())
+            wait_until(lambda: self.recon_window.correlateButton.isEnabled())
             wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
 
         final_cor_value = self.recon_window.rotation_centre
@@ -74,9 +74,9 @@ class TestGuiSystemReconstruction(GuiSystemBase):
 
         for i in range(2, 6):
             QTimer.singleShot(SHORT_DELAY, lambda i=i: self._click_InputDialog(set_int=i))
-            QTest.mouseClick(self.recon_window.minimiseBtn, Qt.MouseButton.LeftButton)
+            QTest.mouseClick(self.recon_window.minimiseButton, Qt.MouseButton.LeftButton)
             QTest.qWait(SHORT_DELAY)
-            wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=500)
+            wait_until(lambda: self.recon_window.minimiseButton.isEnabled(), max_retry=500)
             wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
             QTest.qWait(SHORT_DELAY)
 
@@ -105,12 +105,12 @@ class TestGuiSystemReconstruction(GuiSystemBase):
 
     def test_refine(self):
         QTimer.singleShot(SHORT_DELAY, lambda: self._click_InputDialog(set_int=4))
-        QTest.mouseClick(self.recon_window.minimiseBtn, Qt.MouseButton.LeftButton)
-        wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=200)
+        QTest.mouseClick(self.recon_window.minimiseButton, Qt.MouseButton.LeftButton)
+        wait_until(lambda: self.recon_window.minimiseButton.isEnabled(), max_retry=200)
 
         for _ in range(5):
             QTimer.singleShot(SHORT_DELAY, lambda: self._click_cor_inspect())
-            QTest.mouseClick(self.recon_window.refineCorBtn, Qt.MouseButton.LeftButton)
+            QTest.mouseClick(self.recon_window.refineCorButton, Qt.MouseButton.LeftButton)
             QTest.qWait(SHORT_DELAY * 2)
             wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
 
@@ -120,16 +120,16 @@ class TestGuiSystemReconstruction(GuiSystemBase):
     def test_refine_stress(self):
         for i in range(5):
             print(f"test_refine_stress iteration {i}")
-            QTest.mouseClick(self.recon_window.correlateBtn, Qt.MouseButton.LeftButton)
+            QTest.mouseClick(self.recon_window.correlateButton, Qt.MouseButton.LeftButton)
             QTest.qWait(SHORT_DELAY)
-            wait_until(lambda: self.recon_window.correlateBtn.isEnabled())
+            wait_until(lambda: self.recon_window.correlateButton.isEnabled())
 
             QTimer.singleShot(SHORT_DELAY, lambda: self._click_InputDialog(set_int=3))
-            QTest.mouseClick(self.recon_window.minimiseBtn, Qt.MouseButton.LeftButton)
-            wait_until(lambda: self.recon_window.minimiseBtn.isEnabled(), max_retry=200)
+            QTest.mouseClick(self.recon_window.minimiseButton, Qt.MouseButton.LeftButton)
+            wait_until(lambda: self.recon_window.minimiseButton.isEnabled(), max_retry=200)
 
             QTimer.singleShot(SHORT_DELAY, lambda: self._click_cor_inspect())
-            QTest.mouseClick(self.recon_window.refineCorBtn, Qt.MouseButton.LeftButton)
+            QTest.mouseClick(self.recon_window.refineCorButton, Qt.MouseButton.LeftButton)
             QTest.qWait(SHORT_DELAY * 2)
             wait_until(lambda: len(self.recon_window.presenter.async_tracker) == 0)
 
@@ -143,7 +143,7 @@ class TestGuiSystemReconstruction(GuiSystemBase):
         wait_until(lambda: mock_do_preview_reconstruct_slice.call_count == 1)
 
     @mock.patch("mantidimaging.gui.windows.recon.presenter.ReconstructWindowPresenter._get_reconstruct_slice")
-    def test_clicking_update_now_btn_triggers_preview(self, mock_get_reconstruct_slice):
+    def test_clicking_update_now_Button_triggers_preview(self, mock_get_reconstruct_slice):
         self.recon_window.previewAutoUpdate.setCheckState(Qt.CheckState.Unchecked)
 
         QTest.mouseClick(self.recon_window.updatePreviewButton, Qt.MouseButton.LeftButton)

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -162,7 +162,7 @@
                     </widget>
                    </item>
                    <item row="1" column="1">
-                    <widget class="QDoubleSpinBox" name="resultCor">
+                    <widget class="QDoubleSpinBox" name="resultCorSpinBox">
                      <property name="sizePolicy">
                       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
                        <horstretch>0</horstretch>
@@ -203,7 +203,7 @@
                     </widget>
                    </item>
                    <item row="2" column="1">
-                    <widget class="QDoubleSpinBox" name="resultTilt">
+                    <widget class="QDoubleSpinBox" name="resultTiltSpinBox">
                      <property name="minimumSize">
                       <size>
                        <width>0</width>
@@ -241,7 +241,7 @@
                     </widget>
                    </item>
                    <item row="3" column="1">
-                    <widget class="QDoubleSpinBox" name="resultSlope">
+                    <widget class="QDoubleSpinBox" name="resultSlopeSpinBox">
                      <property name="minimumSize">
                       <size>
                        <width>0</width>
@@ -263,7 +263,7 @@
                     </widget>
                    </item>
                    <item row="4" column="1">
-                    <widget class="QPushButton" name="calculateCors">
+                    <widget class="QPushButton" name="calculateCorsButton">
                      <property name="toolTip">
                       <string>Use the CoR and Tilt above to generate a CoR for each of the slice indices in the table below</string>
                      </property>
@@ -290,7 +290,7 @@
                 </property>
                 <layout class="QHBoxLayout" name="horizontalLayout_3">
                  <item>
-                  <widget class="QPushButton" name="correlateBtn">
+                  <widget class="QPushButton" name="correlateButton">
                    <property name="toolTip">
                     <string>Performs a correlation between the 0 and 180 degree projections to find the shift.</string>
                    </property>
@@ -300,7 +300,7 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QPushButton" name="minimiseBtn">
+                  <widget class="QPushButton" name="minimiseButton">
                    <property name="toolTip">
                     <string>Minimises the square-sum error of the reconstructed slice, for a number of slices. The COR with lowest error will be used.</string>
                    </property>
@@ -350,7 +350,7 @@
                  <item>
                   <layout class="QGridLayout" name="gridLayout">
                    <item row="0" column="1">
-                    <widget class="QPushButton" name="addBtn">
+                    <widget class="QPushButton" name="addButton">
                      <property name="toolTip">
                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a new row to the table.&lt;/p&gt;&lt;p&gt;Slice index defaults to the current preview slice index.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
@@ -360,7 +360,7 @@
                     </widget>
                    </item>
                    <item row="0" column="0">
-                    <widget class="QPushButton" name="removeBtn">
+                    <widget class="QPushButton" name="removeButton">
                      <property name="enabled">
                       <bool>false</bool>
                      </property>
@@ -373,7 +373,7 @@
                     </widget>
                    </item>
                    <item row="1" column="0">
-                    <widget class="QPushButton" name="clearAllBtn">
+                    <widget class="QPushButton" name="clearAllButton">
                      <property name="toolTip">
                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Removes all rows from the table.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
@@ -383,7 +383,7 @@
                     </widget>
                    </item>
                    <item row="1" column="1">
-                    <widget class="QPushButton" name="refineCorBtn">
+                    <widget class="QPushButton" name="refineCorButton">
                      <property name="enabled">
                       <bool>false</bool>
                      </property>
@@ -420,7 +420,7 @@
                     </widget>
                    </item>
                    <item row="2" column="1">
-                    <widget class="QDoubleSpinBox" name="lbhc_a1">
+                    <widget class="QDoubleSpinBox" name="lbhcA1SpinBox">
                      <property name="enabled">
                       <bool>false</bool>
                      </property>
@@ -443,7 +443,7 @@
                     </widget>
                    </item>
                    <item row="4" column="1">
-                    <widget class="QDoubleSpinBox" name="lbhc_a3">
+                    <widget class="QDoubleSpinBox" name="lbhcA3SpinBox">
                      <property name="enabled">
                       <bool>false</bool>
                      </property>
@@ -473,7 +473,7 @@
                     </widget>
                    </item>
                    <item row="3" column="1">
-                    <widget class="QDoubleSpinBox" name="lbhc_a2">
+                    <widget class="QDoubleSpinBox" name="lbhcA2SpinBox">
                      <property name="enabled">
                       <bool>false</bool>
                      </property>
@@ -489,7 +489,7 @@
                     </widget>
                    </item>
                    <item row="1" column="1">
-                    <widget class="QDoubleSpinBox" name="lbhc_a0">
+                    <widget class="QDoubleSpinBox" name="lbhcA0SpinBox">
                      <property name="enabled">
                       <bool>false</bool>
                      </property>
@@ -505,7 +505,7 @@
                     </widget>
                    </item>
                    <item row="0" column="0">
-                    <widget class="QCheckBox" name="lbhc_enabled">
+                    <widget class="QCheckBox" name="lbhcEnabledCheckBox">
                      <property name="text">
                       <string>Enabled</string>
                      </property>
@@ -539,7 +539,7 @@
               <item>
                <layout class="QGridLayout" name="optionsLayout">
                 <item row="1" column="1">
-                 <widget class="QComboBox" name="algorithmName">
+                 <widget class="QComboBox" name="algorithmNameComboBox">
                   <property name="enabled">
                    <bool>false</bool>
                   </property>
@@ -558,7 +558,7 @@
                  </widget>
                 </item>
                 <item row="3" column="1">
-                 <widget class="QSpinBox" name="numIter">
+                 <widget class="QSpinBox" name="numIterSpinBox">
                   <property name="minimum">
                    <number>1</number>
                   </property>
@@ -669,14 +669,14 @@
                  </widget>
                 </item>
                 <item row="9" column="1">
-                 <widget class="QDoubleSpinBox" name="pixelSize">
+                 <widget class="QDoubleSpinBox" name="pixelSizeSpinBox">
                   <property name="maximum">
                    <double>99999.000000000000000</double>
                   </property>
                  </widget>
                 </item>
                 <item row="2" column="1">
-                 <widget class="QComboBox" name="filterName">
+                 <widget class="QComboBox" name="filterNameComboBox">
                   <item>
                    <property name="text">
                     <string>ram-lak</string>
@@ -722,7 +722,7 @@
                  </widget>
                 </item>
                 <item row="0" column="1">
-                 <widget class="QDoubleSpinBox" name="maxProjAngle">
+                 <widget class="QDoubleSpinBox" name="maxProjAngleSpinBox">
                   <property name="maximum">
                    <double>9999.000000000000000</double>
                   </property>
@@ -763,7 +763,7 @@
                </layout>
               </item>
               <item>
-               <widget class="QPushButton" name="refineIterationsBtn">
+               <widget class="QPushButton" name="refineIterationsButton">
                 <property name="enabled">
                  <bool>false</bool>
                 </property>
@@ -793,7 +793,7 @@
                </spacer>
               </item>
               <item>
-               <widget class="QPushButton" name="reconstructSlice">
+               <widget class="QPushButton" name="reconstructSliceButton">
                 <property name="text">
                  <string>Reconstruct Slice</string>
                 </property>
@@ -802,7 +802,7 @@
               <item>
                <layout class="QHBoxLayout" name="reconButtonGroup">
                 <item>
-                 <widget class="QPushButton" name="reconstructVolume">
+                 <widget class="QPushButton" name="reconstructVolumeButton">
                   <property name="text">
                    <string>Reconstruct Volume</string>
                   </property>
@@ -852,14 +852,14 @@
               </widget>
              </item>
              <item row="1" column="1">
-              <widget class="QSpinBox" name="previewProjectionIndex">
+              <widget class="QSpinBox" name="previewProjectionIndexSpinBox">
                <property name="maximum">
                 <number>99999</number>
                </property>
               </widget>
              </item>
              <item row="2" column="1">
-              <widget class="QSpinBox" name="previewSliceIndex">
+              <widget class="QSpinBox" name="previewSliceIndexSpinBox">
                <property name="maximum">
                 <number>99999</number>
                </property>
@@ -948,7 +948,7 @@
             </property>
             <layout class="QHBoxLayout" name="horizontalLayout_5">
              <item>
-              <widget class="QLabel" name="messageIcon">
+              <widget class="QLabel" name="messageIconLabel">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
                  <horstretch>0</horstretch>

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -61,8 +61,8 @@ class ReconstructWindowPresenter(BasePresenter):
         self.model = ReconstructWindowModel(self.view.cor_table_model)
         self.allowed_recon_kwargs: dict[str, list[str]] = self.model.load_allowed_recon_kwargs()
         self.restricted_arg_widgets: dict[str, list[QWidget]] = {
-            'filter_name': [self.view.filterName, self.view.filterNameLabel],
-            'num_iter': [self.view.numIter, self.view.numIterLabel],
+            'filter_name': [self.view.filterNameComboBox, self.view.filterNameLabel],
+            'num_iter': [self.view.numIterSpinBox, self.view.numIterLabel],
             'alpha': [self.view.alphaSpinBox, self.view.alphaLabel],
             'non_negative': [self.view.nonNegativeCheckBox, self.view.nonNegativeLabel],
             'stochastic': [self.view.stochasticCheckBox, self.view.stochasticLabel],
@@ -125,7 +125,7 @@ class ReconstructWindowPresenter(BasePresenter):
             else:
                 for widget in widgets:
                     widget.hide()
-        with BlockQtSignals([self.view.filterName, self.view.numIter]):
+        with BlockQtSignals([self.view.filterNameComboBox, self.view.numIterSpinBox]):
             self.view.set_filters_for_recon_tool(self.model.get_allowed_filters(alg_name))
         self.do_preview_reconstruct_slice()
         self.view.change_refine_iterations()

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -34,9 +34,9 @@ class ReconWindowPresenterTest(unittest.TestCase):
 
     def make_view(self):
         self.view = mock.create_autospec(ReconstructWindowView, instance=True)
-        self.view.filterName = mock.Mock()
+        self.view.filterNameComboBox = mock.Mock()
         self.view.filterNameLabel = mock.Mock()
-        self.view.numIter = mock.Mock()
+        self.view.numIterSpinBox = mock.Mock()
         self.view.numIterLabel = mock.Mock()
         self.view.image_view = mock.Mock()
         self.view.alphaSpinBox = mock.Mock()

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -144,7 +144,7 @@ class ReconstructWindowViewTest(unittest.TestCase):
         image_data = mock.Mock()
         preview_slice_idx = 13
 
-        self.view.previewSliceIndex = preview_slice_index_mock = mock.Mock()
+        self.view.previewSliceIndexSpinBox = preview_slice_index_mock = mock.Mock()
         self.view.update_projection(image_data, preview_slice_idx)
 
         preview_slice_index_mock.setValue.assert_called_once_with(preview_slice_idx)
@@ -182,8 +182,8 @@ class ReconstructWindowViewTest(unittest.TestCase):
 
     def test_on_table_row_count_change(self):
         self.tableView.model.return_value.empty = empty = False
-        self.view.removeBtn = remove_button_mock = mock.Mock()
-        self.view.clearAllBtn = clear_all_button_mock = mock.Mock()
+        self.view.removeButton = remove_button_mock = mock.Mock()
+        self.view.clearAllButton = clear_all_button_mock = mock.Mock()
         self.view.on_table_row_count_change()
 
         remove_button_mock.setEnabled.assert_called_once_with(not empty)
@@ -280,7 +280,7 @@ class ReconstructWindowViewTest(unittest.TestCase):
 
     def test_set_filters_for_recon_tool(self):
         filters = ["abc" for _ in range(3)]
-        with mock.patch.object(self.view, "filterName") as fn:
+        with mock.patch.object(self.view, "filterNameComboBox") as fn:
             self.view.set_filters_for_recon_tool(filters)
             fn.clear.assert_called_once()
             fn.insertItems.assert_called_once_with(0, filters)
@@ -326,8 +326,8 @@ class ReconstructWindowViewTest(unittest.TestCase):
         assert self.view.get_auto_cor_method() == AutoCorMethod.MINIMISATION_SQUARE_SUM
 
     def test_set_correlate_buttons_enables(self):
-        self.view.correlateBtn = correlate_button_mock = mock.Mock()
-        self.view.minimiseBtn = minimise_button_mock = mock.Mock()
+        self.view.correlateButton = correlate_button_mock = mock.Mock()
+        self.view.minimiseButton = minimise_button_mock = mock.Mock()
 
         for enabled in [True, False]:
             with self.subTest(enabled=enabled):
@@ -354,17 +354,17 @@ class ReconstructWindowViewTest(unittest.TestCase):
         show_error_dialog_mock.assert_called_once_with(str(RuntimeError()))
 
     def test_change_refine_iterations_when_algorithm_name_is_sirt(self):
-        self.view.refineIterationsBtn = refine_iterations_button_mock = mock.Mock()
-        self.view.algorithmName = mock.Mock()
-        self.view.algorithmName.currentText.return_value = "SIRT_CUDA"
+        self.view.refineIterationsButton = refine_iterations_button_mock = mock.Mock()
+        self.view.algorithmNameComboBox = mock.Mock()
+        self.view.algorithmNameComboBox.currentText.return_value = "SIRT_CUDA"
 
         self.view.change_refine_iterations()
         refine_iterations_button_mock.setEnabled.assert_called_once_with(True)
 
     def test_change_refine_iterations_when_algorithm_name_is_not_sirt(self):
-        self.view.refineIterationsBtn = refine_iterations_button_mock = mock.Mock()
-        self.view.algorithmName = mock.Mock()
-        self.view.algorithmName.currentText.return_value = "FBP_CUDA"
+        self.view.refineIterationsButton = refine_iterations_button_mock = mock.Mock()
+        self.view.algorithmNameComboBox = mock.Mock()
+        self.view.algorithmNameComboBox.currentText.return_value = "FBP_CUDA"
 
         self.view.change_refine_iterations()
         refine_iterations_button_mock.setEnabled.assert_called_once_with(False)
@@ -372,8 +372,8 @@ class ReconstructWindowViewTest(unittest.TestCase):
     def test_set_recon_buttons_enabled(self):
 
         def assert_button_state_is_correct(is_enabled):
-            self.assertEqual(self.view.reconstructSlice.isEnabled(), is_enabled)
-            self.assertEqual(self.view.reconstructVolume.isEnabled(), is_enabled)
+            self.assertEqual(self.view.reconstructSliceButton.isEnabled(), is_enabled)
+            self.assertEqual(self.view.reconstructVolumeButton.isEnabled(), is_enabled)
 
         assert_button_state_is_correct(is_enabled=True)
 
@@ -397,7 +397,7 @@ class ReconstructWindowViewTest(unittest.TestCase):
 
     def test_WHEN_param_change_THEN_preview_called(self):
         for func, val in [
-            (self.view.numIter.setValue, 2),
+            (self.view.numIterSpinBox.setValue, 2),
             (self.view.alphaSpinBox.setValue, 2),
             (self.view.stochasticCheckBox.setChecked, True),
             (self.view.subsetsSpinBox.setValue, 2),

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -33,54 +33,76 @@ LOG = getLogger(__name__)
 
 
 class ReconstructWindowView(BaseMainWindowView):
-    tableView: RemovableRowTableView
-    imageLayout: QVBoxLayout
+    # COR and Tilt tab
 
-    inputTab: QWidget
-    calculateCors: QPushButton
+    resultsTab: QWidget
 
-    resultTab: QWidget
-    addBtn: QPushButton
-    refineCorBtn: QPushButton
-    refineIterationsBtn: QPushButton
-    clearAllBtn: QPushButton
-    removeBtn: QPushButton
+    stackSelector: DatasetSelectorWidgetView
 
-    correlateBtn: QPushButton
-    minimiseBtn: QPushButton
+    resultCorSpinBox: QDoubleSpinBox
+    resultTiltSpinBox: QDoubleSpinBox
+    resultSlopeSpinBox: QDoubleSpinBox
+    calculateCorsButton: QPushButton
+
+    correlateButton: QPushButton
+    minimiseButton: QPushButton
     corHelpButton: QPushButton
+
+    tableView: RemovableRowTableView
+    removeButton: QPushButton
+    addButton: QPushButton
+    clearAllButton: QPushButton
+    refineCorButton: QPushButton
+
+    # BHC tab
+
+    bhcTab: QWidget
+
+    lbhcEnabledCheckBox: QCheckBox
+    lbhcA0SpinBox: QDoubleSpinBox
+    lbhcA1SpinBox: QDoubleSpinBox
+    lbhcA2SpinBox: QDoubleSpinBox
+    lbhcA3SpinBox: QDoubleSpinBox
+
+    # Reconstruct tab
 
     reconTab: QWidget
 
-    # part of the Reconstruct tab
-    algorithmName: QComboBox
-    filterName: QComboBox
-    numIter: QSpinBox
-    maxProjAngle: QDoubleSpinBox
-    pixelSize: QDoubleSpinBox
+    maxProjAngleSpinBox: QDoubleSpinBox
+    algorithmNameComboBox: QComboBox
+    filterNameComboBox: QComboBox
+    numIterSpinBox: QSpinBox
     alphaSpinBox: QDoubleSpinBox
+
     nonNegativeCheckBox: QCheckBox
     stochasticCheckBox: QCheckBox
+
     subsetsSpinBox: QSpinBox
-    resultCor: QDoubleSpinBox
-    resultTilt: QDoubleSpinBox
-    resultSlope: QDoubleSpinBox
-    reconstructVolume: QPushButton
-    reconstructSlice: QPushButton
+    regPercentSpinBox: QSpinBox
+    pixelSizeSpinBox: QDoubleSpinBox
 
-    lbhc_enabled: QCheckBox
-    lbhc_a0: QDoubleSpinBox
-    lbhc_a1: QDoubleSpinBox
-    lbhc_a2: QDoubleSpinBox
-    lbhc_a3: QDoubleSpinBox
+    refineIterationsButton: QPushButton
+    reconHelpButton: QPushButton
 
-    statusMessageTextEdit: QTextEdit
-    messageIcon: QLabel
+    reconstructSliceButton: QPushButton
+    reconstructVolumeButton: QPushButton
+
+    # ----------------
+    # Preview section
+
+    previewProjectionIndexSpinBox: QSpinBox
+    previewSliceIndexSpinBox: QSpinBox
 
     changeColourPaletteButton: QPushButton
-    change_colour_palette_dialog: PaletteChangerView | None = None
+    changeColourPaletteDialog: PaletteChangerView | None = None
 
-    stackSelector: DatasetSelectorWidgetView
+    messageIconLabel: QLabel
+    statusMessageTextEdit: QTextEdit
+
+    # ----------------
+    # Image section
+
+    imageLayout: QVBoxLayout
 
     def __init__(self, main_window: MainWindowView):
         super().__init__(None, 'gui/ui/recon_window.ui')
@@ -88,24 +110,24 @@ class ReconstructWindowView(BaseMainWindowView):
         self.main_window = main_window
         self.presenter = ReconstructWindowPresenter(self, main_window)
 
-        self.algorithmName.insertItem(1, "FBP_CUDA")
-        self.algorithmName.insertItem(2, "SIRT_CUDA")
-        self.algorithmName.insertItem(3, "CIL_PDHG-TV")
-        self.algorithmName.setCurrentIndex(1)
+        self.algorithmNameComboBox.insertItem(1, "FBP_CUDA")
+        self.algorithmNameComboBox.insertItem(2, "SIRT_CUDA")
+        self.algorithmNameComboBox.insertItem(3, "CIL_PDHG-TV")
+        self.algorithmNameComboBox.setCurrentIndex(1)
         if not CudaChecker().cuda_is_present():
-            self.algorithmName.model().item(1).setEnabled(False)
-            self.algorithmName.model().item(2).setEnabled(False)
-            self.algorithmName.model().item(3).setEnabled(False)
-            self.algorithmName.setCurrentIndex(0)
-        self.algorithmName.setEnabled(True)
+            self.algorithmNameComboBox.model().item(1).setEnabled(False)
+            self.algorithmNameComboBox.model().item(2).setEnabled(False)
+            self.algorithmNameComboBox.model().item(3).setEnabled(False)
+            self.algorithmNameComboBox.setCurrentIndex(0)
+        self.algorithmNameComboBox.setEnabled(True)
 
         self.update_recon_hist_needed = False
         self.stackSelector.presenter.show_stacks = True
         self.stackSelector.stack_selected_uuid.connect(self.presenter.set_stack_uuid)
 
         # Handle preview image selection
-        self.previewProjectionIndex.valueChanged[int].connect(self.presenter.set_preview_projection_idx)
-        self.previewSliceIndex.valueChanged[int].connect(self.presenter.set_preview_slice_idx)
+        self.previewProjectionIndexSpinBox.valueChanged[int].connect(self.presenter.set_preview_projection_idx)
+        self.previewSliceIndexSpinBox.valueChanged[int].connect(self.presenter.set_preview_slice_idx)
 
         self.image_view = ReconImagesView(self)
         self.imageLayout.addWidget(self.image_view)
@@ -133,17 +155,17 @@ class ReconstructWindowView(BaseMainWindowView):
 
         self.cor_table_model.dataChanged.connect(on_data_change)
 
-        self.clearAllBtn.clicked.connect(lambda: self.presenter.notify(PresN.CLEAR_ALL_CORS))
-        self.removeBtn.clicked.connect(lambda: self.presenter.notify(PresN.REMOVE_SELECTED_COR))
-        self.addBtn.clicked.connect(lambda: self.presenter.notify(PresN.ADD_COR))
-        self.refineCorBtn.clicked.connect(lambda: self.presenter.notify(PresN.REFINE_COR))
-        self.refineIterationsBtn.clicked.connect(lambda: self.presenter.notify(PresN.REFINE_ITERS))
-        self.calculateCors.clicked.connect(lambda: self.presenter.notify(PresN.CALCULATE_CORS_FROM_MANUAL_TILT))
-        self.reconstructVolume.clicked.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_VOLUME))
-        self.reconstructSlice.clicked.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_STACK_SLICE))
+        self.clearAllButton.clicked.connect(lambda: self.presenter.notify(PresN.CLEAR_ALL_CORS))
+        self.removeButton.clicked.connect(lambda: self.presenter.notify(PresN.REMOVE_SELECTED_COR))
+        self.addButton.clicked.connect(lambda: self.presenter.notify(PresN.ADD_COR))
+        self.refineCorButton.clicked.connect(lambda: self.presenter.notify(PresN.REFINE_COR))
+        self.refineIterationsButton.clicked.connect(lambda: self.presenter.notify(PresN.REFINE_ITERS))
+        self.calculateCorsButton.clicked.connect(lambda: self.presenter.notify(PresN.CALCULATE_CORS_FROM_MANUAL_TILT))
+        self.reconstructVolumeButton.clicked.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_VOLUME))
+        self.reconstructSliceButton.clicked.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_STACK_SLICE))
 
-        self.correlateBtn.clicked.connect(lambda: self.presenter.notify(PresN.AUTO_FIND_COR_CORRELATE))
-        self.minimiseBtn.clicked.connect(lambda: self.presenter.notify(PresN.AUTO_FIND_COR_MINIMISE))
+        self.correlateButton.clicked.connect(lambda: self.presenter.notify(PresN.AUTO_FIND_COR_CORRELATE))
+        self.minimiseButton.clicked.connect(lambda: self.presenter.notify(PresN.AUTO_FIND_COR_MINIMISE))
 
         self.changeColourPaletteButton.clicked.connect(self.on_change_colour_palette)
 
@@ -164,7 +186,7 @@ class ReconstructWindowView(BaseMainWindowView):
 
             # Only allow buttons which act on selected row to be clicked when a valid
             # row is selected
-            for button in [self.refineCorBtn, self.removeBtn]:
+            for button in [self.refineCorButton, self.removeButton]:
                 button.setEnabled(item.isValid())
 
         self.tableView.selectionModel().currentRowChanged.connect(on_row_change)  # type: ignore
@@ -176,17 +198,17 @@ class ReconstructWindowView(BaseMainWindowView):
         self.stackSelector.stack_selected_uuid.connect(self.check_stack_for_invalid_180_deg_proj)
         self.stackSelector.select_eligible_stack()
 
-        self.maxProjAngle.valueChanged.connect(
+        self.maxProjAngleSpinBox.valueChanged.connect(
             lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))  # type: ignore
-        self.algorithmName.currentTextChanged.connect(
+        self.algorithmNameComboBox.currentTextChanged.connect(
             lambda: self.presenter.notify(PresN.ALGORITHM_CHANGED))  # type: ignore
         self.presenter.notify(PresN.ALGORITHM_CHANGED)
-        self.filterName.currentTextChanged.connect(
+        self.filterNameComboBox.currentTextChanged.connect(
             lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))  # type: ignore
-        self.numIter.valueChanged.connect(
+        self.numIterSpinBox.valueChanged.connect(
             lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))  # type: ignore
 
-        self.pixelSize.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
+        self.pixelSizeSpinBox.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
         self.alphaSpinBox.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
         self.nonNegativeCheckBox.stateChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
         self.stochasticCheckBox.stateChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
@@ -204,10 +226,10 @@ class ReconstructWindowView(BaseMainWindowView):
         self.previewAutoUpdate.stateChanged.connect(self.handle_auto_update_preview_selection)
         self.updatePreviewButton.clicked.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_USER_CLICK))
 
-        for spinbox in [self.lbhc_a0, self.lbhc_a1, self.lbhc_a2, self.lbhc_a3]:
+        for spinbox in [self.lbhcA0SpinBox, self.lbhcA1SpinBox, self.lbhcA2SpinBox, self.lbhcA3SpinBox]:
             spinbox.valueChanged.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
-            self.lbhc_enabled.toggled.connect(spinbox.setEnabled)
-        self.lbhc_enabled.toggled.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
+            self.lbhcEnabledCheckBox.toggled.connect(spinbox.setEnabled)
+        self.lbhcEnabledCheckBox.toggled.connect(lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))
 
     def showEvent(self, e) -> None:
         super().showEvent(e)
@@ -291,8 +313,8 @@ class ReconstructWindowView(BaseMainWindowView):
         :param tilt_angle: Angle of the tilt line
         """
 
-        with QSignalBlocker(self.previewSliceIndex):
-            self.previewSliceIndex.setValue(preview_slice_index)
+        with QSignalBlocker(self.previewSliceIndexSpinBox):
+            self.previewSliceIndexSpinBox.setValue(preview_slice_index)
 
         self.image_view.update_projection(image_data, preview_slice_index)
 
@@ -342,8 +364,8 @@ class ReconstructWindowView(BaseMainWindowView):
         """
         # Disable clear buttons when there are no rows in the table
         empty = self.tableView.model().empty
-        self.removeBtn.setEnabled(not empty)
-        self.clearAllBtn.setEnabled(not empty)
+        self.removeButton.setEnabled(not empty)
+        self.clearAllButton.setEnabled(not empty)
 
     def add_cor_table_row(self, row: int, slice_index: int, cor: float) -> None:
         """
@@ -359,56 +381,56 @@ class ReconstructWindowView(BaseMainWindowView):
 
     @property
     def rotation_centre(self) -> float:
-        return self.resultCor.value()
+        return self.resultCorSpinBox.value()
 
     @rotation_centre.setter
     def rotation_centre(self, value: float) -> None:
-        self.resultCor.setValue(value)
+        self.resultCorSpinBox.setValue(value)
 
     @property
     def tilt(self) -> float:
-        return self.resultTilt.value()
+        return self.resultTiltSpinBox.value()
 
     @tilt.setter
     def tilt(self, value: float) -> None:
-        self.resultTilt.setValue(value)
+        self.resultTiltSpinBox.setValue(value)
 
     @property
     def slope(self) -> float:
-        return self.resultSlope.value()
+        return self.resultSlopeSpinBox.value()
 
     @slope.setter
     def slope(self, value: float) -> None:
-        self.resultSlope.setValue(value)
+        self.resultSlopeSpinBox.setValue(value)
 
     @property
     def max_proj_angle(self) -> float:
-        return self.maxProjAngle.value()
+        return self.maxProjAngleSpinBox.value()
 
     @property
     def algorithm_name(self) -> str:
-        return self.algorithmName.currentText()
+        return self.algorithmNameComboBox.currentText()
 
     @property
     def filter_name(self) -> str:
-        return self.filterName.currentText()
+        return self.filterNameComboBox.currentText()
 
     @property
     def num_iter(self) -> int:
-        return self.numIter.value()
+        return self.numIterSpinBox.value()
 
     @num_iter.setter
     def num_iter(self, iters: int) -> None:
-        self.numIter.setValue(iters)
+        self.numIterSpinBox.setValue(iters)
 
     @property
     def pixel_size(self) -> float:
-        return self.pixelSize.value()
+        return self.pixelSizeSpinBox.value()
 
     @pixel_size.setter
     def pixel_size(self, value: int) -> None:
-        with QSignalBlocker(self.pixelSize):
-            self.pixelSize.setValue(value)
+        with QSignalBlocker(self.pixelSizeSpinBox):
+            self.pixelSizeSpinBox.setValue(value)
 
     @property
     def alpha(self) -> float:
@@ -440,10 +462,10 @@ class ReconstructWindowView(BaseMainWindowView):
 
     @property
     def beam_hardening_coefs(self) -> list[float] | None:
-        if not self.lbhc_enabled.isChecked():
+        if not self.lbhcEnabledCheckBox.isChecked():
             return None
         params = []
-        for spinbox in [self.lbhc_a0, self.lbhc_a1, self.lbhc_a2, self.lbhc_a3]:
+        for spinbox in [self.lbhcA0SpinBox, self.lbhcA1SpinBox, self.lbhcA2SpinBox, self.lbhcA3SpinBox]:
             params.append(spinbox.value())
         if any(params):
             return params
@@ -488,8 +510,8 @@ class ReconstructWindowView(BaseMainWindowView):
         self.image_view.hide_cor_line()
 
     def set_filters_for_recon_tool(self, filters: list[str]) -> None:
-        self.filterName.clear()
-        self.filterName.insertItems(0, filters)
+        self.filterNameComboBox.clear()
+        self.filterNameComboBox.insertItems(0, filters)
 
     def get_number_of_cors(self) -> int | None:
         num, accepted = QInputDialog.getInt(self,
@@ -513,8 +535,8 @@ class ReconstructWindowView(BaseMainWindowView):
             return AutoCorMethod.MINIMISATION_SQUARE_SUM
 
     def set_correlate_buttons_enabled(self, enabled: bool) -> None:
-        self.correlateBtn.setEnabled(enabled)
-        self.minimiseBtn.setEnabled(enabled)
+        self.correlateButton.setEnabled(enabled)
+        self.minimiseButton.setEnabled(enabled)
 
     def open_help_webpage(self, page: str) -> None:
         try:
@@ -523,17 +545,17 @@ class ReconstructWindowView(BaseMainWindowView):
             self.show_error_dialog(str(err))
 
     def change_refine_iterations(self) -> None:
-        self.refineIterationsBtn.setEnabled(self.algorithm_name == "SIRT_CUDA")
+        self.refineIterationsButton.setEnabled(self.algorithm_name == "SIRT_CUDA")
 
     def on_change_colour_palette(self) -> None:
         """
         Opens the Palette Changer window when the "Auto" button has been clicked.
         """
-        self.change_colour_palette_dialog = PaletteChangerView(self,
-                                                               self.image_view.imageview_recon.histogram,
-                                                               self.image_view.imageview_recon.image_data,
-                                                               recon_mode=True)
-        self.change_colour_palette_dialog.show()
+        self.changeColourPaletteDialog = PaletteChangerView(self,
+                                                            self.image_view.imageview_recon.histogram,
+                                                            self.image_view.imageview_recon.image_data,
+                                                            recon_mode=True)
+        self.changeColourPaletteDialog.show()
 
     def show_status_message(self, msg: str) -> None:
         """
@@ -543,16 +565,16 @@ class ReconstructWindowView(BaseMainWindowView):
         """
         self.statusMessageTextEdit.setText(msg)
         if msg:
-            self.messageIcon.setPixmap(QApplication.style().standardPixmap(QStyle.SP_MessageBoxCritical))
+            self.messageIconLabel.setPixmap(QApplication.style().standardPixmap(QStyle.SP_MessageBoxCritical))
         else:
-            self.messageIcon.clear()
+            self.messageIconLabel.clear()
 
     def set_recon_buttons_enabled(self, enabled: bool) -> None:
-        self.reconstructSlice.setEnabled(enabled)
-        self.reconstructVolume.setEnabled(enabled)
+        self.reconstructSliceButton.setEnabled(enabled)
+        self.reconstructVolumeButton.setEnabled(enabled)
 
     def set_max_projection_index(self, max_index: int) -> None:
-        self.previewProjectionIndex.setMaximum(max_index)
+        self.previewProjectionIndexSpinBox.setMaximum(max_index)
 
     def set_max_slice_index(self, max_index: int) -> None:
-        self.previewSliceIndex.setMaximum(max_index)
+        self.previewSliceIndexSpinBox.setMaximum(max_index)


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2709 

### Description

The following changes have been made:
- Added missing widget annotations to `ReconstructWindowView`'s body to improve consistency
- Reordered widget annotations to reflect MI's reconstruction interface and for improved readability

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`

