### PR TITLE
Extract 2d binning code

### DIFF
--- a/mantidimaging/core/utility/sensible_roi.py
+++ b/mantidimaging/core/utility/sensible_roi.py
@@ -45,3 +45,22 @@ class SensibleROI(Iterable[int]):
     @property
     def height(self) -> int:
         return self.bottom - self.top
+
+
+class ROIBinner:
+
+    def __init__(self, roi: SensibleROI, step_size: int, bin_size: int):
+        self.roi = roi
+        self.step_size = step_size
+        self.bin_size = bin_size
+
+        self.left_indexes = range(self.roi.left, self.roi.right - self.bin_size + 1, self.step_size)
+        self.top_indexes = range(self.roi.top, self.roi.bottom - self.bin_size + 1, self.step_size)
+
+    def lengths(self) -> tuple[int, int]:
+        return len(self.left_indexes), len(self.top_indexes)
+
+    def get_sub_roi(self, i: int, j: int) -> SensibleROI:
+        left = self.left_indexes[i]
+        top = self.top_indexes[j]
+        return SensibleROI(left, top, left + self.bin_size, top + self.bin_size)

--- a/mantidimaging/core/utility/sensible_roi.py
+++ b/mantidimaging/core/utility/sensible_roi.py
@@ -50,12 +50,12 @@ class SensibleROI(Iterable[int]):
 class ROIBinner:
 
     def __init__(self, roi: SensibleROI, step_size: int, bin_size: int):
-        self.roi = roi
-        self.step_size = step_size
-        self.bin_size = bin_size
+        self._roi = roi
+        self._step_size = step_size
+        self._bin_size = bin_size
 
-        self.left_indexes = range(self.roi.left, self.roi.right - self.bin_size + 1, self.step_size)
-        self.top_indexes = range(self.roi.top, self.roi.bottom - self.bin_size + 1, self.step_size)
+        self.left_indexes = range(roi.left, roi.right - bin_size + 1, step_size)
+        self.top_indexes = range(roi.top, roi.bottom - bin_size + 1, step_size)
 
     def lengths(self) -> tuple[int, int]:
         return len(self.left_indexes), len(self.top_indexes)
@@ -64,3 +64,15 @@ class ROIBinner:
         left = self.left_indexes[i]
         top = self.top_indexes[j]
         return SensibleROI(left, top, left + self.bin_size, top + self.bin_size)
+
+    @property
+    def roi(self) -> SensibleROI:
+        return self._roi
+
+    @property
+    def step_size(self) -> int:
+        return self._step_size
+
+    @property
+    def bin_size(self) -> int:
+        return self._bin_size

--- a/mantidimaging/core/utility/sensible_roi.py
+++ b/mantidimaging/core/utility/sensible_roi.py
@@ -2,28 +2,20 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
-from collections.abc import Iterator
 
 if TYPE_CHECKING:
     from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint
 
 
-@dataclass
-class SensibleROI(Iterable):
-    __slots__ = ("left", "top", "right", "bottom")
-    left: int
-    top: int
-    right: int
-    bottom: int
-
-    def __init__(self, left=0, top=0, right=0, bottom=0):
-        self.left = left
-        self.top = top
-        self.right = right
-        self.bottom = bottom
+@dataclass(slots=True)
+class SensibleROI(Iterable[int]):
+    left: int = 0
+    top: int = 0
+    right: int = 0
+    bottom: int = 0
 
     @staticmethod
     def from_points(position: CloseEnoughPoint, size: CloseEnoughPoint) -> SensibleROI:

--- a/mantidimaging/core/utility/test/sensibleROI_test.py
+++ b/mantidimaging/core/utility/test/sensibleROI_test.py
@@ -128,6 +128,23 @@ class ROIBinnerTest(unittest.TestCase):
                 self.assertTrue(roi.top <= sub_roi.top <= roi.bottom)
                 self.assertTrue(roi.top <= sub_roi.bottom <= roi.bottom)
 
+    def test_WHEN_index_out_of_range_THEN_exception_raised(self):
+        binner = ROIBinner(SensibleROI(10, 10, 15, 20), 2, 2)
+        self.assertEqual(binner.lengths(), (2, 5))
+        self.assertIsInstance(binner.get_sub_roi(0, 0), SensibleROI)
+        self.assertIsInstance(binner.get_sub_roi(1, 4), SensibleROI)
+        self.assertRaises(IndexError, binner.get_sub_roi, 2, 1)
+        self.assertRaises(IndexError, binner.get_sub_roi, 1, 5)
+
+    def test_dont_allow_modification(self):
+        binner = ROIBinner(SensibleROI(10, 10, 15, 20), 2, 2)
+        with self.assertRaises(AttributeError):
+            binner.roi = SensibleROI(1, 1, 2, 2)
+        with self.assertRaises(AttributeError):
+            binner.step_size = 3
+        with self.assertRaises(AttributeError):
+            binner.bin_size = 4
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/core/utility/test/sensibleROI_test.py
+++ b/mantidimaging/core/utility/test/sensibleROI_test.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import unittest
 
-from mantidimaging.core.utility.sensible_roi import SensibleROI
+from parameterized import parameterized
+
+from mantidimaging.core.utility.sensible_roi import SensibleROI, ROIBinner
 
 
 class CloseEnoughPoint:
@@ -66,6 +68,65 @@ class SensibleROITestCase(unittest.TestCase):
     def test_height(self):
         roi = SensibleROI(1, 2, 4, 6)
         self.assertEqual(roi.height, 4)
+
+
+class ROIBinnerTest(unittest.TestCase):
+
+    def test_get_length(self):
+        roi = SensibleROI(1, 10, 15, 20)
+        step_size = 1
+        bin_size = 1
+        binner = ROIBinner(roi, step_size, bin_size)
+        self.assertEqual(binner.lengths(), (14, 10))
+
+    @parameterized.expand([
+        (4, 1, 4),
+        (4, 2, 2),
+        (4, 4, 1),
+        (5, 2, 3),
+        (6, 2, 3),
+    ])
+    def test_length_step(self, width, step_size, expected_len):
+        for start in [0, 1, 10]:
+            roi = SensibleROI(start, start, start + width, start + width)
+            bin_size = 1
+            binner = ROIBinner(roi, step_size, bin_size)
+            self.assertEqual(binner.lengths(), (expected_len, expected_len))
+
+    @parameterized.expand([
+        (1, 1, 10),
+        (2, 2, 5),
+        (1, 2, 9),
+        (3, 3, 3),
+        (3, 4, 3),
+    ])
+    def test_length_width(self, step_size, bin_size, expected_len):
+        width = 10
+        for start in [0, 1, 10]:
+            roi = SensibleROI(start, start, start + width, start + width)
+            binner = ROIBinner(roi, step_size, bin_size)
+            self.assertEqual(binner.lengths(), (expected_len, expected_len))
+
+    @parameterized.expand([(0, 0, SensibleROI(1, 2, 4, 5)), (0, 1, SensibleROI(1, 4, 4, 7)),
+                           (1, 0, SensibleROI(3, 2, 6, 5))])
+    def test_get_sub_roi(self, i, j, sub_roi):
+        roi = SensibleROI(1, 2, 15, 20)
+        binner = ROIBinner(roi, 2, 3)
+
+        self.assertEqual(binner.get_sub_roi(i, j), sub_roi)
+
+    def test_all_rois(self):
+        roi = SensibleROI(100, 200, 120, 225)
+        binner = ROIBinner(roi, 4, 5)
+        sub_w, sub_h = binner.lengths()
+        self.assertEqual((sub_w, sub_h), (4, 6))
+        for i in range(sub_w):
+            for j in range(sub_h):
+                sub_roi = binner.get_sub_roi(i, j)
+                self.assertTrue(roi.left <= sub_roi.left <= roi.right)
+                self.assertTrue(roi.left <= sub_roi.right <= roi.right)
+                self.assertTrue(roi.top <= sub_roi.top <= roi.bottom)
+                self.assertTrue(roi.top <= sub_roi.bottom <= roi.bottom)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2857

### Description

Create an `ROIBinner` class to hold the logic of 2d binning. This allows it to be unit tested.

Use it in the RITS export code

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- Used the code in the comment to visualise the sub rois
- Run a RITS export with main and this branch (with same data and dimensions) and confirm the outputs are identical

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Use the code in the comment to visualise the sub rois

### Documentation and Additional Notes

Small refactoring, so no release notes needed.