### PR TITLE
Avoid copy of environment when caching for docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,16 +38,6 @@ jobs:
           key:
             ${{runner.os}}-condapkg-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml')}}
 
-      - name: Cache Miniforge environment
-        uses: actions/cache@v4
-        id: cache-miniforge-environment
-        env:
-          CACHE_NUMBER: 0
-        with:
-          path: ${CONDA}/envs/mantidimaging-dev.cache
-          key:
-            ${{runner.os}}-condaenv-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml')}}
-
       - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -55,6 +45,16 @@ jobs:
           activate-environment: mantidimaging-dev
           auto-activate-base: false
           use-mamba: true
+
+      - name: Cache Miniforge environment
+        uses: actions/cache@v4
+        id: cache-miniforge-environment
+        env:
+          CACHE_NUMBER: 0
+        with:
+          path: ${CONDA}/envs/mantidimaging-dev
+          key:
+            ${{runner.os}}-condaenv-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml')}}
 
       - name: Mantid Imaging developer dependencies
         if: steps.cache-miniforge-environment.outputs.cache-hit != 'true'
@@ -89,3 +89,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           dir_name: ${{ github.ref_name }}
+
+      - name: Show disk space at end
+        if: ${{ !cancelled() }}
+        run: |
+          df -h
+        shell: bash


### PR DESCRIPTION
See PR #2980

<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2975 

### Description

This is the same fix from #2980 applied to the docs workflow. This got missed in the orginal PR

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`


### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Check that the actions run


### Documentation and Additional Notes

Not needed