### PR TITLE
Spectrum Viewer: RITS roi can be resized via spinboxes

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -646,7 +646,10 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def do_adjust_roi(self) -> None:
         new_roi = self.view.roi_form.roi_properties_widget.to_roi()
-        roi_name = self.view.table_view.current_roi_name
+        if self.export_mode == ExportMode.ROI_MODE:
+            roi_name = self.view.table_view.current_roi_name
+        elif self.export_mode == ExportMode.IMAGE_MODE:
+            roi_name = "rits_roi"
         self.view.spectrum_widget.adjust_roi(new_roi, roi_name)
         self.handle_notify_roi_moved(self.view.spectrum_widget.roi_dict[roi_name])
 


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2864


### Description

When adjusting the Spectrum Viewer spinboxes, the `ExportMode` is checked to see if it is in `ROI_MODE` or `IMAGE_MODE` and correctly assigns the `roi_name`.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- ...

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] With the Spectrum Viewer open, switch to the Image Tab and adjust the ROI Properties spinboxes and check that the RITS ROI is changed accordingly. 
- [ ] Check that the functionality of the spinboxes is otherwise unchanged.

