### PR TITLE
Reuse cached spectra on ROI moves instead of full recompute

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -132,6 +132,7 @@ class SpectrumViewerWindowModel:
 
     def set_normalise_stack(self, normalise_stack: ImageStack | None) -> None:
         self._normalise_stack = normalise_stack
+        self.spectrum_cache.clear()
         if normalise_stack is not None:
             LOG.info("Normalisation stack set: shape=%s", normalise_stack.data.shape)
         else:


### PR DESCRIPTION
## Issue 
Closes #2839

### Description

- Reuse cached spectra on ROI moves instead of recomputing
- Clear cache when normalise stack changes


### Developer Testing 

- I have verified unit tests pass locally: `python -m pytest -vs`
- Manually tested ROI nudging → spectra snap back instantly if cached
- Verified cache clears correctly on normalise stack changes

### Acceptance Criteria and Reviewer Testing

- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Move an ROI back and forth → confirm cached spectrum is reused (no recompute delay)
- [ ] Change normalise stack → confirm spectra are recomputed, not reused
- [ ] Add a brand new ROI → confirm no errors, spectrum computes normally

### Documentation and Additional Notes

- [ ] Release Notes have been updated 


