### PR TITLE
Show correct window title for Refine Iterations dialog

### DIFF
--- a/mantidimaging/gui/dialogs/cor_inspection/view.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/view.py
@@ -31,8 +31,10 @@ class CORInspectionDialogView(BaseDialogView):
         self.iters_mode = iters_mode
 
         if self.iters_mode:
+            self.setWindowTitle("Refine Iterations")
             self.spin_box = self.stepIterations
         else:
+            self.setWindowTitle("COR Inspection")
             self.spin_box = self.stepCOR
 
         self.presenter = CORInspectionDialogPresenter(self, images, slice_index, initial_cor, recon_params, iters_mode)


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2990

### Description

Updates the Refine Iterations dialog to show the correct window title ("Refine Iterations" instead of "COR Inspection").

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- Manually checked that the dialog title updates correctly when refining iterations.

### Acceptance Criteria and Reviewer Testing

- Open the reconstruction window, Run Recon 
- Then click refine in the COR table, Confirm that the dialog title for COR refinement still displays “COR Inspection” as expected.
- Open the reconstruction window and go to reconstruction tab. Select (SIRT_CUDA), then trigger the “Refine Iterations” button. Confirm that the dialog window title displays “Refine Iterations” (not “COR Inspection”).


