### PR TITLE
2611 Stack properties: Show geometry information

### DIFF
--- a/mantidimaging/core/data/geometry.py
+++ b/mantidimaging/core/data/geometry.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from math import tan, radians, degrees
 
 from cil.framework import AcquisitionGeometry
-
 from mantidimaging.core.utility.data_containers import ScalarCoR
 
 

--- a/mantidimaging/gui/windows/stack_properties_dialog/view.py
+++ b/mantidimaging/gui/windows/stack_properties_dialog/view.py
@@ -2,6 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+from math import degrees
 from typing import TYPE_CHECKING
 
 from PyQt5.QtWidgets import QLabel, QGridLayout
@@ -32,6 +33,25 @@ class StackPropertiesDialog(BaseDialogView):
         self.presenter.set_stack_directory()
         self.log_filename = self.presenter.get_log_filename()
 
+        self.geometry_type = "N/A"
+        if self.stack.geometry is not None:
+            self.geometry_type = f"{self.stack.geometry.geom_type}{self.stack.geometry.dimension}"
+
+        self.angle_range = "N/A"
+        real_projection_angles = self.stack.real_projection_angles()
+        if real_projection_angles is not None:
+            min_angle = degrees(real_projection_angles.value[0])
+            max_angle = degrees(real_projection_angles.value[-1])
+            self.angle_range = f"{min_angle:.2f}° - {max_angle:.2f}°"
+
+        self.cor_and_tilt = "N/A"
+        if self.stack.geometry is not None:
+            mi_cor = f"COR: {self.stack.geometry.cor.value}"
+            mi_tilt = f"Tilt: {self.stack.geometry.tilt:.5g}"
+            ci_rap = f"Rotation Axis Position: {self.stack.geometry.config.system.rotation_axis.position}"
+            ci_rad = f"Rotation Axis Direction: {self.stack.geometry.config.system.rotation_axis.direction}"
+            self.cor_and_tilt = f"{mi_cor}, {mi_tilt}, {ci_rap}, {ci_rad}"
+
         self.setWindowTitle(f"Stack Properties: {origin_dataset.name}")
         self.layout = QGridLayout()
         self.layout.addWidget(QLabel("Dataset Name: "), 1, 1)
@@ -40,6 +60,9 @@ class StackPropertiesDialog(BaseDialogView):
         self.layout.addWidget(QLabel("Memory size: "), 4, 1)
         self.layout.addWidget(QLabel("Shape: "), 5, 1)
         self.layout.addWidget(QLabel("Log file: "), 6, 1)
+        self.layout.addWidget(QLabel("Geometry type: "), 7, 1)
+        self.layout.addWidget(QLabel("Angle range: "), 8, 1)
+        self.layout.addWidget(QLabel("COR/tilt: "), 9, 1)
 
         self.layout.addWidget(QLabel(f"{origin_dataset.name}"), 1, 2)
         self.layout.addWidget(QLabel(f"{self.directory}"), 2, 2)
@@ -47,6 +70,9 @@ class StackPropertiesDialog(BaseDialogView):
         self.layout.addWidget(QLabel(f"{round(self.stack_size_MB, 4)} MB"), 4, 2)
         self.layout.addWidget(QLabel(f"{self.stack_shape}"), 5, 2)
         self.layout.addWidget(QLabel(f"{self.log_filename}"), 6, 2)
+        self.layout.addWidget(QLabel(f"{self.geometry_type}"), 7, 2)
+        self.layout.addWidget(QLabel(f"{self.angle_range}"), 8, 2)
+        self.layout.addWidget(QLabel(f"{self.cor_and_tilt}"), 9, 2)
 
         self.setLayout(self.layout)
 


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2611

### Description

<!-- Add a description of the changes made. -->

The following changes have been made:
- Entries for Geometry type, angle, and COR/tilt have been added to the `ImageStack` properties dialogue box.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- I have verified that updating `ImageStack` data correctly shows in the properties dialogue box.

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Verified that data shows correctly after updating ImageStack data (by any means) 

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [ ] Release Notes have been updated

<!-- 
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

