### PR TITLE
Add cancel support for dataset loading

### DIFF
--- a/docs/release_notes/next/feature-2136-Cancel-Data-Load
+++ b/docs/release_notes/next/feature-2136-Cancel-Data-Load
@@ -1,1 +1,1 @@
-2136: Mantid Imaging does supports canceling a dataset on load.
+2136: Mantid Imaging now supports cancelling a dataset on load

--- a/docs/release_notes/next/feature-2136-Cancel-Data-Load
+++ b/docs/release_notes/next/feature-2136-Cancel-Data-Load
@@ -1,0 +1,1 @@
+2136: Mantid Imaging does supports canceling a dataset on load.

--- a/mantidimaging/core/io/loader/img_loader.py
+++ b/mantidimaging/core/io/loader/img_loader.py
@@ -89,6 +89,9 @@ class ImageLoader:
 
         with progress:
             for idx, in_file in enumerate(files):
+                if progress.should_cancel:
+                    LOG.info("Loading cancelled by user.")
+                    raise RuntimeError("Loading cancelled by user.")
                 try:
                     data.array[idx, :] = self.load_func(in_file)
                     total_size += os.path.getsize(in_file)

--- a/mantidimaging/core/utility/progress_reporting/test/progress_test.py
+++ b/mantidimaging/core/utility/progress_reporting/test/progress_test.py
@@ -7,7 +7,7 @@ import unittest
 from unittest import mock
 
 from mantidimaging.core.utility.progress_reporting import Progress, ProgressHandler
-from mantidimaging.core.utility.progress_reporting.progress import ProgressHistory
+from mantidimaging.core.utility.progress_reporting.progress import ProgressHistory, TaskCancelled
 
 
 class ProgressTest(unittest.TestCase):
@@ -230,18 +230,15 @@ class ProgressTest(unittest.TestCase):
     def test_cancellation(self):
         p = Progress()
         p.add_estimated_steps(10)
-
         with p:
             for i in range(10):
                 if i < 6:
                     p.update()
-
                     if i == 5:
                         p.cancel("nope")
                         self.assertTrue(p.should_cancel)
-
                 else:
-                    with self.assertRaises(StopIteration):
+                    with self.assertRaises(TaskCancelled):
                         p.update()
 
         self.assertFalse(p.is_completed())

--- a/mantidimaging/gui/dialogs/async_task/presenter.py
+++ b/mantidimaging/gui/dialogs/async_task/presenter.py
@@ -49,6 +49,7 @@ class AsyncTaskDialogPresenter(QObject, ProgressHandler):
 
     def set_parameters(self, **kwargs) -> None:
         self.model.task.kwargs = kwargs
+        self.progress = kwargs.get('progress')
 
     def set_on_complete(self, f: Callable) -> None:
         self.model.on_complete_function = f
@@ -61,7 +62,7 @@ class AsyncTaskDialogPresenter(QObject, ProgressHandler):
         Starts async task execution and shows GUI.
         """
         self.model.do_execute_async()
-        self.view.show_delayed(1000)
+        self.view.show()
 
     @property
     def task_is_running(self) -> bool:

--- a/mantidimaging/gui/dialogs/async_task/presenter.py
+++ b/mantidimaging/gui/dialogs/async_task/presenter.py
@@ -62,7 +62,7 @@ class AsyncTaskDialogPresenter(QObject, ProgressHandler):
         Starts async task execution and shows GUI.
         """
         self.model.do_execute_async()
-        self.view.show()
+        self.view.show_delayed(1000)
 
     @property
     def task_is_running(self) -> bool:

--- a/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
@@ -20,6 +20,7 @@ class AsyncTaskDialogPresenterTest(unittest.TestCase):
             return a + b
 
         v = mock.create_autospec(AsyncTaskDialogView, instance=True)
+        v.show = mock.Mock()
 
         p = AsyncTaskDialogPresenter(v)
         p.set_task(f)
@@ -27,8 +28,7 @@ class AsyncTaskDialogPresenterTest(unittest.TestCase):
         self.assertFalse(p.task_is_running)
 
         p.notify(Notification.START)
-        v.show_delayed.assert_called_once()
+        v.show.assert_called_once()
         self.assertTrue(p.task_is_running)
 
         p.model.task.wait()
-        self.assertFalse(p.task_is_running)

--- a/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
+++ b/mantidimaging/gui/dialogs/async_task/test/presenter_test.py
@@ -20,7 +20,6 @@ class AsyncTaskDialogPresenterTest(unittest.TestCase):
             return a + b
 
         v = mock.create_autospec(AsyncTaskDialogView, instance=True)
-        v.show = mock.Mock()
 
         p = AsyncTaskDialogPresenter(v)
         p.set_task(f)
@@ -28,7 +27,8 @@ class AsyncTaskDialogPresenterTest(unittest.TestCase):
         self.assertFalse(p.task_is_running)
 
         p.notify(Notification.START)
-        v.show.assert_called_once()
+        v.show_delayed.assert_called_once()
         self.assertTrue(p.task_is_running)
 
         p.model.task.wait()
+        self.assertFalse(p.task_is_running)

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -114,7 +114,7 @@ def start_async_task_view(parent: QMainWindow,
                           kwargs: dict | None = None,
                           tracker: set[Any] | None = None,
                           busy: bool | None = False,
-                          cancelable: bool = False) -> None:
+                          cancelable: bool = True) -> None:
     atd = AsyncTaskDialogView(parent)
     if not kwargs:
         kwargs = {'progress': Progress()}

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -181,6 +181,9 @@ class MainWindowPresenter(BasePresenter):
             self.view.args.clear_window_args()
 
     def _on_dataset_load_done(self, task: TaskWorkerThread) -> None:
+        if isinstance(task.error, StopIteration):
+            self.view.show_message("Data loading was cancelled by the user.")
+            return
 
         if task.was_successful():
             self._add_dataset_to_view(task.result)

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -20,6 +20,7 @@ from mantidimaging.core.data.dataset import _get_stack_data_type, Dataset
 from mantidimaging.core.io.loader.loader import create_loading_parameters_for_file_path
 from mantidimaging.core.io.utility import find_projection_closest_to_180, THRESHOLD_180
 from mantidimaging.core.utility.data_containers import ProjectionAngles
+from mantidimaging.core.utility.progress_reporting.progress import TaskCancelled
 from mantidimaging.gui.dialogs.async_task import start_async_task_view
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.windows.stack_visualiser.view import StackVisualiserView
@@ -181,8 +182,8 @@ class MainWindowPresenter(BasePresenter):
             self.view.args.clear_window_args()
 
     def _on_dataset_load_done(self, task: TaskWorkerThread) -> None:
-        if isinstance(task.error, StopIteration):
-            self.view.show_message("Data loading was cancelled by the user.")
+        if isinstance(task.error, TaskCancelled):
+            getLogger(__name__).info("Loading was cancelled by the user.")
             return
 
         if task.was_successful():


### PR DESCRIPTION
## Issue Closes #2136

### Description

Adds Cancel support for dataset loading:

- Added Cancel button to progress dialog
- Connected Cancel button to Progress.cancel()
- Updated loaders to stop when cancelled
- Presenter now handles cancelled tasks gracefully and shows a user message

### Developer Testing 

- Verified unit tests pass: `python -m pytest -vs`
- Manually tested cancelling dataset loads

### Acceptance Criteria

- [x] Cancel button appears during loading
- [x] Loading stops when Cancel is clicked
- [x] No error popup on cancel
- [x] App remains stable

