### PR TITLE
(gpu utility) Refactor Codebase for Pathlib Compatibility

### DIFF
--- a/mantidimaging/core/gpu/utility.py
+++ b/mantidimaging/core/gpu/utility.py
@@ -1,8 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
-
-import os
+from pathlib import Path
 import numpy as np
 
 from logging import getLogger
@@ -78,9 +77,8 @@ def _load_cuda_kernel(dtype):
     :param dtype: The data type of the array that is going to be processed.
     :return: The CUDA kernel in string format.
     """
-    cuda_kernel = ""
-    with open(os.path.join(os.path.dirname(__file__), KERNEL_FILENAME)) as f:
-        cuda_kernel += f.read()
+    kernel_path = Path(__file__).parent / KERNEL_FILENAME
+    cuda_kernel = kernel_path.read_text()
     if "float64" in str(dtype):
         return cuda_kernel.replace("float", "double")
     return cuda_kernel


### PR DESCRIPTION
This PR continues the work in #2687 to replace legacy os.path usage with pathlib.Path for robust, cross-platform path handling.

### Description

- Replaced `os.path.join` and `os.path.dirname(__file__)` with `pathlib.Path` for building the path to the CUDA kernel file in `_load_cuda_kernel`.
- Used `Path.read_text()` instead of manual file open/close for reading CUDA kernel text.

### Developer Testing

- Verified unit tests pass locally: `python -m pytest -vs`

### Acceptance Criteria and Reviewer Testing

- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Confirm CUDA kernel loads correctly and replacements work as expected for float64 dtype.
- [ ] Application runs without errors after the refactor
- [ ] All affected code uses `pathlib` instead of `os.path` for path handling
- [ ] No regressions in features related to changes
