### PR TITLE
Update Astra-toolbox from 2.1.0 to 2.1.1

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - tomopy=1.12.*
     - cudatoolkit=11.8.*
     - cupy=12.3.*
-    - astra-toolbox=2.1.0=cuda*
+    - astra-toolbox=2.1.1=cuda*
     - requests=2.32.*
     - h5py=3.9.*
     - hdf5=1.14.2

--- a/docs/release_notes/next/dev-2664-update-astra-toolbox
+++ b/docs/release_notes/next/dev-2664-update-astra-toolbox
@@ -1,0 +1,1 @@
+2664: Update Astra-toolbox from 2.1.0 to 2.1.1


### PR DESCRIPTION
## Issue  
Closes #2664

### Description  
Update Astra-toolbox from 2.1.0 to 2.1.1.

### Developer Testing  
- Verified unit tests pass: `python -m pytest -vs`

### Reviewer Checklist  
- [ ] Unit tests pass: `python -m pytest -vs`
- [ ] No regressions in features using Astra-toolbox

### Notes  
- [ ] Release notes updated (if needed)
- [ ] Screenshot tests (Applitools) updated if required
