### PR TITLE
Spectrum Viewer: Normalise ROIs of Varying Size

### DIFF
--- a/docs/release_notes/next/feature-2347-Spectrum-Viewer-Support-Normalising-ROIs-of-Different-Sizes
+++ b/docs/release_notes/next/feature-2347-Spectrum-Viewer-Support-Normalising-ROIs-of-Different-Sizes
@@ -1,0 +1,1 @@
+2347: Support for Differently-Sized ROIs in Spectrum Normalisation

--- a/docs/release_notes/next/feature-2347-Spectrum-Viewer-Support-Normalising-ROIs-of-Different-Sizes
+++ b/docs/release_notes/next/feature-2347-Spectrum-Viewer-Support-Normalising-ROIs-of-Different-Sizes
@@ -1,1 +1,1 @@
-2347: Support for Differently-Sized ROIs in Spectrum Normalisation
+2347: Support for Differently-Sized ROIs in Spectrum Normalisation.

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -386,6 +386,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         type(self.view.table_view).current_roi_name = mock.PropertyMock(return_value="roi_1")
         self.view.roiSelectionWidget = mock.Mock()
         type(self.view.roiSelectionWidget).current_roi_name = mock.PropertyMock(return_value="roi_1")
+        self.view.get_open_beam_roi = mock.Mock(return_value=None)
         roi_mock = mock.Mock()
         roi_mock.name = "roi_1"
         roi_mock.as_sensible_roi.return_value = SensibleROI(10, 10, 20, 30)
@@ -416,10 +417,12 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         roi_data = {"all": SensibleROI(0, 0, 10, 8), "roi": SensibleROI(1, 4, 3, 2)}
         self.view.spectrum_widget.roi_dict = {roi: mock.Mock() for roi in rois}
         self.view.spectrum_widget.get_roi = mock.Mock(side_effect=roi_data.get)
+        self.view.get_open_beam_roi_choice = mock.Mock(return_value="roi")
+
         self.presenter.model.get_spectrum = mock.Mock()
         self.presenter.redraw_all_rois()
 
-        self.view.spectrum_widget.get_roi.assert_has_calls([mock.call(roi) for roi in rois])
+        self.view.spectrum_widget.get_roi.assert_has_calls([mock.call(roi) for roi in rois], any_order=True)
         self.view.set_spectrum.assert_has_calls([mock.call(roi, mock.ANY) for roi in rois], any_order=True)
 
     def test_WHEN_roi_clicked_THEN_roi_properties_set(self):


### PR DESCRIPTION

## Issue  
Closes #2347

### Description  
Adds support for normalizing a sample ROI against a differently sized open beam ROI in the Spectrum Viewer.

Key updates:
- `Model.get_spectrum` now accepts `(sample_roi, open_beam_roi)` tuple for `SAMPLE_NORMED` mode.
- Refactored Presenter methods
- Added `_make_cache_key()` for improved caching.

### Developer Testing  
- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Manual testing with mismatched ROI sizes
- [x] Verified spectrum redraw and fitting still work

### Acceptance Criteria  
- [ ] Unit tests pass
- [ ] Normalized spectra work with mismatched ROIs
- [ ] No crash/errors on redraw or chunked updates

### Documentation  
- [x] Release Notes updated

