### PR TITLE
Remove Clashing CDN Bootstrap with Bundled Bootstrap in pydata_shinx_theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,10 +105,6 @@ todo_include_todos = True
 html_theme = 'pydata_sphinx_theme'
 
 html_css_files = ['custom.css']
-html_js_files = [('https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js', {
-    'integrity': 'sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p',
-    'crossorigin': 'anonymous'
-})]
 
 # Ensure sidebar displays only the current section's nested headings (local ToC)
 html_sidebars = {


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3045 

### Description

<!-- Add a description of the changes made. -->
Resolve Drop down button interactions by removing CDN bootstrap which clashed with `pydata_sphinx_theme` bundled bootstrap

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified launching docs locally that the drop downs are now open in the top navigation bar for "More" pages and "Choose Versions" - Note for "Choose version", you will need to have older docs in built version directory

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Drop downs in navigation panel perform drop down action

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

N/A

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

