### PR TITLE
1619 lock sidebar for spectrum viewer window

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -9,7 +9,8 @@ from typing import TYPE_CHECKING
 from PyQt5 import QtWidgets
 from pyqtgraph import mkPen
 from PyQt5.QtGui import QPixmap
-from PyQt5.QtWidgets import (QCheckBox, QVBoxLayout, QFileDialog, QLabel, QGroupBox, QActionGroup, QAction)
+from PyQt5.QtWidgets import (QCheckBox, QVBoxLayout, QFileDialog, QLabel, QGroupBox, QActionGroup, QAction, QSplitter,
+                             QTabWidget)
 from PyQt5.QtCore import QModelIndex
 from logging import getLogger
 
@@ -62,6 +63,14 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         super().__init__(None, 'gui/ui/spectrum_viewer.ui')
 
         self.main_window = main_window
+
+        splitter = self.findChild(QSplitter, "splitter")
+        sidebar = self.findChild(QTabWidget, "formTabs")
+
+        if splitter and sidebar:
+            # prevent collapsing
+            splitter.setCollapsible(0, False)  # set sidebar index
+            splitter.setCollapsible(1, False)  # set main area index
 
         icon_path = (finder.ROOT_PATH / "gui" / "ui" / "images" / "exclamation-triangle-red.png").as_posix()
         self.normalise_error_icon_pixmap = QPixmap(icon_path)


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #1619

### Description
Updated the  `gui/windows/spectrum_viewer/view.py` to prevent the sidebar from minimising at all.
<!-- Add a description of the changes made. -->

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] When the Spectrum Viewer window is accessed through the gui, the user shouldnt be able to drag the sidebar to the left to minimise it.

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

