### PR TITLE
feat(recon): add support for selecting projection pairs in correlation

### DIFF
--- a/mantidimaging/core/rotation/test/polyfit_correlation_test.py
+++ b/mantidimaging/core/rotation/test/polyfit_correlation_test.py
@@ -56,6 +56,18 @@ class PolyfitCorrelationTest(unittest.TestCase):
         assert res_cor.value == 4.0, f"Found {res_cor.value}"
         assert abs(res_tilt.value) < 1e-6, f"Found {res_tilt.value}"
 
+    def test_find_center_with_use_projections_matches_proj180deg(self):
+        images = generate_images((10, 10, 10))
+        images.data[0] = np.identity(10)
+        images.data[6] = np.fliplr(np.identity(10))
+        images.proj180deg = ImageStack(np.fliplr(images.data[0:1]))
+        mock_progress = mock.create_autospec(Progress, instance=True)
+        res_cor_default, res_tilt_default = find_center(images, mock_progress)
+        images.proj180deg = None
+        res_cor_tuple, res_tilt_tuple = find_center(images, mock_progress, use_projections=(0, 6))
+        self.assertEqual(res_cor_tuple.value, res_cor_default.value)
+        self.assertEqual(res_tilt_tuple.value, res_tilt_default.value)
+
     def test_find_shift(self):
         images = mock.Mock(height=3)
         min_correlation_error = np.array([[1, 2, 2, 2, 2, 2, 2, 2, 2, 2], [3, 3, 3, 3, 3, 3, 3, 3, 2, 3],

--- a/mantidimaging/gui/windows/recon/model.py
+++ b/mantidimaging/gui/windows/recon/model.py
@@ -257,8 +257,12 @@ class ReconstructWindowModel:
         LOG.info("COR minimisation completed: CORs=%s", cors)
         return cors
 
-    def auto_find_correlation(self, progress: Progress) -> tuple[ScalarCoR, Degrees]:
-        return find_center(self.images, progress)
+    def auto_find_correlation(
+        self,
+        progress: Progress,
+        use_projections: tuple[int, int] | None = None,
+    ) -> tuple[ScalarCoR, Degrees]:
+        return find_center(self.images, progress, use_projections)
 
     def stack_contains_nans(self) -> bool:
         return bool(np.any(np.isnan(self.images.data)))

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -344,12 +344,9 @@ class ReconWindowPresenterTest(unittest.TestCase):
         self.view = mock.MagicMock()
         self.presenter.view = self.view
         self.view.main_window.get_stack = mock.MagicMock(return_value=images)
-
         self.presenter.notify(PresNotification.AUTO_FIND_COR_CORRELATE)
-
         mock_start_async.assert_called_once()
         completed_function = mock_start_async.call_args[0][2]
-
         task = mock.MagicMock()
         task.result = None
         task.error = ValueError("Task Error")


### PR DESCRIPTION
## Issue
subissue of #2685

### Description
Implements the first sub-issue of #2685 by allowing correlation between any
two projections separated by ~180°, without automatically generating or
requiring a 180° projection stack.

- Updated `_auto_find_correlation` to use arbitrary projection indices
- Modified `find_center()` to accept configurable projection pairs
- Removed dependency on `has_proj180deg()` and `.proj180deg`
- Adjusted related unit tests to reflect new behavior

### Developer Testing
- Verified all unit tests pass locally: `python -m pytest -vs`

### Acceptance Criteria and Reviewer Testing
- [ ] Confirm correlation works for arbitrary projection pairs
- [ ] Verify no “180 Projection” stack is auto-generated
- [ ] Unit tests pass locally

### Documentation and Additional Notes
- [ ] Release notes updated to reflect new correlation options


