### PR TITLE
Testing: leak info is only shown if test doesnt pass

### DIFF
--- a/mantidimaging/core/utility/leak_tracker.py
+++ b/mantidimaging/core/utility/leak_tracker.py
@@ -87,7 +87,6 @@ class LeakTracker:
 
     def __init__(self):
         self.tracked_objects = []
-        self.leak_limit_exceeded = False
 
     def add(self, item, msg=""):
         created = traceback.format_stack()[:-1]

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -58,16 +58,18 @@ class GuiSystemBase(unittest.TestCase):
 
         # if self._outcome.result._excinfo is None then there were no AssertionErrors during the test
         test_error = self._outcome.result._excinfo  # type: ignore
-        if test_error is None and (leak_count := leak_tracker.count()) > self.leak_count_limit:
-            print("\nItems still alive:", leak_count)
-            leak_tracker.pretty_print(debug_init=False, debug_owners=False, trace_depth=5)
-            try:
+        try:
+            # if the test passed but there were some leaked objects, print basic info
+            if test_error is None and (leak_count := leak_tracker.count()):
+                print("\nItems still alive:", leak_count)
+                leak_tracker.pretty_print(debug_init=False, debug_owners=False, trace_depth=5)
+                # if too many objects leaked, print debug info
                 if leak_count > self.leak_count_limit:
                     print("details:")
                     leak_tracker.pretty_print(debug_init=True, debug_owners=True, trace_depth=5)
                     raise RuntimeError(f"Too many leaked objects: {leak_count}")
-            finally:
-                leak_tracker.clear()
+        finally:
+            leak_tracker.clear()
 
         for widget in self.app.topLevelWidgets():
             if widget.isVisible():


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2918

### Description

In `GuiSystemBase.tearDown` we now check if an AssertionError is raise during the test and only print the leaked object info if the test fails because of too many leaked objects.

We now have the following situations:

1. Test passes and leaked objects within limits:
No Errors printed
2. Test passes and leaked objects exceed limit:
print `leak_tracker` info and `raise RuntimeError(f"Too many leaked objects: {leak_count}")`
3. Test fails and leaked objects within limits:
Test AssertionError details printed only
4. Test fails and leaked objects exceed limits:
Test AssertionError details printed only

Restricting when the `leak_tracker` info is printed will aid when debugging failed tests so the dev will know whether the test is failing due to a broken test or due to too many leaked objects.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- ...

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] As in the linked issue, add an AssertionError manually to `mantidimaging/gui/test/gui_system_loading_test.py::TestGuiSystemLoading::test_load_log` at around line 107 and run `pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov -o log_cli=true --run-system-tests mantidimaging/gui/test/ -k test_load_log`
- [ ] Check that the expected AssertionError prints but no info about leaked objects prints
- [ ] With the AssertionError, force the leak_tracker to exceed the limit by setting `leak_count_limit = -1` at the top of `TestGuiSystemLoading` and check that only the AssertionError info prints and no info about leaked objects.
- [ ] Now remove the AssertionError and check that the test will now fail due to a raised `RuntimeError(f"Too many leaked objects: {leak_count}")`

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [ ] Release Notes have been updated
