### PR TITLE
Rename the fitting parameter form to fitting_param_form

### DIFF
--- a/mantidimaging/eyes_tests/spectrum_viewer_test.py
+++ b/mantidimaging/eyes_tests/spectrum_viewer_test.py
@@ -102,13 +102,13 @@ class SpectrumViewerWindowTest(BaseEyesTest):
         self._generate_spectrum_dataset()
         self.imaging.show_spectrum_viewer_window()
         self.imaging.spectrum_viewer.formTabs.setCurrentIndex(1)
-        self.imaging.spectrum_viewer.scalable_roi_widget.from_roi_button.click()
+        self.imaging.spectrum_viewer.fitting_param_form.from_roi_button.click()
         self.check_target(widget=self.imaging.spectrum_viewer)
 
     def test_spectrum_viewer_run_fit(self):
         self._generate_spectrum_dataset()
         self.imaging.show_spectrum_viewer_window()
         self.imaging.spectrum_viewer.formTabs.setCurrentIndex(1)
-        self.imaging.spectrum_viewer.scalable_roi_widget.from_roi_button.click()
-        self.imaging.spectrum_viewer.scalable_roi_widget.run_fit_button.click()
+        self.imaging.spectrum_viewer.fitting_param_form.from_roi_button.click()
+        self.imaging.spectrum_viewer.fitting_param_form.run_fit_button.click()
         self.check_target(widget=self.imaging.spectrum_viewer)

--- a/mantidimaging/gui/widgets/spectrum_widgets/fitting_param_form_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/fitting_param_form_widget.py
@@ -18,7 +18,12 @@ BoundType = tuple[float | None, float | None]
 
 class FittingParamFormWidget(QWidget):
     """
-    Scalable widget to display ROI parameters with Initial and Final values.
+    From for inputting and viewing fitting parameters.
+
+    Shows a row for each parameter in the current fitting model, with initial and final values, and controls to fix
+    and set ranges.
+    Has controls for getting initial parameters and running a fit.
+    Has space to show goodness of fit measures.
     """
 
     def __init__(self, presenter: SpectrumViewerWindowPresenter, parent=None) -> None:
@@ -56,7 +61,7 @@ class FittingParamFormWidget(QWidget):
     def set_parameters(self, params: list[str]) -> None:
         """
         Set parameters in the widget.
-        :param params: Dict of label -> (initial, final)
+        :param params: List of parameter names
         """
         self.clear_rows()
 

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -664,19 +664,19 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def setup_fitting_model(self) -> None:
         param_names = self.model.fitting_engine.get_parameter_names()
-        self.view.scalable_roi_widget.set_parameters(param_names)
+        self.view.fitting_param_form.set_parameters(param_names)
         self.view.exportDataTableWidget.set_parameters(param_names)
 
     def get_init_params_from_roi(self) -> None:
         fitting_region = self.view.get_fitting_region()
         init_params = self.model.fitting_engine.get_init_params_from_roi(fitting_region)
-        self.view.scalable_roi_widget.set_parameter_values(init_params)
+        self.view.fitting_param_form.set_parameter_values(init_params)
 
         self.view.fittingDisplayWidget.set_plot_mode("initial")
 
         self.show_initial_fit()
         roi_name = self.view.roiSelectionWidget.current_roi_name
-        self.view.scalable_roi_widget.set_fit_quality(float("nan"), float("nan"))
+        self.view.fitting_param_form.set_fit_quality(float("nan"), float("nan"))
         self.view.exportDataTableWidget.update_roi_data(
             roi_name=roi_name,
             params=init_params,
@@ -685,7 +685,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         )
 
     def _plot_initial_fit(self) -> None:
-        init_params = self.view.scalable_roi_widget.get_initial_param_values()
+        init_params = self.view.fitting_param_form.get_initial_param_values()
         xvals = self.model.tof_data
         init_fit = self.model.fitting_engine.model.evaluate(xvals, init_params)
         self.view.fittingDisplayWidget.show_fit_line(xvals,
@@ -705,18 +705,18 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         if self.view.fittingDisplayWidget.is_initial_fit_visible():
             self._plot_initial_fit()
         else:
-            init_params = self.view.scalable_roi_widget.get_initial_param_values()
+            init_params = self.view.fitting_param_form.get_initial_param_values()
             roi_name = self.view.roiSelectionWidget.current_roi_name
             roi = self.view.spectrum_widget.get_roi(roi_name)
             spectrum = self.model.get_spectrum(roi, self.spectrum_mode)
             xvals = self.model.tof_data
-            bound_params = self.view.scalable_roi_widget.get_bound_parameters()
+            bound_params = self.view.fitting_param_form.get_bound_parameters()
             fit_params, rss, rss_per_dof = self.model.fitting_engine.find_best_fit(xvals,
                                                                                    spectrum,
                                                                                    init_params,
                                                                                    params_bounds=bound_params)
-            self.view.scalable_roi_widget.set_fitted_parameter_values(fit_params)
-            self.view.scalable_roi_widget.set_fit_quality(rss, rss_per_dof)
+            self.view.fitting_param_form.set_fitted_parameter_values(fit_params)
+            self.view.fitting_param_form.set_fit_quality(rss, rss_per_dof)
             self.show_fit(list(fit_params.values()))
             LOG.info("Refit completed for ROI=%s, RSS/DoF=%.3f", roi_name, rss_per_dof)
 
@@ -727,7 +727,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         and evaluates the fitting model using these parameters to generate the initial fit curve.
         """
         xvals = self.model.tof_data
-        init_params = self.view.scalable_roi_widget.get_initial_param_values()
+        init_params = self.view.fitting_param_form.get_initial_param_values()
         init_fit = self.model.fitting_engine.model.evaluate(xvals, init_params)
         self.view.fittingDisplayWidget.show_fit_line(xvals,
                                                      init_fit,
@@ -739,14 +739,14 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         Run a fit on the currently selected ROI and update the GUI/export table.
         """
-        bound_params = self.view.scalable_roi_widget.get_bound_parameters()
+        bound_params = self.view.fitting_param_form.get_bound_parameters()
         result, rss, reduced_rss = self.fit_single_region(self.fitting_spectrum,
                                                           self.view.get_fitting_region(),
                                                           self.model.tof_data,
-                                                          self.view.scalable_roi_widget.get_initial_param_values(),
+                                                          self.view.fitting_param_form.get_initial_param_values(),
                                                           bounds=bound_params)
-        self.view.scalable_roi_widget.set_fitted_parameter_values(result)
-        self.view.scalable_roi_widget.set_fit_quality(rss, reduced_rss)
+        self.view.fitting_param_form.set_fitted_parameter_values(result)
+        self.view.fitting_param_form.set_fit_quality(rss, reduced_rss)
         self.show_fit(list(result.values()))
         roi_name = self.view.roiSelectionWidget.current_roi_name
         self.view.exportDataTableWidget.update_roi_data(
@@ -771,8 +771,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         return self.model.fitting_engine.find_best_fit(xvals, yvals, init_params, params_bounds=bounds)
 
     def fit_all_regions(self):
-        init_params = self.view.scalable_roi_widget.get_initial_param_values()
-        bound_params = self.view.scalable_roi_widget.get_bound_parameters()
+        init_params = self.view.fitting_param_form.get_initial_param_values()
+        bound_params = self.view.fitting_param_form.get_bound_parameters()
         for roi_name, roi_widget in self.view.spectrum_widget.roi_dict.items():
             if roi_name == "rits_roi":
                 continue

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -53,7 +53,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view.experimentSetupFormWidget = mock.Mock(spec=ExperimentSetupFormWidget)
         self.view.experimentSetupFormWidget.time_delay = 0.0
         self.view.fittingDisplayWidget = mock.Mock()
-        self.view.scalable_roi_widget = mock.Mock()
+        self.view.fitting_param_form = mock.Mock()
         self.view.roiSelectionWidget = mock.Mock()
         self.view.fittingDisplayWidget.spectrum_plot = mock.Mock()
         self.view.fittingDisplayWidget.spectrum_plot.spectrum = mock.Mock()
@@ -439,7 +439,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.view.display_normalise_error.assert_called_once()
 
     def test_show_initial_fit_calls_correct_plot_method(self):
-        self.view.scalable_roi_widget.get_initial_param_values = mock.Mock(return_value=[1.0, 2.0, 3.0, 4.0])
+        self.view.fitting_param_form.get_initial_param_values = mock.Mock(return_value=[1.0, 2.0, 3.0, 4.0])
         self.presenter.model.tof_data = np.array([1, 2, 3])
         self.presenter.model.fitting_engine.model.evaluate = mock.Mock(return_value=np.array([10, 20, 30]))
         self.view.fittingDisplayWidget.show_fit_line = mock.Mock()
@@ -463,7 +463,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
                                                              expect_show_fit):
         self.presenter._plot_initial_fit = mock.Mock()
         self.view.fittingDisplayWidget.show_fit_line = mock.Mock()
-        self.view.scalable_roi_widget.get_initial_param_values = mock.Mock(return_value=[1.0, 2.0, 3.0, 4.0])
+        self.view.fitting_param_form.get_initial_param_values = mock.Mock(return_value=[1.0, 2.0, 3.0, 4.0])
         self.view.roiSelectionWidget.current_roi_name = "roi"
         self.view.spectrum_widget.get_roi = mock.Mock(return_value="mock_roi")
         self.presenter.model.get_spectrum = mock.Mock(return_value=np.array([1, 2, 3]))
@@ -478,7 +478,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
             0.0,
             0.0,
         ))
-        self.view.scalable_roi_widget.set_fitted_parameter_values = mock.Mock()
+        self.view.fitting_param_form.set_fitted_parameter_values = mock.Mock()
         self.view.fittingDisplayWidget.is_initial_fit_visible.return_value = is_initial_fit_visible
 
         self.presenter.on_initial_params_edited()
@@ -486,7 +486,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         if expect_plot_initial:
             self.presenter._plot_initial_fit.assert_called_once()
             self.view.fittingDisplayWidget.show_fit_line.assert_not_called()
-            self.view.scalable_roi_widget.set_fitted_parameter_values.assert_not_called()
+            self.view.fitting_param_form.set_fitted_parameter_values.assert_not_called()
         if expect_show_fit:
             self.presenter._plot_initial_fit.assert_not_called()
             self.view.fittingDisplayWidget.show_fit_line.assert_called_once()
@@ -495,7 +495,7 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
             assert kwargs["color"] == (0, 128, 255)
             assert kwargs["label"] == "fit"
             assert kwargs["initial"] is False
-            self.view.scalable_roi_widget.set_fitted_parameter_values.assert_called_once_with({
+            self.view.fitting_param_form.set_fitted_parameter_values.assert_called_once_with({
                 "mu": 1.0,
                 "sigma": 2.0,
                 "h": 3.0,

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -96,8 +96,8 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.fittingLayout.addWidget(self.fittingDisplayWidget)
         self.roiSelectionWidget.selectionChanged.connect(self.handle_fitting_roi_changed)
 
-        self.scalable_roi_widget = FittingParamFormWidget(self.presenter)
-        self.fittingFormLayout.layout().addWidget(self.scalable_roi_widget)
+        self.fitting_param_form = FittingParamFormWidget(self.presenter)
+        self.fittingFormLayout.layout().addWidget(self.fitting_param_form)
 
         self.export_display_tabs = QTabWidget(self)
         self.exportDataTableWidget = ExportDataTableWidget()


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Helpful for #2914

### Description

This is just a rename and some docstring fixes. But the name is used in many places, so moved into its own PR, make the main PR easier to review.

I think the old name was based on description in a mockup. New name is more descriptive of what this currently is. `FittingParamFormWidget` is the form for imputing and viewing fitting parameters.

There are no functional changes, and no instances of the old name in the code base.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`


### Acceptance Criteria and Reviewer Testing

- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Search for the old name and confirm it is no longer used
- [x] check new docstrings

### Documentation and Additional Notes

Not needed