### PR TITLE
Remove workflow parts that upload to old conda repo

### DIFF
--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -5,19 +5,12 @@ inputs:
     description: 'Anaconda repository'
     required: true
     default: 'mantidimaging'
-  repository-old:
-    description: 'Anaconda repository - old'
-    required: true
-    default: 'mantid'
   label:
     description: 'Label'
     required: false
     default: 'unstable'
   token:
     description: 'Anaconda API Token'
-    required: true
-  token-old:
-    description: 'Anaconda API Token - old'
     required: true
 
 description: Build conda package
@@ -46,6 +39,5 @@ runs:
       # if the upload silently fails - check the token expiration. Conda can fail silently!
       conda mambabuild $GITHUB_WORKSPACE/conda
       anaconda -t ${{ inputs.token }} upload --user ${{ inputs.repository }} --label ${{ inputs.label }} ${CONDA_PREFIX}/conda-bld/*/mantidimaging*.tar.bz2 |& tee upload.log
-      anaconda -t ${{ inputs.token-old }} upload --user ${{ inputs.repository-old }} --label ${{ inputs.label }} ${CONDA_PREFIX}/conda-bld/*/mantidimaging*.tar.bz2
       # Check that upload completed
       grep "Upload complete" upload.log

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -152,4 +152,3 @@ jobs:
         with:
           label: unstable
           token: ${{ secrets.ANACONDA_API_TOKEN_MANTIDIMAGING }}
-          token-old: ${{ secrets.ANACONDA_API_TOKEN }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -139,4 +139,3 @@ jobs:
         with:
           label: unstable
           token: ${{ secrets.ANACONDA_API_TOKEN_MANTIDIMAGING }}
-          token-old: ${{ secrets.ANACONDA_API_TOKEN }}

--- a/docs/release_notes/next/dev-2763-conda-upload
+++ b/docs/release_notes/next/dev-2763-conda-upload
@@ -1,0 +1,1 @@
+#2763: Only publish on https://anaconda.org/mantidimaging/mantidimaging


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2763

### Description

Removes the upload line that uploads to the `mantid` conda repo. Now we only upload to the `mantidimaging` repo.
Removes the associated variables.

### Developer Testing 

Not much to test locally.

### Acceptance Criteria and Reviewer Testing
Not much to test locally.

- [ ] Check that the changes look sensible
- [ ] Tests still pass
- [ ] After this has merged, check that packages get uploaded to https://anaconda.org/mantidimaging/mantidimaging/files but not https://anaconda.org/mantid/mantidimaging/files


### Documentation and Additional Notes
Release notes

