### PR TITLE
2714 live viewer task worker thread

### DIFF
--- a/mantidimaging/gui/test/gui_system_liveviewer_test.py
+++ b/mantidimaging/gui/test/gui_system_liveviewer_test.py
@@ -41,8 +41,8 @@ class TestGuiLiveViewer(GuiSystemBase):
         self.live_viewer_window.intensity_action.trigger()
         QTest.qWait(SHORT_DELAY)
         QTest.qWait(SHOW_DELAY)
-        wait_until(lambda: not np.isnan(self.live_viewer_window.presenter.model.mean).any(), max_retry=600)
-        self.assertFalse(np.isnan(self.live_viewer_window.presenter.model.mean).any())
+        wait_until(lambda: not np.isnan(self.live_viewer_window.presenter.model.mean_nan_mask).any(), max_retry=600)
+        self.assertFalse(np.isnan(self.live_viewer_window.presenter.model.mean_nan_mask).any())
         self.assertNotEqual(self.live_viewer_window.splitter.sizes()[1], 0)
         self.assertTrue(self.live_viewer_window.intensity_profile.isVisible())
         self.live_viewer_window.intensity_action.trigger()
@@ -53,14 +53,14 @@ class TestGuiLiveViewer(GuiSystemBase):
         QTest.qWait(SHORT_DELAY * 4)
         self.live_viewer_window.intensity_action.trigger()
         QTest.qWait(SHORT_DELAY)
-        wait_until(lambda: not np.isnan(self.live_viewer_window.presenter.model.mean).any(), max_retry=600)
-        old_mean = self.live_viewer_window.presenter.model.mean
+        wait_until(lambda: not np.isnan(self.live_viewer_window.presenter.model.mean_nan_mask).any(), max_retry=600)
+        old_mean = self.live_viewer_window.presenter.model.mean_nan_mask
         roi = self.live_viewer_window.live_viewer.roi_object
         handle_index = 0
         new_position = (10, 20)
         roi.movePoint(handle_index, new_position)
         self.live_viewer_window.presenter.model.clear_mean_partial()
-        wait_until(lambda: not np.isnan(self.live_viewer_window.presenter.model.mean).any(), max_retry=600)
+        wait_until(lambda: not np.isnan(self.live_viewer_window.presenter.model.mean_nan_mask).any(), max_retry=600)
         QTest.qWait(SHORT_DELAY)
         assert_raises(AssertionError, np.testing.assert_array_equal, old_mean,
-                      self.live_viewer_window.presenter.model.mean)
+                      self.live_viewer_window.presenter.model.mean_nan_mask)

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -200,7 +200,7 @@ class LiveViewerWindowModel:
         self.update_mean(mean_to_add)
 
     def update_mean(self, mean_to_add: float) -> None:
-        self.mean_nan_mask = np.append(self.mean_nan_mask, np.array(mean_to_add))
+        self.mean_nan_mask = np.ma.append(self.mean_nan_mask, np.array(mean_to_add))
 
     def clear_mean_partial(self) -> None:
         self.mean_nan_mask = np.ma.asarray(np.full(len(self.images), np.nan))

--- a/mantidimaging/gui/windows/live_viewer/model.py
+++ b/mantidimaging/gui/windows/live_viewer/model.py
@@ -214,25 +214,40 @@ class LiveViewerWindowModel:
         self.mean = np.full(len(self.images), np.nan)
         self.mean_readable = np.full(len(self.images), 1)
 
-    def calc_mean_chunk(self, chunk_size: int) -> None:
+    def calc_mean_chunk(self, chunk_size: int = 100) -> None:
         if self.images is not None:
+            print("calc_mean_chunk 0")
             nanInds = np.argwhere(np.isnan(self.mean))
             if self.roi:
+                print("calc_mean_chunk 0")
                 left, top, right, bottom = self.roi
             else:
+                print("calc_mean_chunk 0")
                 left, top, right, bottom = (0, 0, -1, -1)
             if nanInds.size > 0:
                 for ind in nanInds[-1:-chunk_size:-1]:
                     try:
                         buffer_data = self.image_cache.load_image(self.images[ind[0]])
+                        #print(f"calc_mean_chunk try: {buffer_data=}")
                         buffer_mean = np.mean(buffer_data[top:bottom, left:right])
+                        #print(f"calc_mean_chunk try: {buffer_mean=}")
                         mean_readable = 1
                     except ImageLoadFailError:
-                        mean_readable = 0
+                        #print(f"Failed to load {self.images[ind[0]]}")
                         buffer_mean = np.nan
+                    if np.isnan(buffer_mean):
+                        print(f"{self.images[ind[0]].image_name=}")
+                        print(f"{buffer_data[top:bottom, left:right]=}")
+                        print(f"{np.isnan(buffer_data[top:bottom, left:right]).any()=}")
+
+                        mean_readable = 0
                     self.mean_paths[self.images[ind[0]].image_path] = (buffer_mean, mean_readable)
                     np.put(self.mean, ind, buffer_mean)
                     np.put(self.mean_readable, ind, mean_readable)
+                    print(f"calc_mean_chunk: {ind=}")
+                    print(f"calc_mean_chunk: {buffer_mean=}")
+                    print(f"calc_mean_chunk: {mean_readable=}")
+                    print(f"calc_mean_chunk: {buffer_mean * mean_readable=}")
 
 
 class ImageWatcher(QObject):

--- a/mantidimaging/gui/windows/live_viewer/presenter.py
+++ b/mantidimaging/gui/windows/live_viewer/presenter.py
@@ -100,11 +100,11 @@ class LiveViewerWindowPresenter(BasePresenter):
                 images_list_paths = [image.image_path for image in images_list]
                 if self.old_image_list_paths == images_list_paths[:-1]:
                     self.try_add_mean(images_list[-1])
-                    self.update_intensity(self.model.mean)
+                    self.update_intensity(self.model.mean_nan_mask)
                     self.old_image_list_paths = images_list_paths
                 else:
                     self.model.clear_mean_partial()
-                    self.run_mean_chunk_calc()
+                    self.handle_roi_moved()
             self.view.set_image_range((0, len(images_list) - 1))
             self.view.set_image_index(len(images_list) - 1)
             self.view.set_load_as_dataset_enabled(True)
@@ -115,11 +115,11 @@ class LiveViewerWindowPresenter(BasePresenter):
     def try_add_mean(self, image: Image_Data) -> None:
         try:
             image_data = self.model.image_cache.load_image(image)
-            self.model.add_mean(image.image_path, image_data)
+            self.model.add_mean(image_data)
             self.update_intensity_with_mean()
         except ImageLoadFailError as error:
             logger.error(error.message)
-            self.model.add_mean(image.image_path, None)
+            self.model.add_mean(None)
 
     def select_image(self, index: int) -> None:
         if not self.model.images:

--- a/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
@@ -74,6 +74,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.model.mean_nan_mask = np.ma.asarray([1, 2, 3, np.nan])
         self.presenter.handle_roi_change_timer = mock.Mock()
         self.presenter.handle_roi_change_timer.isActive.return_value = False
+        self.model.images = np.empty(4)
         self.presenter.try_next_mean_chunk()
         self.presenter.handle_roi_change_timer.start.assert_called_once_with(10)
 
@@ -81,5 +82,10 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.model.mean_nan_mask = np.ma.asarray([1, 2, 3, 4])
         self.presenter.handle_roi_change_timer = mock.Mock()
         self.presenter.handle_roi_change_timer.isActive.return_value = False
-        self.presenter.try_next_mean_chunk()
+        self.model.images = np.empty(4)
+        mock_thread = mock.Mock()
+        mock_thread.error = None
+        self.presenter.set_roi_enabled = mock.Mock()
+        self.presenter.update_intensity_with_mean = mock.Mock()
+        self.presenter.thread_cleanup(mock_thread)
         self.presenter.handle_roi_change_timer.start.assert_not_called()

--- a/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
@@ -21,6 +21,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.main_window = mock.create_autospec(MainWindowView, instance=True)
         self.model = mock.create_autospec(LiveViewerWindowModel, instance=True)
         self.model.image_cache = mock.create_autospec(ImageCache, instance=True)
+        self.model.mean_nan_mask = mock.create_autospec(np.ma.MaskedArray, instance=True)
 
         with mock.patch("mantidimaging.gui.windows.live_viewer.presenter.LiveViewerWindowModel") as mock_model:
             mock_model.return_value = self.model
@@ -70,14 +71,14 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.handle_roi_change_timer.start.assert_called_once()
 
     def test_WHEN_nans_in_mean_THEN_handle_roi_change_timer_start(self):
-        self.model.mean = np.array([1, 2, 3, np.nan])
+        self.model.mean_nan_mask = np.ma.asarray([1, 2, 3, np.nan])
         self.presenter.handle_roi_change_timer = mock.Mock()
         self.presenter.handle_roi_change_timer.isActive.return_value = False
         self.presenter.try_next_mean_chunk()
         self.presenter.handle_roi_change_timer.start.assert_called_once_with(10)
 
     def test_WHEN_no_nans_in_mean_THEN_handle_roi_change_timer_not_started(self):
-        self.model.mean = np.array([1, 2, 3, 4])
+        self.model.mean_nan_mask = np.ma.asarray([1, 2, 3, 4])
         self.presenter.handle_roi_change_timer = mock.Mock()
         self.presenter.handle_roi_change_timer.isActive.return_value = False
         self.presenter.try_next_mean_chunk()

--- a/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/live_viewer/test/presenter_test.py
@@ -89,3 +89,16 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.update_intensity_with_mean = mock.Mock()
         self.presenter.thread_cleanup(mock_thread)
         self.presenter.handle_roi_change_timer.start.assert_not_called()
+
+    def test_WHEN_thread_error_raised_THEN_error_caught_and_logged(self):
+        self.model.mean_nan_mask = np.ma.asarray([1, 2, 3, 4])
+        self.presenter.handle_roi_change_timer = mock.Mock()
+        self.presenter.handle_roi_change_timer.isActive.return_value = False
+        self.model.images = np.empty(4)
+        mock_thread = mock.Mock()
+        mock_thread.error = ValueError()
+        self.presenter.set_roi_enabled = mock.Mock()
+        self.presenter.update_intensity_with_mean = mock.Mock()
+        with self.assertRaises(ValueError):
+            self.presenter.thread_cleanup(mock_thread)
+        self.presenter.handle_roi_change_timer.start.assert_not_called()

--- a/mantidimaging/gui/windows/live_viewer/view.py
+++ b/mantidimaging/gui/windows/live_viewer/view.py
@@ -136,7 +136,7 @@ class LiveViewerWindowView(BaseMainWindowView):
             self.presenter.model.clear_mean_partial()
             if self.presenter.model.images:
                 self.presenter.handle_roi_moved()
-                self.presenter.update_intensity(self.presenter.model.mean)
+                self.presenter.update_intensity(self.presenter.model.mean_nan_mask)
         else:
             self.live_viewer.set_roi_visibility_flags(False)
             self.splitter.setSizes([widget_height, 0])


### PR DESCRIPTION
Issue Closes #2714

### Description

Replaced use of QThread with TaskWorkerThread in the Live Viewer to safely handle exceptions during intensity profile calculations. This prevents crashes from uncaught errors in background threads.

- Refactored to use TaskWorkerThread for model.calc_mean_chunk to safely catch exceptions from background threads 
- Switched to np.ma.MaskedArray for tracking image means, allowing clear handling of corrupt or unreadable files
- Updated presenter.update_image_list to work with masked arrays and improve mean update logic

### Developer Testing 

- I have verified unit tests pass locally: `python -m pytest -vs`
- Manually tested Live Viewer with valid and corrupt images
- 


### Acceptance Criteria and Reviewer Testing

- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Manually tested Live Viewer 
- [x] Errors are logged and UI remains responsive

