### PR TITLE
Increase Windows CI Timeout

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -114,7 +114,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov -o log_cli=true --run-system-tests --durations=10
-        timeout-minutes: 15
+        timeout-minutes: 20
 
       - name: Set display resolution for screenshot tests
         run: |


### PR DESCRIPTION
Windows system tests have often been taking over 14 minutes to complete. 15 minutes therefore is cutting it a bit close so extending it to 20 minutes should result is fewer timeouts causing Windows CI to fail.

<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3064 

### Description

<!-- Add a description of the changes made. -->
Increased timeout from 15 minutes to 20 minutes for Windows CI. This should result in a lower likelihood of timeouts where more often than not, the Windows system tests have taken over 14 minutes to complete and the likelihood of a timeout causing the CI to fail has turned into a regular occurrence 


### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Verify system tests do not timeout unless they have taken longer than 20 minutes (they should not more often than not), a few tests possibly take longer than they should to complete which will be explored as part of #3065 
