### PR TITLE
Handle case of zero y data when opening spectrum viewer

### DIFF
--- a/mantidimaging/eyes_tests/spectrum_viewer_test.py
+++ b/mantidimaging/eyes_tests/spectrum_viewer_test.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from unittest import mock
 
 import numpy as np
-import pytest
 from PyQt5.QtWidgets import QApplication
 from mantidimaging.core.data.dataset import Dataset
 from mantidimaging.core.io.instrument_log import InstrumentLog, LogColumn
@@ -46,7 +45,6 @@ class SpectrumViewerWindowTest(BaseEyesTest):
                    max_retry=600)
         self.check_target(widget=self.imaging.spectrum_viewer)
 
-    @pytest.mark.xfail
     def test_spectrum_viewer_opens_with_data_with_tof(self):
         dataset = self._generate_spectrum_dataset()
         dataset.sample.log_file = self._generate_spectra_log()

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -98,7 +98,7 @@ class FittingDisplayWidget(QWidget):
 
     def set_default_region_if_needed(self, x_data: np.ndarray, y_data: np.ndarray) -> None:
         """Position the ROI centrally over the plotted data, if valid data and not in existing region"""
-        if y_data.size == 0 or x_data.size == 0 or np.all(np.isnan(y_data)):
+        if y_data.size == 0 or x_data.size == 0 or np.all(np.isnan(y_data)) or np.all(y_data == 0):
             self.fitting_region.hide()
             return
 


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2721

### Description

When using an image stack with time of flight data from a spectra file, `set_default_region_if_needed()` gets called with y_data set to all zeros. This then causes an error when `set_default_region_if_needed()` is called again and tries to check `is_data_in_region()` which fails because the region does not have a positive height.

I have added a screenshot test that set the ToF data and can trigger the issue

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`


### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Confirm that the first commit catches the error
  - `git checkout dffabd803b320440b4c3a712e2f8be70d0ded9b7`
  - e.g. on linux run `APPLITOOLS_API_KEY=local APPLITOOLS_IMAGE_DIR=/tmp/eyes/ xvfb-run --auto-servernum pytest -p no:xdist -p no:randomly -p no:cov mantidimaging/eyes_tests/ -vs --run-eyes-tests -k test_spectrum_viewe`
  - Confirm that there is and xfailed test (I see `2 xfailed`, not sure why)
  - Switch to head of branch, `git switch 2721-spectrum-region-tof`
  - Confirm there are no 'xfail'
### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

