### PR TITLE
(Manager) Refactor Codebase for Pathlib Compatibility

### DIFF
--- a/mantidimaging/core/parallel/manager.py
+++ b/mantidimaging/core/parallel/manager.py
@@ -7,6 +7,7 @@ from multiprocessing import get_context
 import os
 import uuid
 from logging import getLogger
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import psutil
@@ -78,7 +79,8 @@ def free_shared_memory_linux(mem_names: list[str]) -> None:
 
 def _is_safe_to_remove(mem_name: str) -> bool:
     process_start = psutil.Process().create_time()
-    if _is_mi_shared_mem(mem_name) and os.path.getmtime(f'{MEM_DIR_LINUX}/{mem_name}') < process_start:
+    mem_path = Path(MEM_DIR_LINUX) / mem_name
+    if _is_mi_shared_mem(mem_name) and mem_path.exists() and mem_path.stat().st_mtime < process_start:
         try:
             pid = int(mem_name.split('_')[1])
             _lookup_process(pid)

--- a/mantidimaging/core/parallel/test/manager_test.py
+++ b/mantidimaging/core/parallel/test/manager_test.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import psutil
 from psutil import NoSuchProcess, AccessDenied
@@ -45,17 +45,21 @@ class ParallelManagerTest(unittest.TestCase):
         self.assertEqual([], pm.find_memory_from_previous_process_linux())
 
     @patch('mantidimaging.core.parallel.manager._get_shared_mem_names_linux')
-    @patch('os.path.getmtime')
     @patch('mantidimaging.core.parallel.manager._lookup_process', new_callable=lambda: _lookup_process_mock)
-    def test_find_memory_from_previous_process_linux_with_mem_to_clear(self, _mock_lookup_process, _mock_getmtime,
-                                                                       _mock_get_shared_mem_names_linux):
+    @patch('pathlib.Path.stat')
+    def test_find_memory_from_previous_process_linux_with_mem_to_clear(
+        self,
+        mock_stat,
+        _,
+        mock_get_shared_mem_names_linux,
+    ):
+
         all_mem_files = [
             f'MI_{CURRENT_PID}_123', f'Other_{CURRENT_PID}_123', f'MI_{OLD_PID}_123', f'MI_{CURRENT_PID + 2}_123',
             f'MI_{OLD_PID}_124', 'MI_1234', 'MI_test_123-456-789', 'MI-1234-125'
         ]
         files_to_remove = [f'MI_{OLD_PID}_123', f'MI_{OLD_PID}_124']
 
-        _mock_get_shared_mem_names_linux.return_value = all_mem_files
-        _mock_getmtime.return_value = psutil.Process().create_time() - 3600
-
+        mock_get_shared_mem_names_linux.return_value = all_mem_files
+        mock_stat.return_value = MagicMock(st_mtime=psutil.Process().create_time() - 3600)
         self.assertEqual(files_to_remove, pm.find_memory_from_previous_process_linux())


### PR DESCRIPTION
This PR continues the work in #2687 to replace legacy os.path usage with pathlib.Path for robust, cross-platform path handling. 

### Description



### Developer Testing

- Verified unit tests pass locally: `python -m pytest -vs`
-  Application runs without errors after the refactor

### Acceptance Criteria 

- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Application runs without errors after the refactor
- [x] File loading, saving, and path manipulations work correctly using `pathlib`
- [x] All affected code uses `pathlib` instead of `os.path` for path handling
- [x] No regressions in features related to changes



