### PR TITLE
Updated scikit-image from 0.22.0 to 0.25.2.

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - pip
     - astropy=6.0.*
     - scipy=1.14.*
-    - scikit-image=0.22.*
+    - scikit-image=0.25.*
     - tifffile=2023.7.18
     - imagecodecs=2023.9.18
     - numpy=1.26.*

--- a/docs/release_notes/next/dev-2668-update-Scikit-Image
+++ b/docs/release_notes/next/dev-2668-update-Scikit-Image
@@ -1,0 +1,1 @@
+2668: Updated scikit-image from 0.22.0 to 0.25.2.


### PR DESCRIPTION
## Issue Closes #2668

### Description

Updated `scikit-image` from `0.22.0` to `0.25.2`.  
No compatibility issues were found with any dependencies or Mantid Imaging functionality using this package.

### Developer Testing 

- I have verified unit tests pass locally: `python -m pytest -vs`
- Manually tested image processing features and workflows relying on `scikit-image` 

### Acceptance Criteria and Reviewer Testing

- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Verify that tools using `scikit-image` behave as expected


### Documentation and Additional Notes

- [x] Release Notes have been updated  

