### PR TITLE
Refactor Codebase for Pathlib Compatibility

### DIFF
--- a/docs/release_notes/next/feature-2687-update-pathlib
+++ b/docs/release_notes/next/feature-2687-update-pathlib
@@ -1,0 +1,1 @@
+2687: Replaced all os.path usage with pathlib.Path for more robust, readable, and modern path handling.

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -2,7 +2,6 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-import os
 from pathlib import Path
 import unittest
 from unittest import mock
@@ -28,8 +27,8 @@ SHORT_DELAY = 100
 
 @mock_versions
 @pytest.mark.system
-@unittest.skipUnless(os.path.exists(LOAD_SAMPLE), LOAD_SAMPLE_MISSING_MESSAGE)
-@unittest.skipUnless(os.path.exists(LOAD_SAMPLE_FOLDER), LOAD_SAMPLE_MISSING_MESSAGE)
+@unittest.skipUnless(Path(LOAD_SAMPLE).exists(), LOAD_SAMPLE_MISSING_MESSAGE)
+@unittest.skipUnless(Path(LOAD_SAMPLE_FOLDER).exists(), LOAD_SAMPLE_MISSING_MESSAGE)
 @start_qapplication
 class GuiSystemBase(unittest.TestCase):
     app: QApplication

--- a/mantidimaging/gui/utility/qt_helpers.py
+++ b/mantidimaging/gui/utility/qt_helpers.py
@@ -5,10 +5,10 @@ Module containing helper functions relating to PyQt.
 """
 from __future__ import annotations
 
-import os
 from abc import ABCMeta
 from enum import IntEnum, auto
 from logging import getLogger
+from pathlib import Path
 from typing import Any
 from collections.abc import Callable
 
@@ -48,8 +48,8 @@ class BlockQtSignals:
 
 
 def compile_ui(ui_file: str, qt_obj=None) -> QWidget:
-    base_path = finder.ROOT_PATH
-    return uic.loadUi(os.path.join(base_path, ui_file), qt_obj)
+    ui_path = Path(finder.ROOT_PATH) / ui_file
+    return uic.loadUi(str(ui_path), qt_obj)
 
 
 def select_directory(field: QWidget, caption: str) -> None:


### PR DESCRIPTION
## Issue Closes #2687

This PR continues the work in #2687 to replace legacy os.path usage with pathlib.Path for robust, cross-platform path handling. 

### Description

Updated methods to accept and return Path objects where appropriate.
Removed redundant os imports where no longer necessary.


### Developer Testing

- Verified unit tests pass locally: `python -m pytest -vs`
-  Application runs without errors after the refactor

### Acceptance Criteria 

- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Application runs without errors after the refactor
- [x] File loading, saving, and path manipulations work correctly using `pathlib`
- [x] All affected code uses `pathlib` instead of `os.path` for path handling
- [x] No regressions in features related to changes

