### PR TITLE
update main window angles after geometry creation

### DIFF
--- a/docs/release_notes/next/feature-3023-update-main-window-angles-after-geometry-creation
+++ b/docs/release_notes/next/feature-3023-update-main-window-angles-after-geometry-creation
@@ -1,0 +1,1 @@
+#3023: update main window angles after geometry creation

--- a/mantidimaging/gui/windows/geometry/presenter.py
+++ b/mantidimaging/gui/windows/geometry/presenter.py
@@ -145,6 +145,8 @@ class GeometryWindowPresenter(BasePresenter):
         stack.geometry.set_geometry_from_cor_tilt(new_cor, new_tilt)
         stack.geometry.set_source_detector_positions(new_source_position, new_detector_position)
 
+        self.main_window.presenter.add_projection_angles_to_sample(stack.id, new_angles)
+
         self.handle_stack_changed()
 
     def handle_convert_geometry(self) -> None:


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3023 

### Description

Ensure the main window’s image view displays projection angles immediately after new geometry is created in the Geometry window. This fixes the issue where angles were not shown until a reload or manual update.



### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] After creating geometry for a stack with no angles, the main window immediately displays the angles above the slider.


