### PR TITLE
Spectrum Viewer: Prevent QThread from accessing Presenter data during runtime

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import csv
-import threading
 from enum import Enum
 from functools import partial
 from typing import TYPE_CHECKING
@@ -71,8 +70,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.handle_roi_change_timer = QTimer()
         self.handle_roi_change_timer.setSingleShot(True)
         self.handle_roi_change_timer.timeout.connect(self.handle_roi_moved)
-
-        self.spectrum_calculation_lock = threading.Lock()
 
     def handle_stack_modified(self) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -334,9 +334,14 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         if self.normalise_error_issue and self.normalisation_enabled():
             self.normaliseErrorIcon.setPixmap(self.normalise_error_icon_pixmap)
             self.normaliseErrorIcon.setToolTip(self.normalise_error_issue)
+            for roi_name in self.table_view.get_roi_names():
+                self.set_roi_visibility_flags(roi_name, visible=False)
         else:
             self.normaliseErrorIcon.setPixmap(QPixmap())
             self.normaliseErrorIcon.setToolTip("")
+            for roi_name in self.table_view.get_roi_names():
+                self.set_roi_visibility_flags(roi_name, visible=True)
+                self.presenter.redraw_spectrum(roi_name)
 
     def normalisation_enabled(self) -> bool:
         return self.normaliseCheckBox.isChecked()


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2715

### Description

The PR is to prevent the QThread in the Spectrum Viewer from changing data which may be accessed by different processes, while the QThread is running as this may lead to unreliable results due to a race condition. To achieve this, the function in the Worker Thread no longer directly accesses the attributes in the presenter, but instead takes them as arguments and outputs the altered attributes as `thread.result()`. The attributes in the presenter space are then changed during the `thread_cleanup` instead of inside the thread itself.

Also to make sure that nothing could be changed in the running of the thread, a `Lock()` is used inside the thread function.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`


### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Load data in the spectrum viewer and open multiple ROIs
- [x] Move the position and sizes of the ROIs in any combination of ways you can think of and as fast as you feasibly can.
- [x] ensure that the spectrums update as expected and that no errors are raised.


