### PR TITLE
Operations: Fix progress bar not appearing for operations

### DIFF
--- a/docs/release_notes/next/fix-2879-progress-bar-not-appearing-for-operations
+++ b/docs/release_notes/next/fix-2879-progress-bar-not-appearing-for-operations
@@ -1,0 +1,1 @@
+#2879: Fixes a bug that was preventing the progress bar from updating during the flat fielding operation and added a progress bar for rescale operation.

--- a/mantidimaging/core/operations/flat_fielding/flat_fielding.py
+++ b/mantidimaging/core/operations/flat_fielding/flat_fielding.py
@@ -133,7 +133,8 @@ class FlatFieldFilter(BaseFilter):
                                  f"flat had shape: {flat_avg.shape}, and dark had shape: {dark_avg.shape}")
 
         params = {'flat_avg': flat_avg, 'dark_avg': dark_avg}
-        ps.run_compute_func(FlatFieldFilter._compute_flat_field, len(images.data), [images.shared_array], params)
+        ps.run_compute_func(FlatFieldFilter._compute_flat_field, len(images.data), [images.shared_array], params,
+                            progress)
 
         h.check_data_stack(images)
         return images

--- a/mantidimaging/core/operations/rescale/rescale.py
+++ b/mantidimaging/core/operations/rescale/rescale.py
@@ -43,7 +43,7 @@ class RescaleFilter(BaseFilter):
         """
 
         params = {'min_input': min_input, 'max_input': max_input, 'max_output': max_output}
-        ps.run_compute_func(RescaleFilter.compute_function, len(images.data), [images.shared_array], params)
+        ps.run_compute_func(RescaleFilter.compute_function, len(images.data), [images.shared_array], params, progress)
         return images
 
     @staticmethod


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2879 

### Description

Added progress tracking to  `run_compute_func` for flat-fielding and rescale operations.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Load a dataset in Mantid Imaging
- [ ] Navigate to Operations -> Flat Fielding
- [ ] Check if a progress bar appears when Flat Fielding is applied to the data
- [ ] Navigate to Operations -> Rescale
- [ ] Check if a progress bar appears when Rescale is applied to data

