### PR TITLE
update SciPy

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - python=3.12.*
     - pip
     - astropy=6.0.*
-    - scipy=1.14.*
+    - scipy=1.15.*
     - scikit-image=0.22.*
     - tifffile=2023.7.18
     - imagecodecs=2023.9.18

--- a/docs/release_notes/next/dev-2666-update-scipy
+++ b/docs/release_notes/next/dev-2666-update-scipy
@@ -1,0 +1,1 @@
+2666: Update scipy from 1.14.1 to 1.15.2


### PR DESCRIPTION
## Issue  
Closes #2680

---

### Description

Update `scipy` from **1.14.1** to **1.15.2**.

- Fixed any compatibility issues introduced by the upgrade.
- Manually tested areas of Mantid Imaging that rely on `scipy`.

---

### Developer Testing

- ✅ I have verified unit tests pass locally: `python -m pytest -vs`
- ✅ Manually tested relevant features that use `scipy`

---

### Acceptance Criteria and Reviewer Testing

- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Check for any compatibility issues with `scipy` upgrade
- [ ] Manually verify key features relying on `scipy` continue to work correctly

---

### Documentation and Additional Notes

- [ ] Release Notes have been updated

