### PR TITLE
Remove Duplicate Reset Layout Code in setup_shortcuts()

### DIFF
--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -268,11 +268,6 @@ class MainWindowView(BaseMainWindowView):
         self.actionResetLayout.setShortcut("Ctrl+Shift+R")
         self.actionResetLayout.triggered.connect(self.reset_layout)
 
-        # Add Reset Layout action
-        self.actionResetLayout = QAction("Reset Layout", self)
-        self.actionResetLayout.setShortcut("Ctrl+Shift+R")
-        self.actionResetLayout.triggered.connect(self.reset_layout)
-
         # Spectrum Viewer
         self.actionSpectrumViewer.setShortcut("Ctrl+P")
 


### PR DESCRIPTION
## Issue Closes #2944

### Description
Removed duplicated Reset Layout QAction creation inside `setup_shortcuts()`. The action is now created once and added cleanly to the View menu.

### Developer Testing
- Verified the application launches normally.
- Verified the Reset Layout option still appears in the View menu.
- Verified `Ctrl+Shift+R` still triggers the layout reset.
- Verified no other shortcuts or actions were affected.

### Acceptance Criteria and Reviewer Testing
- [x] Only one Reset Layout QAction is created.
- [x] Reset Layout still appears under the View menu.
- [x] `Ctrl+Shift+R` resets the layout correctly.
- [x] Application starts without errors.

### Documentation and Additional Notes
No documentation changes required. This is a straightforward code cleanup.


