### PR TITLE
FLASH PR: Update Token to Use Custom Token

### DIFF
--- a/.github/workflows/pr_to_draft_on_change_request.yml
+++ b/.github/workflows/pr_to_draft_on_change_request.yml
@@ -15,4 +15,5 @@ jobs:
       - name: Convert PR to Draft
         uses: JackEAllen/DraftOnChangeRequested@v1.0.0
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ACTION_CONVERT_TO_DRAFT }}
+          


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
Resolve Repo permissions by creating a new fine-grained token called `ACTION_CONVERT_TO_DRAFT` to allow for #2769 to work as expected which is currently failing with: `Error: A GitHub token is required with the pull_requests:write permission`