### PR TITLE
System Tests: Limit number of allowed alive objects during tearDown

### DIFF
--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -33,13 +33,12 @@ SHORT_DELAY = 100
 @start_qapplication
 class GuiSystemBase(unittest.TestCase):
     app: QApplication
-    leak_count_limit: int
+    leak_count_limit: int = 0
 
     def setUp(self) -> None:
         self.main_window = MainWindowView()
         self.main_window.show()
         QTest.qWait(SHORT_DELAY)
-        self.leak_count_limit = 0
 
     def tearDown(self) -> None:
         """

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -55,11 +55,15 @@ class GuiSystemBase(unittest.TestCase):
         if leak_count := leak_tracker.count():
             print("\nItems still alive:", leak_count)
             leak_tracker.pretty_print(debug_init=False, debug_owners=False, trace_depth=5)
+            if leak_count > 10:
+                print("details:")
+                leak_tracker.pretty_print(debug_init=True, debug_owners=True, trace_depth=5)
+                raise RuntimeError(f"Too many leaked objects: {leak_count}")
             leak_tracker.clear()
 
         for widget in self.app.topLevelWidgets():
             if widget.isVisible():
-                RuntimeError(f"\n\nWindow still open {widget=}")
+                raise RuntimeError(f"\n\nWindow still open {widget=}")
 
     @classmethod
     def _check_no_open_dialogs(cls) -> None:

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -33,11 +33,13 @@ SHORT_DELAY = 100
 @start_qapplication
 class GuiSystemBase(unittest.TestCase):
     app: QApplication
+    leak_count_limit: int
 
     def setUp(self) -> None:
         self.main_window = MainWindowView()
         self.main_window.show()
         QTest.qWait(SHORT_DELAY)
+        self.leak_count_limit = 0
 
     def tearDown(self) -> None:
         """
@@ -55,7 +57,7 @@ class GuiSystemBase(unittest.TestCase):
         if leak_count := leak_tracker.count():
             print("\nItems still alive:", leak_count)
             leak_tracker.pretty_print(debug_init=False, debug_owners=False, trace_depth=5)
-            if leak_count > 10:
+            if leak_count > self.leak_count_limit:
                 print("details:")
                 leak_tracker.pretty_print(debug_init=True, debug_owners=True, trace_depth=5)
                 raise RuntimeError(f"Too many leaked objects: {leak_count}")

--- a/mantidimaging/gui/test/gui_system_liveviewer_test.py
+++ b/mantidimaging/gui/test/gui_system_liveviewer_test.py
@@ -13,6 +13,7 @@ from mantidimaging.test_helpers.qt_test_helpers import wait_until
 
 
 class TestGuiLiveViewer(GuiSystemBase):
+    leak_count_limit = 2
 
     def setUp(self) -> None:
         patcher_show_error_dialog = mock.patch(
@@ -20,7 +21,6 @@ class TestGuiLiveViewer(GuiSystemBase):
         self.mock_show_error_dialog = patcher_show_error_dialog.start()
         self.addCleanup(patcher_show_error_dialog.stop)
         super().setUp()
-        self.leak_count_limit = 2
         self._close_welcome()
 
         self._open_live_viewer()

--- a/mantidimaging/gui/test/gui_system_liveviewer_test.py
+++ b/mantidimaging/gui/test/gui_system_liveviewer_test.py
@@ -20,6 +20,7 @@ class TestGuiLiveViewer(GuiSystemBase):
         self.mock_show_error_dialog = patcher_show_error_dialog.start()
         self.addCleanup(patcher_show_error_dialog.stop)
         super().setUp()
+        self.leak_count_limit = 2
         self._close_welcome()
 
         self._open_live_viewer()

--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -25,6 +25,7 @@ class TestGuiSystemLoading(GuiSystemBase):
 
     def setUp(self) -> None:
         super().setUp()
+        self.leak_count_limit = 10
         self._close_welcome()
 
     def tearDown(self) -> None:

--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -22,10 +22,10 @@ from mantidimaging.test_helpers.qt_test_helpers import wait_until
 
 
 class TestGuiSystemLoading(GuiSystemBase):
+    leak_count_limit = 10
 
     def setUp(self) -> None:
         super().setUp()
-        self.leak_count_limit = 10
         self._close_welcome()
 
     def tearDown(self) -> None:

--- a/mantidimaging/gui/test/gui_system_operations_test.py
+++ b/mantidimaging/gui/test/gui_system_operations_test.py
@@ -57,6 +57,7 @@ class TestGuiSystemOperations(GuiSystemBase):
 
     def setUp(self) -> None:
         super().setUp()
+        self.leak_count_limit = 3
         self._close_welcome()
         self._load_data_set()
 

--- a/mantidimaging/gui/test/gui_system_operations_test.py
+++ b/mantidimaging/gui/test/gui_system_operations_test.py
@@ -54,10 +54,10 @@ ALLOWED_ERRORS = [
 
 @start_multiprocessing_pool
 class TestGuiSystemOperations(GuiSystemBase):
+    leak_count_limit = 3
 
     def setUp(self) -> None:
         super().setUp()
-        self.leak_count_limit = 3
         self._close_welcome()
         self._load_data_set()
 

--- a/mantidimaging/gui/test/gui_system_reconstruction_test.py
+++ b/mantidimaging/gui/test/gui_system_reconstruction_test.py
@@ -16,6 +16,7 @@ from mantidimaging.test_helpers.start_qapplication import start_multiprocessing_
 
 @start_multiprocessing_pool
 class TestGuiSystemReconstruction(GuiSystemBase):
+    leak_count_limit = 4
 
     def setUp(self) -> None:
         patcher_show_error_dialog = mock.patch(
@@ -23,7 +24,6 @@ class TestGuiSystemReconstruction(GuiSystemBase):
         self.mock_show_error_dialog = patcher_show_error_dialog.start()
         self.addCleanup(patcher_show_error_dialog.stop)
         super().setUp()
-        self.leak_count_limit = 4
         self._close_welcome()
         self._load_data_set()
 

--- a/mantidimaging/gui/test/gui_system_reconstruction_test.py
+++ b/mantidimaging/gui/test/gui_system_reconstruction_test.py
@@ -23,6 +23,7 @@ class TestGuiSystemReconstruction(GuiSystemBase):
         self.mock_show_error_dialog = patcher_show_error_dialog.start()
         self.addCleanup(patcher_show_error_dialog.stop)
         super().setUp()
+        self.leak_count_limit = 4
         self._close_welcome()
         self._load_data_set()
 

--- a/mantidimaging/gui/test/gui_system_windows_test.py
+++ b/mantidimaging/gui/test/gui_system_windows_test.py
@@ -56,6 +56,7 @@ class TestGuiSystemWindows(GuiSystemBase):
         QTest.qWait(SHOW_DELAY)
 
     def test_open_reconstruction(self):
+        self.leak_count_limit = 4
         self._close_welcome()
         self._load_data_set()
 


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2787 

### Description

A `leak_count_limit` of zero has been imposed at the `GuiSystembase` level, but this can be superseded by the system tests at a Class level or a method level. This allows specific tests to have an amount of leaked objects without failing (i.e. if we would expect the test to have leaked objects), but prevents new tests having uncounted leaked objects and tells us if tests are unexpectedly leaking objects.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- `make test-system`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] run `make test-system` and check that no leaked objects warnings/errors appear
- [ ] locate a test which leaks objects, i.e. `mantidimaging/gui/test/gui_system_operations_test.py::TestGuiSystemOperations` and alter the `self.leak_count_limit` to a lower number. Running the tests again should raise a `Leak_Tracker` error

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [ ] Release Notes have been updated

