### PR TITLE
Environment: update PyInstaller to 6.14.*

### DIFF
--- a/docs/release_notes/next/dev-2659-update-pyinstaller-6.14
+++ b/docs/release_notes/next/dev-2659-update-pyinstaller-6.14
@@ -1,0 +1,1 @@
+#2659: PyInstaller has been updated to 6.14.* to include fixes for pkg_resources depreciation

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -26,7 +26,7 @@ dependencies:
   - coveralls==4.0.*
   - pyfakefs==5.3.*
   - parameterized==0.9.*
-  - pyinstaller==6.9.*
+  - pyinstaller==6.14.*
   - pyright==1.1.391
   - make==4.3
   - ruff=0.3.7


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2659

### Description

Updating to `PyInstaller 6.14` includes the fix from `PyInstaller` dealing with the `pkg_resources` depreciation. I have not come across any issues caused by updating PyInstaller.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Rebuild Dev Env and then ensure that Pyinstaller==6.14.* (`pip list`)
- [ ] `cd packaging` -> `python PackageWithPyInstaller.py`
- [ ] after the build created, go to `mantidimaging\packing\dist\MantidImaging` and run `MantidImaging.exe`
- [ ] Make sure that there are no warnings in the CLI and that the build runs as expected.

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [ ] Release Notes have been updated

