### PR TITLE
Refactor: Make ImageStack.data setter safe and add shape property

### DIFF
--- a/mantidimaging/core/data/imagestack.py
+++ b/mantidimaging/core/data/imagestack.py
@@ -282,8 +282,23 @@ class ImageStack:
         :param value: new numpy array containing image data.
         """
 
-        self._shared_array.array = value
+        if isinstance(value, pu.SharedArray):
+            self._shared_array = value
+        else:
+            self._shared_array = pu.SharedArray(value, None)
         self.set_geometry_panels()
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return self._shared_array.array.shape
+
+    @property
+    def ndim(self) -> int:
+        return self._shared_array.array.ndim
+
+    @property
+    def size(self) -> int:
+        return self._shared_array.array.size
 
     @property
     def shared_array(self) -> pu.SharedArray:

--- a/mantidimaging/core/data/test/image_stack_test.py
+++ b/mantidimaging/core/data/test/image_stack_test.py
@@ -202,7 +202,7 @@ class ImageStackTest(unittest.TestCase):
 
     def test_create_empty_image_stack(self):
         images = ImageStack.create_empty_image_stack((15, 10, 10), np.float32, {})
-        self.assertEqual(images.data.shape, (15, 10, 10))
+        self.assertEqual(images.shape, (15, 10, 10))
 
     def test_get_projection_angles_from_logfile(self):
         images = generate_images()

--- a/mantidimaging/core/io/test/io_test.py
+++ b/mantidimaging/core/io/test/io_test.py
@@ -137,7 +137,7 @@ class IOTest(FileOutputtingTestCase):
         saver.image_save(expected_images, self.output_directory, out_format=img_format, indices=saver_indices)
         # Assert the expected files exist
         base_name = Path(self.output_directory) / saver.DEFAULT_NAME_PREFIX
-        self.assert_files_exist(base_name, img_format, data_as_stack, expected_images.data.shape[0], saver_indices)
+        self.assert_files_exist(base_name, img_format, data_as_stack, expected_images.shape[0], saver_indices)
 
         # Load the saved file group
         filename = f"{saver.DEFAULT_NAME_PREFIX}_000000.{img_format}"
@@ -158,7 +158,7 @@ class IOTest(FileOutputtingTestCase):
         saver.image_save(images, self.output_directory, out_format=img_format)
         data_as_stack = False
         base_name = Path(self.output_directory) / saver.DEFAULT_NAME_PREFIX
-        self.assert_files_exist(base_name, img_format, data_as_stack, images.data.shape[0])
+        self.assert_files_exist(base_name, img_format, data_as_stack, images.shape[0])
 
         filename = f"{saver.DEFAULT_NAME_PREFIX}_000000.tiff"
         group = FilenameGroup.from_file(Path(self.output_directory) / filename)

--- a/mantidimaging/core/operations/arithmetic/arithmetic.py
+++ b/mantidimaging/core/operations/arithmetic/arithmetic.py
@@ -47,8 +47,7 @@ class ArithmeticFilter(BaseFilter):
             raise ValueError("Unable to proceed with operation because division/multiplication value is zero.")
 
         params = {'div': div_val, 'mult': mult_val, 'add': add_val, 'sub': sub_val}
-        ps.run_compute_func(ArithmeticFilter.compute_function, images.data.shape[0], images.shared_array, params,
-                            progress)
+        ps.run_compute_func(ArithmeticFilter.compute_function, images.shape[0], images.shared_array, params, progress)
 
         return images
 

--- a/mantidimaging/core/operations/divide/divide.py
+++ b/mantidimaging/core/operations/divide/divide.py
@@ -48,7 +48,7 @@ class DivideFilter(BaseFilter):
             value *= 1e-4
 
         params = {'value': value}
-        ps.run_compute_func(DivideFilter.compute_function, images.data.shape[0], images.shared_array, params, progress)
+        ps.run_compute_func(DivideFilter.compute_function, images.shape[0], images.shared_array, params, progress)
 
         return images
 

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -127,9 +127,9 @@ class FlatFieldFilter(BaseFilter):
             if flat_avg.ndim != 2 or dark_avg.ndim != 2:
                 raise ValueError(
                     f"Incorrect shape of the flat image ({flat_avg.shape}) or dark image ({dark_avg.shape}) "
-                    f"which should match the shape of the sample images ({images.data.shape[1:]})")
-            if not (images.data.shape[1:] == flat_avg.shape == dark_avg.shape):
-                raise ValueError(f"Not all images are the expected shape: {images.data.shape[1:]}, instead "
+                    f"which should match the shape of the sample images ({images.shape[1:]})")
+            if not (images.shape[1:] == flat_avg.shape == dark_avg.shape):
+                raise ValueError(f"Not all images are the expected shape: {images.shape[1:]}, instead "
                                  f"flat had shape: {flat_avg.shape}, and dark had shape: {dark_avg.shape}")
 
         params = {'flat_avg': flat_avg, 'dark_avg': dark_avg}

--- a/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
+++ b/mantidimaging/core/operations/flat_fielding/test/flat_fielding_test.py
@@ -48,7 +48,7 @@ class FlatFieldingTest(unittest.TestCase):
         flat_before.data[:] = 7.
         dark_before.data[:] = 6.
 
-        expected = np.full(images.data.shape, 20.)
+        expected = np.full(images.shape, 20.)
 
         # we dont want anything to be cropped out
         result = FlatFieldFilter.filter_func(images,
@@ -66,7 +66,7 @@ class FlatFieldingTest(unittest.TestCase):
         flat_after.data[:] = 7.
         dark_after.data[:] = 6.
 
-        expected = np.full(images.data.shape, 20.)
+        expected = np.full(images.shape, 20.)
 
         # we dont want anything to be cropped out
         result = FlatFieldFilter.filter_func(images,
@@ -87,7 +87,7 @@ class FlatFieldingTest(unittest.TestCase):
         dark_after.data[:] = 7.
         dark_before.data[:] = 5.
 
-        expected = np.full(images.data.shape, 20.)
+        expected = np.full(images.shape, 20.)
 
         # we dont want anything to be cropped out
         result = FlatFieldFilter.filter_func(images,

--- a/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
+++ b/mantidimaging/core/operations/monitor_normalisation/monitor_normalisation.py
@@ -46,7 +46,7 @@ class MonitorNormalisation(BaseFilter):
         normalization_factor = counts.value / counts.value[0]
         params = {'normalization_factor': normalization_factor}
 
-        ps.run_compute_func(MonitorNormalisation.compute_function, images.data.shape[0], images.shared_array, params,
+        ps.run_compute_func(MonitorNormalisation.compute_function, images.shape[0], images.shared_array, params,
                             progress)
         return images
 

--- a/mantidimaging/core/operations/outliers/outliers.py
+++ b/mantidimaging/core/operations/outliers/outliers.py
@@ -60,8 +60,7 @@ class OutliersFilter(BaseFilter):
             raise ValueError(f'radius parameter must be greater than 0. Value provided was {radius}')
 
         params = {'diff': diff, 'radius': radius, 'mode': mode}
-        ps.run_compute_func(OutliersFilter.compute_function, images.data.shape[0], images.shared_array, params,
-                            progress)
+        ps.run_compute_func(OutliersFilter.compute_function, images.shape[0], images.shared_array, params, progress)
 
         return images
 

--- a/mantidimaging/core/operations/overlap_correction/overlap_correction.py
+++ b/mantidimaging/core/operations/overlap_correction/overlap_correction.py
@@ -50,7 +50,7 @@ class OverlapCorrection(BaseFilter):
         else:
             raise RuntimeError("No loaded Shutter Count file for this stack.")
 
-        output = pu.create_array(images.data.shape, images.dtype)
+        output = pu.create_array(images.shape, images.dtype)
         output.array = execute_single(images.data, shutters, progress)
         images.shared_array = output
         return images

--- a/mantidimaging/core/operations/rebin/rebin.py
+++ b/mantidimaging/core/operations/rebin/rebin.py
@@ -46,7 +46,7 @@ class RebinFilter(BaseFilter):
         if isinstance(rebin_param, tuple):
             new_shape = rebin_param
         elif isinstance(rebin_param, (int | float)):
-            current_shape = images.data.shape[1:]
+            current_shape = images.shape[1:]
             new_shape = (int(current_shape[0] * rebin_param), int(current_shape[1] * rebin_param))
         else:
             raise ValueError("Invalid type for rebin_param")
@@ -54,7 +54,7 @@ class RebinFilter(BaseFilter):
         output = _create_reshaped_array(images, rebin_param)
 
         params = {'new_shape': new_shape, 'mode': mode}
-        ps.run_compute_func(RebinFilter.compute_function, images.data.shape[0], [images.shared_array, output], params,
+        ps.run_compute_func(RebinFilter.compute_function, images.shape[0], [images.shared_array, output], params,
                             progress)
         images.shared_array = output
         return images
@@ -147,7 +147,7 @@ class RebinFilter(BaseFilter):
 
 
 def _create_reshaped_array(images, rebin_param):
-    old_shape = images.data.shape
+    old_shape = images.shape
     num_images = old_shape[0]
 
     # use SciPy's calculation to find the expected dimensions

--- a/mantidimaging/core/operations/rebin/test/rebin_test.py
+++ b/mantidimaging/core/operations/rebin/test/rebin_test.py
@@ -49,8 +49,8 @@ class RebinTest(unittest.TestCase):
         images = th.generate_images(dtype=dtype)
         mode = 'reflect'
 
-        expected_x = int(images.data.shape[1] * val)
-        expected_y = int(images.data.shape[2] * val)
+        expected_x = int(images.shape[1] * val)
+        expected_y = int(images.shape[2] * val)
 
         result = RebinFilter.filter_func(images, val, mode)
 

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -81,7 +81,7 @@ class RoiNormalisationFilter(BaseFilter):
             'normalisation_factors': global_params
         }
 
-        ps.run_compute_func(RoiNormalisationFilter.compute_function, images.data.shape[0], images.shared_array, params)
+        ps.run_compute_func(RoiNormalisationFilter.compute_function, images.shape[0], images.shared_array, params)
 
         h.check_data_stack(images)
 

--- a/mantidimaging/core/operations/rotate_stack/test/rotate_stack_test.py
+++ b/mantidimaging/core/operations/rotate_stack/test/rotate_stack_test.py
@@ -87,7 +87,7 @@ class RotateStackTest(unittest.TestCase):
 
         images = th.generate_images([5, 6, 7])
         _do_rotation(images, 90, mock.Mock())
-        self.assertNotEqual([5, 7, 6], images.data.shape)
+        self.assertNotEqual([5, 7, 6], images.shape)
 
     def test_WHEN_compute_rotation_called_WITH_angle_THEN_data_aspect_ratio_remains_the_same(self):
         """

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -368,7 +368,7 @@ class CILRecon(BaseRecon):
         pixel_num_h = images.width
         pixel_num_v = images.height
 
-        projection_size = full_size_KB(images.data.shape, images.dtype)
+        projection_size = full_size_KB(images.shape, images.dtype)
         recon_volume_shape = pixel_num_h, pixel_num_h, pixel_num_v
         recon_volume_size = full_size_KB(recon_volume_shape, images.dtype)
         if recon_params.stochastic:
@@ -388,7 +388,7 @@ class CILRecon(BaseRecon):
 
         with cil_mutex:
             t0 = time.perf_counter()
-            LOG.info(f"Starting 3D PDHG-TV reconstruction: input shape {images.data.shape}"
+            LOG.info(f"Starting 3D PDHG-TV reconstruction: input shape {images.shape}"
                      f"output shape {recon_volume_shape}\n"
                      f"Num iter {recon_params.num_iter}, alpha {recon_params.alpha}, "
                      f"Non-negative {recon_params.non_negative},"
@@ -456,7 +456,7 @@ class CILRecon(BaseRecon):
                     volume = algo.solution.as_array()
                 LOG.info(f'Reconstructed 3D volume with shape: {volume.shape}')
             t1 = time.perf_counter()
-            LOG.info(f"full reconstruction time: {t1-t0}s for shape {images.data.shape}")
+            LOG.info(f"full reconstruction time: {t1-t0}s for shape {images.shape}")
             ImageStack(volume).metadata['convergence'] = {'iterations': algo.iterations, 'losses': algo.loss}
             return ImageStack(volume)
 

--- a/mantidimaging/gui/windows/operations/model.py
+++ b/mantidimaging/gui/windows/operations/model.py
@@ -137,7 +137,7 @@ class FiltersWindowModel:
 
         if not is_preview:
             LOG.info(f"Starting operation: {self.selected_filter.__name__} "
-                     f"(shape={images.data.shape}, {params})")
+                     f"(shape={images.shape}, {params})")
             perf_logger.info(f"{self.selected_filter.filter_name} completed in {duration:.3f}s")
 
         # store the executed filter in history if it executed successfully


### PR DESCRIPTION
## Issue  
Closes #2625

### Description

- Updated the `ImageStack.data` setter to safely handle both `SharedArray` and `ndarray` inputs.
- Constructor now uses `self.data = data` to unify logic and prevent duplication.
- Added `.shape` property to `ImageStack` to allow direct access (`images.shape` instead of `images.data.shape`).
- Replaced `.data.shape` in core codebase where appropriate.

### Developer Testing 

- I have verified unit tests pass locally: `python -m pytest -vs`
- Manually tested shared memory use cases to confirm no link breakage.
- Verified `.shape` behaves identically to `.data.shape`.

### Acceptance Criteria and Reviewer Testing

- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Assigning both `ndarray` and `SharedArray` to `ImageStack.data` results in valid internal state.
- [ ] No shared memory warnings or breakage when processing data across operations.
- [ ] `images.shape` returns the expected tuple (matches `images.data.shape`).
- [ ] Create `ImageStack` check `stack.shape`, confirm output.
- [ ] Load and run a typical operation pipeline to confirm functionality is unaffected.

