### PR TITLE
Fix SPDHG progress bar to show correct number of steps

### DIFF
--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -279,10 +279,15 @@ class CILRecon(BaseRecon):
         if recon_params.stochastic:
             # The UI will pass the number of epochs in this case
             num_iter *= num_subsets
-
-        if progress:
-            progress.add_estimated_steps(num_iter + 1)
-            progress.update(steps=1, msg='CIL: Setting up reconstruction', force_continue=False)
+            if progress:
+                # For SPDHG, don't add extra setup step, just use num_iter
+                progress.add_estimated_steps(num_iter)
+                progress.update(steps=0, msg='CIL: Setting up reconstruction', force_continue=False)
+        else:
+            if progress:
+                # For non-stochastic, add 1 extra step for setup
+                progress.add_estimated_steps(num_iter + 1)
+                progress.update(steps=1, msg='CIL: Setting up reconstruction', force_continue=False)
 
         if cil_mutex.locked():
             LOG.warning("CIL recon already in progress")


### PR DESCRIPTION
## Issue
Closes #2911

### Description

Fix SPDHG progress bar to show the correct number of steps. The progress bar now matches the actual number of iterations for SPDHG (no extra setup step), while non-stochastic algorithms still include a setup step. This resolves the issue where the progress bar showed two extra steps for SPDHG.

### Developer Testing 

- I have verified unit tests pass locally: `python -m pytest -vs`
- Manual test: Ran SPDHG and confirmed progress bar matches expected iteration count.

### Acceptance Criteria and Reviewer Testing

- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] SPDHG progress bar matches expected number of iterations (no extra steps)
- [ ] Other algorithms’ progress bars remain unchanged

### Documentation and Additional Notes

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
-->
