### PR TITLE
Fix: Only show RITS ROI in Image sub-tab when "Normalise to open beam…

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -488,6 +488,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.redraw_all_rois()
         self.view.display_normalise_error()
         self.update_displayed_image(autoLevels=True)
+        self.view.on_visibility_change()
 
     def set_shuttercount_error(self, enabled: bool = False) -> None:
         """


### PR DESCRIPTION
…" is toggled

<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3054 

### Description

Ensures that toggling "Normalise to open beam" does not make all ROIs visible in the Image sub-tab. Only the RITS ROI is shown in the Image sub-tab, matching expected behaviour. Non-RITS ROIs remain hidden unless the ROIs sub-tab is selected.


### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Only RITS ROI is visible in the Image sub-tab after toggling "Normalise to open beam"
- [x]  Non-RITS ROIs are only visible in the ROIs sub-tab
