### PR TITLE
Fix welcome screen layout warnings

### DIFF
--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -13,7 +13,7 @@ import numpy as np
 from PyQt5.QtCore import Qt, pyqtSignal, QUrl, QPoint
 from PyQt5.QtGui import QIcon, QDragEnterEvent, QDropEvent, QDesktopServices
 from PyQt5.QtWidgets import QAction, QDialog, QLabel, QMessageBox, QMenu, QFileDialog, QSplitter, \
-    QTreeWidgetItem, QTreeWidget, QDockWidget, QWidget
+    QTreeWidgetItem, QTreeWidget, QDockWidget, QWidget, QVBoxLayout
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.io.utility import find_first_file_that_is_possibly_a_sample
@@ -180,7 +180,9 @@ class MainWindowView(BaseMainWindowView):
         self.welcome_screen.closed.connect(self.close_welcome_screen)
         self.welcome_dock = QDockWidget("About Mantid Imaging", self)
         self.welcome_dock.setWidget(self.welcome_screen)
-        self.welcome_dock.setTitleBarWidget(QWidget())
+        hidden_title_bar = QWidget()
+        hidden_title_bar.setLayout(QVBoxLayout())
+        self.welcome_dock.setTitleBarWidget(hidden_title_bar)
         self.welcome_dock.setFeatures(QDockWidget.DockWidgetClosable)
         self.welcome_dock.setStyleSheet("QDockWidget::title { background: transparent; }")
         self.welcome_dock.setAllowedAreas(Qt.RightDockWidgetArea)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -174,21 +174,25 @@ class MainWindowView(BaseMainWindowView):
 
         self.presenter.do_update_UI()
 
-    def create_welcome_screen(self):
+    def create_welcome_screen(self) -> None:
         self.welcome_presenter = WelcomeScreenPresenter(self)
         self.welcome_screen = self.welcome_presenter.view
         self.welcome_screen.closed.connect(self.close_welcome_screen)
         self.welcome_dock = QDockWidget("About Mantid Imaging", self)
         self.welcome_dock.setWidget(self.welcome_screen)
-        hidden_title_bar = QWidget()
-        hidden_title_bar.setLayout(QVBoxLayout())
-        self.welcome_dock.setTitleBarWidget(hidden_title_bar)
+        self._hide_dock_widget_title(self.welcome_dock)
         self.welcome_dock.setFeatures(QDockWidget.DockWidgetClosable)
         self.welcome_dock.setStyleSheet("QDockWidget::title { background: transparent; }")
         self.welcome_dock.setAllowedAreas(Qt.RightDockWidgetArea)
 
         self.welcome_dock.id = "welcome_screen"
         self.addDockWidget(Qt.RightDockWidgetArea, self.welcome_dock)
+
+    @staticmethod
+    def _hide_dock_widget_title(dock: QDockWidget) -> None:
+        hidden_title_bar = QWidget()
+        hidden_title_bar.setLayout(QVBoxLayout())
+        dock.setTitleBarWidget(hidden_title_bar)
 
     def refresh_welcome_links(self):
         """

--- a/mantidimaging/gui/windows/welcome_screen/view.py
+++ b/mantidimaging/gui/windows/welcome_screen/view.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from PyQt5.QtCore import Qt, QSize, QTimer, pyqtSignal
-from PyQt5.QtWidgets import QWidget, QLabel, QVBoxLayout, QPushButton
+from PyQt5.QtWidgets import QWidget, QLabel, QPushButton
 from PyQt5.QtGui import QPixmap, QIcon
 
 from mantidimaging.core.utility import finder
@@ -41,12 +41,9 @@ class WelcomeScreenView(QWidget):
 
         compile_ui("gui/ui/welcome_widget.ui", self)
 
-        if not self.Banner_container.layout():
-            self.Banner_container.setLayout(QVBoxLayout())
-
         # Set the banner image
         banner = (finder.ROOT_PATH / "gui" / "ui" / "images" / "welcome_banner.png").as_posix()
-        self.banner_label = QLabel(self)
+        self.banner_label = QLabel()
         self.banner_label.setPixmap(QPixmap(banner))
         self.banner_label.setScaledContents(False)
         self.banner_label.setMinimumSize(self.Banner_container.size())


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2754

### Description
Fixes warnings related to the welcome window

- don't setLayout on banner container. This is always created in the ui file so is never needed.
- set layout on widget passed to setTitleBarWidget(). We pass an empty QWidget to hide the title, but it needs to have a valid sizeHint which requires it to have a layout

Also extract method to hide the title for a DockWidget to make it clear what is happening

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- Run the system test and check that the warnings from the issue are not visible
- Open Mantid Imaging and check that the welcome screen is shown

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Run the system test and check that the warnings from the issue are not visible
- [x] Open Mantid Imaging and check that the welcome screen is shown


### Documentation and Additional Notes

Release notes not needed, just a warning seen in tests
