### PR TITLE
Add Chi² fit quality display to Spectrum Viewer

### DIFF
--- a/mantidimaging/core/fitting/fitting_engine.py
+++ b/mantidimaging/core/fitting/fitting_engine.py
@@ -22,17 +22,29 @@ class FittingEngine:
     def get_init_params_from_roi(self, region: FittingRegion) -> dict[str, float]:
         return self.model.get_init_params_from_roi(region)
 
-    def find_best_fit(self, xdata: np.ndarray, ydata: np.ndarray, initial_params: list[float]) -> dict[str, float]:
-        additional_params = self.model.prefitting(xdata, ydata, initial_params)
-        params_to_fit = initial_params[:len(initial_params) - len(additional_params)]
+    def find_best_fit(self, xdata: np.ndarray, ydata: np.ndarray,
+                      initial_params: list[float]) -> tuple[dict[str, float], float]:
+        """
+        Perform a model fit and return the fitted parameters and chi-squared value.
 
-        def f(params_to_fit):
-            if additional_params:
-                params_to_fit = np.concatenate((params_to_fit, np.array(additional_params)), axis=None)
-            return ((self.model.evaluate(xdata, params_to_fit) - ydata)**2).sum()
+        :param xdata: TOF data (independent variable)
+        :param ydata: Spectrum data (dependent variable)
+        :param initial_params: Initial parameter estimates
+        :return: (fit_params, chi_squared)
+        """
+        additional_params: list[float] = self.model.prefitting(xdata, ydata, initial_params)
+        fit_param_count = len(initial_params) - len(additional_params)
+        params_to_fit: np.ndarray = np.array(initial_params[:fit_param_count])
 
-        result = minimize(f, params_to_fit, method="Nelder-Mead")
+        def chi_squared(params_subset: list[float]) -> float:
+            full_params = list(params_subset) + additional_params
+            residuals = self.model.evaluate(xdata, full_params) - ydata
+            return float(np.sum(residuals**2))
 
+        result = minimize(chi_squared, params_to_fit, method="Nelder-Mead")
         all_param_names = self.model.get_parameter_names()
-        all_params = list(result.x) + additional_params
-        return dict(zip(all_param_names, all_params, strict=True))
+        all_params: list[float] = list(result.x) + additional_params
+        fit_params: dict[str, float] = dict(zip(all_param_names, all_params, strict=True))
+        final_residuals = self.model.evaluate(xdata, all_params) - ydata
+        chi2: float = float(np.sum(final_residuals**2))
+        return fit_params, chi2

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_param_form_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_param_form_widget.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from logging import getLogger
 
+import numpy as np
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QSizePolicy, QPushButton
 from PyQt5.QtGui import QDoubleValidator
 
@@ -42,6 +43,9 @@ class FittingParamFormWidget(QWidget):
         self.layout().addWidget(self.run_fit_button)
         self.run_fit_button.clicked.connect(self.presenter.run_region_fit)
         self._param_values_logged = False
+
+        self.chi2_label = QLabel("Fitting Quality (χ²): N/A")
+        main_layout.addWidget(self.chi2_label)
 
     def set_parameters(self, params: list[str]) -> None:
         """
@@ -101,3 +105,9 @@ class FittingParamFormWidget(QWidget):
             self.params_layout.layout().removeItem(row_layout)
         self._rows.clear()
         LOG.debug("Parameter form rows cleared")
+
+    def set_chi_squared(self, chi2: float) -> None:
+        if np.isnan(chi2) or np.isinf(chi2):
+            self.chi2_label.setText("Fitting Quality (χ²): N/A")
+        else:
+            self.chi2_label.setText(f"Fitting Quality (χ²): {chi2:.2f}")

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -675,9 +675,10 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             roi = self.view.spectrum_widget.get_roi(roi_name)
             spectrum = self.model.get_spectrum(roi, self.spectrum_mode)
             xvals = self.model.tof_data
-            result = self.model.fitting_engine.find_best_fit(xvals, spectrum, init_params)
-            self.view.scalable_roi_widget.set_fitted_parameter_values(result)
-            self.show_fit(list(result.values()))
+            fit_params, chi2 = self.model.fitting_engine.find_best_fit(xvals, spectrum, init_params)
+            self.view.scalable_roi_widget.set_fitted_parameter_values(fit_params)
+            self.view.scalable_roi_widget.set_fit_quality(chi2)
+            self.show_fit(list(fit_params.values()))
 
     def show_initial_fit(self) -> None:
         """
@@ -695,17 +696,18 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                                                      initial=True)
 
     def run_region_fit(self) -> None:
-        result = self.fit_single_region(self.fitting_spectrum, self.view.get_fitting_region(), self.model.tof_data,
-                                        self.view.scalable_roi_widget.get_initial_param_values())
-
+        result, chi2 = self.fit_single_region(self.fitting_spectrum, self.view.get_fitting_region(),
+                                              self.model.tof_data,
+                                              self.view.scalable_roi_widget.get_initial_param_values())
         self.view.scalable_roi_widget.set_fitted_parameter_values(result)
+        self.view.scalable_roi_widget.set_chi_squared(chi2)
         self.show_fit(list(result.values()))
         roi_name = self.view.roiSelectionWidget.current_roi_name
         self.view.exportDataTableWidget.update_roi_data(roi_name=roi_name, params=result, status="Fitted")
-        LOG.info("Fit completed for ROI=%s, params=%s", roi_name, result)
+        LOG.info("Fit completed for ROI=%s, params=%s, chi²=%.4f", roi_name, result, chi2)
 
     def fit_single_region(self, spectrum: np.ndarray, fitting_region: FittingRegion, tof_data: np.ndarray,
-                          init_params: list[float]) -> dict[str, float]:
+                          init_params: list[float]) -> tuple[dict[str, float], float]:
         fitting_slice = slice(*np.searchsorted(tof_data, (fitting_region[0], fitting_region[1])))
         xvals = tof_data[fitting_slice]
         yvals = spectrum[fitting_slice]
@@ -721,15 +723,16 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             spectrum = self.model.get_spectrum(roi, self.spectrum_mode, self.view.shuttercount_norm_enabled())
             fitting_region = self.view.get_fitting_region()
             try:
-                result = self.fit_single_region(spectrum, fitting_region, self.model.tof_data, init_params)
+                result, chi2 = self.fit_single_region(spectrum, fitting_region, self.model.tof_data, init_params)
                 status = "Fitted"
             except (ValueError, BadFittingRoiError) as e:
                 LOG.warning(f"Failed to find fit for {roi_name}: {e}")
-                result = {param_name: 0 for param_name in self.model.fitting_engine.get_parameter_names()}
+                param_names = self.model.fitting_engine.get_parameter_names()
+                result = {param_name: 0 for param_name in param_names}
+                chi2 = float('nan')
                 status = "Failed"
-
             self.view.exportDataTableWidget.update_roi_data(roi_name=roi_name, params=result, status=status)
-            LOG.info("Fit completed for ROI=%s, params=%s", roi_name, result)
+            LOG.info("Fit completed for ROI=%s, params=%s, chi²=%.2f", roi_name, result, chi2)
 
     def show_fit(self, params: list[float]) -> None:
         xvals = self.model.tof_data


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2831

### Description

This PR introduces the display of fitting quality (Chi²) in the Spectrum Viewer GUI. The fitting engine now returns the sum of squared residuals (Chi²) alongside the parameter results. This value is shown below the parameter table for each ROI fit, helping users evaluate fit accuracy quantitatively.

### Developer Testing 

- I have verified unit tests pass locally: python -m pytest -vs
- Manually tested single-ROI and multi-ROI fitting flow in GUI

### Acceptance Criteria and Reviewer Testing

- Run fit and check that "Fitting Quality (χ²)" is displayed below parameter table
- Edit initial parameters, re-fit, and confirm updated Chi² value
- Run "Fit All ROIs" and confirm Chi² shown correctly for each

### Documentation and Additional Notes

<!-- - [ ] Release Notes have been updated
