### PR TITLE
(Main) Refactor Codebase for Pathlib Compatibility and Type Safety

### DIFF
--- a/mantidimaging/core/io/loader/loader.py
+++ b/mantidimaging/core/io/loader/loader.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
-import os
 from dataclasses import dataclass, field
 from logging import getLogger
 from pathlib import Path
@@ -179,14 +178,13 @@ def load(filename_group: FilenameGroup,
 
 
 def create_loading_parameters_for_file_path(file_path: Path) -> LoadingParameters | None:
-    sample_file = find_first_file_that_is_possibly_a_sample(str(file_path))
+    sample_file = find_first_file_that_is_possibly_a_sample(file_path)
     if sample_file is None:
         return None
 
     loading_parameters = LoadingParameters()
-    loading_parameters.name = os.path.basename(sample_file)
-
-    sample_fg = FilenameGroup.from_file(sample_file)
+    loading_parameters.name = sample_file.stem
+    sample_fg = FilenameGroup.from_file(str(sample_file))
     sample_fg.find_all_files()
     sample_fg.find_shutter_count_file()
     sample_fg.find_log_file()
@@ -202,5 +200,4 @@ def create_loading_parameters_for_file_path(file_path: Path) -> LoadingParameter
         if file_type.tname == "Flat":
             fg.find_log_file()
         loading_parameters.image_stacks[file_type] = ImageParameters(fg, fg.log_path, fg.shutter_count_path)
-
     return loading_parameters

--- a/mantidimaging/core/io/test/utility_test.py
+++ b/mantidimaging/core/io/test/utility_test.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
+from pathlib import Path
 
 from mantidimaging.core.io.utility import find_first_file_that_is_possibly_a_sample
 from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
@@ -9,15 +10,16 @@ from mantidimaging.test_helpers.unit_test_helper import FakeFSTestCase
 class UtilityTest(FakeFSTestCase):
 
     def test_find_possible_sample(self):
-        for f in "a/a.txt a/flat_0.tif a/dark_1.tif a/a_0.tif a/a_1.tif".split():
+        files = "a/a.txt a/flat_0.tif a/dark_1.tif a/a_0.tif a/a_1.tif".split()
+        for f in files:
             self.fs.create_file(f)
-
-        found = find_first_file_that_is_possibly_a_sample("a")
+        found = find_first_file_that_is_possibly_a_sample(Path("a"))
+        self.assertIsNotNone(found)
         self._files_equal(found, "a/a_0.tif")
 
     def test_find_possible_sample_no_good_file(self):
-        for f in "a/a.txt a/flat_0.tif a/dark_1.tif".split():
+        files = "a/a.txt a/flat_0.tif a/dark_1.tif".split()
+        for f in files:
             self.fs.create_file(f)
-
-        found = find_first_file_that_is_possibly_a_sample("a")
+        found = find_first_file_that_is_possibly_a_sample(Path("a"))
         self.assertIsNone(found)

--- a/mantidimaging/core/io/utility.py
+++ b/mantidimaging/core/io/utility.py
@@ -1,9 +1,8 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
+from pathlib import Path
 
-import glob
-import os
 import numpy as np
 from logging import getLogger
 
@@ -15,20 +14,19 @@ NEXUS_PROCESSED_DATA_PATH = 'processed-data'
 THRESHOLD_180 = np.radians(1)
 
 
-def find_first_file_that_is_possibly_a_sample(file_path: str) -> str | None:
+def find_first_file_that_is_possibly_a_sample(file_path: Path) -> Path | None:
     """
     Finds the first file that is possibly a tif, .tiff, .fit or .fits sample file.
     If files are found, the files are sorted and filtered based on name and returned.
     """
     file_types = ['tif', 'tiff', 'fit', 'fits']
-    for file_type in file_types:
-        possible_files = glob.glob(os.path.join(file_path, f'**/*.{file_type}'), recursive=True)
+    for ext in file_types:
+        possible_files = list(file_path.rglob(f'*.{ext}'))
         if possible_files:
-            break
-    for possible_file in sorted(possible_files):
-        lower_filename = os.path.basename(possible_file).lower()
-        if 'flat' not in lower_filename and 'dark' not in lower_filename and '180' not in lower_filename:
-            return possible_file
+            for possible_file in sorted(possible_files):
+                lower_filename = possible_file.name.lower()
+                if 'flat' not in lower_filename and 'dark' not in lower_filename and '180' not in lower_filename:
+                    return possible_file
     return None
 
 

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -231,7 +231,7 @@ class LiveViewerWindowPresenter(BasePresenter):
     def load_as_dataset(self) -> None:
         if self.model.images:
             image_dir = self.model.images[0].image_path.parent
-            self.main_window.show_image_load_dialog_with_path(str(image_dir))
+            self.main_window.show_image_load_dialog_with_path(image_dir)
 
     def update_intensity(self, spec_data: list | np.ndarray) -> None:
         self.view.intensity_profile.clearPlots()

--- a/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
@@ -30,10 +30,8 @@ class MainWindowPresenterTest(unittest.TestCase):
         image_dir = Path("/path/to/dir")
         image_paths = [image_dir / f"image_{i:03d}.tif" for i in range(5)]
         self.model.images = [mock.create_autospec(Image_Data, image_path=p, instance=True) for p in image_paths]
-
         self.presenter.load_as_dataset()
-
-        self.main_window.show_image_load_dialog_with_path.assert_called_once_with(str(image_dir))
+        self.main_window.show_image_load_dialog_with_path.assert_called_once_with(image_dir)
 
     def test_load_as_dataset_empty_dir(self):
         self.model.images = []

--- a/mantidimaging/gui/windows/main/nexus_save_dialog.py
+++ b/mantidimaging/gui/windows/main/nexus_save_dialog.py
@@ -66,8 +66,8 @@ class NexusSaveDialog(BaseDialogView):
     def _check_extension(self) -> None:
         path = Path(self.save_path())
         if path.suffix != NXS_EXT:
-            new_path = path.with_suffix(NXS_EXT)
-            self.savePath.setText(str(new_path))
+            path_with_nxs_ext = path.with_suffix(NXS_EXT)
+            self.savePath.setText(str(path_with_nxs_ext))
 
     @property
     def save_as_float(self) -> bool:

--- a/mantidimaging/gui/windows/main/nexus_save_dialog.py
+++ b/mantidimaging/gui/windows/main/nexus_save_dialog.py
@@ -1,9 +1,10 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
-import os
+
 import uuid
 from collections.abc import Iterable
+from pathlib import Path
 
 from PyQt5.QtWidgets import QDialogButtonBox, QFileDialog, QRadioButton
 
@@ -63,9 +64,10 @@ class NexusSaveDialog(BaseDialogView):
         self._check_extension()
 
     def _check_extension(self) -> None:
-        path = self.save_path()
-        if os.path.splitext(path)[1] != NXS_EXT:
-            self.savePath.setText(path + NXS_EXT)
+        path = Path(self.save_path())
+        if path.suffix != NXS_EXT:
+            new_path = path.with_suffix(NXS_EXT)
+            self.savePath.setText(str(new_path))
 
     @property
     def save_as_float(self) -> bool:

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -2,7 +2,6 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-import os
 import uuid
 from logging import getLogger
 from pathlib import Path
@@ -135,19 +134,19 @@ class MainWindowView(BaseMainWindowView):
         self.setup_shortcuts()
         self.update_shortcuts()
         self.setAcceptDrops(True)
-        base_path = finder.ROOT_PATH
 
+        base_path = Path(finder.ROOT_PATH)
         self.open_dialogs = open_dialogs
         if self.open_dialogs:
             if versions.is_prerelease():
                 self.setWindowTitle("Mantid Imaging Unstable")
-                bg_image = os.path.join(base_path, "gui/ui/images/mantid_imaging_unstable_64px.png")
+                image_path = "gui/ui/images/mantid_imaging_unstable_64px.png"
             else:
-                bg_image = os.path.join(base_path, "gui/ui/images/mantid_imaging_64px.png")
+                image_path = "gui/ui/images/mantid_imaging_64px.png"
         else:
-            bg_image = os.path.join(base_path, "gui/ui/images/mantid_imaging_64px.png")
-        self.setWindowIcon(QIcon(bg_image))
-
+            image_path = "gui/ui/images/mantid_imaging_64px.png"
+        bg_image = base_path / image_path
+        self.setWindowIcon(QIcon(str(bg_image)))
         self.wizard = None
 
         # Recon and operation windows are launched from view using self.args
@@ -284,16 +283,18 @@ class MainWindowView(BaseMainWindowView):
         self.image_load_dialog = ImageLoadDialog(self)
         self.image_load_dialog.show()
 
-    def show_image_load_dialog_with_path(self, file_path: str) -> bool:
+    def show_image_load_dialog_with_path(self, file_path: str | Path) -> bool:
         """
         Open the dataset loading dialog with a given file_path preset as the sample
         """
-        sample_file = find_first_file_that_is_possibly_a_sample(file_path)
+        file_path = Path(file_path)
+        sample_file = find_first_file_that_is_possibly_a_sample(str(file_path))
         if sample_file is None:
-            sample_file = find_first_file_that_is_possibly_a_sample(os.path.dirname(file_path))
+            sample_file = find_first_file_that_is_possibly_a_sample(str(file_path.parent))
+
         if sample_file is not None:
             self.image_load_dialog = ImageLoadDialog(self)
-            self.image_load_dialog.presenter.do_update_sample(sample_file)
+            self.image_load_dialog.presenter.do_update_sample(str(sample_file))
             self.image_load_dialog.show()
         return sample_file is not None
 
@@ -636,10 +637,10 @@ class MainWindowView(BaseMainWindowView):
 
     def dropEvent(self, event: QDropEvent) -> None:
         for url in event.mimeData().urls():
-            file_path = url.toLocalFile()
-            if not os.path.exists(file_path):
+            file_path = Path(url.toLocalFile())
+            if not file_path.exists():
                 continue
-            if os.path.isdir(file_path):
+            if file_path.is_dir():
                 sample_loading = self.show_image_load_dialog_with_path(file_path)
                 if not sample_loading:
                     QMessageBox.critical(

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -281,15 +281,13 @@ class MainWindowView(BaseMainWindowView):
         self.image_load_dialog = ImageLoadDialog(self)
         self.image_load_dialog.show()
 
-    def show_image_load_dialog_with_path(self, file_path: str | Path) -> bool:
+    def show_image_load_dialog_with_path(self, file_path: Path) -> bool:
         """
         Open the dataset loading dialog with a given file_path preset as the sample
         """
-        file_path = Path(file_path)
         sample_file = find_first_file_that_is_possibly_a_sample(file_path)
         if sample_file is None:
             sample_file = find_first_file_that_is_possibly_a_sample(file_path.parent)
-
         if sample_file is not None:
             self.image_load_dialog = ImageLoadDialog(self)
             self.image_load_dialog.presenter.do_update_sample(str(sample_file))

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -137,12 +137,10 @@ class MainWindowView(BaseMainWindowView):
 
         base_path = Path(finder.ROOT_PATH)
         self.open_dialogs = open_dialogs
-        if self.open_dialogs:
-            if versions.is_prerelease():
-                self.setWindowTitle("Mantid Imaging Unstable")
-                image_path = "gui/ui/images/mantid_imaging_unstable_64px.png"
-            else:
-                image_path = "gui/ui/images/mantid_imaging_64px.png"
+
+        if self.open_dialogs and versions.is_prerelease():
+            self.setWindowTitle("Mantid Imaging Unstable")
+            image_path = "gui/ui/images/mantid_imaging_unstable_64px.png"
         else:
             image_path = "gui/ui/images/mantid_imaging_64px.png"
         bg_image = base_path / image_path
@@ -288,9 +286,9 @@ class MainWindowView(BaseMainWindowView):
         Open the dataset loading dialog with a given file_path preset as the sample
         """
         file_path = Path(file_path)
-        sample_file = find_first_file_that_is_possibly_a_sample(str(file_path))
+        sample_file = find_first_file_that_is_possibly_a_sample(file_path)
         if sample_file is None:
-            sample_file = find_first_file_that_is_possibly_a_sample(str(file_path.parent))
+            sample_file = find_first_file_that_is_possibly_a_sample(file_path.parent)
 
         if sample_file is not None:
             self.image_load_dialog = ImageLoadDialog(self)


### PR DESCRIPTION
This PR continues work in #2687 to replace legacy os.path usage with pathlib.Path for cross-platform path handling.

### Description

- Refactored file handling in the main view and Nexus save logic to use pathlib.

### Developer Testing

- Verified unit tests pass locally: `python -m pytest -vs`

### Acceptance Criteria and Reviewer Testing

- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] App runs without errors in main view and Nexus file dialogs.

