### PR TITLE
Pyproject.toml: Pyright Optional Call Flag removed

### DIFF
--- a/mantidimaging/test_helpers/start_qapplication.py
+++ b/mantidimaging/test_helpers/start_qapplication.py
@@ -129,20 +129,24 @@ def augment_test_setup_methods(cls, setup=None, teardown=None, setup_class=None,
         pass
 
     def setUp(self):
-        setup(self)
-        setup_orig(self)
+        if setup:
+            setup(self)
+            setup_orig(self)
 
     def tearDown(self):
         teardown_orig(self)
-        teardown(self)
+        if teardown:
+            teardown(self)
 
     def setUpClass(cls):
-        setup_class()
-        setup_class_orig()
+        if setup_class:
+            setup_class()
+            setup_class_orig()
 
     def tearDownClass(cls):
-        teardown_class()
-        teardown_class_orig()
+        if teardown_class:
+            teardown_class()
+            teardown_class_orig()
 
     if setup:
         setup_orig = cls.setUp if hasattr(cls, 'setUp') else do_nothing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ include = ["mantidimaging/**/*.py"]
 exclude =  ["tests/**/*.py", "test/**/*.py", "**/*test.py"]
 reportMissingTypeStubs = false
 reportAttributeAccessIssue = false
-reportOptionalCall = false
 reportOptionalMemberAccess = false
 reportCallIssue = false
 reportArgumentType = false


### PR DESCRIPTION
## Issue Progresses #2682

### Description

This PR removes the Pyright optional call flag from pyproject.toml. The flag is no longer needed with the current version of Pyright, and removing it simplifies configuration while keeping type checking behavior consistent.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] run `pyright mantidimaging` and check that no errors or warning occur

