### PR TITLE
FLASHPR: Pin numba to 0.61 to avoid incompatibility with coverage

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,6 +8,7 @@ channels:
 dependencies:
   - mantidimaging>=2.5.0
   - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774
+  - numba==0.61.* # https://github.com/numba/numba/issues/10239
   - pip
   - pip:
       - eyes-images==5.23.*

--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,5 @@ channels:
 dependencies:
   - mantidimaging>=2.5.0
   - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774
+  - numba==0.61.* # https://github.com/numba/numba/issues/10239
   - ipp=2021.12 # https://github.com/mantidproject/mantidimaging/issues/2354


### PR DESCRIPTION
Work around https://github.com/numba/numba/issues/10239

### Description
Pin numba version

Its not a direct dependency, so need to pin in the environment

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- ...

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] ...

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

