### PR TITLE
Update operations validation method to have access to the ImageStack

### DIFF
--- a/docs/release_notes/next/dev-2795-ops-validation
+++ b/docs/release_notes/next/dev-2795-ops-validation
@@ -1,0 +1,1 @@
+#2795: Allow operation validation method to access image stack

--- a/mantidimaging/core/operations/base_filter.py
+++ b/mantidimaging/core/operations/base_filter.py
@@ -88,7 +88,7 @@ class BaseFilter:
         return {}
 
     @staticmethod
-    def validate_execute_kwargs(kwargs: dict[str, Any]) -> bool:
+    def validate_execute_kwargs(kwargs: dict[str, Any], images: ImageStack) -> bool:
         return True
 
     @staticmethod

--- a/mantidimaging/core/operations/base_filter.py
+++ b/mantidimaging/core/operations/base_filter.py
@@ -88,8 +88,15 @@ class BaseFilter:
         return {}
 
     @staticmethod
-    def validate_execute_kwargs(kwargs: dict[str, Any], images: ImageStack) -> bool:
-        return True
+    def validate_execute_kwargs(kwargs: dict[str, Any], images: ImageStack) -> str | None:
+        """
+        Check operation parameters to highlight issues that need to be caught before calling filter_func()
+
+        The method also has access to the ImageStack so it can check dimensions and metadata if needed.
+
+        :return: None if no issues, a string message if the is a problem
+        """
+        return None
 
     @staticmethod
     def group_name() -> FilterGroup:

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -264,7 +264,7 @@ class FlatFieldFilter(BaseFilter):
                        use_dark=use_dark)
 
     @staticmethod
-    def validate_execute_kwargs(kwargs):
+    def validate_execute_kwargs(kwargs, images):
         # Validate something is in both path text inputs
         if 'selected_flat_fielding_widget' not in kwargs:
             return False

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -264,19 +264,19 @@ class FlatFieldFilter(BaseFilter):
                        use_dark=use_dark)
 
     @staticmethod
-    def validate_execute_kwargs(kwargs, images):
+    def validate_execute_kwargs(kwargs: dict[str, Any], images: ImageStack) -> str | None:
         # Validate something is in both path text inputs
         if 'selected_flat_fielding_widget' not in kwargs:
-            return False
+            return "Not all required parameters specified"
 
         if 'flat_before_widget' not in kwargs and 'dark_before_widget' not in kwargs or\
                 'flat_after_widget' not in kwargs and 'dark_after_widget' not in kwargs:
-            return False
+            return "Not all required parameters specified"
         assert isinstance(kwargs["flat_before_widget"], DatasetSelectorWidgetView)
         assert isinstance(kwargs["flat_after_widget"], DatasetSelectorWidgetView)
         assert isinstance(kwargs["dark_before_widget"], DatasetSelectorWidgetView)
         assert isinstance(kwargs["dark_after_widget"], DatasetSelectorWidgetView)
-        return True
+        return None
 
     @staticmethod
     def group_name() -> FilterGroup:

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from functools import partial
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from collections.abc import Callable
 
 import numpy as np
@@ -37,7 +37,7 @@ class MonitorNormalisation(BaseFilter):
         if images.num_projections == 1:
             # we can't really compute the preview as the image stack copy
             # passed in doesn't have the logfile in it
-            raise RuntimeError("No logfile available for this stack.")
+            return images
 
         counts = images.counts()
         if counts is None:
@@ -61,3 +61,13 @@ class MonitorNormalisation(BaseFilter):
     @staticmethod
     def execute_wrapper(*args) -> partial:
         return partial(MonitorNormalisation.filter_func)
+
+    @staticmethod
+    def validate_execute_kwargs(kwargs: dict[str, Any], images: ImageStack) -> str | None:
+        counts = images.counts()
+        if counts is None:
+            return "Image stack has no counts. Ensure these have been loaded with a log file"
+
+        if counts.value.size != images.num_projections:
+            return "Number of entries in counts does not match number of images"
+        return None

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -2,7 +2,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 from functools import partial
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from collections.abc import Callable
 
 import numpy as np
@@ -61,7 +61,3 @@ class MonitorNormalisation(BaseFilter):
     @staticmethod
     def execute_wrapper(*args) -> partial:
         return partial(MonitorNormalisation.filter_func)
-
-    @staticmethod
-    def validate_execute_kwargs(kwargs: dict[str, Any]) -> bool:
-        return True

--- a/mantidimaging/core/operations/overlap_correction/overlap_correction.py
+++ b/mantidimaging/core/operations/overlap_correction/overlap_correction.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from collections.abc import Callable
 from logging import getLogger
 
@@ -75,10 +75,6 @@ class OverlapCorrection(BaseFilter):
     @staticmethod
     def execute_wrapper(*args) -> partial:
         return partial(OverlapCorrection.filter_func)
-
-    @staticmethod
-    def validate_execute_kwargs(kwargs: dict[str, Any]) -> bool:
-        return True
 
     @staticmethod
     def get_shutters(data_dir: Path) -> list[ShutterInfo]:

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -115,7 +115,3 @@ class RescaleFilter(BaseFilter):
             max_output = 2147483647.0
 
         return partial(RescaleFilter.filter_func, min_input=min_input, max_input=max_input, max_output=max_output)
-
-    @staticmethod
-    def validate_execute_kwargs(kwargs: dict[str, Any]) -> bool:
-        return True

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -125,7 +125,7 @@ class FiltersWindowModel:
     def apply_to_images(self, images: ImageStack, progress=None, is_preview=False) -> None:
         input_kwarg_widgets = self.filter_widget_kwargs.copy()
         # Validate required kwargs are supplied so pre-processing does not happen unnecessarily
-        if not self.selected_filter.validate_execute_kwargs(input_kwarg_widgets):
+        if not self.selected_filter.validate_execute_kwargs(input_kwarg_widgets, images):
             raise ValueError("Not all required parameters specified")
 
         # Run filter

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -120,13 +120,11 @@ class FiltersWindowModel:
         it to the function that actually processes the images.
         """
         for stack in stacks:
+            self.validate_kwargs(stack)
             self.apply_to_images(stack, progress=progress)
 
     def apply_to_images(self, images: ImageStack, progress=None, is_preview=False) -> None:
         input_kwarg_widgets = self.filter_widget_kwargs.copy()
-        # Validate required kwargs are supplied so pre-processing does not happen unnecessarily
-        if message := self.selected_filter.validate_execute_kwargs(input_kwarg_widgets, images) is not None:
-            raise ValueError("Issue with operation inputs: %s", message)
 
         # Run filter
         exec_func = self.selected_filter.execute_wrapper(**input_kwarg_widgets)
@@ -148,6 +146,14 @@ class FiltersWindowModel:
             self.selected_filter.filter_name,
             *exec_func.args,
             **exec_func.keywords)
+
+    def validate_kwargs(self, images: ImageStack) -> None:
+        """
+        Validate required kwargs are supplied so pre-processing does not happen unnecessarily
+        """
+        input_kwarg_widgets = self.filter_widget_kwargs.copy()
+        if (message := self.selected_filter.validate_execute_kwargs(input_kwarg_widgets, images)) is not None:
+            raise ValueError(f"Issue with operation inputs: {message}")
 
     def do_apply_filter(self, stacks: list[ImageStack], post_filter: Callable[[Any], None]):
         """

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -125,8 +125,8 @@ class FiltersWindowModel:
     def apply_to_images(self, images: ImageStack, progress=None, is_preview=False) -> None:
         input_kwarg_widgets = self.filter_widget_kwargs.copy()
         # Validate required kwargs are supplied so pre-processing does not happen unnecessarily
-        if not self.selected_filter.validate_execute_kwargs(input_kwarg_widgets, images):
-            raise ValueError("Not all required parameters specified")
+        if message := self.selected_filter.validate_execute_kwargs(input_kwarg_widgets, images) is not None:
+            raise ValueError("Issue with operation inputs: %s", message)
 
         # Run filter
         exec_func = self.selected_filter.execute_wrapper(**input_kwarg_widgets)

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -386,6 +386,7 @@ class FiltersWindowPresenter(BasePresenter):
         # Take copies for display to prevent issues when shared memory is cleaned
         before_image = np.copy(subset.data.squeeze(squeeze_axis))
         try:
+            self.model.validate_kwargs(self.stack)
             self.model.apply_to_images(subset, is_preview=True)
         except Exception as e:
             msg = f"Error applying filter for preview: {e}"

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -354,6 +354,9 @@ class FiltersWindowPresenter(BasePresenter):
         self.model.do_apply_filter_sync(apply_to, partial(self._post_filter, apply_to))
 
     def do_update_previews(self) -> None:
+        if not self.view.window_ready:
+            return
+
         if self.stack is None:
             self.view.clear_previews()
             return
@@ -383,8 +386,7 @@ class FiltersWindowPresenter(BasePresenter):
         # Take copies for display to prevent issues when shared memory is cleaned
         before_image = np.copy(subset.data.squeeze(squeeze_axis))
         try:
-            if self.model.filter_widget_kwargs:
-                self.model.apply_to_images(subset, is_preview=True)
+            self.model.apply_to_images(subset, is_preview=True)
         except Exception as e:
             msg = f"Error applying filter for preview: {e}"
             self.show_error(msg, traceback.format_exc())

--- a/mantidimaging/gui/windows/operations/test/model_test.py
+++ b/mantidimaging/gui/windows/operations/test/model_test.py
@@ -46,7 +46,7 @@ class FiltersWindowModelTest(unittest.TestCase):
         orig_exec, orig_validate = f.execute_wrapper, f.validate_execute_kwargs
         self.model.setup_filter("", {})
         f.execute_wrapper = lambda: execute_mock
-        f.validate_execute_kwargs = lambda _: True
+        f.validate_execute_kwargs = lambda _, __: True
 
         return orig_exec, orig_validate
 

--- a/mantidimaging/gui/windows/operations/test/model_test.py
+++ b/mantidimaging/gui/windows/operations/test/model_test.py
@@ -46,7 +46,7 @@ class FiltersWindowModelTest(unittest.TestCase):
         orig_exec, orig_validate = f.execute_wrapper, f.validate_execute_kwargs
         self.model.setup_filter("", {})
         f.execute_wrapper = lambda: execute_mock
-        f.validate_execute_kwargs = lambda _, __: True
+        f.validate_execute_kwargs = lambda _, __: None
 
         return orig_exec, orig_validate
 
@@ -144,6 +144,7 @@ class FiltersWindowModelTest(unittest.TestCase):
         selected_filter_mock.__name__ = mock.Mock()
         selected_filter_mock.__name__.return_value = "Test filter"
         selected_filter_mock.filter_name.return_value = "Test filter"
+        selected_filter_mock.validate_execute_kwargs.return_value = None
         progress_mock = mock.Mock()
 
         callback_mock = mock.Mock()

--- a/mantidimaging/gui/windows/operations/test/model_test.py
+++ b/mantidimaging/gui/windows/operations/test/model_test.py
@@ -153,7 +153,6 @@ class FiltersWindowModelTest(unittest.TestCase):
         self.model.selected_filter = selected_filter_mock
         self.model.apply_to_images(images, progress=progress_mock)
 
-        selected_filter_mock.validate_execute_kwargs.assert_called_once()
         callback_mock.assert_called_once_with(images, progress=progress_mock)
 
     def test_get_filter_module_name(self):

--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -35,6 +35,7 @@ def _strip_filter_name(filter_name: str):
 class FiltersWindowView(BaseMainWindowView):
     auto_update_triggered = pyqtSignal()
     filter_applied = pyqtSignal()
+    window_ready = False
 
     splitter: QSplitter
     collapseToggleButton: QPushButton
@@ -113,6 +114,7 @@ class FiltersWindowView(BaseMainWindowView):
         self.collapseToggleButton.pressed.connect(self.toggle_filters_section)
 
         self.handle_filter_selection("")
+        self.window_ready = True
 
     def closeEvent(self, e):
         if self.presenter.filter_is_running:


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2795 
### Description

Operations have a `validate_execute_kwargs()` method, but this was previously limited to only be able to check the parameters. This PR makes this method useful for checking conditions of the ImageStack as well.

There are several changes

- `validate_execute_kwargs()` now takes the ImageStack as an argument
- `validate_execute_kwargs()` now returns an error message or None
- in `FiltersWindowModel` extract method `validate_kwargs` is it can be passed the full stack in `do_update_previews()`

Also:

- Remove overridden methods that are identical to base method
- Prevent preview running while Operations window is setting up

The PR also add a `validate_execute_kwargs()` to MonitorNormalisation to check the counts exist and have the correct size. This allows it to run in preview mode without raising an exception (it did not before because the validation was skip for operations with no parameters as a work around for problems running previews will setting up the operations window).

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- checked running some operations

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Check that you can run some operations on a dataset
- [ ] Check that Monitor Normalisation still runs for dataset with log file (e.g. flower dataset), with safe apply, press the ROI button, you should see a change intensity plot for an air region. 
<img width="1431" height="789" alt="image" src="https://github.com/user-attachments/assets/20bf0a0c-609e-4f19-a772-158eed9eab42" />

- [ ] Check that if you load an imagestack without its log file you get a helpful message when selecting the Monitor Normalisation operation


### Documentation and Additional Notes

- [ ] Release notes has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info)

