### PR TITLE
Spectrum Viewer: Prevent showing fitting region for single image ImageStack

### DIFF
--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_display_widget.py
@@ -98,7 +98,8 @@ class FittingDisplayWidget(QWidget):
 
     def set_default_region_if_needed(self, x_data: np.ndarray, y_data: np.ndarray) -> None:
         """Position the ROI centrally over the plotted data, if valid data and not in existing region"""
-        if y_data.size == 0 or x_data.size == 0 or np.all(np.isnan(y_data)) or np.all(y_data == 0):
+        if (y_data.size == 0 or x_data.size == 0 or np.all(np.isnan(y_data)) or np.all(y_data == 0)
+                or (x_data.size == 1 and y_data.size == 1)):
             self.fitting_region.hide()
             return
 


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2858

### Description

When updating the plots after changing stacks in the Spectrum Viewer, we now check if the spectrum as a length of 1 and if so, prevent the fitting region and the spectrum from being plotted in the Fitting Tab.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- ...

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Load a Dataset which has a single image ImageStack, e.g. 180, or Flat/Dark
- [ ] In the Spectrum Viewer, select the single ImageStack.
- [ ] Check that no AssertionErrors are raised and the Spectrum plots as normal
- [ ] Check that the plots in the Fitting Tab behave and display as expected.
