### PR TITLE
Add Keyboard Shortcut for Spectrum Viewer

### DIFF
--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -258,6 +258,7 @@ class MainWindowView(BaseMainWindowView):
         self.actionViewer3d.triggered.connect(self.open_3d_viewer)
         self.actionLiveViewer.triggered.connect(self.live_view_choose_directory)
         self.actionSettings.triggered.connect(self.show_settings_window)
+        self.actionSpectrumViewer.triggered.connect(self.show_spectrum_viewer_window)
 
         self.actionCompareImages.triggered.connect(self.show_stack_select_dialog)
 
@@ -271,6 +272,9 @@ class MainWindowView(BaseMainWindowView):
         self.actionResetLayout = QAction("Reset Layout", self)
         self.actionResetLayout.setShortcut("Ctrl+Shift+R")
         self.actionResetLayout.triggered.connect(self.reset_layout)
+
+        # Spectrum Viewer
+        self.actionSpectrumViewer.setShortcut("Ctrl+P")
 
         # Add to View menu (menuView always exists now)
         self.menuView.addAction(self.actionResetLayout)


### PR DESCRIPTION
## Issue Closes #2943

### Description
Added a keyboard shortcut (Ctrl+P) to open the Spectrum Viewer. This improves accessibility and brings it in line with other workflow tools that already have shortcuts.

### Developer Testing
I verified the Spectrum Viewer opens using Ctrl+P.  
I verified the menu still opens it normally.  
I verified no shortcut conflicts occur.  
I verified the application runs normally after the change.

### Acceptance Criteria and Reviewer Testing
- [x] Pressing Ctrl+P opens the Spectrum Viewer.  
- [x] The existing menu action still opens Spectrum Viewer.  
- [x] No conflicts with other shortcuts (R, O, S, Q).  
- [x] Application launches without errors.

### Documentation and Additional Notes
No documentation changes required. This is a small accessibility improvement.
