### PR TITLE
Add Chi² fit  display to Spectrum Viewer

### DIFF
--- a/docs/release_notes/next/feature-2902-Chi-fitting
+++ b/docs/release_notes/next/feature-2902-Chi-fitting
@@ -1,0 +1,1 @@
+#2902: Updated fitting engine to return both Residual Sum of Squares (RSS) and Reduced RSS (RSS/DoF).

--- a/mantidimaging/core/fitting/fitting_engine.py
+++ b/mantidimaging/core/fitting/fitting_engine.py
@@ -22,22 +22,45 @@ class FittingEngine:
     def get_init_params_from_roi(self, region: FittingRegion) -> dict[str, float]:
         return self.model.get_init_params_from_roi(region)
 
-    def find_best_fit(self,
-                      xdata: np.ndarray,
-                      ydata: np.ndarray,
-                      initial_params: list[float],
-                      params_bounds: list[tuple[float | None, float | None]] | None = None) -> dict[str, float]:
+    def find_best_fit(
+        self,
+        xdata: np.ndarray,
+        ydata: np.ndarray,
+        initial_params: list[float],
+        params_bounds: list[tuple[float | None, float | None]] | None = None,
+    ) -> tuple[dict[str, float], float, float]:
+        """
+        Fit the model to the given spectrum using unweighted least squares.
+
+        Returns:
+            - fit_params: dictionary of parameter names → fitted values
+            - rss: residual sum of squares (Σ(residual²))
+            - reduced_rss: rss / degrees of freedom, where DoF = N - p
+
+        Notes:
+            Uses the Nelder–Mead minimizer on the unweighted residuals.
+        """
+
         additional_params = self.model.prefitting(xdata, ydata, initial_params)
+
         if additional_params:
             params_to_fit = initial_params[:-len(additional_params)] + additional_params
         else:
             params_to_fit = initial_params
 
-        def f(params_to_fit):
-            return ((self.model.evaluate(xdata, params_to_fit) - ydata)**2).sum()
+        def residual_sum_squares(params_subset):
+            residuals = self.model.evaluate(xdata, params_subset) - ydata
+            return np.sum(residuals**2)
 
-        result = minimize(f, params_to_fit, method="Nelder-Mead", bounds=params_bounds)
+        result = minimize(residual_sum_squares, params_to_fit, method="Nelder-Mead", bounds=params_bounds)
 
         all_param_names = self.model.get_parameter_names()
         all_params = list(result.x)
-        return dict(zip(all_param_names, all_params, strict=True))
+        fit_params = dict(zip(all_param_names, all_params, strict=True))
+
+        rss = float(result.fun)
+        n_points = ydata.size
+        dof = max(n_points - len(all_params), 1)
+        reduced_rss = rss / dof
+
+        return fit_params, rss, reduced_rss

--- a/mantidimaging/core/fitting/test/fitting_engine_test.py
+++ b/mantidimaging/core/fitting/test/fitting_engine_test.py
@@ -41,7 +41,7 @@ class FittingEngineTest(unittest.TestCase):
         xvals = np.linspace(1, 10, 20)
         yvals = 3.1 * xvals + 2.7
 
-        result = self.engine.find_best_fit(xvals, yvals, [1, 1])
+        result, sse, _ = self.engine.find_best_fit(xvals, yvals, [1, 1])
         self.assertAlmostEqual(result['a'], 3.1, 4)
         self.assertAlmostEqual(result['b'], 2.7, 4)
 
@@ -50,7 +50,7 @@ class FittingEngineTest(unittest.TestCase):
         yvals = 3.1 * xvals + 2.7
         bounds = [(0.8, 0.8), (0.99, 0.99)]
 
-        result = self.engine.find_best_fit(xvals, yvals, [1, 1], params_bounds=bounds)
+        result, _, _ = self.engine.find_best_fit(xvals, yvals, [1, 1], params_bounds=bounds)
         self.assertEqual(result['a'], bounds[0][0])
         self.assertEqual(result['b'], bounds[1][0])
 
@@ -59,6 +59,6 @@ class FittingEngineTest(unittest.TestCase):
         yvals = 3.1 * xvals + 2.7
         bounds = [(0.8, 0.85), (0.9, 0.99)]
 
-        result = self.engine.find_best_fit(xvals, yvals, [1, 1], params_bounds=bounds)
+        result, _, _ = self.engine.find_best_fit(xvals, yvals, [1, 1], params_bounds=bounds)
         self.assertTrue(bounds[0][0] <= result['a'] <= bounds[0][1])
         self.assertTrue(bounds[1][0] <= result['b'] <= bounds[1][1])

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_param_form_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_param_form_widget.py
@@ -43,6 +43,11 @@ class FittingParamFormWidget(QWidget):
         self.run_fit_button.clicked.connect(self.presenter.run_region_fit)
         self._param_values_logged = False
 
+        self.rss_label = QLabel("RSS:")
+        self.reduced_rss_label = QLabel("RSS/DoF:")
+        main_layout.addWidget(self.rss_label)
+        main_layout.addWidget(self.reduced_rss_label)
+
     def set_parameters(self, params: list[str]) -> None:
         """
         Set parameters in the widget.
@@ -101,3 +106,10 @@ class FittingParamFormWidget(QWidget):
             self.params_layout.layout().removeItem(row_layout)
         self._rows.clear()
         LOG.debug("Parameter form rows cleared")
+
+    def set_fit_quality(self, rss: float, rss_per_dof: float) -> None:
+        """
+        Update the fit quality display with raw and reduced residual sum of squares.
+        """
+        self.rss_label.setText(f"RSS: {rss:.2g}")
+        self.reduced_rss_label.setText(f"RSS/DoF: {rss_per_dof:.2g}")

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -466,12 +466,16 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view.spectrum_widget.get_roi = mock.Mock(return_value="mock_roi")
         self.presenter.model.get_spectrum = mock.Mock(return_value=np.array([1, 2, 3]))
         self.presenter.model.tof_data = np.array([1, 2, 3])
-        self.presenter.model.fitting_engine.find_best_fit = mock.Mock(return_value={
-            "mu": 1.0,
-            "sigma": 2.0,
-            "h": 3.0,
-            "a": 4.0
-        })
+        self.presenter.model.fitting_engine.find_best_fit = mock.Mock(return_value=(
+            {
+                "mu": 1.0,
+                "sigma": 2.0,
+                "h": 3.0,
+                "a": 4.0,
+            },
+            0.0,
+            0.0,
+        ))
         self.view.scalable_roi_widget.set_fitted_parameter_values = mock.Mock()
         self.view.fittingDisplayWidget.is_initial_fit_visible.return_value = is_initial_fit_visible
 

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -303,8 +303,14 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         else:
             return None
 
-    def update_export_table(self, roi_name: str, params: dict[str, float], status: str = "Ready") -> None:
-        self.exportDataTableWidget.update_roi_data(roi_name, params, status)
+    def update_export_table(
+        self,
+        roi_name: str,
+        params: dict[str, float],
+        status: str = "Ready",
+        chi2: float | None = None,
+    ) -> None:
+        self.exportDataTableWidget.update_roi_data(roi_name, params, status=status, chi2=chi2)
 
     def set_image(self, image_data: np.ndarray, autoLevels: bool = True) -> None:
         self.spectrum_widget.image.setImage(image_data, autoLevels=autoLevels)


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2831

### Description

This PR introduces the display of fitting quality (Chi²) in the Spectrum Viewer GUI. The fitting engine now returns the sum of squared residuals (Chi²) alongside the parameter results. This value is shown below the parameter table for each ROI fit, helping users evaluate fit accuracy quantitatively.

### Developer Testing 

- I have verified unit tests pass locally: python -m pytest -vs
- Manually tested single-ROI and multi-ROI fitting flow in GUI

### Acceptance Criteria and Reviewer Testing

- Run fit and check that "Fitting Quality (χ²)" is displayed below parameter table
- Edit initial parameters, re-fit, and confirm updated Chi² value
- Run "Fit All ROIs" and confirm Chi² shown correctly for each

### Documentation and Additional Notes

<!-- - [ ] Release Notes have been updated
