### PR TITLE
Correct Outdated URL for Stable Version

### DIFF
--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -1,13 +1,13 @@
 [
     {
-        "name": "v3.0.0 (dev)",
-        "version": "3.0.0a1",
+        "name": "v3.1.0 (dev)",
+        "version": "3.1.0a1",
         "url": "/mantidimaging/"
     },
     {
         "name": "v3.0.0 (stable)",
         "version": "3.0.0",
-        "url": "/mantidimaging/2.8.0"
+        "url": "/mantidimaging/3.0.0"
     },
     {
         "name": "v2.8.0",


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->

### Description

<!-- Add a description of the changes made. -->

* Correct Outdated URL for `docs/_static/version_switcher.json` stable version of Mantid Imaging 3.0.0
* Add Version 3.1.0 for dev
