### PR TITLE
Added type annotations across several parts of Mantid Imaging

### DIFF
--- a/mantidimaging/gui/gui.py
+++ b/mantidimaging/gui/gui.py
@@ -14,7 +14,7 @@ from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.core.parallel import manager as pm
 
 
-def execute():
+def execute() -> None:
     # all data will be row-major, so this needs to be specified as the default is col-major
     pyqtgraph.setConfigOptions(imageAxisOrder="row-major")
 
@@ -25,7 +25,7 @@ def execute():
         "".join(traceback.format_exception_only(exc_type, exc_value)), "".join(
             traceback.format_exception(exc_type, exc_value, exc_traceback)))
 
-    def dont_let_qt_shutdown_while_debugging(type, value, tback):
+    def dont_let_qt_shutdown_while_debugging(type, value, tback) -> None:
         # log the exception here
         logging.getLogger(__name__).error(
             f"Exception {type} encountered:\n{traceback.format_exception(type, value, tback)}")
@@ -37,7 +37,7 @@ def execute():
 
     application_window.show()
 
-    def clean_up_old_memory():
+    def clean_up_old_memory() -> None:
         if sys.platform == 'linux':
             memory_to_clean = pm.find_memory_from_previous_process_linux()
             if memory_to_clean:

--- a/mantidimaging/gui/windows/move_stack_dialog/presenter.py
+++ b/mantidimaging/gui/windows/move_stack_dialog/presenter.py
@@ -22,7 +22,7 @@ class MoveStackPresenter(BasePresenter):
     def __init__(self, view: MoveStackDialog):
         super().__init__(view)
 
-    def notify(self, n: Notification):
+    def notify(self, n: Notification) -> None:
         try:
             if n == Notification.ACCEPTED:
                 self._on_accepted()
@@ -31,14 +31,14 @@ class MoveStackPresenter(BasePresenter):
         except RuntimeError as err:
             self.view.show_error_dialog(str(err))
 
-    def _on_accepted(self):
+    def _on_accepted(self) -> None:
         """
         Calls the execute move stack method in the main view.
         """
         self.view.parent_view.execute_move_stack(self.view.origin_dataset_id, self.view.stack_id,
                                                  self.view.destination_stack_type, self.view.destination_dataset_id)
 
-    def _on_dataset_changed(self):
+    def _on_dataset_changed(self) -> None:
         """
         Change the contents of the destination type combo box when the destination dataset has changed.
         """

--- a/mantidimaging/gui/windows/move_stack_dialog/view.py
+++ b/mantidimaging/gui/windows/move_stack_dialog/view.py
@@ -40,7 +40,7 @@ class MoveStackDialog(BaseDialogView):
         self.presenter.notify(Notification.ACCEPTED)
         self.close()
 
-    def _on_destination_dataset_changed(self):
+    def _on_destination_dataset_changed(self) -> None:
         self.presenter.notify(Notification.DATASET_CHANGED)
 
     @property

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -72,14 +72,14 @@ class NexusLoadPresenter:
         self.flat_after_array: np.ndarray | None = None
         self.dark_after_array: np.ndarray | None = None
 
-    def notify(self, n: Notification):
+    def notify(self, n: Notification) -> None:
         try:
             if n == Notification.NEXUS_FILE_SELECTED:
                 self.scan_nexus_file()
         except RuntimeError as err:
             self.view.show_exception(str(err), traceback.format_exc())
 
-    def scan_nexus_file(self):
+    def scan_nexus_file(self) -> None:
         """
         Try to open the NeXus file and display its contents on the view.
         """
@@ -146,7 +146,7 @@ class NexusLoadPresenter:
 
         return rotation_angles if np.any(rotation_angles) else None
 
-    def _missing_data_error(self, field: str):
+    def _missing_data_error(self, field: str) -> None:
         """
         Create a missing data message and display it on the view.
         :param field: The name of the field that couldn't be found in the NeXus file.
@@ -213,7 +213,7 @@ class NexusLoadPresenter:
         self.view.disable_ok_button()
         return None
 
-    def _look_for_recon_entries(self):
+    def _look_for_recon_entries(self) -> None:
         """
         Tries to find recon entries in the NeXus file then stores the data in a list.
         """
@@ -240,7 +240,7 @@ class NexusLoadPresenter:
         except KeyError:
             return None
 
-    def _get_data_from_image_key(self):
+    def _get_data_from_image_key(self) -> None:
         """
         Looks for the projection and dark/flat before/after images and update the information on the view.
         """
@@ -322,7 +322,7 @@ class NexusLoadPresenter:
 
         return ds, self.title
 
-    def _create_sample_images(self):
+    def _create_sample_images(self) -> ImageStack:
         """
         Creates the sample ImageStack object.
         :return: An ImageStack object containing projections. If given, projection angles, pixel size, and 180deg are

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -101,6 +101,7 @@ class NexusLoadPresenter:
                 self.image_key_dataset = self.image_key_dataset[:]
 
                 self.rotation_angles = self._look_for_tomo_data_and_update_view(ROTATION_ANGLE_PATH, 1)
+
                 if self.rotation_angles is None:
                     return
 
@@ -109,8 +110,11 @@ class NexusLoadPresenter:
                     degrees = np.abs(self.rotation_angles).max() > 2 * np.pi
                 else:
                     degrees = "deg" in str(self.rotation_angles.attrs["units"])
+
                 if degrees:
                     self.rotation_angles = np.radians(self.rotation_angles)
+                    assert isinstance(self.rotation_angles, np.ndarray)
+
                 self.rotation_angles = self.rotation_angles[:]
 
                 self._look_for_recon_entries()

--- a/mantidimaging/gui/windows/nexus_load_dialog/view.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/view.py
@@ -136,7 +136,7 @@ class NexusLoadDialog(BaseDialogView):
         data_section.setText(PATH_COLUMN, path)
         data_section.setText(SHAPE_COLUMN, str(shape))
 
-    def set_images_found(self, position: int, found: bool, shape: tuple[int, int, int]) -> None:
+    def set_images_found(self, position: int, found: bool, shape: tuple[int, ...]) -> None:
         """
         Indicate on the QTreeWidget if the projections and dark/flat before/after images were found in the data array.
         :param position: The row position for the image type.

--- a/mantidimaging/gui/windows/settings/presenter.py
+++ b/mantidimaging/gui/windows/settings/presenter.py
@@ -33,7 +33,7 @@ class SettingsWindowPresenter(BasePresenter):
         else:
             self.current_menu_font_size = settings.value('selected_font_size')
 
-    def set_theme(self):
+    def set_theme(self) -> None:
         self.current_theme = self.view.current_theme
         settings.setValue('theme_selection', self.current_theme)
         if self.current_theme == 'Fusion':
@@ -42,14 +42,14 @@ class SettingsWindowPresenter(BasePresenter):
             self.view.darkModeCheckBox.setEnabled(False)
         self.main_window.presenter.do_update_UI()
 
-    def set_extra_style(self):
+    def set_extra_style(self) -> None:
         extra_style = settings.value('extra_style')
         settings.setValue('selected_font_size', self.view.current_menu_font_size)
         extra_style.update({'font_size': self.view.current_menu_font_size + 'px'})
         settings.setValue('extra_style', extra_style)
         self.main_window.presenter.do_update_UI()
 
-    def set_dark_mode(self):
+    def set_dark_mode(self) -> None:
         if self.view.darkModeCheckBox.isChecked():
             use_dark_mode = 'True'
         else:
@@ -59,7 +59,7 @@ class SettingsWindowPresenter(BasePresenter):
         settings.setValue('override_os_theme', 'True')
         self.main_window.presenter.do_update_UI()
 
-    def set_to_os_defaults(self):
+    def set_to_os_defaults(self) -> None:
         if self.view.osDefaultsCheckBox.isChecked():
             settings.setValue('use_os_defaults', 'True')
             theme_text = 'Fusion'
@@ -93,7 +93,7 @@ class SettingsWindowPresenter(BasePresenter):
             self.view.darkModeCheckBox.setEnabled(dark_mode_enabled)
         self.main_window.presenter.do_update_UI()
 
-    def set_processes_value(self):
+    def set_processes_value(self) -> None:
         settings.setValue('multiprocessing/process_count', self.view.current_processes_value)
 
     def set_log_directory(self, directory: str) -> None:
@@ -106,7 +106,7 @@ class SettingsWindowPresenter(BasePresenter):
         settings.setValue("logging/log_level", value)
         initialise_logging()
 
-    def set_performance_logging(self):
+    def set_performance_logging(self) -> None:
         perf_logging = self.view.performanceLoggingCheckBox.isChecked()
         settings.setValue("logging/performance_log", perf_logging)
 

--- a/mantidimaging/gui/windows/settings/view.py
+++ b/mantidimaging/gui/windows/settings/view.py
@@ -70,7 +70,7 @@ class SettingsWindowView(BaseMainWindowView, QtStyleTools):
         self.processesSpinBox.setValue(settings.value("multiprocessing/process_count", 8, type=int))
         self.processesSpinBox.valueChanged.connect(self.presenter.set_processes_value)
 
-    def _create_logging_tab(self):
+    def _create_logging_tab(self) -> None:
         settings = QSettings()
 
         self.loggingTab = QWidget()
@@ -133,7 +133,7 @@ class SettingsWindowView(BaseMainWindowView, QtStyleTools):
         self.logDirectoryButton.clicked.connect(self.select_log_directory)
         self.performanceLoggingCheckBox.stateChanged.connect(self.presenter.set_performance_logging)
 
-    def select_log_directory(self):
+    def select_log_directory(self) -> None:
         directory = QFileDialog.getExistingDirectory(self, "Select Log Directory")
         if directory:
             self.logDirectoryLineEdit.setText(directory)

--- a/mantidimaging/gui/windows/stack_choice/compare_presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/compare_presenter.py
@@ -23,10 +23,10 @@ class StackComparePresenter(StackChoicePresenterMixin):
         self.view.originalStackLabel.setText(stack_one.name)
         self.view.newStackLabel.setText(stack_two.name)
 
-    def show(self):
+    def show(self) -> None:
         self.view.show()
 
-    def notify(self, signal):
+    def notify(self, signal) -> None:
         try:
             super().notify(signal)
         except Exception as e:

--- a/mantidimaging/gui/windows/stack_choice/presenter.py
+++ b/mantidimaging/gui/windows/stack_choice/presenter.py
@@ -25,10 +25,10 @@ class StackChoicePresenter(StackChoicePresenterMixin):
         self.done = False
         self.use_new_data = False
 
-    def show(self):
+    def show(self) -> None:
         self.view.show()
 
-    def notify(self, signal):
+    def notify(self, signal: Notification) -> None:
         try:
             if signal == Notification.CHOOSE_ORIGINAL:
                 self.do_reapply_original_data()
@@ -40,13 +40,13 @@ class StackChoicePresenter(StackChoicePresenterMixin):
         except Exception as e:
             self.show_error(e, traceback.format_exc())
 
-    def do_reapply_original_data(self):
+    def do_reapply_original_data(self) -> None:
         self.new_stack.shared_array = self.original_stack.shared_array
         self.new_stack.metadata = self.original_stack.metadata
         self.view.choice_made = True
         self.close_view()
 
-    def do_clean_up_original_data(self):
+    def do_clean_up_original_data(self) -> None:
         self.view.choice_made = True
         self.close_view()
 
@@ -55,6 +55,6 @@ class StackChoicePresenter(StackChoicePresenterMixin):
         self.original_stack = None
         self.done = True
 
-    def enable_nonpositive_check(self):
+    def enable_nonpositive_check(self) -> None:
         self.view.original_stack.enable_nonpositive_check()
         self.view.new_stack.enable_nonpositive_check()

--- a/mantidimaging/gui/windows/stack_choice/presenter_base.py
+++ b/mantidimaging/gui/windows/stack_choice/presenter_base.py
@@ -13,11 +13,11 @@ class StackChoicePresenterMixin(BasePresenter):
     to be mixed into another presenter that extends it
     """
 
-    def notify(self, signal: Notification):
+    def notify(self, signal: Notification) -> None:
         if signal == Notification.TOGGLE_LOCK_HISTOGRAMS:
             self.do_toggle_lock_histograms()
 
-    def do_toggle_lock_histograms(self):
+    def do_toggle_lock_histograms(self) -> None:
         # The state of the button changes before this signal is triggered
         # so on first click you get isChecked = True
         histograms_should_lock = self.view.lockHistograms.isChecked()

--- a/mantidimaging/gui/windows/stack_choice/view.py
+++ b/mantidimaging/gui/windows/stack_choice/view.py
@@ -88,7 +88,7 @@ class StackChoiceView(BaseMainWindowView):
         self.choice_made = False
         self.roi_shown = False
 
-    def _ensure_range_is_the_same(self):
+    def _ensure_range_is_the_same(self) -> None:
         new_range = self.new_stack.ui.histogram.getLevels()
         original_range = self.original_stack.ui.histogram.getLevels()
 
@@ -108,7 +108,7 @@ class StackChoiceView(BaseMainWindowView):
         self.original_stack.roi.maxBounds = self.original_stack.roi.parentBounds()
         self.new_stack.roi.maxBounds = self.new_stack.roi.parentBounds()
 
-    def _toggle_roi(self):
+    def _toggle_roi(self) -> None:
         if self.roi_shown:
             self.roi_shown = False
             self.original_stack.ui.roiBtn.setChecked(False)
@@ -122,7 +122,7 @@ class StackChoiceView(BaseMainWindowView):
             self.original_stack.roiClicked()
             self.new_stack.roiClicked()
 
-    def _setup_stack_for_view(self, stack: MIImageView, data: np.ndarray):
+    def _setup_stack_for_view(self, stack: MIImageView, data: np.ndarray) -> None:
         stack.setContentsMargins(4, 4, 4, 4)
         stack.setImage(data)
         stack.ui.menuBtn.hide()
@@ -134,29 +134,29 @@ class StackChoiceView(BaseMainWindowView):
         stack.details.setSizePolicy(details_size_policy)
         self.roiButton.clicked.connect(stack.roiClicked)
 
-    def _sync_roi_plot_for_new_stack_with_old_stack(self):
+    def _sync_roi_plot_for_new_stack_with_old_stack(self) -> None:
         self.new_stack.roi.sigRegionChanged.disconnect(self._sync_roi_plot_for_old_stack_with_new_stack)
         self.new_stack.roi.setPos(self.original_stack.roi.pos())
         self.new_stack.roi.setSize(self.original_stack.roi.size())
         self.new_stack.roi.sigRegionChanged.connect(self._sync_roi_plot_for_old_stack_with_new_stack)
 
-    def _sync_roi_plot_for_old_stack_with_new_stack(self):
+    def _sync_roi_plot_for_old_stack_with_new_stack(self) -> None:
         self.original_stack.roi.sigRegionChanged.disconnect(self._sync_roi_plot_for_new_stack_with_old_stack)
         self.original_stack.roi.setPos(self.new_stack.roi.pos())
         self.original_stack.roi.setSize(self.new_stack.roi.size())
         self.original_stack.roi.sigRegionChanged.connect(self._sync_roi_plot_for_new_stack_with_old_stack)
 
-    def _sync_timelines_for_new_stack_with_old_stack(self, index, _):
+    def _sync_timelines_for_new_stack_with_old_stack(self, index, _) -> None:
         self.new_stack.sigTimeChanged.disconnect(self._sync_timelines_for_old_stack_with_new_stack)
         self.new_stack.setCurrentIndex(index)
         self.new_stack.sigTimeChanged.connect(self._sync_timelines_for_old_stack_with_new_stack)
 
-    def _sync_timelines_for_old_stack_with_new_stack(self, index, _):
+    def _sync_timelines_for_old_stack_with_new_stack(self, index, _) -> None:
         self.original_stack.sigTimeChanged.disconnect(self._sync_timelines_for_new_stack_with_old_stack)
         self.original_stack.setCurrentIndex(index)
         self.original_stack.sigTimeChanged.connect(self._sync_timelines_for_new_stack_with_old_stack)
 
-    def _sync_both_image_axis(self):
+    def _sync_both_image_axis(self) -> None:
         self.original_stack.view.linkView(ViewBox.XAxis, self.new_stack.view)
         self.original_stack.view.linkView(ViewBox.YAxis, self.new_stack.view)
 
@@ -190,7 +190,7 @@ class StackChoiceView(BaseMainWindowView):
         levels: tuple[float, float] = self.new_stack.ui.histogram.getLevels()
         self.original_stack.ui.histogram.setLevels(*levels)
 
-    def connect_histogram_changes(self):
+    def connect_histogram_changes(self) -> None:
         self._set_from_old_to_new()
 
         self.original_stack.ui.histogram.sigLevelsChanged.connect(self._set_from_old_to_new)
@@ -199,7 +199,7 @@ class StackChoiceView(BaseMainWindowView):
         self.new_stack.ui.histogram.vb.linkView(ViewBox.YAxis, self.original_stack.ui.histogram.vb)
         self.new_stack.ui.histogram.vb.linkView(ViewBox.XAxis, self.original_stack.ui.histogram.vb)
 
-    def disconnect_histogram_changes(self):
+    def disconnect_histogram_changes(self) -> None:
         self.original_stack.ui.histogram.sigLevelsChanged.disconnect(self._set_from_old_to_new)
         self.new_stack.ui.histogram.sigLevelsChanged.disconnect(self._set_from_new_to_old)
 

--- a/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
+++ b/mantidimaging/gui/windows/stack_visualiser/metadata_dialog.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-
+from typing import Any
 from PyQt5.QtWidgets import (QWidget, QTreeWidget, QTreeWidgetItem, QDialogButtonBox, QVBoxLayout, QShortcut,
                              QPushButton)
 from PyQt5.QtGui import QKeySequence, QGuiApplication
@@ -44,7 +44,7 @@ class MetadataDialog(BaseDialogView):
         shortcut.activated.connect(self.copy_metadata_to_clipboard)
 
     @staticmethod
-    def build_metadata_tree(metadata):
+    def build_metadata_tree(metadata: dict[str, Any]) -> QTreeWidget:
         """
         Builds a QTreeWidget from the 'operation_history' metadata of an image.
 
@@ -64,7 +64,7 @@ class MetadataDialog(BaseDialogView):
         return main_widget
 
     @staticmethod
-    def _build_operation_history(main_widget, metadata):
+    def _build_operation_history(main_widget: QTreeWidget, metadata: dict[str, Any]) -> None:
         for i, op in enumerate(metadata[const.OPERATION_HISTORY]):
             operation_item = QTreeWidgetItem(main_widget)
             if const.OPERATION_DISPLAY_NAME in op and op[const.OPERATION_DISPLAY_NAME]:
@@ -88,6 +88,6 @@ class MetadataDialog(BaseDialogView):
                     kwargs_item = QTreeWidgetItem(kwargs_list_item)
                     kwargs_item.setText(0, f"{kw}: {val}")
 
-    def copy_metadata_to_clipboard(self):
+    def copy_metadata_to_clipboard(self) -> None:
         meta_data_as_text = json.dumps(self.metadata, indent=4)
         QGuiApplication.clipboard().setText(meta_data_as_text)

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -6,7 +6,7 @@ import numpy as np
 import traceback
 from enum import IntEnum, auto
 from logging import getLogger
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.operation_history import const
@@ -51,7 +51,7 @@ class StackVisualiserPresenter(BasePresenter):
         self.image_mode: SVImageMode = SVImageMode.NORMAL
         self.summed_image = None
 
-    def notify(self, signal):
+    def notify(self, signal) -> None:
         try:
             if signal == SVNotification.REFRESH_IMAGE:
                 self.refresh_image()
@@ -72,13 +72,13 @@ class StackVisualiserPresenter(BasePresenter):
         self.view.cleanup()
         self.view = None
 
-    def refresh_image(self):
+    def refresh_image(self) -> None:
         if self.image_mode is SVImageMode.SUMMED:
             self.view.image = self.summed_image
         else:
             self.view.set_image(self.images)
 
-    def get_parameter_value(self, parameter: SVParameters):
+    def get_parameter_value(self, parameter: SVParameters) -> Any:
         """
         Gets a parameter from the stack visualiser for use elsewhere (e.g. operations).
         :param parameter: The parameter value to be retrieved
@@ -89,7 +89,7 @@ class StackVisualiserPresenter(BasePresenter):
             raise ValueError("Invalid parameter name has been requested from the Stack "
                              f"Visualiser, parameter: {parameter}")
 
-    def toggle_image_mode(self):
+    def toggle_image_mode(self) -> None:
         if self.image_mode is SVImageMode.NORMAL:
             self.image_mode = SVImageMode.SUMMED
         else:
@@ -101,7 +101,7 @@ class StackVisualiserPresenter(BasePresenter):
             self.summed_image = self.model.sum_images(self.images.data)
         self.refresh_image()
 
-    def create_swapped_axis_stack(self):
+    def create_swapped_axis_stack(self) -> None:
         with operation_in_progress("Creating sinograms, copying data, this may take a while",
                                    "The data is being copied, this may take a while.", self.view):
             new_stack = self.images.copy(flip_axes=True)
@@ -109,21 +109,21 @@ class StackVisualiserPresenter(BasePresenter):
             new_stack.record_operation(const.OPERATION_NAME_AXES_SWAP, display_name="Axes Swapped")
             self.add_sinograms_to_model_and_update_view(new_stack)
 
-    def dupe_stack(self):
+    def dupe_stack(self) -> None:
         with operation_in_progress("Copying data, this may take a while",
                                    "The data is being copied, this may take a while.", self.view):
             new_images = self.images.copy(flip_axes=False)
             new_images.name = self.images.name
             self.add_new_dataset_to_model_and_update_view(new_images)
 
-    def dupe_stack_roi(self):
+    def dupe_stack_roi(self) -> None:
         with operation_in_progress("Copying data, this may take a while",
                                    "The data is being copied, this may take a while.", self.view):
             new_images = self.images.copy_roi(SensibleROI.from_points(*self.view.image_view.get_roi()))
             new_images.name = self.images.name
             self.add_new_dataset_to_model_and_update_view(new_images)
 
-    def add_new_dataset_to_model_and_update_view(self, images: ImageStack):
+    def add_new_dataset_to_model_and_update_view(self, images: ImageStack) -> None:
         dataset = Dataset(stacks=[images], name=images.name)
         self.view._main_window.presenter.model.add_dataset_to_model(dataset)
         self.view._main_window.presenter.update_dataset_tree()
@@ -140,5 +140,5 @@ class StackVisualiserPresenter(BasePresenter):
                 return index
         return len(self.images.projection_angles().value)
 
-    def add_sinograms_to_model_and_update_view(self, new_stack: ImageStack):
+    def add_sinograms_to_model_and_update_view(self, new_stack: ImageStack) -> None:
         self.view._main_window.presenter.add_sinograms_to_dataset_and_update_view(new_stack, self.images.id)

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -89,7 +89,7 @@ class StackVisualiserPresenter(BasePresenter):
             raise ValueError("Invalid parameter name has been requested from the Stack "
                              f"Visualiser, parameter: {parameter}")
 
-    def toggle_image_mode(self) -> None:
+    def toggle_image_mode(self):
         if self.image_mode is SVImageMode.NORMAL:
             self.image_mode = SVImageMode.SUMMED
         else:

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -2,8 +2,9 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+import uuid
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtGui import QGuiApplication
 from PyQt5.QtWidgets import QAction, QDockWidget, QInputDialog, QMenu, QMessageBox, QVBoxLayout, QWidget
@@ -81,11 +82,11 @@ class StackVisualiserView(QDockWidget):
             lambda: self.presenter.notify(SVNotification.REFRESH_IMAGE))
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.windowTitle()
 
     @name.setter
-    def name(self, name: str):
+    def name(self, name: str) -> None:
         self.setWindowTitle(name)
 
     @property
@@ -93,11 +94,11 @@ class StackVisualiserView(QDockWidget):
         return SensibleROI.from_points(*self.image_view.get_roi())
 
     @property
-    def image(self):
+    def image(self) -> Any:
         return self.image_view.imageItem
 
     @image.setter
-    def image(self, to_display: np.ndarray):
+    def image(self, to_display: np.ndarray) -> None:
         self.image_view.setImage(to_display)
 
     def set_image(self, image_stack: ImageStack):
@@ -109,23 +110,23 @@ class StackVisualiserView(QDockWidget):
         return self._main_window
 
     @property
-    def context_actions(self):
+    def context_actions(self) -> QMenu:
         return self._context_actions
 
     @property
-    def actions(self):
+    def actions(self) -> list[tuple[str, Any]]:
         return self._actions
 
     @property
-    def id(self):
+    def id(self) -> uuid.UUID:
         return self.presenter.images.id
 
-    def closeEvent(self, event):
+    def closeEvent(self, event) -> None:
         self.setFloating(False)
         self.hide()
         super().closeEvent(event)
 
-    def roi_changed_callback(self, roi: SensibleROI):
+    def roi_changed_callback(self, roi: SensibleROI) -> None:
         self.roi_updated.emit(roi)
 
     def build_context_menu(self) -> QMenu:
@@ -133,7 +134,7 @@ class StackVisualiserView(QDockWidget):
         populate_menu(menu, self.actions)
         return menu
 
-    def goto_projection(self):
+    def goto_projection(self) -> None:
         projection_to_goto, accepted = QInputDialog.getInt(
             self,
             "Enter Projection",
@@ -145,7 +146,7 @@ class StackVisualiserView(QDockWidget):
         if accepted:
             self.image_view.set_selected_image(projection_to_goto)
 
-    def goto_angle(self):
+    def goto_angle(self) -> None:
         projection_to_goto, accepted = QInputDialog.getDouble(
             self,
             "Enter Angle",
@@ -158,7 +159,7 @@ class StackVisualiserView(QDockWidget):
         if accepted:
             self.image_view.set_selected_image(self.presenter.find_image_from_angle(projection_to_goto))
 
-    def set_roi(self):
+    def set_roi(self) -> None:
         roi, accepted = QInputDialog.getText(
             self,
             "Manual ROI",
@@ -170,11 +171,11 @@ class StackVisualiserView(QDockWidget):
             self.image_view.set_roi(roi)
             self.image_view.roi.show()
 
-    def copy_roi_to_clipboard(self):
+    def copy_roi_to_clipboard(self) -> None:
         pos, size = self.image_view.get_roi()
         QGuiApplication.clipboard().setText(f"{pos.x}, {pos.y}, {pos.x + size.x}, {pos.y + size.y}")
 
-    def change_window_name_clicked(self):
+    def change_window_name_clicked(self) -> None:
         new_window_name, ok = QInputDialog().getText(self,
                                                      "Change window name",
                                                      "Name:",
@@ -189,11 +190,11 @@ class StackVisualiserView(QDockWidget):
                 error.setText(f"There is already a window named {new_window_name}")
                 error.exec()
 
-    def show_image_metadata(self):
+    def show_image_metadata(self) -> None:
         dialog = MetadataDialog(self, self.presenter.images)
         dialog.show()
 
-    def mark_as_sinograms(self):
+    def mark_as_sinograms(self) -> None:
         # 1 is position of sinograms, 0 is projections
         current = 1 if self.presenter.images._is_sinograms else 0
         item, accepted = QInputDialog.getItem(self,
@@ -205,7 +206,7 @@ class StackVisualiserView(QDockWidget):
             self.presenter.images._is_sinograms = False if item == "projections" else True
             self._main_window.stack_changed.emit()
 
-    def ask_confirmation(self, msg: str):
+    def ask_confirmation(self, msg: str) -> bool:
         response = QMessageBox.question(self, "Confirm action", msg, QMessageBox.Ok | QMessageBox.Cancel)  # type:ignore
         return response == QMessageBox.Ok
 

--- a/mantidimaging/helper.py
+++ b/mantidimaging/helper.py
@@ -62,7 +62,7 @@ def initialise_logging(arg_level: str | None = None) -> None:
             perf_logger.addHandler(file_log)
 
 
-def check_data_stack(data, expected_dims=3, expected_class=ImageStack):
+def check_data_stack(data, expected_dims=3, expected_class=ImageStack) -> None:
     """
     Make sure the data has expected dimensions and class.
     """


### PR DESCRIPTION
### Description

This PR adds type annotations across several parts of Mantid Imaging.  

Type annotations are formal type hints added to Python code to declare what kind of data structures and objects are expected in variables and function inputs and outputs. For example, we can state explicitly that a variable should hold an array of floating-point numbers, or that a function returns an ImageStack.

- For example:
  ```python
  def add(a: int, b: int) -> int:
      return a + b

This change makes the code clearer for both people and tools, helps avoid certain bugs, and helps developers understand the code better. 

### Developer Testing 

- I have verified unit tests pass locally: `python -m pytest -vs`
- Ran `pre-commit run --all-files` to check formatting, linting, and type safety.
- Manually tested GUI workflows to confirm no crashes after refactoring.

### Acceptance Criteria and Reviewer Testing

- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Ran `pre-commit run --all-files` to check formatting, linting, and type safety.
- [x] Loading and viewing image stacks works correctly.
- [x] Perform at least one operation/filter in the GUI to confirm no runtime errors.
- [x] Check that type annotations look correct and follow Python conventions.

