### PR TITLE
2791 Allow Resizing ROI from All Corners

### DIFF
--- a/docs/release_notes/next/feature-2800-allow-resizing-roi-from-all-corners
+++ b/docs/release_notes/next/feature-2800-allow-resizing-roi-from-all-corners
@@ -1,0 +1,1 @@
+2800: Updated the code so that the ROI created in the Operations window for Crop Coordinates, as well as the ROI set in the Main window, can now be resized from all four corners.

--- a/mantidimaging/gui/test/gui_system_liveviewer_test.py
+++ b/mantidimaging/gui/test/gui_system_liveviewer_test.py
@@ -68,4 +68,4 @@ class TestGuiLiveViewer(GuiSystemBase):
         wait_until(lambda: not np.isnan(self.live_viewer_window.presenter.model.mean_nan_mask).any(), max_retry=600)
         QTest.qWait(SHORT_DELAY)
         assert_raises(AssertionError, np.testing.assert_array_equal, old_mean,
-                    self.live_viewer_window.presenter.model.mean_nan_mask)
+                      self.live_viewer_window.presenter.model.mean_nan_mask)

--- a/mantidimaging/gui/test/gui_system_liveviewer_test.py
+++ b/mantidimaging/gui/test/gui_system_liveviewer_test.py
@@ -7,6 +7,7 @@ from unittest import mock
 import numpy as np
 from PyQt5.QtTest import QTest
 from numpy.testing import assert_raises
+from parameterized import parameterized
 
 from mantidimaging.gui.test.gui_system_base import GuiSystemBase, SHORT_DELAY, SHOW_DELAY
 from mantidimaging.test_helpers.qt_test_helpers import wait_until
@@ -49,18 +50,22 @@ class TestGuiLiveViewer(GuiSystemBase):
         self.assertEqual(self.live_viewer_window.splitter.sizes()[1], 0)
         QTest.qWait(SHOW_DELAY)
 
-    def test_roi_resized(self):
+    @parameterized.expand([
+        (0, (10, 20)),  # top-left
+        (1, (30, 20)),  # top-right
+        (2, (10, 40)),  # bottom-left
+        (3, (30, 40)),  # bottom-right
+    ])
+    def test_roi_resized(self, handle_index, new_position):
         QTest.qWait(SHORT_DELAY * 4)
         self.live_viewer_window.intensity_action.trigger()
         QTest.qWait(SHORT_DELAY)
         wait_until(lambda: not np.isnan(self.live_viewer_window.presenter.model.mean_nan_mask).any(), max_retry=600)
         old_mean = self.live_viewer_window.presenter.model.mean_nan_mask
         roi = self.live_viewer_window.live_viewer.roi_object
-        handle_index = 0
-        new_position = (10, 20)
         roi.movePoint(handle_index, new_position)
         self.live_viewer_window.presenter.model.clear_mean_partial()
         wait_until(lambda: not np.isnan(self.live_viewer_window.presenter.model.mean_nan_mask).any(), max_retry=600)
         QTest.qWait(SHORT_DELAY)
         assert_raises(AssertionError, np.testing.assert_array_equal, old_mean,
-                      self.live_viewer_window.presenter.model.mean_nan_mask)
+                    self.live_viewer_window.presenter.model.mean_nan_mask)

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -33,7 +33,11 @@ class UnrotateablePlotROI(ROI):
 
     def __init__(self):
         ROI.__init__(self, pos=[0, 0])
-        self.addScaleHandle([1, 1], [0, 0])
+        # Add scale handles to all four corners
+        self.addScaleHandle([0, 0], [1, 1])  # top-left
+        self.addScaleHandle([1, 0], [0, 1])  # top-right
+        self.addScaleHandle([0, 1], [1, 0])  # bottom-left
+        self.addScaleHandle([1, 1], [0, 0])  # bottom-right
 
 
 def clip(value, lower, upper):


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2791 

### Description

<!-- Add a description of the changes made. -->

- Updated the code so that the ROI created in the Operations window for Crop Coordinates, as well as the ROI set in the Main window, can now be resized from all four corners.

- Updated the `gui_system_liveviewer_test.py` test suite to include coverage for ROI corner resizing in Live Viewer window

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m unittest -v mantidimaging.gui.test.gui_system_liveviewer_test`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Run `python -m unittest -v mantidimaging.gui.test.gui_system_liveviewer_test` and verify all tests pass.


### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->
- [x] Screenshot tests have been updated
<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated

  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

