### PR TITLE
Update tomopy from 1.12.2 to 1.15.2

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - numpy=1.26.*
     - numexpr=2.8.*
     - algotom=1.6.*
-    - tomopy=1.12.*
+    - tomopy=1.15.*
     - cudatoolkit=11.8.*
     - cupy=12.3.*
     - astra-toolbox=2.1.0=cuda*

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -26,8 +26,9 @@ requirements:
     - numexpr=2.8.*
     - algotom=1.6.*
     - tomopy=1.15.*
-    - cudatoolkit=11.8.*
+    - cudatoolkit=12.*
     - cupy=12.3.*
+    - cupy-cuda11x=12.3.*
     - astra-toolbox=2.1.0=cuda*
     - requests=2.27.*
     - h5py=3.9.*

--- a/docs/release_notes/next/feature-2667-update-tomopy
+++ b/docs/release_notes/next/feature-2667-update-tomopy
@@ -1,0 +1,1 @@
+2667: Update tomopy from 1.12.2 to 1.15.2


### PR DESCRIPTION

## Issue Closes #2667

### Description

Updated `tomopy` from `1.12.2` to `1.15.2`.  
No compatibility issues were identified with Mantid Imaging after this upgrade.  
Manual and automated tests confirmed correct behavior in core features that rely on TomoPy.

### Developer Testing 

- I have verified unit tests pass locally: `python -m pytest -vs`
- Manually tested operations that use TomoPy

### Testing
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Run reconstruction
- [ ] Ring removall
- [ ] rotation center 

### Documentation and Additional Notes

- [x] Release Notes have been updated  
<!-- - [ ] Sphinx documentation has been updated -->
<!-- - [ ] Screenshot tests have been updated -->


