### PR TITLE
Operations: Safe Apply checkbox saved as QSetting

### DIFF
--- a/mantidimaging/gui/windows/operations/view.py
+++ b/mantidimaging/gui/windows/operations/view.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import functools
 from typing import TYPE_CHECKING
 
-from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtCore import pyqtSignal, QSettings
 from PyQt5.QtWidgets import (QApplication, QCheckBox, QComboBox, QLabel, QPushButton, QSizePolicy, QSplitter, QStyle,
                              QVBoxLayout)
 
@@ -21,6 +21,8 @@ from ...widgets.roi_selector.view import ROISelectorView
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401  # pragma: no cover
     from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
+
+settings = QSettings('mantidproject', 'Mantid Imaging')
 
 
 def _strip_filter_name(filter_name: str):
@@ -115,7 +117,8 @@ class FiltersWindowView(BaseMainWindowView):
         self.filterHelpButton.pressed.connect(self.open_help_webpage)
         self.collapseToggleButton.pressed.connect(self.toggle_filters_section)
 
-        self.safeApply.setChecked(False)
+        self.safeApply.setChecked(settings.value('safeApply', False, bool))
+        self.safeApply.stateChanged.connect(self.handle_safe_apply_check)
 
         self.handle_filter_selection("")
         self.window_ready = True
@@ -165,6 +168,9 @@ class FiltersWindowView(BaseMainWindowView):
         # Update preview on filter selection (on the off chance the default
         # options are valid)
         self.auto_update_triggered.emit()
+
+    def handle_safe_apply_check(self):
+        settings.setValue('safeApply', self.safeApply.isChecked())
 
     def on_auto_update_triggered(self):
         """


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2977

### Description

When `FiltersWindowView` is initialised, we read the default value of the "Safe Apply" checkbox from a QSetting, defaulting to `False` if no value can be found. This will allow users to change the value of the checkbox to what they want and MI will remember for next time.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- ...

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Load data and open the Operations window
- [x] Check that the Safe Apply checkbox is unchecked by default.
- [x] Check the checkbox and restart MI
- [ ] Check that the default value of the "Safe Apply" checkbox is `True`

