### PR TITLE
Refactor MonitorNormalisation tests

### DIFF
--- a/mantidimaging/core/operations/monitor_normalisation/test/monitor_normalisation_test.py
+++ b/mantidimaging/core/operations/monitor_normalisation/test/monitor_normalisation_test.py
@@ -20,13 +20,13 @@ class MonitorNormalisationTest(unittest.TestCase):
         images = generate_images((1, 1, 1))
         images._log_file = mock.Mock()
         images._log_file.counts = mock.Mock(return_value=Counts(np.sin(np.linspace(0, 1, images.num_projections))))
-        npt.assert_raises(RuntimeError, MonitorNormalisation.filter_func, images)
+        self.assertRaises(RuntimeError, MonitorNormalisation.filter_func, images)
 
     def test_no_counts(self):
         images = generate_images((2, 2, 2))
         images._log_file = mock.Mock()
         images._log_file.counts = mock.Mock(return_value=None)
-        npt.assert_raises(RuntimeError, MonitorNormalisation.filter_func, images)
+        self.assertRaises(RuntimeError, MonitorNormalisation.filter_func, images)
 
     def test_execute(self):
         images = generate_images()
@@ -36,6 +36,7 @@ class MonitorNormalisationTest(unittest.TestCase):
         original = images.copy()
         MonitorNormalisation.filter_func(images)
         images._log_file.counts.assert_called_once()
+        self.assertEqual(original.data.shape, original.data.shape)
         assert_not_equals(original.data, images.data)
 
     def test_execute2(self):
@@ -54,9 +55,9 @@ class MonitorNormalisationTest(unittest.TestCase):
         npt.assert_equal(original.data, images.data)
 
     def test_register_gui(self):
-        assert MonitorNormalisation.register_gui(None, None, None) == {}
+        self.assertEqual(MonitorNormalisation.register_gui(None, None, None), {})
 
     def test_execute_wrapper(self):
         wrapper = MonitorNormalisation.execute_wrapper()
-        assert wrapper is not None
-        assert isinstance(wrapper, partial)
+        self.assertIsNotNone(wrapper)
+        self.assertIsInstance(wrapper, partial)

--- a/mantidimaging/core/operations/monitor_normalisation/test/monitor_normalisation_test.py
+++ b/mantidimaging/core/operations/monitor_normalisation/test/monitor_normalisation_test.py
@@ -61,7 +61,3 @@ def test_execute_wrapper():
     wrapper = MonitorNormalisation.execute_wrapper()
     assert wrapper is not None
     assert isinstance(wrapper, partial)
-
-
-def test_validate_execute_kwargs():
-    assert MonitorNormalisation.validate_execute_kwargs({}) is True

--- a/mantidimaging/core/operations/monitor_normalisation/test/monitor_normalisation_test.py
+++ b/mantidimaging/core/operations/monitor_normalisation/test/monitor_normalisation_test.py
@@ -1,9 +1,11 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
-from functools import partial
 
+import unittest
+from functools import partial
 from unittest import mock
+
 import numpy as np
 import numpy.testing as npt
 
@@ -12,52 +14,49 @@ from mantidimaging.test_helpers.unit_test_helper import generate_images, assert_
 from ..monitor_normalisation import MonitorNormalisation
 
 
-def test_one_projection():
-    images = generate_images((1, 1, 1))
-    images._log_file = mock.Mock()
-    images._log_file.counts = mock.Mock(return_value=Counts(np.sin(np.linspace(0, 1, images.num_projections))))
-    npt.assert_raises(RuntimeError, MonitorNormalisation.filter_func, images)
+class MonitorNormalisationTest(unittest.TestCase):
 
+    def test_one_projection(self):
+        images = generate_images((1, 1, 1))
+        images._log_file = mock.Mock()
+        images._log_file.counts = mock.Mock(return_value=Counts(np.sin(np.linspace(0, 1, images.num_projections))))
+        npt.assert_raises(RuntimeError, MonitorNormalisation.filter_func, images)
 
-def test_no_counts():
-    images = generate_images((2, 2, 2))
-    images._log_file = mock.Mock()
-    images._log_file.counts = mock.Mock(return_value=None)
-    npt.assert_raises(RuntimeError, MonitorNormalisation.filter_func, images)
+    def test_no_counts(self):
+        images = generate_images((2, 2, 2))
+        images._log_file = mock.Mock()
+        images._log_file.counts = mock.Mock(return_value=None)
+        npt.assert_raises(RuntimeError, MonitorNormalisation.filter_func, images)
 
+    def test_execute(self):
+        images = generate_images()
+        images._log_file = mock.Mock()
+        images._log_file.counts = mock.Mock(return_value=Counts(np.sin(np.linspace(0, 1, images.num_projections))))
 
-def test_execute():
-    images = generate_images()
-    images._log_file = mock.Mock()
-    images._log_file.counts = mock.Mock(return_value=Counts(np.sin(np.linspace(0, 1, images.num_projections))))
+        original = images.copy()
+        MonitorNormalisation.filter_func(images)
+        images._log_file.counts.assert_called_once()
+        assert_not_equals(original.data, images.data)
 
-    original = images.copy()
-    MonitorNormalisation.filter_func(images)
-    images._log_file.counts.assert_called_once()
-    assert_not_equals(original.data, images.data)
+    def test_execute2(self):
+        """
+        Test that the counts are correctly divided by the value at counts[0].
 
+        In this test that will make all the counts equal to 1, and the data will remain unchanged
+        """
+        images = generate_images()
+        images._log_file = mock.Mock()
+        images._log_file.counts = mock.Mock(return_value=Counts(np.full((10, ), 10)))
 
-def test_execute2():
-    """
-    Test that the counts are correctly divided by the value at counts[0].
+        original = images.copy()
+        MonitorNormalisation.filter_func(images)
+        images._log_file.counts.assert_called_once()
+        npt.assert_equal(original.data, images.data)
 
-    In this test that will make all the counts equal to 1, and the data will remain unchanged
-    """
-    images = generate_images()
-    images._log_file = mock.Mock()
-    images._log_file.counts = mock.Mock(return_value=Counts(np.full((10, ), 10)))
+    def test_register_gui(self):
+        assert MonitorNormalisation.register_gui(None, None, None) == {}
 
-    original = images.copy()
-    MonitorNormalisation.filter_func(images)
-    images._log_file.counts.assert_called_once()
-    npt.assert_equal(original.data, images.data)
-
-
-def test_register_gui():
-    assert MonitorNormalisation.register_gui(None, None, None) == {}
-
-
-def test_execute_wrapper():
-    wrapper = MonitorNormalisation.execute_wrapper()
-    assert wrapper is not None
-    assert isinstance(wrapper, partial)
+    def test_execute_wrapper(self):
+        wrapper = MonitorNormalisation.execute_wrapper()
+        assert wrapper is not None
+        assert isinstance(wrapper, partial)

--- a/mantidimaging/core/operations/overlap_correction/test/overlap_correction_test.py
+++ b/mantidimaging/core/operations/overlap_correction/test/overlap_correction_test.py
@@ -55,6 +55,3 @@ class OverlapCorrectionTest(unittest.TestCase):
         wrapper = OverlapCorrection.execute_wrapper()
         assert wrapper is not None
         assert isinstance(wrapper, partial)
-
-    def test_validate_execute_kwargs(self):
-        assert OverlapCorrection.validate_execute_kwargs({}) is True


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Related to #2795

### Description

In prep for work that will touch these tests, update them to using `unittest.TestCase` and `unittest` style asserts.

This is cherry picking patches from my work on #2795, so it also picked up removing a trival test from overlap correction.

Note: the hide whitespace option on the github diff viewer will make this PR easier to read

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`

### Documentation and Additional Notes

Not needed