### PR TITLE
Update coverage  from 7.3.4 to 7.9.1

### DIFF
--- a/docs/release_notes/next/feature-2674-Update-Coverage
+++ b/docs/release_notes/next/feature-2674-Update-Coverage
@@ -1,0 +1,1 @@
+2674: Update coverage from 7.3.4 to 7.9.1

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -22,7 +22,7 @@ dependencies:
   - pytest-xdist==3.3.*
   - testfixtures==7.2.*
   - gitpython==3.1.*
-  - coverage==7.3.*
+  - coverage==7.9.*
   - coveralls==4.0.*
   - pyfakefs==5.3.*
   - parameterized==0.9.*


### PR DESCRIPTION
## Issue Closes #2674

### Description

This PR updates `coverage` from `7.3.4` to `7.9.1` as part of post-release package upgrades.  
No breaking changes or compatibility issues were found.

### Developer Testing 

- I have verified unit tests pass locally: `python -m pytest -vs`
- Coverage report generation tested and working as expected

### Acceptance Criteria and Reviewer Testing

- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Confirm coverage reporting still works

### Documentation and Additional Notes

- [x] Release Notes have been updated

