### PR TITLE
Separate caching logic from spectrum calculation

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -87,7 +87,6 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             except RuntimeError:
                 norm_stack = None
             self.model.set_normalise_stack(norm_stack)
-
         self.model.set_tof_unit_mode_for_stack()
         self.model.spectrum_cache.clear()
         sample_roi = SensibleROI.from_list([0, 0, *self.model.get_image_shape()])


### PR DESCRIPTION
## Closes #2839 (Sub-Issue 1)

### Description
Refactored get_spectrum() in the Spectrum Viewer model so that all caching logic now lives in one place.  
Introduced _compute_spectrum() to handle only the numeric calculation.  
get_spectrum() now manages cache lookup and storage.  
Removed duplicate caching logic from other parts of the model and presenter.  
Added clearer flow for full vs. chunked spectrum calculations.  
This makes caching consistent, easier to maintain, and prepares for later sub-issues (key standardisation, thread-safety).

### Developer Testing
Verified all existing unit tests pass locally:
Manually checked that ROI spectrum recalculates correctly and uses cache on repeated calls.

### Acceptance Criteria / Reviewer Testing
- [x] Unit tests pass locally (`python -m pytest -vs`)
- [ ] ROI movements trigger recalculation only when parameters change
- [ ] Cached spectra are reused on identical inputs
- [ ] No presenter-side caching logic remains

### Documentation / Notes
No user-facing changes.  
Part 1 of the Spectrum Viewer caching refactor (#2839).

