### PR TITLE
Export Window: Create/Add ImageView (Mapping) to Export Window

### DIFF
--- a/mantidimaging/gui/widgets/spectrum_widgets/export_image_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_image_widget.py
@@ -1,0 +1,28 @@
+from PyQt5.QtWidgets import QWidget, QVBoxLayout
+from pyqtgraph import ImageView, ROI, mkPen
+import numpy as np
+
+class ExportImageViewWidget(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        self.image_view = ImageView(self)
+        layout.addWidget(self.image_view)
+
+        self.roi_overlays = []
+
+    def update_image(self, image: np.ndarray):
+        """Set image to display."""
+        self.image_view.setImage(image, autoLevels=True)
+        self.clear_rois()
+
+    def add_roi_overlay(self, roi_data):
+        """Draw ROI rectangle on top of the image."""
+        roi = ROI(pos=(roi_data.x, roi_data.y), size=(roi_data.width, roi_data.height), pen=mkPen((0,255,0), width=2))
+        self.image_view.addItem(roi)
+        self.roi_overlays.append(roi)
+
+    def clear_rois(self):
+        for roi in self.roi_overlays:
+            self.image_view.removeItem(roi)
+        self.roi_overlays.clear()

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -206,6 +206,24 @@ class SpectrumViewerWindowModel:
             return "Stack shapes must match"
         return ""
 
+    def get_export_image(self) -> np.ndarray | None:
+        """Return a 2D image to preview in Export > Image."""
+        def to_2d(stack) -> np.ndarray | None:
+            arr = getattr(stack, "data", None)
+            if arr is None:
+                return None
+            if arr.ndim == 2:
+                return arr
+            if arr.ndim == 3:
+                return arr.mean(axis=0)
+            return None
+        for src in (getattr(self, "normalised_stack", None),
+                    getattr(self, "sample_stack", None)):
+            img = to_2d(src)
+            if img is not None:
+                return img
+        return None
+
     def shuttercount_issue(self) -> str:
         """
         Return an error message if there is an issue with the shutter count data.

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -690,6 +690,16 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         fit = self.model.fitting_engine.model.evaluate(xvals, params)
         self.view.fittingDisplayWidget.show_fit_line(xvals, fit, color=(0, 128, 255), label="fit", initial=False)
 
+    def on_export_tab_changed(self, index: int):
+        tab_name = self.view.export_tab_widget.tabText(index)
+        if tab_name == "Image":
+            self.update_export_image_view()
+
+    def update_export_image_view(self):
+        image = self.model.get_export_image()
+        if image is not None:
+            self.view.export_image_widget.update_image(image)
+
     def handle_export_table(self) -> None:
         """
         Export the ROI fitting results table to CSV.


### PR DESCRIPTION
## Issue Closes #2395

### Description

Adds an Image preview to the Export tab and makes the Table/Image view switchable from within the Export tab. 

- Added Image preview to Export alongside Table via a nested QTabWidget.
- Moved export table into this tab widget.
- Hooked tab change → refresh preview.

### Acceptance Criteria and Reviewer Testing

- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Launched Spectrum Viewer; loaded sample + (optionally) normalise stacks.
- [ ] Verified Export shows Table/Image tabs on the right; switching updates image.
- [ ] Image/ Fit/Export flows unchanged; no crashes.

### Documentation and Additional Notes

 - [ ] Release Notes have been updated
