### PR TITLE
changed overlay threshold value

### DIFF
--- a/docs/release_notes/next/fix-2803-ring-remove-thershold-bug
+++ b/docs/release_notes/next/fix-2803-ring-remove-thershold-bug
@@ -1,0 +1,1 @@
+#2803: Fixes a bug in the Overlay Difference view for filters like Ring Removal.

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -21,7 +21,7 @@ before_pen = (200, 0, 0)
 after_pen = (0, 200, 0)
 diff_pen = (0, 0, 200)
 
-OVERLAY_THRESHOLD = 1e-3
+OVERLAY_THRESHOLD = 1e-6
 OVERLAY_COLOUR_DIFFERENCE = [0, 255, 255, 255]
 
 


### PR DESCRIPTION
## Issue Closes #2803

### Description

Fixes a bug in the Overlay Difference view for filters like Ring Removal.  
Previously, the overlay only showed differences above a hardcoded threshold (`1e-3`), which caused many real changes to be hidden. So updated hardcoded threshold (`1e-6`), so changes are now accurately reflected in the overlay.

### Developer Testing 

- [x] Manually verified overlay now matches the full difference image visually
- [x] Overlay correctly highlights faint ring artifacts that were previously missed
- [ ] I have verified unit tests pass locally: `python -m pytest -vs`

### Acceptance Criteria and Reviewer Testing

- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Load any reconstructed volume and apply the Ring Removal filter
- [ ] Enable "Overlay difference" checkbox
- [ ] Confirm that the overlay now reflects all differences (even subtle ones)
- [ ] Visually verify that overlay matches the “Image difference” panel more accurately than before

### Documentation and Additional Notes

- [x] Release Notes have been updated (if applicable)
