### PR TITLE
(Saver) Refactor Codebase for Pathlib Compatibility

### DIFF
--- a/mantidimaging/core/io/saver.py
+++ b/mantidimaging/core/io/saver.py
@@ -2,7 +2,6 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 import datetime
-import os
 from logging import getLogger
 from typing import TYPE_CHECKING
 from collections.abc import Callable
@@ -69,7 +68,7 @@ def write_nxs(data: np.ndarray,
 
 
 def image_save(images: ImageStack,
-               output_dir: str,
+               output_dir: str | Path,
                name_prefix: str = DEFAULT_NAME_PREFIX,
                swap_axes: bool = False,
                out_format: str = DEFAULT_IO_FILE_FORMAT,
@@ -79,11 +78,10 @@ def image_save(images: ImageStack,
                name_postfix: str = DEFAULT_NAME_POSTFIX,
                indices: list[int] | Indices | None = None,
                pixel_depth: str | None = None,
-               progress: Progress | None = None) -> list[str]:
+               progress: Progress | None = None) -> list[Path]:
     """
     Save image volume (3d) into a series of slices along the Z axis.
     The Z axis in the script is the ndarray.shape[0].
-
     :param images: Data as images/slices stores in numpy array
     :param output_dir: Output directory for the files
     :param name_prefix: Prefix for the names of the images,
@@ -112,75 +110,65 @@ def image_save(images: ImageStack,
     :returns: The filename/filenames of the saved data.
     """
     progress = Progress.ensure_instance(progress, task_name='Save')
-
-    # expand the path for plugins that don't do it themselves
-    output_dir = os.path.abspath(os.path.expanduser(output_dir))
+    output_dir = Path(output_dir).expanduser().resolve()
     make_dirs_if_needed(output_dir, overwrite_all)
 
-    # Define current parameters
     min_value: float = np.nanmin(images.data)
     max_value: float = np.nanmax(images.data)
     int_16_slope = max_value / INT16_SIZE
 
-    # Do rescale if needed.
     if pixel_depth is None or pixel_depth == "float32":
         rescale_params: dict[str, str | float] | None = None
         rescale_info = ""
     elif pixel_depth == "int16":
-        # turn the offset to string otherwise json throws a TypeError when trying to save float32
         rescale_params = {"offset": str(min_value), "slope": int_16_slope}
-        rescale_info = "offset = {offset} \n slope = {slope}".format(**rescale_params)
+        rescale_info = f"offset = {rescale_params['offset']} \n slope = {rescale_params['slope']}"
     else:
-        raise ValueError("The pixel depth given is not handled: " + pixel_depth)
+        raise ValueError(f"The pixel depth given is not handled: {pixel_depth}")
 
-    # Save metadata
-    metadata_filename = os.path.join(output_dir, name_prefix + '.json')
-    LOG.debug(f'Metadata filename: {metadata_filename}')
-    with open(metadata_filename, 'w+') as f:
+    metadata_filename = output_dir / f"{name_prefix}.json"
+    LOG.debug(f"Metadata filename: {metadata_filename}")
+    with metadata_filename.open("w+") as f:
         images.save_metadata(f, rescale_params)
 
     data = images.data
-
     if swap_axes:
         data = np.swapaxes(data, 0, 1)
 
-    if out_format in ['nxs']:
-        filename = os.path.join(output_dir, name_prefix + name_postfix)
-        write_nxs(data, filename + '.nxs', overwrite=overwrite_all)
-        return [filename]
+    if out_format in ["nxs"]:
+        filename_base = output_dir / f"{name_prefix}{name_postfix}"
+        filename_with_ext = filename_base.with_suffix(".nxs")
+        write_nxs(data, str(filename_with_ext), overwrite=overwrite_all)
+        return [filename_with_ext]
     else:
-        if out_format in ['fit', 'fits']:
+        if out_format in ["fit", "fits"]:
             write_func: Callable[[np.ndarray, str, bool, str | None], None] = write_fits
         else:
-            # pass all other formats to skimage
             write_func = write_img
 
         num_images = data.shape[0]
         progress.set_estimated_steps(num_images)
 
         names = generate_names(name_prefix, indices, num_images, custom_idx, zfill_len, name_postfix, out_format)
-
-        for i in range(len(names)):
-            names[i] = os.path.join(output_dir, names[i])
+        names = [output_dir / name for name in names]
 
         with progress:
             for idx in range(num_images):
-                # Overwrite images with the copy that has been rescaled.
                 if pixel_depth == "int16":
                     output_data = RescaleFilter.filter_array(np.copy(images.data[idx]),
                                                              min_input=min_value,
                                                              max_input=max_value,
                                                              max_output=INT16_SIZE - 1).astype(np.uint16)
-                    write_func(output_data, names[idx], overwrite_all, rescale_info)
+                    write_func(output_data, str(names[idx]), overwrite_all, rescale_info)
                 else:
-                    write_func(data[idx, :, :], names[idx], overwrite_all, rescale_info)
+                    write_func(data[idx, :, :], str(names[idx]), overwrite_all, rescale_info)
 
-                progress.update(msg='Image')
+                progress.update(msg="Image")
 
         return names
 
 
-def nexus_save(dataset: Dataset, path: str, sample_name: str, save_as_float: bool) -> None:
+def nexus_save(dataset: Dataset, path: Path, sample_name: str, save_as_float: bool) -> None:
     """
     Uses information from a Dataset to create a NeXus file.
     :param dataset: The dataset to save as a NeXus file.
@@ -188,17 +176,16 @@ def nexus_save(dataset: Dataset, path: str, sample_name: str, save_as_float: boo
     :param sample_name: The sample name.
     """
     try:
-        nexus_file = h5py.File(path, "w", driver="core")
+        nexus_file = h5py.File(str(path), "w", driver="core")
     except OSError as exc:
-        raise RuntimeError("Unable to save NeXus file. " + str(exc)) from exc
+        raise RuntimeError(f"Unable to save NeXus file. {exc}") from exc
 
     try:
         _nexus_save(nexus_file, dataset, sample_name, save_as_float)
     except OSError as exc:
         nexus_file.close()
-        os.remove(path)
-        raise RuntimeError("Unable to save NeXus file. " + str(exc)) from exc
-
+        path.unlink(missing_ok=True)
+        raise RuntimeError(f"Unable to save NeXus file. {exc}") from exc
     nexus_file.close()
 
 
@@ -401,7 +388,7 @@ def generate_names(name_prefix: str,
                    custom_idx: int | None = None,
                    zfill_len: int = DEFAULT_ZFILL_LENGTH,
                    name_postfix: str = DEFAULT_NAME_POSTFIX,
-                   out_format: str = DEFAULT_IO_FILE_FORMAT) -> list[str]:
+                   out_format: str = DEFAULT_IO_FILE_FORMAT) -> list[Path]:
     start_index = indices[0] if indices else 0
     if custom_idx:
         index = custom_idx
@@ -413,28 +400,29 @@ def generate_names(name_prefix: str,
     names = []
     for _ in range(num_images):
         # create the file name, and use the format as extension
-        names.append(name_prefix + '_' + str(index).zfill(zfill_len) + name_postfix + "." + out_format)
+        filename = f"{name_prefix}_{str(index).zfill(zfill_len)}{name_postfix}.{out_format}"
+        names.append(Path(filename))
         index += increment
     return names
 
 
-def make_dirs_if_needed(dirname: str | None = None, overwrite_all: bool = False) -> None:
+def make_dirs_if_needed(dirname: str | Path | None = None, overwrite_all: bool = False) -> None:
     """
     Makes sure that the directory needed (for example to save a file)
     exists, otherwise creates it.
 
-    :param dirname :: (output) directory to check
+    :param dirname: (output) directory to check
+    :param overwrite_all: Whether to allow overwriting non-empty directories
     """
     if dirname is None:
         return
-
-    path = os.path.abspath(os.path.expanduser(dirname))
-
-    if not os.path.exists(path):
-        os.makedirs(path)
-    elif os.listdir(path) and not overwrite_all:
-        raise RuntimeError(f"The output directory is NOT empty:{path}\nThis can be "
-                           "overridden by specifying 'Overwrite on name conflict'.")
+    # Convert to Path if given as str
+    path = Path(dirname).expanduser().resolve()
+    if not path.exists():
+        path.mkdir(parents=True, exist_ok=True)
+    elif any(path.iterdir()) and not overwrite_all:
+        raise RuntimeError(f"The output directory is NOT empty: {path}\n"
+                           f"This can be overridden by specifying 'Overwrite on name conflict'.")
 
 
 def create_rits_format(tof: np.ndarray, transmission: np.ndarray, transmission_error: np.ndarray) -> str:

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -73,7 +73,7 @@ class MainWindowModel:
         images = loader.load_stack_from_group(group, progress)
         return images
 
-    def do_images_saving(self, images_id: uuid.UUID, output_dir: str, name_prefix: str, image_format: str,
+    def do_images_saving(self, images_id: uuid.UUID, output_dir: str | Path, name_prefix: str, image_format: str,
                          overwrite: bool, pixel_depth: str, progress: Progress) -> bool:
         logger.info(f"Starting export of ImageStack {images_id} to {output_dir} with format {image_format}")
         images = self.get_images_by_uuid(images_id)
@@ -88,12 +88,12 @@ class MainWindowModel:
                                      pixel_depth=pixel_depth,
                                      progress=progress)
 
-        images.filenames = filenames
+        images.filenames = [str(p) for p in filenames]
         logger.info(f"Export completed. Files saved: {filenames[:2]}{' ...' if len(filenames) > 2 else ''} "
                     f"(total {len(filenames)} files)")
         return True
 
-    def do_nexus_saving(self, dataset_id: uuid.UUID, path: str, sample_name: str, save_as_float: bool) -> bool:
+    def do_nexus_saving(self, dataset_id: uuid.UUID, path: Path, sample_name: str, save_as_float: bool) -> bool:
         logger.info(f"Starting NeXus export for dataset {dataset_id} to file {path}")
         dataset = self.datasets.get(dataset_id)
         if not dataset:


### PR DESCRIPTION
This PR continues the work in #2687 to replace legacy os.path usage with pathlib.Path for robust, cross-platform path handling. 

### Description

Updated methods to accept and return Path objects where appropriate.
Removed redundant os imports where no longer necessary.


### Developer Testing

- Verified unit tests pass locally: `python -m pytest -vs`
-  Application runs without errors after the refactor

### Acceptance Criteria 

- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Application runs without errors after the refactor
- [x] File loading, saving, and path manipulations work correctly using `pathlib`
- [x] All affected code uses `pathlib` instead of `os.path` for path handling
- [x] No regressions in features related to changes
