### PR TITLE
Flash PR: Fix indent for wait in system test

### DIFF
--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -108,7 +108,7 @@ class GuiSystemBase(unittest.TestCase):
             for widget in cls.app.topLevelWidgets():
                 if isinstance(widget, widget_type) and widget.isVisible():
                     return True
-        QTest.qWait(int(delay * 1000))
+            QTest.qWait(int(delay * 1000))
         raise RuntimeError("_wait_for_stack_selector reach max retries")
 
     @mock.patch("mantidimaging.gui.windows.image_load_dialog.view.ImageLoadDialog.select_file")


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes
No issue filed, but might be related to some unreliable system tests people have seen recently.

### Description

Wait should be within the loop.

Issue introduced in #2029 which fixed a warning but accidentally changed the indent

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `make test-system`


### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `make test-system`


### Documentation and Additional Notes

Not needed