### PR TITLE
(operations load) Refactor Codebase for Pathlib Compatibility 

### DIFF
--- a/mantidimaging/core/operations/loader.py
+++ b/mantidimaging/core/operations/loader.py
@@ -1,10 +1,11 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
-import os
+
 import pkgutil
 import sys
 from importlib.util import module_from_spec
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -16,7 +17,8 @@ _OPERATION_MODULES_LIST: list[BaseFilterClass] = []
 
 def _find_operation_modules() -> list[BaseFilterClass]:
     module_list: list[BaseFilterClass] = []
-    for finder, module_name, ispkg in pkgutil.walk_packages([os.path.dirname(__file__)]):
+    search_path = str(Path(__file__).parent)
+    for finder, module_name, ispkg in pkgutil.walk_packages([search_path]):
         if not ispkg:
             continue
 
@@ -26,10 +28,8 @@ def _find_operation_modules() -> list[BaseFilterClass]:
                 continue
             # If we're running a PyInstaller executable then we need to use a full module path
             module_name = f'mantidimaging.core.operations.{module_name}'
-
         # near impossible to type check as find can be a pyinstaller specific type that we can't normally import
         spec = finder.find_spec(module_name)  # type: ignore[call-arg]
-
         assert spec is not None
         assert spec.loader is not None
         module = module_from_spec(spec)
@@ -37,7 +37,6 @@ def _find_operation_modules() -> list[BaseFilterClass]:
         spec.loader.exec_module(module)
         if hasattr(module, 'FILTER_CLASS'):
             module_list.append(module.FILTER_CLASS)
-
     return module_list
 
 


### PR DESCRIPTION
This PR continues the work in #2687 to replace legacy os.path usage with pathlib.Path for robust, cross-platform path handling. 

### Description

- Replaced os.path calls with pathlib in module logic (_find_operation_modules).

### Developer Testing

- Verified unit tests pass locally: `python -m pytest -vs`
-  Application runs without errors after the refactor

### Acceptance Criteria 

- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Application runs without errors after the refactor
- [ ] File loading, saving, and path manipulations work correctly using `pathlib`
- [ ] All affected code uses `pathlib` instead of `os.path` for path handling
- [ ] No regressions in features related to changes
