### PR TITLE
2779 Fix bug where CIL reconstruction was being passed the wrong COR

### DIFF
--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -387,7 +387,7 @@ class CILRecon(BaseRecon):
             if images.geometry is None:
                 raise ValueError("images.geometry is not set")
 
-            images.geometry.set_geometry_from_cor_tilt(cors[pixel_num_v // 2], tilt)
+            images.geometry.set_geometry_from_cor_tilt(cors[0], tilt)
             images.geometry.set_labels(data_order)
             ig = images.geometry.get_ImageGeometry()
 


### PR DESCRIPTION

<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2779

### Description

<!-- Add a description of the changes made. -->

This bug occured because a previous commit changed the Geometry logic to accept the topmost COR (matching MI convention), converting it to the midpoint COR (matching CIL convention), rather than passing in the midpoint COR directly. However, the call to set_geometry_from_cor_tilt() wasn't updated to reflect this.

The following changes have been made:
- In `cil_recon.py`'s `full()` reconstruction method, changed the call to `set_geometry_from_cor_tilt()` to use `cors[0]` instead of `cors[pixel_num_v // 2]`

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- I have performed a reconstruction and verified that the halo effect no longer shows, as described in #2779

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] CIL reconstruction generates images that match the expectations described in #2779

### Documentation and Additional Notes

N/A

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

