### PR TITLE
2870 Explicitly Collect Imagecodecs Hidden Imports

### DIFF
--- a/docs/release_notes/next/fix-2870-explicit_import_of_imagecodec_modules
+++ b/docs/release_notes/next/fix-2870-explicit_import_of_imagecodec_modules
@@ -1,0 +1,1 @@
+#2870: Fixes a bug in Pyinstaller where image codec modules were not being explicitly imported, leading to missing codecs in the packaged application due to automatic delayed imports did not include them.

--- a/packaging/PackageWithPyInstaller.py
+++ b/packaging/PackageWithPyInstaller.py
@@ -9,6 +9,8 @@ import pkgutil
 import subprocess
 import sys
 from pathlib import Path
+
+import imagecodecs
 from PyInstaller.utils.hooks import conda_support, collect_data_files
 import PyInstaller.__main__
 
@@ -42,6 +44,8 @@ def add_hidden_imports(run_options):
         # https://github.com/mantidproject/mantidimaging/issues/2298
         if "test.support" not in ops_module:
             imports.append(f'mantidimaging.core.operations.{ops_module}')
+
+    imports.extend(["imagecodecs." + x for x in imagecodecs._extensions()] + ["imagecodecs._shared"])
 
     run_options.extend([f'--hidden-import={name}' for name in imports])
 


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2870 

### Description

<!-- Add a description of the changes made. -->

Add imagecodecs extensions to `add_hidden_imports()` so that PyInstaller can see it.

Imagecodecs uses a defered import hack, which mean PyInstaller was missing them from the build.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- Built a Windows executable and manually tested locally on Windows that a variety of `.tif` compression types can be.

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] built a Windows executable and manually tested locally on Windows that a variety of `.tif` compression types can be loaded into Mantid Imaging.
    - [x] Created a fresh dev environment `python ./setup.py create_dev_env` and activated it (`mamba activate mantidimaging-dev `)
    - [x] navigated to `packaging`: `cd packaging` and executed `python PackageWithPyInstaller.py`
    - [x] `makensis nsis_settings.nsi` (if needed ‘mamba install nsis’). This will make an installer in the dist folder that can be used to test loading of a compressed `.tif` file.
- [x] Run the Built Mantid Imaging package and follow the replication steps in #2870 

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

Matlab to load a `.tif` perform basic processing and output a new `.tif` with packbits compression. Replace "packbits" with a few other compression types to test loading into mantid Imaging (`Proj_0001.tif` can be downloaded from SharePoint example data):
```matlab
input_tiff = 'Proj_0001.tif';
img = imread(input_tiff) + 100;
imwrite(img, 'modified_with_packbits.tif', 'TIFF', 'Compression', 'packbits');
```

- [ ] Release Notes have been updated
<!-- - [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

