### PR TITLE
(finder) Refactor Codebase for Pathlib Compatibility

### DIFF
--- a/mantidimaging/core/utility/finder.py
+++ b/mantidimaging/core/utility/finder.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
+from pathlib import Path
 
-import os
 import mantidimaging
 "Path to the MantidImaging module"
-ROOT_PATH = os.path.dirname(mantidimaging.__file__)
+ROOT_PATH = Path(mantidimaging.__file__).parent

--- a/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
+++ b/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
@@ -99,7 +99,7 @@ class BadDataOverlay(ABC, metaclass=_metaclass_sip_abc):
     def enable_check(self, name: str, color: list[int], pos: int, func: Callable, message: str,
                      actions: list[tuple[str, Callable]] | None) -> None:
         if name not in self.enabled_checks:
-            icon_path = finder.ROOT_PATH + "/gui/ui/images/exclamation-triangle-red.png"
+            icon_path = (finder.ROOT_PATH / "gui" / "ui" / "images" / "exclamation-triangle-red.png").as_posix()
             indicator = IndicatorIconView(self.viewbox, icon_path, pos, color, message)
             if actions is not None:
                 indicator.add_actions(actions)
@@ -131,7 +131,7 @@ class BadDataOverlay(ABC, metaclass=_metaclass_sip_abc):
 
     def enable_message(self, enable: bool = True) -> None:
         if enable:
-            icon_path = finder.ROOT_PATH + "/gui/ui/images/exclamation-triangle-red.png"
+            icon_path = (finder.ROOT_PATH / "gui" / "ui" / "images" / "exclamation-triangle-red.png").as_posix()
             self.message_indicator = IndicatorIconView(self.viewbox, icon_path, 0, OVERLAY_COLOUR_MESSAGE, "")
             self.message_indicator.setVisible(False)
         else:

--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
@@ -43,7 +43,7 @@ class ROIFormWidget(BaseWidget):
         self.image_output_mode_combobox.currentTextChanged.connect(self.set_binning_visibility)
         self.set_binning_visibility()
 
-        icon_path = finder.ROOT_PATH + "/gui/ui/images/exclamation-triangle-red.png"
+        icon_path = (finder.ROOT_PATH / "gui" / "ui" / "images" / "exclamation-triangle-red.png").as_posix()
         self.rits_warning_icon_pixmap = QPixmap(icon_path)
 
         self.ritsWarningIcon = QLabel(self)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -63,7 +63,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         self.main_window = main_window
 
-        icon_path = finder.ROOT_PATH / "gui/ui/images/exclamation-triangle-red.png"
+        icon_path = (finder.ROOT_PATH / "gui" / "ui" / "images" / "exclamation-triangle-red.png").as_posix()
         self.normalise_error_icon_pixmap = QPixmap(icon_path)
 
         self.presenter = SpectrumViewerWindowPresenter(self, main_window)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -63,7 +63,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         self.main_window = main_window
 
-        icon_path = finder.ROOT_PATH + "/gui/ui/images/exclamation-triangle-red.png"
+        icon_path = finder.ROOT_PATH / "gui/ui/images/exclamation-triangle-red.png"
         self.normalise_error_icon_pixmap = QPixmap(icon_path)
 
         self.presenter = SpectrumViewerWindowPresenter(self, main_window)

--- a/mantidimaging/gui/windows/welcome_screen/view.py
+++ b/mantidimaging/gui/windows/welcome_screen/view.py
@@ -14,8 +14,8 @@ class CloseButton(QPushButton):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        self.default_icon = QIcon(finder.ROOT_PATH + "/gui/ui/images/x_button.png")
-        self.hover_icon = QIcon(finder.ROOT_PATH + "/gui/ui/images/x_button_hover.png")
+        self.default_icon = QIcon((finder.ROOT_PATH / "gui" / "ui" / "images" / "x_button.png").as_posix())
+        self.hover_icon = QIcon((finder.ROOT_PATH / "gui" / "ui" / "images" / "x_button_hover.png").as_posix())
 
         self.setIcon(self.default_icon)
         self.setIconSize(QSize(20, 20))
@@ -45,7 +45,7 @@ class WelcomeScreenView(QWidget):
             self.Banner_container.setLayout(QVBoxLayout())
 
         # Set the banner image
-        banner = finder.ROOT_PATH.replace('\\', '/') + '/gui/ui/images/welcome_banner.png'
+        banner = (finder.ROOT_PATH / "gui" / "ui" / "images" / "welcome_banner.png").as_posix()
         self.banner_label = QLabel(self)
         self.banner_label.setPixmap(QPixmap(banner))
         self.banner_label.setScaledContents(False)


### PR DESCRIPTION
This PR continues the work in #2687 to replace legacy os.path usage with pathlib.Path for robust, cross-platform path handling. 

### Description

This PR refactors the finder module to use pathlib.Path for defining ROOT_PATH, replacing legacy os.path logic. All subsequent path constructions now use Path objects, improving cross-platform compatibility and code clarity.

### Developer Testing

- Verified unit tests pass locally: `python -m pytest -vs`
-  Application runs without errors after the refactor

### Acceptance Criteria 

- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Application runs without errors after the refactor
- [x] File loading, saving, and path manipulations work correctly using `pathlib`
- [x] All affected code uses `pathlib` instead of `os.path` for path handling
- [x] No regressions in features related to changes



