### PR TITLE
(Eyes tests) Refactor Codebase for Pathlib Compatibility

### DIFF
--- a/mantidimaging/eyes_tests/eyes_manager.py
+++ b/mantidimaging/eyes_tests/eyes_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import inspect
 import os
 import sys
+from pathlib import Path
 from tempfile import mkdtemp
 from typing import TYPE_CHECKING, Any
 from unittest import mock
@@ -59,9 +60,10 @@ class EyesManager:
         self.eyes.abort_if_not_closed()
 
     def check_target(self, widget: QWidget = None):
-        test_file_name = os.path.basename(inspect.stack()[2][1])
+        caller_path = Path(inspect.stack()[2][1])
+        test_file_name = caller_path.name
         test_method_name = inspect.stack()[2][3]
-        test_image_name = test_file_name.rpartition(".")[0] + "_" + test_method_name
+        test_image_name = f"{caller_path.stem}_{test_method_name}"
 
         image = self._take_screenshot(widget=widget, image_name=test_image_name)
 
@@ -93,9 +95,9 @@ class EyesManager:
         :return: Will return the path to the saved image, or None if failed.
         """
         if self.image_directory is None:
-            directory = mkdtemp()
+            directory = Path(mkdtemp())
         else:
-            directory = self.image_directory
+            directory = Path(self.image_directory)
 
         if widget is None and self.imaging is not None:
             widget = self.imaging
@@ -111,12 +113,11 @@ class EyesManager:
         if image_name is None:
             image_name = str(uuid4())
 
-        file_path = os.path.join(directory, image_name) + ".png"
+        file_path = directory / f"{image_name}.png"
+        if not window_image.save(file_path.as_posix(), "PNG"):
+            raise OSError(f"Failed to save screenshot to {file_path}")
 
-        if window_image.save(file_path, "PNG"):
-            return file_path
-        else:
-            raise OSError("Failed to save", file_path)
+        return file_path
 
     def close_eyes(self):
         if self.eyes.is_open:

--- a/mantidimaging/eyes_tests/nexus_load_dialog_test.py
+++ b/mantidimaging/eyes_tests/nexus_load_dialog_test.py
@@ -14,14 +14,14 @@ class NexusLoadDialogTest(BaseEyesTest):
 
     def test_load_nexus_file_populates_window(self):
         self.imaging.actionLoadNeXusFile.trigger()
-        self.imaging.nexus_load_dialog.filePathLineEdit.setText(NEXUS_SAMPLE)
+        self.imaging.nexus_load_dialog.filePathLineEdit.setText(NEXUS_SAMPLE.as_posix())
 
         self.imaging.nexus_load_dialog.presenter.scan_nexus_file()
         self.check_target(widget=self.imaging.nexus_load_dialog)
 
     def test_load_nexus_file_creates_stack(self):
         self.imaging.actionLoadNeXusFile.trigger()
-        self.imaging.nexus_load_dialog.filePathLineEdit.setText(NEXUS_SAMPLE)
+        self.imaging.nexus_load_dialog.filePathLineEdit.setText(NEXUS_SAMPLE.as_posix())
 
         self.imaging.nexus_load_dialog.presenter.scan_nexus_file()
         self.imaging.presenter.load_nexus_file()


### PR DESCRIPTION
This PR continues the work in #2687 to replace legacy os.path usage with pathlib.Path for robust, cross-platform path handling. 

### Description

This PR refactors the Eyes tests and related code to replace all os.path usage with pathlib.Path for clearer, cross-platform path handling. It updates base_eyes.py to search multiple locations for test data—including an environment variable, a sibling repo directory, and the user’s home directory—removing the previous hard-coded reliance on Path.home(). The changes simplify the code, ensure proper typing to avoid errors, and have been verified to pass tests and run correctly on both Windows and Linux.


### Developer Testing

- Verified unit tests pass locally: `python -m pytest -vs`
-  Application runs without errors after the refactor

### Acceptance Criteria 

- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Application runs without errors after the refactor
- [x] File loading, saving, and path manipulations work correctly using `pathlib`
- [x] All affected code uses `pathlib` instead of `os.path` for path handling
- [x] No regressions in features related to changes
- [x] Run screenshot tests locally: `make test-system` 


