### PR TITLE
2614 geometry refactor projection angles handling

### DIFF
--- a/docs/release_notes/next/dev-2614-refactor-projection-angles
+++ b/docs/release_notes/next/dev-2614-refactor-projection-angles
@@ -1,0 +1,1 @@
+#2614: ProjectionAngles are no longer stored in both Geometry and ImageStack, only Geometry.

--- a/mantidimaging/core/data/dataset.py
+++ b/mantidimaging/core/data/dataset.py
@@ -148,7 +148,7 @@ class Dataset:
     def nexus_rotation_angles(self) -> list[np.ndarray]:
         proj_angles = []
         for image_stack in self._nexus_stack_order:
-            angles = image_stack.real_projection_angles()
+            angles = image_stack.projection_angles()
             proj_angles.append(angles.value if angles else np.zeros(image_stack.num_images))
         return proj_angles
 

--- a/mantidimaging/core/data/geometry.py
+++ b/mantidimaging/core/data/geometry.py
@@ -6,6 +6,8 @@ from enum import Enum
 from math import tan, radians, degrees
 
 from cil.framework import AcquisitionGeometry
+from numpy import ndarray
+
 from mantidimaging.core.utility.data_containers import ScalarCoR
 
 
@@ -16,16 +18,19 @@ class GeometryType(Enum):
 
 class Geometry(AcquisitionGeometry):
 
-    def __init__(self,
-                 type: GeometryType = GeometryType.PARALLEL3D,
-                 num_pixels: list | tuple = (10, 10),
-                 pixel_size: list | tuple = (1., 1.),
-                 source_position: list | tuple = (0, -1, 0),
-                 detector_position: list | tuple = (0, 1, 0),
-                 angle_unit: str = "radian",
-                 units: str = "default",
-                 *args,
-                 **kwargs):
+    def __init__(
+            self,
+            angles: ndarray,
+            angle_unit: str = "radian",
+            type: GeometryType = GeometryType.PARALLEL3D,
+            num_pixels: list | tuple = (10, 10),
+            pixel_size: list | tuple = (1.0, 1.0),
+            source_position: list | tuple = (0, -1, 0),
+            detector_position: list | tuple = (0, 1, 0),
+            units: str = "default",
+            *args,
+            **kwargs,
+    ):
         """
         Uses CIL conventions to determine geometry and centre of rotation.
         By default, the Geometry object is instantiated using a Parallel3D configuration.
@@ -53,7 +58,7 @@ class Geometry(AcquisitionGeometry):
             self.config = conebeam_3d.config
 
         self.set_panel(num_pixels=num_pixels, pixel_size=pixel_size)
-        self.set_angles(angles=range(0, 180), angle_unit=angle_unit)
+        self.set_angles(angles=angles, angle_unit=angle_unit)
 
     def set_geometry_from_cor_tilt(self, cor: ScalarCoR, tilt: float) -> None:
         """

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -417,6 +417,7 @@ class ImageStack:
         """
         Creates an AcquisitionGeometry belonging to the ImageStack.
         """
+
         self.geometry = Geometry(angles.value,
                                  type=geom_type,
                                  num_pixels=(self.width, self.height),

--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -413,13 +413,14 @@ class ImageStack:
             if num > 1000:
                 raise ValueError(f"Could not make unique name for: {name}")
 
-    def create_geometry(self, geom_type: GeometryType = GeometryType.PARALLEL3D) -> None:
+    def create_geometry(self, angles: ProjectionAngles, geom_type: GeometryType = GeometryType.PARALLEL3D) -> None:
         """
         Creates an AcquisitionGeometry belonging to the ImageStack.
         """
-        self.geometry = Geometry(type=geom_type, num_pixels=(self.width, self.height), pixel_size=(1., 1.))
-        self.set_geometry_angles()
-        self.set_geometry_panels()
+        self.geometry = Geometry(angles.value,
+                                 type=geom_type,
+                                 num_pixels=(self.width, self.height),
+                                 pixel_size=(1., 1.))
 
     def set_geometry_panels(self) -> None:
         """

--- a/mantidimaging/core/data/test/dataset_test.py
+++ b/mantidimaging/core/data/test/dataset_test.py
@@ -14,14 +14,8 @@ from mantidimaging.core.utility.data_containers import ProjectionAngles, FILE_TY
 from mantidimaging.test_helpers.unit_test_helper import generate_images, generate_standard_dataset
 
 
-def _set_fake_projection_angles(image_stack: ImageStack):
-    """
-    Sets the private projection angles attribute.
-    :param image_stack: The ImageStack object.
-    """
+def _set_projection_angles(image_stack: ImageStack):
     image_stack.set_projection_angles(ProjectionAngles(np.array([0, 180])))
-    #image_stack.real_projection_angles.return_value = image_stack._projection_angles
-    #image_stack.projection_angles.return_value = image_stack._projection_angles
 
 
 class DatasetTest(unittest.TestCase):
@@ -185,7 +179,7 @@ class DatasetTest(unittest.TestCase):
     def test_rotation_angles(self):
         ds, images = generate_standard_dataset()
         for stack in images:
-            _set_fake_projection_angles(stack)
+            _set_projection_angles(stack)
         assert np.array_equal(ds.nexus_rotation_angles, [
             ds.dark_before.projection_angles().value,
             ds.flat_before.projection_angles().value,
@@ -205,9 +199,9 @@ class DatasetTest(unittest.TestCase):
     def test_partially_incomplete_nexus_rotation_angles(self):
         ds, _ = generate_standard_dataset()
 
-        _set_fake_projection_angles(ds.dark_before)
-        _set_fake_projection_angles(ds.flat_before)
-        _set_fake_projection_angles(ds.dark_after)
+        _set_projection_angles(ds.dark_before)
+        _set_projection_angles(ds.flat_before)
+        _set_projection_angles(ds.dark_after)
         expected_list = [
             ds.dark_before.projection_angles().value,
             ds.flat_before.projection_angles().value,

--- a/mantidimaging/core/data/test/dataset_test.py
+++ b/mantidimaging/core/data/test/dataset_test.py
@@ -19,7 +19,7 @@ def _set_fake_projection_angles(image_stack: ImageStack):
     Sets the private projection angles attribute.
     :param image_stack: The ImageStack object.
     """
-    image_stack._projection_angles = ProjectionAngles(np.array([0, 180]))
+    image_stack.set_projection_angles(ProjectionAngles(np.array([0, 180])))
     #image_stack.real_projection_angles.return_value = image_stack._projection_angles
     #image_stack.projection_angles.return_value = image_stack._projection_angles
 

--- a/mantidimaging/core/data/test/geometry_test.py
+++ b/mantidimaging/core/data/test/geometry_test.py
@@ -14,6 +14,8 @@ from parameterized import parameterized
 from mantidimaging.core.data.geometry import Geometry, GeometryType
 from mantidimaging.core.utility.data_containers import ScalarCoR
 
+TEST_ANGLES = np.array(range(0, 180))
+
 
 class GeometryTest(unittest.TestCase):
 

--- a/mantidimaging/core/data/test/geometry_test.py
+++ b/mantidimaging/core/data/test/geometry_test.py
@@ -23,7 +23,7 @@ class GeometryTest(unittest.TestCase):
         """
         Tests the instantiation of a default Geometry object.
         """
-        geo = Geometry()
+        geo = Geometry(TEST_ANGLES)
 
         self.assertTrue(geo.type == GeometryType.PARALLEL3D)
         npt.assert_array_equal(geo.config.system.ray.direction, np.array([0, 1, 0]))
@@ -45,24 +45,26 @@ class GeometryTest(unittest.TestCase):
         self.assertEqual(geo.get_centre_of_rotation()["angle"], (0.0, "radian"))
 
     @parameterized.expand([
-        ("512x512", Geometry(num_pixels=(512, 512), pixel_size=(2., 2.), angle_unit="degree", units="pixels"), {
-            "num_pixels": (512, 512),
-            "pixel_size": (2., 2.),
-            "angle_unit": "degree",
-            "units": "pixels"
-        }),
-        ("8x8", Geometry(num_pixels=(8, 8), pixel_size=(4., 4.), angle_unit="degree", units="pixels"), {
+        ("512x512",
+         Geometry(TEST_ANGLES, num_pixels=(512, 512), pixel_size=(2., 2.), angle_unit="degree", units="pixels"), {
+             "num_pixels": (512, 512),
+             "pixel_size": (2., 2.),
+             "angle_unit": "degree",
+             "units": "pixels"
+         }),
+        ("8x8", Geometry(TEST_ANGLES, num_pixels=(8, 8), pixel_size=(4., 4.), angle_unit="degree", units="pixels"), {
             "num_pixels": (8, 8),
             "pixel_size": (4., 4.),
             "angle_unit": "degree",
             "units": "pixels"
         }),
-        ("256x128", Geometry(num_pixels=(256, 128), pixel_size=(8., 4.), angle_unit="degree", units="pixels"), {
-            "num_pixels": (256, 128),
-            "pixel_size": (8., 4.),
-            "angle_unit": "degree",
-            "units": "pixels"
-        }),
+        ("256x128",
+         Geometry(TEST_ANGLES, num_pixels=(256, 128), pixel_size=(8., 4.), angle_unit="degree", units="pixels"), {
+             "num_pixels": (256, 128),
+             "pixel_size": (8., 4.),
+             "angle_unit": "degree",
+             "units": "pixels"
+         }),
     ])
     def test_custom_geometry(self, _, geo, expected_values):
         """
@@ -79,7 +81,7 @@ class GeometryTest(unittest.TestCase):
         """
         Tests converting and setting the AcquisitionGeometry centre of rotation value.
         """
-        geo = Geometry()
+        geo = Geometry(TEST_ANGLES)
         geo.set_geometry_from_cor_tilt(cor, tilt)
 
         self.assertEqual(geo.cor.value, cor.value)
@@ -95,7 +97,7 @@ class GeometryTest(unittest.TestCase):
         num_pixels = (512, 512)
         pixel_size = (1., 1.)
 
-        geo = Geometry(num_pixels=num_pixels, pixel_size=pixel_size)
+        geo = Geometry(TEST_ANGLES, num_pixels=num_pixels, pixel_size=pixel_size)
         geo.set_geometry_from_cor_tilt(cor, tilt)
 
         self.assertAlmostEqual(geo.cor.value, cor.value, delta=0.0001)
@@ -111,7 +113,7 @@ class GeometryTest(unittest.TestCase):
         num_pixels = (8, 8)
         pixel_size = (1., 1.)
 
-        geo = Geometry(num_pixels=num_pixels, pixel_size=pixel_size)
+        geo = Geometry(TEST_ANGLES, num_pixels=num_pixels, pixel_size=pixel_size)
         geo.set_geometry_from_cor_tilt(cor, tilt)
 
         self.assertEqual(geo.cor.value, cor.value)
@@ -130,7 +132,7 @@ class GeometryTest(unittest.TestCase):
         num_pixels = (128, 128)
         pixel_size = (1., 1.)
 
-        geo = Geometry(num_pixels=num_pixels, pixel_size=pixel_size)
+        geo = Geometry(TEST_ANGLES, num_pixels=num_pixels, pixel_size=pixel_size)
         geo.set_geometry_from_cor_tilt(cor, tilt)
 
         cil_offset = geo.get_centre_of_rotation()['offset'][0]
@@ -153,7 +155,7 @@ class GeometryTest(unittest.TestCase):
         num_pixels = (256, 512)
         pixel_size = (1., 1.)
 
-        geo = Geometry(num_pixels=num_pixels, pixel_size=pixel_size)
+        geo = Geometry(TEST_ANGLES, num_pixels=num_pixels, pixel_size=pixel_size)
         geo.set_geometry_from_cor_tilt(cor, tilt)
 
         cil_offset = geo.get_centre_of_rotation()['offset'][0]
@@ -168,5 +170,5 @@ class GeometryTest(unittest.TestCase):
         """
         num_pixels = (256, 512)
         pixel_size = (1., 1.)
-        geo = Geometry(num_pixels=num_pixels, pixel_size=pixel_size)
+        geo = Geometry(TEST_ANGLES, num_pixels=num_pixels, pixel_size=pixel_size)
         self.assertEqual(geo.type, GeometryType.PARALLEL3D)

--- a/mantidimaging/core/data/test/image_stack_test.py
+++ b/mantidimaging/core/data/test/image_stack_test.py
@@ -222,10 +222,9 @@ class ImageStackTest(unittest.TestCase):
         np.testing.assert_equal(actual.value, expected)
 
     def test_get_projection_angles_no_logfile(self):
-        images = generate_images_with_geometry(max_angle=360)
+        images = generate_images()
         actual = images.projection_angles()
-        self.assertEqual(10, len(actual.value))
-        self.assertAlmostEqual(np.deg2rad(360), actual.value[-1], places=4)
+        self.assertIsNone(actual)
 
         angles = generate_angles(275.69, images.num_projections)
         images.set_projection_angles(angles)

--- a/mantidimaging/core/data/test/image_stack_test.py
+++ b/mantidimaging/core/data/test/image_stack_test.py
@@ -226,13 +226,6 @@ class ImageStackTest(unittest.TestCase):
         actual = images.projection_angles()
         self.assertIsNone(actual)
 
-        angles = generate_angles(275.69, images.num_projections)
-        images.set_projection_angles(angles)
-
-        actual = images.projection_angles()
-        self.assertEqual(10, len(actual.value))
-        self.assertAlmostEqual(np.deg2rad(275.69), actual.value[-1], places=4)
-
     def test_metadata_gets_updated_with_logfile(self):
         images = generate_images()
         images.log_file = generate_txt_logfile()

--- a/mantidimaging/core/data/test/image_stack_test.py
+++ b/mantidimaging/core/data/test/image_stack_test.py
@@ -24,14 +24,6 @@ from mantidimaging.test_helpers.unit_test_helper import generate_images, generat
 
 class ImageStackTest(unittest.TestCase):
 
-    @staticmethod
-    def generate_images_with_geometry() -> ImageStack:
-        data = generate_images().data
-        images = ImageStack(data=data)
-        test_angles = generate_angles(360, images.num_projections)
-        images.create_geometry(test_angles)
-        return images
-
     def test_parse_metadata_file(self):
         json_file = io.StringIO('{"a_int": 42, "a_string": "yes", "a_arr": ["one", "two", '
                                 '"three"], "a_float": 3.65e-05, "a_bool": true}')
@@ -368,7 +360,7 @@ class ImageStackTest(unittest.TestCase):
         self.assertFalse(images.is_processed)
 
     def test_default_geometry(self):
-        images = self.generate_images_with_geometry()
+        images = generate_images_with_geometry(max_angle=360.0)
         num_pixels = images.width, images.height
         pixel_size = (1., 1.)
         npt.assert_array_equal(images.geometry.config.panel.num_pixels, np.array(num_pixels))
@@ -376,7 +368,7 @@ class ImageStackTest(unittest.TestCase):
 
     @parameterized.expand([("shapes_match", 10, 10, 10, 10, True), ("shapes_do_not_match", 10, 10, 20, 10, False)])
     def test_proj_180_degree_shape_matches_images(self, _, height, width, proj180_height, proj180_width, expected):
-        images = self.generate_images_with_geometry()
+        images = generate_images_with_geometry(max_angle=360.0)
         angles = range(0, 360)
         angle_unit = "radian"
         pixel_size = (1., 1.)
@@ -394,7 +386,7 @@ class ImageStackTest(unittest.TestCase):
         self.assertEqual(images.proj_180_degree_shape_matches_images(), expected)
 
     def test_proj_180_degree_shape_matches_images_where_no_180_present(self):
-        images = self.generate_images_with_geometry()
+        images = generate_images_with_geometry(max_angle=360.0)
         images.has_proj180deg = mock.MagicMock(return_value=False)
 
         self.assertFalse(images.proj_180_degree_shape_matches_images())

--- a/mantidimaging/core/data/test/image_stack_test.py
+++ b/mantidimaging/core/data/test/image_stack_test.py
@@ -208,7 +208,7 @@ class ImageStackTest(unittest.TestCase):
         images = generate_images()
         images.log_file = generate_txt_logfile()
         expected = np.deg2rad(np.asarray([0.0, 0.3152, 0.6304, 0.9456, 1.2608, 1.576, 1.8912, 2.2064, 2.5216, 2.8368]))
-        actual = images.projection_angles(360.0)
+        actual = images.projection_angles()
         self.assertEqual(len(actual.value), len(expected))
         np.testing.assert_equal(actual.value, expected)
 

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -188,7 +188,8 @@ class IOTest(FileOutputtingTestCase):
     def test_nexus_simple_dataset_save(self):
         sample = th.generate_images()
         sample.data *= 12
-        sample._projection_angles = sample.projection_angles()
+        test_angles = th.generate_angles(360, sample.num_projections)
+        sample.set_projection_angles(test_angles)
 
         sd = Dataset(sample=sample)
         sd.sample.record_operation("", "")
@@ -232,7 +233,6 @@ class IOTest(FileOutputtingTestCase):
         shape = (10, 8, 10)
         sample = th.generate_images(shape)
         flat_before = th.generate_images(shape)
-        flat_before._projection_angles = flat_before.projection_angles()
 
         sd = Dataset(sample=sample, flat_before=flat_before)
         path = "nexus/file/path"
@@ -244,7 +244,7 @@ class IOTest(FileOutputtingTestCase):
             rotation_angle_entry = tomo_entry["sample"]["rotation_angle"]
 
             # test rotation angle fields
-            expected = np.concatenate([flat_before.projection_angles().value, np.zeros(shape[0])])
+            expected =  np.zeros(shape[0] * 2)
             npt.assert_array_equal(expected, np.array(rotation_angle_entry))
 
             # test rotation angle links
@@ -253,10 +253,9 @@ class IOTest(FileOutputtingTestCase):
     def test_nexus_complex_processed_dataset_save(self):
         image_stacks = []
         for _ in range(5):
-            image_stack = th.generate_images()
+            image_stack = th.generate_images_with_geometry(max_angle=360)
             image_stack.data *= 12
             image_stacks.append(image_stack)
-            image_stack._projection_angles = image_stack.projection_angles()
 
         sd = Dataset(sample=image_stacks[0],
                      flat_before=image_stacks[1],

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -295,7 +295,6 @@ class IOTest(FileOutputtingTestCase):
             image_stack = th.generate_images()
             image_stack.data *= 12
             image_stacks.append(image_stack)
-            image_stack._projection_angles = image_stack.projection_angles()
 
         sd = Dataset(sample=image_stacks[0],
                      flat_before=image_stacks[1],
@@ -342,7 +341,6 @@ class IOTest(FileOutputtingTestCase):
     @mock.patch("mantidimaging.core.io.saver._save_recon_to_nexus")
     def test_save_recons_if_present(self, recon_save_mock: mock.Mock):
         sample = _create_sample_with_filename()
-        sample._projection_angles = sample.projection_angles()
 
         sd = Dataset(sample=sample)
         sd.recons.data = [th.generate_images(), th.generate_images()]
@@ -371,7 +369,6 @@ class IOTest(FileOutputtingTestCase):
     def test_dont_save_recons_if_none_present(self, recon_save_mock: mock.Mock):
 
         sample = th.generate_images()
-        sample._projection_angles = sample.projection_angles()
 
         sd = Dataset(sample=sample)
 

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -230,6 +230,9 @@ class IOTest(FileOutputtingTestCase):
             self.assertEqual(tomo_entry["data"]["image_key"], tomo_entry["instrument"]["detector"]["image_key"])
 
     def test_nexus_missing_projection_angles_save_as_zeros(self):
+        """
+        Test that writing an imagestack with no angle/geometry data to nexus files writes all zeroes to the angle field
+        """
         shape = (10, 8, 10)
         sample = th.generate_images(shape)
         flat_before = th.generate_images(shape)
@@ -244,7 +247,7 @@ class IOTest(FileOutputtingTestCase):
             rotation_angle_entry = tomo_entry["sample"]["rotation_angle"]
 
             # test rotation angle fields
-            expected =  np.zeros(shape[0] * 2)
+            expected = np.zeros(shape[0] * 2)
             npt.assert_array_equal(expected, np.array(rotation_angle_entry))
 
             # test rotation angle links

--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -122,7 +122,8 @@ class AstraRecon(BaseRecon):
         assert (images.geometry is not None)
         sino = images.sino(slice_idx)
         cor = images.geometry.get_cor_at_slice_index(slice_idx)
-        proj_angles = images.projection_angles(recon_params.max_projection_angle)
+        proj_angles = images.projection_angles()
+        assert (proj_angles is not None)
 
         assert sino.ndim == 2, "Sinogram must be a 2D image"
 

--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -92,9 +92,8 @@ class AstraRecon(BaseRecon):
         Larger squared sum -> bigger deviance from the mean, i.e. larger distance between noise and data
         """
 
-        assert (images.geometry is not None)
-        original_cor = images.geometry.cor
-        original_tilt = images.geometry.tilt
+        proj_angles = images.projection_angles()
+        assert proj_angles is not None
 
         def get_sumsq(image: np.ndarray) -> float:
             return float(np.sum(image**2))
@@ -109,8 +108,6 @@ class AstraRecon(BaseRecon):
             start_cor = float(start_cor[0])
 
         minimized_cor = minimize(minimizer_function, start_cor, method='nelder-mead', tol=0.1).x[0]
-        images.geometry.cor = original_cor
-        images.geometry.tilt = original_tilt
 
         return minimized_cor
 
@@ -153,6 +150,9 @@ class AstraRecon(BaseRecon):
         output_shape = (images.num_sinograms, images.width, images.width)
         output_images: ImageStack = ImageStack.create_empty_image_stack(output_shape, images.dtype, images.metadata)
         output_images.record_operation('AstraRecon.full', 'Volume Reconstruction', **recon_params.to_dict())
+
+        proj_angles = images.projection_angles()
+        assert proj_angles is not None
 
         for i in range(images.height):
             output_images.data[i] = AstraRecon.single_sino(images, i, recon_params)

--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -94,6 +94,10 @@ class AstraRecon(BaseRecon):
 
         proj_angles = images.projection_angles()
         assert proj_angles is not None
+        assert images.geometry is not None
+
+        original_cor = images.geometry.cor
+        original_tilt = images.geometry.tilt
 
         def get_sumsq(image: np.ndarray) -> float:
             return float(np.sum(image**2))
@@ -107,7 +111,9 @@ class AstraRecon(BaseRecon):
         if isinstance(start_cor, np.ndarray):
             start_cor = float(start_cor[0])
 
-        minimized_cor = minimize(minimizer_function, start_cor, method='nelder-mead', tol=0.1).x[0]
+        minimized_cor = minimize(minimizer_function, start_cor, method="nelder-mead", tol=0.1).x[0]
+        images.geometry.cor = original_cor
+        images.geometry.tilt = original_tilt
 
         return minimized_cor
 

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -248,6 +248,9 @@ class CILRecon(BaseRecon):
 
     @staticmethod
     def find_cor(images: ImageStack, slice_idx: int, start_cor: float, recon_params: ReconstructionParameters) -> float:
+        projection_angles = images.projection_angles()
+        assert projection_angles is not None
+
         return tomopy.find_center(images.sinograms,
                                   images.projection_angles(recon_params.max_projection_angle).value,
                                   ind=slice_idx,

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -270,7 +270,8 @@ class CILRecon(BaseRecon):
         assert (images.geometry is not None)
         sino = images.sino(slice_idx)
         cor = images.geometry.get_cor_at_slice_index(slice_idx)
-        proj_angles = images.projection_angles(recon_params.max_projection_angle)
+        proj_angles = images.projection_angles()
+        assert (proj_angles is not None)
         geom_type = images.geometry.type
 
         num_iter = recon_params.num_iter

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -242,7 +242,7 @@ class CILRecon(BaseRecon):
                 # COMPAT CIL < 24.1  - workaround for https://github.com/TomographicImaging/CIL/issues/1445
                 data.geometry = BlockGeometry(*geo)
         else:
-            data.reorder('astra')
+            data.reorder("astra")
 
         return data
 

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -252,7 +252,7 @@ class CILRecon(BaseRecon):
         assert projection_angles is not None
 
         return tomopy.find_center(images.sinograms,
-                                  images.projection_angles(recon_params.max_projection_angle).value,
+                                  projection_angles.value,
                                   ind=slice_idx,
                                   init=start_cor,
                                   sinogram_order=True)

--- a/mantidimaging/core/reconstruct/tomopy_recon.py
+++ b/mantidimaging/core/reconstruct/tomopy_recon.py
@@ -40,7 +40,8 @@ class TomopyRecon(BaseRecon):
         assert (images.geometry is not None)
         sino = BaseRecon.prepare_sinogram(images.sino(slice_idx), recon_params)
         cor = images.geometry.get_cor_at_slice_index(slice_idx)
-        proj_angles = images.projection_angles(recon_params.max_projection_angle)
+        proj_angles = images.projection_angles()
+        assert (proj_angles is not None)
 
         volume = tomopy.recon(tomo=[sino],
                               sinogram_order=True,

--- a/mantidimaging/core/reconstruct/tomopy_recon.py
+++ b/mantidimaging/core/reconstruct/tomopy_recon.py
@@ -69,13 +69,17 @@ class TomopyRecon(BaseRecon):
         cors = images.geometry.get_all_cors()
 
         import multiprocessing
+
         ncores = multiprocessing.cpu_count()
+
+        projection_angles = images.projection_angles()
+        assert projection_angles is not None
 
         kwargs = {
             'ncore': ncores,
             'tomo': BaseRecon.prepare_sinogram(images.data, recon_params),
             'sinogram_order': images._is_sinograms,
-            'theta': images.projection_angles(recon_params.max_projection_angle).value,
+            'theta': projection_angles.value,
             'center': [cor.value for cor in cors],
             'algorithm': recon_params.algorithm,
             'filter_name': recon_params.filter_name

--- a/mantidimaging/core/reconstruct/tomopy_recon.py
+++ b/mantidimaging/core/reconstruct/tomopy_recon.py
@@ -25,11 +25,11 @@ class TomopyRecon(BaseRecon):
     def find_cor(images: ImageStack, slice_idx: int, start_cor: float, recon_params: ReconstructionParameters) -> float:
         sino = np.maximum(images.sinograms[slice_idx:slice_idx + 1], 1e-6)
         sino = BaseRecon.prepare_sinogram(sino, recon_params)
-        return tomopy.find_center(sino,
-                                  images.projection_angles(recon_params.max_projection_angle).value,
-                                  ind=0,
-                                  init=start_cor,
-                                  sinogram_order=True)
+
+        projection_angles = images.projection_angles()
+        assert projection_angles is not None
+
+        return tomopy.find_center(sino, projection_angles.value, ind=0, init=start_cor, sinogram_order=True)
 
     @staticmethod
     def single_sino(images: ImageStack,

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -21,7 +21,7 @@ from mantidimaging.eyes_tests.eyes_manager import EyesManager
 from mantidimaging.test_helpers.start_qapplication import start_qapplication
 import mantidimaging.core.parallel.utility as pu
 from mantidimaging.core.io.filenames import FilenameGroup
-from mantidimaging.test_helpers.unit_test_helper import generate_images
+from mantidimaging.test_helpers.unit_test_helper import generate_images, generate_angles
 
 import matplotlib.pyplot  # noqa: F401 - need to import before FakeFileSystem, see Issue #2480
 
@@ -134,9 +134,10 @@ class BaseEyesTest(unittest.TestCase):
         filename_group = FilenameGroup.from_file(Path(LOAD_SAMPLE))
         filename_group.find_all_files()
         image_stack = loader.load(filename_group, indices=Indices(0, 100, 2))
-        dataset = Dataset(sample=image_stack)
-        image_stack.create_geometry()
+        test_angles = generate_angles(360, image_stack.num_projections)
+        image_stack.create_geometry(test_angles)
         image_stack.name = "Stack 1"
+        dataset = Dataset(sample=image_stack)
         self.imaging.presenter.model.add_dataset_to_model(dataset)
         self.imaging.presenter._add_dataset_to_view(dataset)
         assert dataset.sample  # Dataset has a sample

--- a/mantidimaging/eyes_tests/base_eyes.py
+++ b/mantidimaging/eyes_tests/base_eyes.py
@@ -134,10 +134,10 @@ class BaseEyesTest(unittest.TestCase):
         filename_group = FilenameGroup.from_file(Path(LOAD_SAMPLE))
         filename_group.find_all_files()
         image_stack = loader.load(filename_group, indices=Indices(0, 100, 2))
+        dataset = Dataset(sample=image_stack)
         test_angles = generate_angles(360, image_stack.num_projections)
         image_stack.create_geometry(test_angles)
         image_stack.name = "Stack 1"
-        dataset = Dataset(sample=image_stack)
         self.imaging.presenter.model.add_dataset_to_model(dataset)
         self.imaging.presenter._add_dataset_to_view(dataset)
         assert dataset.sample  # Dataset has a sample

--- a/mantidimaging/eyes_tests/operations_window_test.py
+++ b/mantidimaging/eyes_tests/operations_window_test.py
@@ -14,7 +14,8 @@ class OperationsWindowTest(BaseEyesTest):
         super().setUp()
 
     def tearDown(self):
-        self.imaging.filters.close()
+        if self.imaging.filters:
+            self.imaging.filters.close()
         super().tearDown()
 
     def test_operation_window_opens(self):

--- a/mantidimaging/eyes_tests/reconstruct_window_test.py
+++ b/mantidimaging/eyes_tests/reconstruct_window_test.py
@@ -18,7 +18,8 @@ class ReconstructionWindowTest(BaseEyesTest):
         super().setUp()
 
     def tearDown(self):
-        self.imaging.recon.close()
+        if self.imaging.recon:
+            self.imaging.recon.close()
         super().tearDown()
 
     def _show_recon_window(self):

--- a/mantidimaging/eyes_tests/reconstruct_window_test.py
+++ b/mantidimaging/eyes_tests/reconstruct_window_test.py
@@ -7,7 +7,7 @@ from PyQt5.QtTest import QTest
 from PyQt5.QtWidgets import QApplication
 
 from mantidimaging.eyes_tests.base_eyes import BaseEyesTest
-from mantidimaging.test_helpers.unit_test_helper import generate_images
+from mantidimaging.test_helpers.unit_test_helper import generate_images_with_geometry
 from mantidimaging.core.data.dataset import Dataset
 from mantidimaging.test_helpers.qt_test_helpers import wait_until
 
@@ -54,8 +54,7 @@ class ReconstructionWindowTest(BaseEyesTest):
         self.check_target(widget=self.imaging.recon)
 
     def test_negative_nan_overlay(self):
-        images = generate_images(seed=10)
-        images.create_geometry()
+        images = generate_images_with_geometry(360, seed=10)
         images.name = "bad_data"
         ds = Dataset(stacks=[images])
         self.imaging.presenter.model.add_dataset_to_model(ds)

--- a/mantidimaging/gui/dialogs/cor_inspection/model.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/model.py
@@ -83,10 +83,12 @@ class CORInspectionDialogModel:
 
     def _recon_cor_preview(self, image: ImageType) -> np.ndarray:
         assert (self.images.geometry is not None)
+        assert self.proj_angles is not None
         self.images.geometry.cor = ScalarCoR(self.cor(image))
         return self.reconstructor.single_sino(self.images, self.slice_idx, self.recon_params)
 
     def _recon_iters_preview(self, image: ImageType) -> np.ndarray:
+        assert self.proj_angles is not None
         iters = self.iterations(image)
         new_params = replace(self.recon_params, num_iter=int(iters))
         return self.reconstructor.single_sino(self.images, self.slice_idx, new_params)

--- a/mantidimaging/gui/dialogs/cor_inspection/model.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/model.py
@@ -40,7 +40,7 @@ class CORInspectionDialogModel:
             self._divide_step = self._divide_cor_step
 
         # Cache projection angles
-        self.proj_angles = images.projection_angles(recon_params.max_projection_angle)
+        self.proj_angles = images.projection_angles()
         self.recon_params = recon_params
         self.reconstructor = get_reconstructor_for(recon_params.algorithm)
 

--- a/mantidimaging/gui/dialogs/cor_inspection/test/model_test.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/test/model_test.py
@@ -11,13 +11,13 @@ from mantidimaging.core.utility.data_containers import ScalarCoR, Reconstruction
 from mantidimaging.gui.dialogs.cor_inspection import CORInspectionDialogModel
 from mantidimaging.gui.dialogs.cor_inspection.model import INIT_ITERS_CENTRE_VALUE, INIT_ITERS_STEP
 from mantidimaging.gui.dialogs.cor_inspection.types import ImageType
-from mantidimaging.test_helpers.unit_test_helper import generate_images
+from mantidimaging.test_helpers.unit_test_helper import generate_images, generate_images_with_geometry
 
 
 class CORInspectionDialogModelTest(unittest.TestCase):
 
     def test_construct(self):
-        images = generate_images()
+        images = generate_images_with_geometry(360)
         slice_idx = 5
         m = CORInspectionDialogModel(images, slice_idx, ScalarCoR(20), ReconstructionParameters('FBP_CUDA', 'ram-lak'),
                                      False)
@@ -110,7 +110,7 @@ class CORInspectionDialogModelTest(unittest.TestCase):
 
     @patch('mantidimaging.gui.dialogs.cor_inspection.model.replace')
     def test_recon_iters_preview(self, replace_mock):
-        images = generate_images()
+        images = generate_images_with_geometry(360)
         m = CORInspectionDialogModel(images, 5, ScalarCoR(20), ReconstructionParameters('FBP_CUDA', 'ram-lak'), True)
 
         m.reconstructor = Mock()

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -11,6 +11,8 @@ from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtTest import QTest
 from PyQt5.QtWidgets import QApplication, QMessageBox, QInputDialog, QDialog
 import pytest
+
+from mantidimaging.core.utility.data_containers import FILE_TYPES
 from mantidimaging.test_helpers.qt_test_message_handler import qt_message_handler
 
 from mantidimaging.core.utility.leak_tracker import leak_tracker
@@ -126,7 +128,7 @@ class GuiSystemBase(unittest.TestCase):
         raise RuntimeError("_wait_for_stack_selector reach max retries")
 
     @mock.patch("mantidimaging.gui.windows.image_load_dialog.view.ImageLoadDialog.select_file")
-    def _load_data_set(self, mocked_select_file):
+    def _load_data_set(self, mocked_select_file, load_log=True):
         mocked_select_file.return_value = LOAD_SAMPLE
         initial_stacks = len(self.main_window.presenter.get_active_stack_visualisers())
 
@@ -137,6 +139,10 @@ class GuiSystemBase(unittest.TestCase):
         self.main_window.actionLoadDataset.trigger()
         QTest.qWait(SHOW_DELAY)
         self.main_window.image_load_dialog.presenter.do_update_field(self.main_window.image_load_dialog.sample)
+
+        # Uncheck if load_log is set to False
+        self.main_window.image_load_dialog.fields[FILE_TYPES.SAMPLE_LOG.fname].use = load_log
+
         QTest.qWait(SHOW_DELAY)
         self.main_window.image_load_dialog.accept()
         wait_until(test_func, max_retry=600)

--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -220,7 +220,7 @@ class TestGuiSystemLoading(GuiSystemBase):
         image_count, *image_shape = sample.shape
         self.assertEqual(image_shape, [128, 128])
         self.assertEqual(image_count, expected_count)
-        self.assertEqual(len(sample.real_projection_angles().value), expected_count)
+        self.assertEqual(len(sample.projection_angles().value), expected_count)
 
     @mock.patch("mantidimaging.gui.windows.main.MainWindowView._get_file_name")
     def test_replace_image_stack(self, mocked_select_file):

--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -75,29 +75,43 @@ class TestGuiSystemLoading(GuiSystemBase):
         raise ValueError(f"Could not extract angle from: {log_path}")
 
     @mock.patch("mantidimaging.gui.windows.main.MainWindowView._get_file_name")
-    def test_load_log(self, mocked_select_file):
-        log_path = Path(LOAD_SAMPLE).parents[1] / "TomoIMAT00010675_FlowerFine_log.txt"
-        mocked_select_file.return_value = log_path
+    def test_load_dataset(self, mocked_select_file):
+        """
+        Verify that all stacks are loaded by the "Load dataset" dialogue
+        """
         self.assertEqual(len(self.main_window.presenter.get_active_stack_visualisers()), 0)
-        self._load_data_set()
-        self.assertEqual(len(self.main_window.presenter.get_active_stack_visualisers()), 5)
 
+        self._load_data_set()
+
+        self.assertEqual(len(self.main_window.presenter.get_active_stack_visualisers()), 5)
         self.assertEqual(len(self.main_window.presenter.datasets), 1)
         sample = list(self.main_window.presenter.datasets)[0].sample
         self.assertIn("log_file", sample.metadata)
 
-        sample.log_file = None
-        sample._projection_angles = None
-        self.assertNotIn("log_file", sample.metadata)
+        log_path = Path(LOAD_SAMPLE).parents[1] / "TomoIMAT00010675_FlowerFine_log.txt"
+        log_angle = math.radians(self._get_log_angle(log_path))
+        self.assertAlmostEqual(sample.projection_angles().value[1], log_angle, 8)
 
-        stack_len = sample.num_images
-        self.assertAlmostEqual(sample.projection_angles().value[1], 2 * math.pi / (stack_len - 1), 12)
+    @mock.patch("mantidimaging.gui.windows.main.MainWindowView._get_file_name")
+    def test_load_log(self, mocked_select_file):
+        """
+        Verify that manually loading a log file after a dataset is loaded correctly loads angle data
+        """
+        log_path = Path(LOAD_SAMPLE).parents[1] / "TomoIMAT00010675_FlowerFine_log.txt"
+        mocked_select_file.return_value = log_path
+        self.assertEqual(len(self.main_window.presenter.get_active_stack_visualisers()), 0)
+        self._load_data_set(load_log=False)
+        self.assertEqual(len(self.main_window.presenter.get_active_stack_visualisers()), 5)
+
+        # Verify state is as expected with no log file selected
+        sample = list(self.main_window.presenter.datasets)[0].sample
+        self.assertNotIn("log_file", sample.metadata)
+        self.assertIsNone(sample.projection_angles())
 
         # Load sample log
         QTimer.singleShot(SHORT_DELAY, lambda: self._click_stack_selector())
         QTimer.singleShot(SHORT_DELAY * 2, lambda: self._click_messageBox("OK"))
         self.main_window.actionSampleLoadLog.trigger()
-
         self.assertIn("log_file", sample.metadata)
         self.assertEqual(sample.metadata['log_file'], str(log_path))
 
@@ -113,21 +127,13 @@ class TestGuiSystemLoading(GuiSystemBase):
 
     @mock.patch("mantidimaging.gui.windows.main.MainWindowView._get_file_name")
     def test_load_angles(self, mocked_select_file):
-        self.assertEqual(len(self.main_window.presenter.get_active_stack_visualisers()), 0)
-        self._load_data_set()
-        self.assertEqual(len(self.main_window.presenter.get_active_stack_visualisers()), 5)
+        """
+        Verify that manually loading a projection angles file after a dataset is loaded correctly loads angle data
+        """
+        self._load_data_set(load_log=False)
 
-        self.assertEqual(len(self.main_window.presenter.datasets), 1)
         sample = list(self.main_window.presenter.datasets)[0].sample
-        self.assertIn("log_file", sample.metadata)
-
-        sample.log_file = None
-        sample._projection_angles = None
-        self.assertNotIn("log_file", sample.metadata)
-
         stack_len = sample.num_images
-        self.assertAlmostEqual(sample.projection_angles().value[1], 2 * math.pi / (stack_len - 1), 12)
-
         test_angles = numpy.linspace(0, 100, stack_len)
         angle_file = self._make_angles_file(test_angles)
 
@@ -139,7 +145,7 @@ class TestGuiSystemLoading(GuiSystemBase):
         self.main_window.actionLoadProjectionAngles.trigger()
 
         # After loading angles should match file
-        self.assertAlmostEqual(sample.projection_angles().value[1], math.radians(test_angles[1]), 12)
+        self.assertAlmostEqual(sample.projection_angles().value[1], math.radians(test_angles[1]), 4)
         os.remove(angle_file.name)
 
     def test_save_images(self):

--- a/mantidimaging/gui/windows/geometry/presenter.py
+++ b/mantidimaging/gui/windows/geometry/presenter.py
@@ -59,7 +59,7 @@ class GeometryWindowPresenter(BasePresenter):
         geometry_type = stack.geometry.type.value
 
         angle_range = "N/A"
-        real_projection_angles = stack.real_projection_angles()
+        real_projection_angles = stack.projection_angles()
         if real_projection_angles is not None:
             min_angle = degrees(real_projection_angles.value[0])
             max_angle = degrees(real_projection_angles.value[-1])

--- a/mantidimaging/gui/windows/geometry/presenter.py
+++ b/mantidimaging/gui/windows/geometry/presenter.py
@@ -122,13 +122,12 @@ class GeometryWindowPresenter(BasePresenter):
 
         new_angles = ProjectionAngles(
             np.linspace(np.deg2rad(new_min_angle), np.deg2rad(new_max_angle), stack.num_projections))
-        stack.set_projection_angles(new_angles)
 
         geometry_type = GeometryType.PARALLEL3D
         if new_type == "Cone 3D":
             geometry_type = GeometryType.CONE3D
 
-        stack.create_geometry(geometry_type)
+        stack.create_geometry(new_angles, geometry_type)
         assert stack.geometry is not None
         stack.geometry.set_geometry_from_cor_tilt(new_cor, new_tilt)
         stack.geometry.set_source_detector_positions(new_source_position, new_detector_position)
@@ -158,8 +157,7 @@ class GeometryWindowPresenter(BasePresenter):
         existing_angles = stack.projection_angles()
         assert existing_angles is not None
 
-        stack.create_geometry(geom_type=new_type)
-        stack.set_projection_angles(existing_angles)
+        stack.create_geometry(existing_angles, new_type)
         self.handle_stack_changed()
 
     def _get_current_stack_with_assert(self) -> ImageStack:

--- a/mantidimaging/gui/windows/geometry/presenter.py
+++ b/mantidimaging/gui/windows/geometry/presenter.py
@@ -154,7 +154,12 @@ class GeometryWindowPresenter(BasePresenter):
             return
 
         LOG.debug(f"Converting Geometry from {current_type} to {new_type}")
+
+        existing_angles = stack.projection_angles()
+        assert existing_angles is not None
+
         stack.create_geometry(geom_type=new_type)
+        stack.set_projection_angles(existing_angles)
         self.handle_stack_changed()
 
     def _get_current_stack_with_assert(self) -> ImageStack:

--- a/mantidimaging/gui/windows/geometry/test/model_test.py
+++ b/mantidimaging/gui/windows/geometry/test/model_test.py
@@ -8,8 +8,8 @@ import numpy as np
 from matplotlib.figure import Figure
 
 from mantidimaging.core.data import ImageStack
-from mantidimaging.core.data.geometry import Geometry
 from mantidimaging.gui.windows.geometry import GeometryWindowModel
+from mantidimaging.test_helpers.unit_test_helper import generate_angles
 
 
 class GeometryWindowModelTest(unittest.TestCase):
@@ -17,7 +17,8 @@ class GeometryWindowModelTest(unittest.TestCase):
     def setUp(self):
         self.model = GeometryWindowModel()
         self.data = ImageStack(data=np.ndarray(shape=(10, 128, 256), dtype=np.float32))
-        self.data.geometry = Geometry(num_pixels=(128, 128), pixel_size=(1.0, 1.0))
+        test_angles = generate_angles(360, self.data.num_projections)
+        self.data.set_projection_angles(test_angles)
 
     def test_generate_figure(self):
         test_figure = self.model.generate_figure(self.data)

--- a/mantidimaging/gui/windows/geometry/test/presenter_test.py
+++ b/mantidimaging/gui/windows/geometry/test/presenter_test.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from mantidimaging.core.data.geometry import GeometryType
 from mantidimaging.core.utility.data_containers import ProjectionAngles
+from mantidimaging.test_helpers.unit_test_helper import generate_angles
 
 from mantidimaging.core.data import ImageStack
 from mantidimaging.gui.windows.geometry import GeometryWindowPresenter, GeometryWindowView
@@ -49,7 +50,6 @@ class GeometryWindowPresenterTest(unittest.TestCase):
         self.reset_new_stack()
         test_stack = self.main_window.get_stack()
         test_stack.set_projection_angles(ProjectionAngles(numpy.linspace(0, 360, test_stack.num_projections)))
-        test_stack.create_geometry()
         self.presenter.update_parameters(test_stack)
         test_geometry_type = GeometryType.PARALLEL3D.value
         self.assertEqual(self.view.type, test_geometry_type)
@@ -67,7 +67,8 @@ class GeometryWindowPresenterTest(unittest.TestCase):
     def test_converting_geometry(self):
         self.reset_new_stack()
         test_stack = self.main_window.get_stack()
-        test_stack.create_geometry()
+        test_angles = generate_angles(360, test_stack.num_projections)
+        test_stack.create_geometry(test_angles)
         self.assertEqual(test_stack.geometry.type, GeometryType.PARALLEL3D)
         self.view.conversion_type = "Cone 3D"
         self.presenter.handle_convert_geometry()

--- a/mantidimaging/gui/windows/main/model.py
+++ b/mantidimaging/gui/windows/main/model.py
@@ -42,7 +42,6 @@ class MainWindowModel:
             return loader.load_stack_from_image_params(im_param, progress, dtype=parameters.dtype)
 
         sample = load(parameters.image_stacks[FILE_TYPES.SAMPLE])
-        sample.create_geometry()
         ds = Dataset(sample=sample)
         sample._is_sinograms = parameters.sinograms
         sample.pixel_size = parameters.pixel_size

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -129,7 +129,7 @@ class MainWindowPresenter(BasePresenter):
 
         image_stack = self.get_stack(stack_id)
         if image_stack is not None:
-            proj_angles = image_stack.real_projection_angles()
+            proj_angles = image_stack.projection_angles()
             if proj_angles is not None:
                 self.stack_visualisers[stack_id].image_view.angles = proj_angles
 
@@ -238,8 +238,10 @@ class MainWindowPresenter(BasePresenter):
         if dataset.sample.has_proj180deg() and dataset.sample.proj180deg.filenames:  # type: ignore
             return
         else:
+            projection_angles = dataset.sample.projection_angles()
+            assert projection_angles is not None
             closest_projection, diff = find_projection_closest_to_180(dataset.sample.projections,
-                                                                      dataset.sample.projection_angles().value)
+                                                                      projection_angles.value)
             if diff <= THRESHOLD_180 or self.view.ask_to_use_closest_to_180(diff):
                 _180_arr = np.reshape(closest_projection, (1, ) + closest_projection.shape).copy()
                 proj180deg = ImageStack(_180_arr, name=f"{dataset.name}_180")

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -237,15 +237,18 @@ class MainWindowPresenter(BasePresenter):
         assert dataset.sample is not None
         if dataset.sample.has_proj180deg() and dataset.sample.proj180deg.filenames:  # type: ignore
             return
+
+        projection_angles = dataset.sample.projection_angles()
+        if projection_angles is None:
+            closest_projection = dataset.sample.projection(dataset.sample.num_projections // 2)
+            diff = 0.0
         else:
-            projection_angles = dataset.sample.projection_angles()
-            assert projection_angles is not None
             closest_projection, diff = find_projection_closest_to_180(dataset.sample.projections,
                                                                       projection_angles.value)
-            if diff <= THRESHOLD_180 or self.view.ask_to_use_closest_to_180(diff):
-                _180_arr = np.reshape(closest_projection, (1, ) + closest_projection.shape).copy()
-                proj180deg = ImageStack(_180_arr, name=f"{dataset.name}_180")
-                self.add_images_to_existing_dataset(dataset.id, proj180deg, "proj_180")
+        if diff <= THRESHOLD_180 or self.view.ask_to_use_closest_to_180(diff):
+            _180_arr = np.reshape(closest_projection, (1, ) + closest_projection.shape).copy()
+            proj180deg = ImageStack(_180_arr, name=f"{dataset.name}_180")
+            self.add_images_to_existing_dataset(dataset.id, proj180deg, "proj_180")
 
     def create_dataset_stack_visualisers(self, dataset: Dataset) -> None:
         """Creates StackVisualiserView widgets for a new dataset and tabifies them."""

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -18,7 +18,7 @@ from mantidimaging.gui.dialogs.async_task import TaskWorkerThread
 from mantidimaging.gui.windows.image_load_dialog import ImageLoadDialog
 from mantidimaging.gui.windows.main import MainWindowView, MainWindowPresenter, MainWindowModel
 from mantidimaging.gui.windows.main.presenter import Notification, RECON_TEXT
-from mantidimaging.test_helpers.unit_test_helper import generate_images, generate_standard_dataset
+from mantidimaging.test_helpers.unit_test_helper import generate_images, generate_standard_dataset, generate_angles
 
 
 class MainWindowPresenterTest(unittest.TestCase):
@@ -166,6 +166,8 @@ class MainWindowPresenterTest(unittest.TestCase):
     def test_create_new_stack_dataset_and_reject_180(self):
         self.view.ask_to_use_closest_to_180.return_value = False
 
+        test_angles = generate_angles(360, self.dataset.sample.num_projections)
+        self.dataset.sample.set_projection_angles(test_angles)
         self.dataset.sample.proj180deg = None
         self.presenter.add_alternative_180_if_required(self.dataset)
         self.assertIsNone(self.dataset.proj180deg)

--- a/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/presenter.py
@@ -309,7 +309,6 @@ class NexusLoadPresenter:
         """
         sample_images = self._create_sample_images()
         sample_images.name = self.title
-        sample_images.create_geometry()
         assert self.flat_before_array is not None and self.flat_after_array is not None
         assert self.dark_before_array is not None and self.dark_after_array is not None
         ds = Dataset(sample=sample_images,

--- a/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
+++ b/mantidimaging/gui/windows/nexus_load_dialog/test/presenter_test.py
@@ -332,11 +332,11 @@ class NexusLoaderTest(unittest.TestCase):
         self.nexus_loader.scan_nexus_file()
         ds, _ = self.nexus_loader.get_dataset()
 
-        self.assertIsNone(ds.flat_before._projection_angles)
-        self.assertIsNone(ds.dark_before._projection_angles)
-        self.assertIsNone(ds.sample._projection_angles)
-        self.assertIsNone(ds.dark_after._projection_angles)
-        self.assertIsNone(ds.flat_after._projection_angles)
+        self.assertIsNone(ds.flat_before.projection_angles())
+        self.assertIsNone(ds.dark_before.projection_angles())
+        self.assertIsNone(ds.sample.projection_angles())
+        self.assertIsNone(ds.dark_after.projection_angles())
+        self.assertIsNone(ds.flat_after.projection_angles())
 
     def test_projection_angles_set_correctly_when_only_some_are_zero(self):
         del self.tomo_entry[ROTATION_ANGLE_PATH]
@@ -349,11 +349,11 @@ class NexusLoaderTest(unittest.TestCase):
         self.nexus_loader.scan_nexus_file()
         ds, _ = self.nexus_loader.get_dataset()
 
-        self.assertIsNone(ds.flat_before._projection_angles)
-        self.assertIsNone(ds.dark_before._projection_angles)
+        self.assertIsNone(ds.flat_before.projection_angles())
+        self.assertIsNone(ds.dark_before.projection_angles())
         assert np.array_equal(ds.sample.projection_angles().value, [rotation_angle_data[4], rotation_angle_data[5]])
-        self.assertIsNone(ds.dark_after._projection_angles)
-        self.assertIsNone(ds.flat_after._projection_angles)
+        self.assertIsNone(ds.dark_after.projection_angles())
+        self.assertIsNone(ds.flat_after.projection_angles())
 
     def test_recon_entry_found_in_file(self):
         recon = generate_images()

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -116,13 +116,17 @@ class ReconstructWindowModel:
         # Async task needs a non-None result of some sort
         return True
 
+    @staticmethod
+    def _image_stack_is_recon_ready(images: ImageStack) -> bool:
+        return images is not None and images.projection_angles() is not None
+
     def run_preview_recon(self,
                           slice_idx: int,
                           recon_params: ReconstructionParameters,
                           progress: Progress | None = None) -> ImageStack | None:
         # Ensure we have some sample data
         images = self.images
-        if images is None:
+        if not self._image_stack_is_recon_ready(images):
             return None
 
         # Perform single slice reconstruction
@@ -145,8 +149,9 @@ class ReconstructWindowModel:
     def run_full_recon(self, recon_params: ReconstructionParameters, progress: Progress) -> ImageStack | None:
         # Ensure we have some sample data
         images = self.images
-        if images is None:
+        if not self._image_stack_is_recon_ready(images):
             return None
+
         LOG.info("Starting full reconstruction: algorithm=%s, slices=%d", recon_params.algorithm, self.images.height)
 
         reconstructor = get_reconstructor_for(recon_params.algorithm)

--- a/mantidimaging/gui/windows/recon/presenter.py
+++ b/mantidimaging/gui/windows/recon/presenter.py
@@ -27,6 +27,9 @@ if TYPE_CHECKING:
     from mantidimaging.gui.windows.recon.view import ReconstructWindowView  # pragma: no cover
     from mantidimaging.gui.windows.main import MainWindowView
 
+NO_GEOMETRY_MESSAGE = "Geometry not found for imagestack. Cannot perform reconstruction. Please load or create "\
+    "geometry data."
+
 
 class AutoCorMethod(Enum):
     CORRELATION = auto()
@@ -259,6 +262,10 @@ class ReconstructWindowPresenter(BasePresenter):
         if not self.model.has_results:
             raise ValueError("Fit is not performed on the data, therefore the CoR cannot be found for each slice.")
 
+        if self.model.images.geometry is None:
+            self.view.show_status_message(NO_GEOMETRY_MESSAGE)
+            return
+
         self.recon_is_running = True
         self.view.set_recon_buttons_enabled(False)
         start_async_task_view(self.view,
@@ -296,6 +303,10 @@ class ReconstructWindowPresenter(BasePresenter):
             return
 
         slice_idx = self._get_preview_slice_index(slice_idx)
+
+        if self.model.images.geometry is None:
+            self.view.show_status_message(NO_GEOMETRY_MESSAGE)
+            return
 
         self.view.update_sinogram(self.model.images.sino(slice_idx))
         if self.view.is_auto_update_preview() or force_update:

--- a/mantidimaging/gui/windows/recon/test/model_test.py
+++ b/mantidimaging/gui/windows/recon/test/model_test.py
@@ -159,7 +159,7 @@ class ReconWindowModelTest(unittest.TestCase):
             assert self.model.load_allowed_recon_kwargs() == allowed_args
 
     def test_stack_contains_nans_returns_false(self):
-        self.model.images.data = np.array([1, 2, 3])
+        self.model.images.data = np.ones((1, 1, 3))
         self.assertFalse(self.model.stack_contains_nans())
 
     def test_stack_contains_nans_returns_true(self):
@@ -167,17 +167,17 @@ class ReconWindowModelTest(unittest.TestCase):
         self.assertTrue(self.model.stack_contains_nans())
 
     def test_stack_contains_zeroes_returns_false(self):
-        self.model.images.data = np.array([1, 2, 3])
+        self.model.images.data = np.ones((1, 1, 3))
         self.assertFalse(self.model.stack_contains_zeroes())
 
     def test_stack_contains_zeroes_returns_true(self):
-        self.model.images.data = np.array([0, 0, 0])
+        self.model.images.data = np.zeros((1, 1, 3))
         self.assertTrue(self.model.stack_contains_zeroes())
 
     def test_stack_contains_negative_values_returns_true(self):
-        self.model.images.data = np.array([-1, 0, 0])
+        self.model.images.data = np.array([[[-1, 0, 0]]])
         self.assertTrue(self.model.stack_contains_negative_values())
 
     def test_stack_contains_negative_values_returns_false(self):
-        self.model.images.data = np.array([0, 0, 0])
+        self.model.images.data = np.zeros((1, 1, 3))
         self.assertFalse(self.model.stack_contains_negative_values())

--- a/mantidimaging/gui/windows/recon/test/model_test.py
+++ b/mantidimaging/gui/windows/recon/test/model_test.py
@@ -15,8 +15,8 @@ from mantidimaging.core.reconstruct.tomopy_recon import allowed_recon_kwargs as 
 from mantidimaging.core.reconstruct.cil_recon import allowed_recon_kwargs as cil_allowed_kwargs
 from mantidimaging.core.rotation.data_model import Point
 from mantidimaging.core.utility.data_containers import Degrees, ScalarCoR, ReconstructionParameters
-from mantidimaging.gui.windows.recon import (ReconstructWindowModel, CorTiltPointQtModel)
-from mantidimaging.test_helpers.unit_test_helper import assert_called_once_with, generate_images
+from mantidimaging.gui.windows.recon import ReconstructWindowModel, CorTiltPointQtModel
+from mantidimaging.test_helpers.unit_test_helper import assert_called_once_with, generate_images, generate_angles
 
 
 class ReconWindowModelTest(unittest.TestCase):
@@ -25,6 +25,9 @@ class ReconWindowModelTest(unittest.TestCase):
         self.model = ReconstructWindowModel(CorTiltPointQtModel())
 
         self.data = ImageStack(data=np.ndarray(shape=(10, 128, 256), dtype=np.float32))
+        test_angles = generate_angles(360, self.data.num_projections)
+        self.data.set_projection_angles(test_angles)
+
         self.model.initial_select_data(self.data)
 
     def test_empty_init(self):
@@ -106,7 +109,8 @@ class ReconWindowModelTest(unittest.TestCase):
         expected_cor = ScalarCoR(15)
         expected_recon_params = ReconstructionParameters("FBP_CUDA", "ram-lak")
 
-        self.model.images.create_geometry()
+        test_angles = generate_angles(360, self.model.images.num_projections)
+        self.model.images.create_geometry(test_angles)
         self.model.images.geometry.cor = expected_cor
         self.model.run_preview_recon(expected_idx, expected_recon_params)
 

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -16,6 +16,7 @@ from mantidimaging.core.rotation.data_model import Point
 from mantidimaging.core.utility.data_containers import ScalarCoR, ReconstructionParameters
 from mantidimaging.gui.windows.recon import ReconstructWindowPresenter, ReconstructWindowView
 from mantidimaging.gui.windows.recon.presenter import Notifications as PresNotification
+from mantidimaging.test_helpers.unit_test_helper import generate_angles
 
 TEST_PIXEL_SIZE = 1443
 
@@ -27,7 +28,8 @@ class ReconWindowPresenterTest(unittest.TestCase):
 
         self.data = ImageStack(data=np.ndarray(shape=(128, 10, 128), dtype=np.float32))
         self.data.pixel_size = TEST_PIXEL_SIZE
-        self.data.geometry = Geometry(num_pixels=(128, 128), pixel_size=(1., 1.))
+        test_angles = np.linspace(0, np.deg2rad(360), self.data.num_projections)
+        self.data.geometry = Geometry(angles=test_angles, num_pixels=(128, 128), pixel_size=(1., 1.))
 
         self.main_window = mock.MagicMock()
         self.main_window.get_stack.return_value = self.data
@@ -461,6 +463,8 @@ class ReconWindowPresenterTest(unittest.TestCase):
         type(self.view).tilt = PropertyMock(return_value=tilt)
         type(self.view).rotation_centre = PropertyMock(return_value=cor)
 
+        test_angles = generate_angles(360, self.data.num_projections)
+        self.data.create_geometry(test_angles)
         self.presenter._update_imagestack_geometry_data()
 
         self.assertAlmostEqual(self.data.geometry.cor.value, cor, places=10)

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -537,8 +537,12 @@ class ReconstructWindowView(BaseMainWindowView):
 
     def show_status_message(self, msg: str) -> None:
         """
-        Shows a status message indicating that zero/negative/NaN pixels were found in the stack. If the msg argument is
-        empty then this is taken to mean that no such pixels were found, so the warning message and icon are cleared.
+        Shows a status message in the reconstruction window.
+
+        Typically used to indicate that zero/negative/NaN pixels were found in the stack.
+        If the msg argument is empty then this is taken to mean that no such pixels were found,
+        so the warning message and icon are cleared.
+
         :param msg: The status message.
         """
         self.statusMessageTextEdit.setText(msg)

--- a/mantidimaging/gui/windows/stack_properties_dialog/view.py
+++ b/mantidimaging/gui/windows/stack_properties_dialog/view.py
@@ -38,7 +38,7 @@ class StackPropertiesDialog(BaseDialogView):
             self.geometry_type = self.stack.geometry.type.value
 
         self.angle_range = "N/A"
-        real_projection_angles = self.stack.real_projection_angles()
+        real_projection_angles = self.stack.projection_angles()
         if real_projection_angles is not None:
             min_angle = degrees(real_projection_angles.value[0])
             max_angle = degrees(real_projection_angles.value[-1])

--- a/mantidimaging/gui/windows/stack_visualiser/presenter.py
+++ b/mantidimaging/gui/windows/stack_visualiser/presenter.py
@@ -130,10 +130,17 @@ class StackVisualiserPresenter(BasePresenter):
 
     def find_image_from_angle(self, selected_angle: float) -> int:
         selected_angle = np.deg2rad(selected_angle)
-        for index, angle in enumerate(self.images.projection_angles().value):
+        projection_angles = self.images.projection_angles()
+        assert projection_angles is not None
+
+        for index, angle in enumerate(projection_angles.value):
             if angle >= selected_angle:
                 return index
-        return len(self.images.projection_angles().value)
+
+        projection_angles = self.images.projection_angles()
+        assert projection_angles is not None
+
+        return len(projection_angles.value)
 
     def add_sinograms_to_model_and_update_view(self, new_stack: ImageStack) -> None:
         self.view._main_window.presenter.add_sinograms_to_dataset_and_update_view(new_stack, self.images.id)

--- a/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
+++ b/mantidimaging/gui/windows/stack_visualiser/test/presenter_test.py
@@ -13,6 +13,7 @@ import mantidimaging.test_helpers.unit_test_helper as th
 from mantidimaging.core.data import ImageStack
 from mantidimaging.gui.windows.stack_visualiser import StackVisualiserPresenter, StackVisualiserView, SVNotification, \
     SVImageMode
+from mantidimaging.test_helpers.unit_test_helper import generate_angles
 
 
 class StackVisualiserPresenterTest(unittest.TestCase):
@@ -23,6 +24,8 @@ class StackVisualiserPresenterTest(unittest.TestCase):
         # mock the view so it has the same methods
         self.view = mock.create_autospec(StackVisualiserView, instance=True)
         self.presenter = StackVisualiserPresenter(self.view, self.test_data)
+        test_angles = generate_angles(360, self.presenter.images.num_projections)
+        self.presenter.images.set_projection_angles(test_angles)
         self.presenter.model = mock.Mock()
         self.view._main_window = mock.Mock()
 

--- a/mantidimaging/gui/windows/stack_visualiser/view.py
+++ b/mantidimaging/gui/windows/stack_visualiser/view.py
@@ -104,7 +104,7 @@ class StackVisualiserView(QDockWidget):
 
     def set_image(self, image_stack: ImageStack):
         self.image = image_stack.data
-        self.image_view.angles = image_stack.real_projection_angles()
+        self.image_view.angles = image_stack.projection_angles()
 
     @property
     def main_window(self) -> MainWindowView:

--- a/mantidimaging/test_helpers/unit_test_helper.py
+++ b/mantidimaging/test_helpers/unit_test_helper.py
@@ -31,9 +31,20 @@ def gen_img_numpy_rand(shape=g_shape, seed: int | None = None) -> np.ndarray:
     return rng.random(shape)
 
 
+def generate_angles(max_angle: float, num_projections: int) -> ProjectionAngles:
+    return ProjectionAngles(np.linspace(0, np.deg2rad(max_angle), num_projections))
+
+
 def generate_images(shape=g_shape, dtype=np.float32, seed: int | None = None) -> ImageStack:
     d = pu.create_array(shape, dtype)
     return _set_random_data(d, shape, seed=seed)
+
+
+def generate_images_with_geometry(max_angle, seed: int | None = None) -> ImageStack:
+    images = generate_images(seed=seed)
+    angles = generate_angles(max_angle, images.num_projections)
+    images.create_geometry(angles)
+    return images
 
 
 def generate_images_for_parallel(shape: tuple[int, int, int] = (15, 8, 10), dtype=np.float32,


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #<ISSUE>

### Description

The following changes have been made:
- Refactored `ProjectionAngles` logic in `Geometry` and `ImageStack`. `Geometry` is now the sole source of truth for angle data.
- Added guards against `None` for `ProjectionAngles` at point of use
- Updated some reconstruction tests to use more accurate 3D-array test data.
- Improved method docstrings in reconstruction window and I/O testing code.

<!-- Add a description of the changes made. -->

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- I have manually verified that reconstruction continues to work as expected

### Acceptance Criteria and Reviewer Testing
 - [ ] Unit tests pass locally: python -m pytest -vs
 - [ ]  Verify that reconstruction performs as expected (recon results match previous commits)

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [x] Release Notes have been updated

<!--
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

