### PR TITLE
Wait for Window Close Instead of always waiting 100MS

### DIFF
--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -55,7 +55,10 @@ class GuiSystemBase(unittest.TestCase):
 
         QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("Yes"))
         self.main_window.close()
-        QTest.qWait(SHORT_DELAY)
+        wait_until(lambda: not self.main_window.isVisible(),
+                   delay=0.05,
+                   max_retry=60,
+                   message="Main window did not close within 3 seconds")
         self.assertDictEqual(self.main_window.presenter.model.datasets, {})
 
         # if self._outcome.result._excinfo is None then there were no AssertionErrors during the test

--- a/mantidimaging/test_helpers/qt_test_helpers.py
+++ b/mantidimaging/test_helpers/qt_test_helpers.py
@@ -7,12 +7,15 @@ from collections.abc import Callable
 from PyQt5.QtTest import QTest
 
 
-def wait_until(test_func: Callable[[], bool], delay=0.1, max_retry=100):
+def wait_until(test_func: Callable[[], bool],
+               delay=0.1,
+               max_retry=100,
+               message: str = "wait_until reached max retries"):
     """
-    Repeat test_func every delay seconds until is becomes true. Or if max_retry is reached return false.
+    Repeat test_func every delay seconds until it becomes true. Raises RuntimeError if max_retry is reached.
     """
     for _ in range(max_retry):
         if test_func():
             return True
         QTest.qWait(int(delay * 1000))
-    raise RuntimeError("wait_until reach max retries")
+    raise RuntimeError(message)


### PR DESCRIPTION
Pool every 50ms for up to 3 seconds for the window to close/become invisible instead of waiting for a fixed time of 100ms. if the window closes quickly, it moves on immediatly. If it takes longer, it has time to complete. If it takes longer than 3 seconds, we raise a RuntimeError with a clear message

<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #<ISSUE>

### Description

<!-- Add a description of the changes made. -->

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified Windows tests pass
- That I haven't seen the error mentioned below relating to teardown with the proposed change

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Windows tests pass
- [x] The below error referenced does not appear during review of the PR

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->


Exploring window closure issues with Windows GUI tests (https://github.com/mantidproject/mantidimaging/actions/runs/23261203964/job/67755864292?pr=3059#annotation:16:4183):
```python
________________ TestGuiSystemWindows.test_open_reconstruction ________________

self = <mantidimaging.gui.test.gui_system_windows_test.TestGuiSystemWindows testMethod=test_open_reconstruction>

    def tearDown(self) -> None:
        self._close_image_stacks()
>       super().tearDown()

mantidimaging\gui\test\gui_system_windows_test.py:15: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
mantidimaging\test_helpers\start_qapplication.py:137: in tearDown
    teardown_orig(self)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <mantidimaging.gui.test.gui_system_windows_test.TestGuiSystemWindows testMethod=test_open_reconstruction>

    def tearDown(self) -> None:
        """
        Closes the main window
        Will report any leaked images
        Expects all other windows to be closed, otherwise will raise a RuntimeError
        """
        self._check_no_open_dialogs()
    
        QTimer.singleShot(SHORT_DELAY, lambda: self._click_messageBox("Yes"))
        self.main_window.close()
        QTest.qWait(SHORT_DELAY)
        self.assertDictEqual(self.main_window.presenter.model.datasets, {})
    
        # if self._outcome.result._excinfo is None then there were no AssertionErrors during the test
        test_error = self._outcome.result._excinfo  # type: ignore
        try:
            # if the test passed but there were some leaked objects, print basic info
            if test_error is None and (leak_count := leak_tracker.count()):
                print("\nItems still alive:", leak_count)
                leak_tracker.pretty_print(debug_init=False, debug_owners=False, trace_depth=5)
                # if too many objects leaked, print debug info
                if leak_count > self.leak_count_limit:
                    print("details:")
                    leak_tracker.pretty_print(debug_init=True, debug_owners=True, trace_depth=5)
                    raise RuntimeError(f"Too many leaked objects: {leak_count}")
        finally:
            leak_tracker.clear()
    
        for widget in self.app.topLevelWidgets():
            if widget.isVisible():
>               raise RuntimeError(f"\n\nWindow still open {widget=}")
E               RuntimeError: 
E               
E               Window still open widget=<mantidimaging.gui.windows.main.view.MainWindowView object at 0x000001B48A212E70>

mantidimaging\gui\test\gui_system_base.py:78: RuntimeError
============================== warnings summary ===============================
C:\Users\runneradmin\miniconda3\envs\mantidimaging-dev\Lib\site-packages\cupy\_environment.py:216
mantidimaging/gui/test/gui_system_liveviewer_test.py::TestGuiLiveViewer::test_open_close_intensity_profile
  C:\Users\runneradmin\miniconda3\envs\mantidimaging-dev\Lib\site-packages\cupy\_environment.py:216: UserWarning: CUDA path could not be detected. Set CUDA_PATH environment variable if CuPy fails to load.
    warnings.warn(

mantidimaging\test_helpers\start_qapplication.py:93
mantidimaging\test_helpers\start_qapplication.py:93
  D:\a\mantidimaging\mantidimaging\mantidimaging\test_helpers\start_qapplication.py:93: PytestUnknownMarkWarning: Unknown pytest.mark.xdist_group - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    cls = pytest.mark.xdist_group("uses_multiprocessing")(cls)

mantidimaging/gui/test/gui_system_reconstruction_test.py: 25 warnings
  D:\a\mantidimaging\mantidimaging\mantidimaging\core\rotation\data_model.py:64: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    self._points[idx] = Point(self._points[idx].slice_index, float(cor))

mantidimaging/gui/test/gui_system_spectrum_test.py::TestGuiSpectrumViewer::test_fit_model_does_not_update_export_table
  D:\a\mantidimaging\mantidimaging\mantidimaging\core\fitting\fitting_functions.py:57: RuntimeWarning: divide by zero encountered in divide
    y = h * 0.5 * (1 + erf((xdata - mu) / (sigma * sqrt(2)))) + a

```
