### PR TITLE
Reduce Initialisation Size of COR Inspection Dialog

### DIFF
--- a/mantidimaging/gui/ui/cor_inspection_dialog.ui
+++ b/mantidimaging/gui/ui/cor_inspection_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1274</width>
-    <height>914</height>
+    <width>1074</width>
+    <height>734</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3014 

### Description

<!-- Add a description of the changes made. -->

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified that the default size of the COR Inspection dialog window is smaller on launch

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] The default size of the COR Inspection dialog window is smaller on launch

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

Flash PR - Release notes not necessary 

