### PR TITLE
Improve conda caching in workflows - avoid copy

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -145,3 +145,9 @@ jobs:
         with:
           label: unstable
           token: ${{ secrets.ANACONDA_API_TOKEN_MANTIDIMAGING }}
+
+      - name: Show disk space at end
+        if: ${{ !cancelled() }}
+        run: |
+          df -h
+        shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -139,3 +139,9 @@ jobs:
         with:
           label: unstable
           token: ${{ secrets.ANACONDA_API_TOKEN_MANTIDIMAGING }}
+
+      - name: Show disk space at end
+        if: ${{ !cancelled() }}
+        run: |
+          df -h
+        shell: bash


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2975

### Description

Avoid having to copy the conda environment to prevent the work disk being filled.

The original implementation was in #1350. It has the comment:

> Using the cache in-place as described at https://github.com/conda-incubator/setup-miniconda#caching-packages does not give a working environment. Instead cache a copy of the folder, and copy back on cache hit.

The problem may just have been the order of the steps.

When it was implemented in the windows workflow, a simpler approach without the copy was used  #1411.

> I have slightly changed the approach used to cache the environment here, but I'm not sure if I'm misunderstanding why it was written as it was originally, so please shout if so 🙂. For that reason I've not changed the conda workflow version to match, but I could if we thought that would be beneficial.


### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- Checked that this runs ok with cache miss and cache hit

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Look at the conda workflow runs for this PR, the first run created the cache, and the second run used it: https://github.com/mantidproject/mantidimaging/actions/runs/20036580597/job/57461458292?pr=2980

### Documentation and Additional Notes

Not needed
