### PR TITLE
2759 add dedicated geometry window

### DIFF
--- a/docs/release_notes/next/feature-2759-new-geometry-window
+++ b/docs/release_notes/next/feature-2759-new-geometry-window
@@ -1,0 +1,1 @@
+#2759: Added a new Geometry window for editing, visualising, and creating new ImageStack Geometry data

--- a/mantidimaging/gui/ui/main_window.ui
+++ b/mantidimaging/gui/ui/main_window.ui
@@ -59,6 +59,7 @@
     </property>
     <addaction name="actionFilters"/>
     <addaction name="actionRecon"/>
+    <addaction name="actionGeometry"/>
     <addaction name="actionCompareImages"/>
     <addaction name="actionSpectrumViewer"/>
    </widget>
@@ -127,6 +128,14 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+R</string>
+   </property>
+  </action>
+  <action name="actionGeometry">
+   <property name="text">
+    <string>Geometry</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+G</string>
    </property>
   </action>
   <action name="actionManual_Center_of_Rotation">

--- a/mantidimaging/gui/windows/geometry/__init__.py
+++ b/mantidimaging/gui/windows/geometry/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from .model import GeometryWindowModel  # noqa: F401
+from .presenter import GeometryWindowPresenter  # noqa: F401
+from .view import GeometryWindowView  # noqa: F401

--- a/mantidimaging/gui/windows/geometry/model.py
+++ b/mantidimaging/gui/windows/geometry/model.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
+
+from cil.utilities.display import show_geometry
+
+from mantidimaging.core.data import ImageStack
+
+
+class GeometryWindowModel:
+
+    def generate_figure(self, stack: ImageStack) -> Figure | None:
+        geometry = stack.geometry
+
+        if geometry is None:
+            return None
+
+        # Apply dark styling
+        plt.style.use("dark_background")
+        figure: Figure = show_geometry(geometry, show=False).figure
+        figure.set_facecolor("black")
+
+        return figure

--- a/mantidimaging/gui/windows/geometry/presenter.py
+++ b/mantidimaging/gui/windows/geometry/presenter.py
@@ -1,0 +1,122 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+import numpy
+from math import degrees
+
+from mantidimaging.core.data import ImageStack
+from mantidimaging.core.data.imagestack import StackNotFoundError
+from mantidimaging.core.utility.data_containers import ScalarCoR, ProjectionAngles
+from mantidimaging.gui.mvp_base import BasePresenter
+from mantidimaging.gui.windows.geometry.model import GeometryWindowModel
+
+if TYPE_CHECKING:
+    from mantidimaging.gui.windows.geometry.view import GeometryWindowView  # pragma: no cover
+    from mantidimaging.gui.windows.main import MainWindowView
+
+
+class GeometryWindowPresenter(BasePresenter):
+    view: GeometryWindowView
+
+    def __init__(self, view: GeometryWindowView, main_window: MainWindowView):
+        super().__init__(view)
+        self.view = view
+        self.model = GeometryWindowModel()
+        self.main_window = main_window
+
+    def handle_stack_changed(self) -> None:
+        current_stack_uuid = self.view.current_stack
+        if current_stack_uuid is None:
+            # Stack has likely been cleared from the main window
+            self.view.clear_plot()
+            self.view.set_widget_stack_page(0)
+            return
+
+        current_stack = self.main_window.get_stack(current_stack_uuid)
+        if current_stack is None:
+            raise StackNotFoundError("No ImageStack found for UUID")
+
+        if current_stack.geometry is None:
+            self.set_default_new_parameters(current_stack)
+            self.view.set_widget_stack_page(2)
+        else:
+            self.update_parameters(current_stack)
+            self.view.set_widget_stack_page(1)
+
+        self.refresh_plot(current_stack)
+
+    def update_parameters(self, stack: ImageStack) -> None:
+        if stack.geometry is None:
+            raise RuntimeError("Attempted to update parameters for ImageStack without geometry")
+
+        geometry_type = stack.geometry.type.value
+
+        angle_range = "N/A"
+        real_projection_angles = stack.real_projection_angles()
+        if real_projection_angles is not None:
+            min_angle = degrees(real_projection_angles.value[0])
+            max_angle = degrees(real_projection_angles.value[-1])
+            angle_range = f"{min_angle:.2f}° - {max_angle:.2f}°"
+
+        mi_cor = stack.geometry.cor.value
+        mi_tilt = stack.geometry.tilt
+
+        self.view.type = geometry_type
+        self.view.angles = angle_range
+        self.view.rotation_axis = mi_cor
+        self.view.tilt = mi_tilt
+
+    def set_default_new_parameters(self, stack: ImageStack) -> None:
+        default_cor = stack.width / 2
+
+        self.view.new_rotation_axis = default_cor
+        self.view.new_tilt = .0
+        self.view.new_min_angle = 0
+        self.view.new_max_angle = 360
+
+    def handle_parameter_updates(self) -> None:
+        updated_cor = ScalarCoR(self.view.rotation_axis)
+        updated_tilt = self.view.tilt
+
+        stack = self._get_current_stack_with_assert()
+        assert stack.geometry is not None
+        stack.geometry.set_geometry_from_cor_tilt(updated_cor, updated_tilt)
+
+        self.refresh_plot(stack)
+
+    def refresh_plot(self, stack: ImageStack) -> None:
+        figure = self.model.generate_figure(stack)
+
+        if figure is None:
+            self.view.clear_plot()
+        else:
+            self.view.refresh_plot(figure)
+
+    def handle_create_new_geometry(self) -> None:
+        stack = self._get_current_stack_with_assert()
+
+        new_cor = ScalarCoR(self.view.new_rotation_axis)
+        new_tilt = self.view.new_tilt
+        new_min_angle = self.view.new_min_angle
+        new_max_angle = self.view.new_max_angle
+
+        new_angles = ProjectionAngles(numpy.linspace(new_min_angle, new_max_angle, stack.num_projections))
+        stack.set_projection_angles(new_angles)
+        stack.set_geometry()
+        assert stack.geometry is not None
+        stack.geometry.set_geometry_from_cor_tilt(new_cor, new_tilt)
+
+        self.handle_stack_changed()
+
+    def _get_current_stack_with_assert(self) -> ImageStack:
+        # It shouldn't be possible to call this method with an invalid stack selected
+        current_stack_uuid = self.view.current_stack
+        assert current_stack_uuid is not None
+
+        current_stack = self.main_window.get_stack(current_stack_uuid)
+        assert current_stack is not None
+
+        return current_stack

--- a/mantidimaging/gui/windows/geometry/test/__init__.py
+++ b/mantidimaging/gui/windows/geometry/test/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations

--- a/mantidimaging/gui/windows/geometry/test/model_test.py
+++ b/mantidimaging/gui/windows/geometry/test/model_test.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+from matplotlib.figure import Figure
+
+from mantidimaging.core.data import ImageStack
+from mantidimaging.core.data.geometry import Geometry
+from mantidimaging.gui.windows.geometry import GeometryWindowModel
+
+
+class GeometryWindowModelTest(unittest.TestCase):
+
+    def setUp(self):
+        self.model = GeometryWindowModel()
+        self.data = ImageStack(data=np.ndarray(shape=(10, 128, 256), dtype=np.float32))
+        self.data.geometry = Geometry(num_pixels=(128, 128), pixel_size=(1.0, 1.0))
+
+    def test_generate_figure(self):
+        test_figure = self.model.generate_figure(self.data)
+        self.assertIsInstance(test_figure, Figure)

--- a/mantidimaging/gui/windows/geometry/test/presenter_test.py
+++ b/mantidimaging/gui/windows/geometry/test/presenter_test.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+import unittest
+
+from unittest import mock
+
+import numpy
+import numpy as np
+
+from mantidimaging.core.data.geometry import GeometryType
+from mantidimaging.core.utility.data_containers import ProjectionAngles
+
+from mantidimaging.core.data import ImageStack
+from mantidimaging.gui.windows.geometry import GeometryWindowPresenter, GeometryWindowView
+
+TEST_PIXEL_SIZE = 1443
+
+
+class GeometryWindowPresenterTest(unittest.TestCase):
+
+    def setUp(self):
+        self.data = ImageStack(data=np.ndarray(shape=(128, 10, 128), dtype=np.float32))
+        self.uuid = self.data.id
+
+        self.main_window = mock.MagicMock()
+        self.main_window.get_stack.return_value = self.data
+
+        self.make_view()
+        self.presenter = GeometryWindowPresenter(view=self.view, main_window=self.main_window)
+
+    def make_view(self):
+        self.view = mock.create_autospec(GeometryWindowView, instance=True)
+        self.view.type = "N/A"
+        self.view.rotation_axis = 0
+        self.view.tilt = 0
+        self.view.new_rotation_axis = 0
+        self.view.new_tilt = 0
+        self.view.new_min_angle = 0
+        self.view.new_max_angle = 0
+        self.view.current_stack = self.uuid
+
+    def reset_new_stack(self):
+        self.data = ImageStack(data=np.ndarray(shape=(128, 10, 128), dtype=np.float32))
+
+    def test_update_parameters(self):
+        self.reset_new_stack()
+        test_stack = self.main_window.get_stack()
+        test_stack.set_projection_angles(ProjectionAngles(numpy.linspace(0, 360, test_stack.num_projections)))
+        test_stack.set_geometry()
+        self.presenter.update_parameters(test_stack)
+        test_geometry_type = GeometryType.PARALLEL3D.value
+        self.assertEqual(self.view.type, test_geometry_type)
+        self.assertEqual(self.view.rotation_axis, test_stack.geometry.cor.value)
+        self.assertEqual(self.view.tilt, test_stack.geometry.tilt)
+
+    def test_create_geometry_button_creates_geometry(self):
+        self.reset_new_stack()
+        test_stack = self.main_window.get_stack()
+        self.assertIsNone(test_stack.geometry)
+        self.presenter.set_default_new_parameters(stack=test_stack)
+        self.presenter.handle_create_new_geometry()
+        self.assertIsNotNone(test_stack.geometry)
+
+    def test_changing_cor_tilt_updates_geometry(self):
+        self.presenter.handle_create_new_geometry()
+        test_cor = 240
+        test_tilt = 15
+        self.view.rotation_axis = test_cor
+        self.view.tilt = test_tilt
+        self.presenter.handle_parameter_updates()
+        self.assertAlmostEqual(self.data.geometry.cor.value, test_cor, places=10)
+        self.assertAlmostEqual(self.data.geometry.tilt, test_tilt, places=10)

--- a/mantidimaging/gui/windows/geometry/view.py
+++ b/mantidimaging/gui/windows/geometry/view.py
@@ -1,0 +1,336 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+from uuid import UUID
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QScrollArea,
+    QFrame,
+    QWidget,
+    QVBoxLayout,
+    QDoubleSpinBox,
+    QLabel,
+    QGroupBox,
+    QFormLayout,
+    QHBoxLayout,
+    QSizePolicy,
+    QComboBox,
+    QPushButton,
+    QStackedWidget,
+    QApplication,
+    QStyle,
+)
+
+import matplotlib
+from matplotlib import pyplot
+from matplotlib.figure import Figure
+
+matplotlib.use('Qt5Agg')
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+
+from mantidimaging.gui.mvp_base import BaseMainWindowView
+from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
+from mantidimaging.gui.windows.geometry.presenter import GeometryWindowPresenter
+
+if TYPE_CHECKING:
+    from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
+
+
+class CustomRangeSpinBox(QDoubleSpinBox):
+
+    def __init__(self, min: int = -10000, max: int = 10000, parent=None):
+        super().__init__(parent)
+        self.setRange(min, max)
+
+
+class GeometryWindowView(BaseMainWindowView):
+
+    def __init__(self, main_window: MainWindowView):
+        super().__init__(parent=None)
+
+        self.main_window = main_window
+        self.presenter = GeometryWindowPresenter(self, main_window)
+
+        self._init_window()
+        self._init_widgets()
+        self._init_layout()
+
+        self._init_stack_selector()
+        self._init_connect_signals()
+
+    def _init_window(self) -> None:
+        self.setWindowTitle("Geometry")
+        self.resize(1300, 800)
+
+    def _init_widgets(self) -> None:
+        self.stackSelector = DatasetSelectorWidgetView(self)
+
+        self.geometryPagesWidget = QStackedWidget()
+
+        self.typeDisplay = QLabel("N/A")
+        self.angleDisplay = QLabel("N/A")
+        self.corSpinBox = CustomRangeSpinBox()
+        self.tiltSpinBox = CustomRangeSpinBox(-45, 45)
+
+        self.geomTypeSelector = QComboBox()
+        self.minAngleSpinBox = CustomRangeSpinBox(-360, 360)
+        self.maxAngleSpinBox = CustomRangeSpinBox(-360, 360)
+        self.loadAnglesButton = QPushButton("Load Angles from File")
+        self.newCorSpinBox = CustomRangeSpinBox()
+        self.newTiltSpinBox = CustomRangeSpinBox(-45, 45)
+        self.createGeometryButton = QPushButton("Create Geometry")
+
+        self.figureCanvas = FigureCanvas()
+
+    def _init_layout(self) -> None:
+        central_container = QWidget(self)
+        central_layout = QHBoxLayout(central_container)
+
+        central_layout.addWidget(self._build_left_pane())
+        central_layout.addWidget(self._build_plot_visualiser())
+
+        self.setCentralWidget(central_container)
+
+    def _build_left_pane(self) -> QWidget:
+        left_scroll_area = QScrollArea()
+        left_scroll_area.setFrameShape(QFrame.NoFrame)
+        left_scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        left_scroll_area.setWidgetResizable(True)
+        left_scroll_area.setSizePolicy(QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Preferred))
+
+        left_container = QWidget()
+        left_layout = QVBoxLayout(left_container)
+
+        left_layout.addWidget(self._build_imagestack_selector_group())
+        left_layout.addWidget(self._build_geometry_pages_widget())
+        left_layout.addStretch()
+
+        left_scroll_area.setWidget(left_container)
+        return left_scroll_area
+
+    def _build_imagestack_selector_group(self) -> QWidget:
+        stack_selector_group = QGroupBox("Stack")
+        stack_selector_layout = QFormLayout(stack_selector_group)
+        stack_selector_layout.addRow(self.stackSelector)
+
+        return stack_selector_group
+
+    def _build_geometry_pages_widget(self) -> QWidget:
+        self.geometryPagesWidget.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
+
+        self.geometryPagesWidget.addWidget(self._build_no_stack_data_page())  # page 0 (Empty / no ImageStack)
+        self.geometryPagesWidget.addWidget(self._build_geometry_data_display_page())  # page 1 (Geometry exists)
+        self.geometryPagesWidget.addWidget(self._build_new_geometry_page())  # page 2 (Geometry doesn't exist)
+
+        return self.geometryPagesWidget
+
+    def _build_no_stack_data_page(self):
+        no_stack_data_page = QWidget()
+        no_stack_data_layout = QVBoxLayout(no_stack_data_page)
+
+        warning_message = "No stack data available"
+        no_stack_data_layout.addWidget(self._build_warning_message(warning_message))
+        no_stack_data_layout.addStretch()
+
+        return no_stack_data_page
+
+    def _build_geometry_data_display_page(self) -> QWidget:
+        data_display_page = QWidget()
+        data_display_layout = QVBoxLayout(data_display_page)
+
+        data_display_layout.addWidget(self._build_data_display_group())
+        data_display_layout.addStretch()
+
+        return data_display_page
+
+    def _build_data_display_group(self) -> QWidget:
+        data_display_group = QGroupBox("Geometry Data")
+        data_display_group.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
+        data_display_group_layout = QFormLayout(data_display_group)
+
+        data_display_group_layout.addRow(QLabel("Type:"), self.typeDisplay)
+        data_display_group_layout.addRow(QLabel("Angles:"), self.angleDisplay)
+        data_display_group_layout.addRow(QLabel("COR:"), self.corSpinBox)
+        data_display_group_layout.addRow(QLabel("Tilt:"), self.tiltSpinBox)
+
+        return data_display_group
+
+    def _build_new_geometry_page(self) -> QWidget:
+        new_geometry_page = QWidget()
+        new_geometry_layout = QVBoxLayout(new_geometry_page)
+
+        warning_message = "No Geometry for selected stack"
+        new_geometry_layout.addWidget(self._build_warning_message(warning_message))
+        new_geometry_layout.addWidget(self._build_new_params_group())
+        new_geometry_layout.addWidget(self.createGeometryButton)
+        new_geometry_layout.addStretch()
+
+        return new_geometry_page
+
+    def _build_warning_message(self, message: str) -> QWidget:
+        style = QApplication.style()
+        font_pt = self.font().pointSizeF()
+        icon_size = int(font_pt * 1.8)
+        pixmap = style.standardIcon(QStyle.SP_MessageBoxWarning).pixmap(icon_size, icon_size)
+
+        icon = QLabel()
+        icon.setPixmap(pixmap)
+        icon.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+        text = QLabel(message)
+        text.setWordWrap(True)
+        text.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+
+        warning_message = QWidget()
+        warning_layout = QHBoxLayout(warning_message)
+        warning_layout.setContentsMargins(4, 2, 4, 2)
+        warning_layout.setSpacing(8)
+        warning_layout.addWidget(icon)
+        warning_layout.addWidget(text)
+
+        return warning_message
+
+    def _build_new_params_group(self) -> QWidget:
+        new_params_group = QGroupBox("New Geometry")
+        new_params_layout = QFormLayout(new_params_group)
+
+        self.geomTypeSelector.addItem("Parallel 3D")
+        # self.geomTypeSelector.addItem("Conebeam 3D")
+
+        new_params_layout.addRow(QLabel("Type:"), self.geomTypeSelector)
+        new_params_layout.addRow(self._build_angle_range_container())
+        new_params_layout.addRow(QLabel(""), self.loadAnglesButton)
+        new_params_layout.addRow(QLabel("COR:"), self.newCorSpinBox)
+        new_params_layout.addRow(QLabel("Tilt:"), self.newTiltSpinBox)
+
+        return new_params_group
+
+    def _build_angle_range_container(self) -> QWidget:
+        angle_range_container = QWidget()
+        angle_range_layout = QHBoxLayout(angle_range_container)
+
+        angle_range_layout.addWidget(QLabel("Angles:"))
+        angle_range_layout.addWidget(QLabel("Min"))
+        angle_range_layout.addWidget(self.minAngleSpinBox)
+        angle_range_layout.addWidget(QLabel("Max"))
+        angle_range_layout.addWidget(self.maxAngleSpinBox)
+
+        return angle_range_container
+
+    def _build_plot_visualiser(self) -> QWidget:
+        plot_visualiser = QWidget()
+        visualiser_layout = QVBoxLayout(plot_visualiser)
+        visualiser_layout.addWidget(self.figureCanvas)
+        # visualiser_layout.addWidget(self.figureToolbar)
+
+        return plot_visualiser
+
+    def _init_stack_selector(self) -> None:
+        # These stackSelector operations need to happen in this order
+        self.stackSelector.presenter.show_stacks = True
+        self.stackSelector.stack_selected_uuid.connect(self.presenter.handle_stack_changed)
+        self.stackSelector.subscribe_to_main_window(self.main_window)
+        self.stackSelector.select_eligible_stack()
+
+    def _init_connect_signals(self) -> None:
+        self.createGeometryButton.clicked.connect(self.presenter.handle_create_new_geometry)
+        self.corSpinBox.valueChanged.connect(self.presenter.handle_parameter_updates)
+        self.tiltSpinBox.valueChanged.connect(self.presenter.handle_parameter_updates)
+
+    def set_widget_stack_page(self, index: int) -> None:
+        self.geometryPagesWidget.setCurrentIndex(index)
+
+    def refresh_plot(self, figure: Figure) -> None:
+        # Clear the plot otherwise pyplot retains the previous figure, leaking memory
+        self.clear_plot()
+        figure.set_canvas(self.figureCanvas)
+
+        self.figureCanvas.figure = figure
+        self.figureCanvas.draw_idle()
+
+        # Trigger a window resize to force the FigureCanvas to correct its size
+        old_size = self.size()
+        self.adjustSize()
+        self.resize(old_size)
+
+    def clear_plot(self) -> None:
+        if self.figureCanvas.figure is not None:
+            pyplot.close(self.figureCanvas.figure)
+            self.figureCanvas.figure.clear()
+            self.figureCanvas.draw_idle()
+
+    @property
+    def current_stack(self) -> UUID | None:
+        return self.stackSelector.current()
+
+    @property
+    def type(self) -> str:
+        return self.typeDisplay.text()
+
+    @type.setter
+    def type(self, value):
+        self.typeDisplay.setText(value)
+
+    @property
+    def angles(self) -> str:
+        return self.angleDisplay.text()
+
+    @angles.setter
+    def angles(self, value) -> None:
+        self.angleDisplay.setText(value)
+
+    @property
+    def rotation_axis(self) -> float:
+        return self.corSpinBox.value()
+
+    @rotation_axis.setter
+    def rotation_axis(self, value) -> None:
+        self.corSpinBox.setValue(value)
+
+    @property
+    def tilt(self) -> float:
+        return self.tiltSpinBox.value()
+
+    @tilt.setter
+    def tilt(self, value) -> None:
+        self.tiltSpinBox.setValue(value)
+
+    @property
+    def new_type(self) -> str:
+        return self.geomTypeSelector.currentText()
+
+    @property
+    def new_min_angle(self) -> float:
+        return self.minAngleSpinBox.value()
+
+    @new_min_angle.setter
+    def new_min_angle(self, value) -> None:
+        self.minAngleSpinBox.setValue(value)
+
+    @property
+    def new_max_angle(self) -> float:
+        return self.maxAngleSpinBox.value()
+
+    @new_max_angle.setter
+    def new_max_angle(self, value) -> None:
+        self.maxAngleSpinBox.setValue(value)
+
+    @property
+    def new_rotation_axis(self) -> float:
+        return self.newCorSpinBox.value()
+
+    @new_rotation_axis.setter
+    def new_rotation_axis(self, value) -> None:
+        self.newCorSpinBox.setValue(value)
+
+    @property
+    def new_tilt(self) -> float:
+        return self.newTiltSpinBox.value()
+
+    @new_tilt.setter
+    def new_tilt(self, value) -> None:
+        self.newTiltSpinBox.setValue(value)

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -35,6 +35,7 @@ from mantidimaging.gui.windows.move_stack_dialog.view import MoveStackDialog
 from mantidimaging.gui.windows.nexus_load_dialog.view import NexusLoadDialog
 from mantidimaging.gui.windows.operations import FiltersWindowView
 from mantidimaging.gui.windows.recon import ReconstructWindowView
+from mantidimaging.gui.windows.geometry import GeometryWindowView
 from mantidimaging.gui.windows.settings.view import SettingsWindowView
 from mantidimaging.gui.windows.spectrum_viewer.view import SpectrumViewerWindowView
 from mantidimaging.gui.windows.live_viewer.view import LiveViewerWindowView
@@ -83,6 +84,7 @@ class MainWindowView(BaseMainWindowView):
 
     actionRecon: QAction
     actionFilters: QAction
+    actionGeometry: QAction
     actionCompareImages: QAction
     actionSpectrumViewer: QAction
     actionLiveViewer: QAction
@@ -99,6 +101,7 @@ class MainWindowView(BaseMainWindowView):
 
     filters: FiltersWindowView | None = None
     recon: ReconstructWindowView | None = None
+    geometry: GeometryWindowView | None = None
     spectrum_viewer: SpectrumViewerWindowView | None = None
     live_viewer_list: list[LiveViewerWindowView] = []
     settings_window: SettingsWindowView | None = None
@@ -244,6 +247,7 @@ class MainWindowView(BaseMainWindowView):
 
         self.actionFilters.triggered.connect(self.show_filters_window)
         self.actionRecon.triggered.connect(self.show_recon_window)
+        self.actionGeometry.triggered.connect(self.show_geometry_window)
         self.actionSpectrumViewer.triggered.connect(self.show_spectrum_viewer_window)
         self.actionLiveViewer.triggered.connect(self.live_view_choose_directory)
         self.actionSettings.triggered.connect(self.show_settings_window)
@@ -474,6 +478,17 @@ class MainWindowView(BaseMainWindowView):
             self.recon.raise_()
             self.recon.show()
 
+    def show_geometry_window(self) -> None:
+        self.close_welcome_screen()
+
+        if not self.geometry:
+            self.geometry = GeometryWindowView(self)
+            self.geometry.show()
+        else:
+            self.geometry.activateWindow()
+            self.geometry.raise_()
+            self.geometry.show()
+
     def show_filters_window(self) -> None:
         if not self.filters:
             self.filters = FiltersWindowView(self)
@@ -584,6 +599,8 @@ class MainWindowView(BaseMainWindowView):
             # Close additional windows which do not have the MainWindow as parent
             if self.recon:
                 self.recon.close()
+            if self.geometry:
+                self.geometry.close()
             while self.live_viewer_list:
                 self.live_viewer_list[-1].close()
             if self.spectrum_viewer:


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2759 

### Depends on

#2812 Update CIL to [v25.0](https://github.com/TomographicImaging/CIL/releases/tag/v25.0.0)

### Description

<!-- Add a description of the changes made. -->

Add a new window for editing, visualising, and creating new `Geometry` data.

Selecting an `ImageStack` with `Geometry` data:
- Will present the user with the current `Geometry` type, angle range, COR, and tilt. The latter two are editable by the user.
- On the right will be a visualiser pane that uses `matplotlib`'s `FigureCanvas` to interactively display `Figure` data generated by CIL's `show_geometry` [method](https://tomographicimaging.github.io/CIL/v23.1.0/utilities.html#show-geometry-display-system-geometry).
- The visualiser updates in real-time when COR and tilt are edited by the user.

Selecting an `ImageStack` with no `Geometry` data:
- Will present the user with a warning message and a form for creating a new Geometry object
- The user can input COR and tilt data, and manually input angle data or supply a relevant file.
- The fields will be populated with suitable default data based on the selected `ImageStack`'s parameters. 
- Pressing the `Create Geometry` button will create a new `Geometry` object for the selected `ImageStack` and automatically present the user with the interface described in the above section.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- I have manually verified the above behaviour works as expected. 

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Manually verify the program behaves as described above

### Documentation

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->
- [ ] Release Notes have been updated
- [ ] Screenshot tests have been updated
- [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
- [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
- [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) 

<!--
- [ ] Sphinx documentation has been updated
-->

Additional Notes

- Creating `Conebeam3D Geometry` is currently not supported but planned for the near future.

<img width="1400" height="990" alt="Screenshot 2025-08-12 121218" src="https://github.com/user-attachments/assets/424166e2-2408-4910-9a88-6a6f53195c11" />
<img width="1402" height="987" alt="Screenshot 2025-08-12 121231" src="https://github.com/user-attachments/assets/9d5e3c13-6797-494c-a487-6e19be6d9957" />

