### PR TITLE
Refactoring ROI Binner validation

### DIFF
--- a/mantidimaging/core/utility/sensible_roi.py
+++ b/mantidimaging/core/utility/sensible_roi.py
@@ -54,6 +54,9 @@ class ROIBinner:
         self._step_size = step_size
         self._bin_size = bin_size
 
+        if step_size < 1:
+            raise ValueError("ROIBinner step_size must greater than zero")
+
         self.left_indexes = range(roi.left, roi.right - bin_size + 1, step_size)
         self.top_indexes = range(roi.top, roi.bottom - bin_size + 1, step_size)
 
@@ -76,3 +79,21 @@ class ROIBinner:
     @property
     def bin_size(self) -> int:
         return self._bin_size
+
+    def is_valid(self) -> tuple[bool, str]:
+        """
+        Validates that the bin_size and step_size are compatible with aech other the roi dimensions
+        - bin_size must be greater than zero (step_size must be checked at construction)
+        - bin_size must be greater or equal than step_size (to avoid gaps)
+        - bin_size must be less than or equal to roi width and height (to fit in the roi)
+        Returns:
+            validity (bool), message (str)
+        """
+        if self.bin_size < 1:
+            return False, "bin_size must be greater than zero"
+        if self.bin_size < self.step_size:
+            return False, "bin_size must be greater or equal than step_size"
+        if self.bin_size > self.roi.width or self.bin_size > self.roi.height:
+            return False, "step_size must be less than or equal to roi width and height"
+
+        return True, ""

--- a/mantidimaging/core/utility/sensible_roi.py
+++ b/mantidimaging/core/utility/sensible_roi.py
@@ -97,3 +97,11 @@ class ROIBinner:
             return False, "step_size must be less than or equal to roi width and height"
 
         return True, ""
+
+    def check_fits_exactly(self) -> bool:
+        """
+        Check that the bins fit exactly in the roi
+        """
+        right_edge = self.left_indexes[-1] + self.bin_size
+        bottom_edge = self.top_indexes[-1] + self.bin_size
+        return right_edge == self.roi.right and bottom_edge == self.roi.bottom

--- a/mantidimaging/core/utility/test/sensibleROI_test.py
+++ b/mantidimaging/core/utility/test/sensibleROI_test.py
@@ -161,6 +161,18 @@ class ROIBinnerTest(unittest.TestCase):
         is_valid, reason = binner.is_valid()
         self.assertEqual(is_valid, expect_is_valid)
 
+    @parameterized.expand([
+        ("good_fit_same", SensibleROI(0, 0, 20, 20), 5, 5, True),
+        ("good_fit_different", SensibleROI(0, 0, 23, 26), 5, 3, True),
+        ("good_fit_moved", SensibleROI(1, 2, 21, 22), 5, 5, True),
+        ("bad_fit_small_step", SensibleROI(0, 0, 20, 20), 5, 4, False),
+        ("bad_fit_horizontal", SensibleROI(0, 0, 11, 12), 3, 3, False),
+        ("bad_fit_vertical", SensibleROI(0, 0, 12, 11), 3, 3, False),
+    ])
+    def test_binner_fits_exactly_check(self, _, roi, bin_size, step_size, expected):
+        binner = ROIBinner(roi, step_size, bin_size)
+        self.assertEqual(binner.check_fits_exactly(), expected)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/core/utility/test/sensibleROI_test.py
+++ b/mantidimaging/core/utility/test/sensibleROI_test.py
@@ -145,6 +145,22 @@ class ROIBinnerTest(unittest.TestCase):
         with self.assertRaises(AttributeError):
             binner.bin_size = 4
 
+    def test_dont_allow_zero_step_size(self):
+        with self.assertRaisesRegex(ValueError, "step_size"):
+            ROIBinner(SensibleROI(0, 0, 5, 5), 0, 1)
+
+    @parameterized.expand([
+        ("larger_than_1", 0, 1, False),  # bin_size < 1
+        ("bin_less_than_or_equal_to_step", 1, 2, False),  # bin_size <= step_size
+        ("less_than_roi", 9, 10, False),  # bin_size and step_size > min(roi.width, roi.height)
+        ("less_than_roi", 10, 9, False),  # bin_size and step_size > min(roi.width, roi.height)
+        ("valid", 2, 1, True),  # valid case
+    ])
+    def test_binner_is_valid(self, _, bin_size, step_size, expect_is_valid):
+        binner = ROIBinner(SensibleROI(0, 0, 5, 5), step_size, bin_size)
+        is_valid, reason = binner.is_valid()
+        self.assertEqual(is_valid, expect_is_valid)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
@@ -83,23 +83,14 @@ class ROIFormWidget(BaseWidget):
         roi = self.roi_properties_widget.to_roi()
         step = self.bin_step_spinBox.value()
         bin_size = self.bin_size_spinBox.value()
-        self._check_rits_step_validity(roi, step, bin_size)
         binner = ROIBinner(roi, step_size=step, bin_size=bin_size)
-        self.binningChanged.emit(binner)
-
-    def _check_rits_step_validity(self, roi: SensibleROI, step: int, bin_size: int) -> None:
-        roi_width = roi.right - roi.left
-        roi_height = roi.bottom - roi.top
-        norm_mode = self.transmission_error_mode_combobox.currentText()
-
-        if ((roi_width - bin_size) % step != 0 or (roi_height - bin_size) % step != 0):
+        if not binner.check_fits_exactly():
             warning = (f"Step size {step} and bin size {bin_size} do not evenly divide ROI dimensions "
-                       f"({roi_width}x{roi_height}). Some rows or columns may not be exported.")
+                       f"({roi.width}x{roi.height}). Some rows or columns may not be exported.")
             self.show_rits_warning(warning)
         else:
-            LOG.info("RITS config valid — bin=%d, step=%d, norm_error=%s, roi_size=%dx%d", bin_size, step, norm_mode,
-                     roi_width, roi_height)
             self.show_rits_warning(None)
+        self.binningChanged.emit(binner)
 
 
 class ROIPropertiesTableWidget(BaseWidget):

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -441,23 +441,6 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         self.assertRaises(ValueError, ErrorMode.get_by_value, "")
 
     @parameterized.expand([
-        ("larger_than_1", 1, 0, ValueError),  # bin_size and step_size < 1
-        ("bin_less_than_or_equal_to_step", 1, 2, ValueError),  # bin_size <= step_size
-        ("less_than_roi", 10, 10, ValueError),  # bin_size and step_size > min(roi.width, roi.height)
-        ("valid", 2, 1, None),  # valid case
-    ])
-    def test_validate_bin_and_step_size(self, _, bin_size, step_size, expected_exception):
-        roi = SensibleROI.from_list([0, 0, 5, 5])
-        if expected_exception:
-            with self.assertRaises(expected_exception):
-                self.model.validate_bin_and_step_size(roi, bin_size, step_size)
-        else:
-            try:
-                self.model.validate_bin_and_step_size(roi, bin_size, step_size)
-            except ValueError:
-                self.fail("validate_bin_and_step_size() raised ValueError unexpectedly!")
-
-    @parameterized.expand([
         (["5x5_bin_2_step_1", 5, 2, 1]),
         (["5x5_bin_2_step_2", 5, 3, 2]),
         (["7x7_bin_2_step_3", 7, 4, 1]),


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Cleanup related to #2914 

### Description

`ROIBinner` is used for 2d binning within an ROI. It originally existed for RITS export, but will now be used for BE mapping. There were a couple of existing points in the code which check if the Binner values were valid and if they bins fitted exactly.

This refactor moves both of those checks into the `ROIBinner` class where they can be tested in isolation. It changes `ROIFormWidget` and `SpectrumViewerWindowModel` to use the check methods.

This moves some logic away from the GUI and makes it easier to test and reuse.

This also fixes some harmless typos in the checks:
`if bin_size and step_size > min(roi.width, roi.height):`
does not check that `bin_size` is greater than the `min(roi.width, roi.height)`. Though the previous line enforces that `bin_size` greater or equal to `step_size`, so it would have already failed in that case.


### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `pixi run test-gpu`
- ...

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Unit tests pass locally: `pixi run test-gpu`

### Documentation and Additional Notes

Not needed
