### PR TITLE
SystemTest: clear leak tracker in setUp so tests it always starts clean

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -114,7 +114,7 @@ jobs:
       - name: GUI Tests System
         shell: bash -l {0}
         run: |
-          xvfb-run --auto-servernum /bin/time -v python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov -o log_cli=true --run-system-tests --durations=10
+          xvfb-run --auto-servernum /bin/time -v python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov -o log_cli=true mantidimaging/gui/test/ --run-system-tests --durations=10
         timeout-minutes: 30
 
       - name: GUI Tests Screenshots Applitools

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -113,7 +113,7 @@ jobs:
       - name: GUI Tests System
         shell: bash -l {0}
         run: |
-          python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov -o log_cli=true --run-system-tests --durations=10
+          python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov -o log_cli=true mantidimaging/gui/test/ --run-system-tests --durations=10
         timeout-minutes: 20
 
       - name: Set display resolution for screenshot tests

--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -41,6 +41,7 @@ class GuiSystemBase(unittest.TestCase):
     leak_count_limit: int = 0
 
     def setUp(self) -> None:
+        leak_tracker.clear()
         self.main_window = MainWindowView()
         self.main_window.show()
         QTest.qWait(SHORT_DELAY)
@@ -63,18 +64,16 @@ class GuiSystemBase(unittest.TestCase):
 
         # if self._outcome.result._excinfo is None then there were no AssertionErrors during the test
         test_error = self._outcome.result._excinfo  # type: ignore
-        try:
-            # if the test passed but there were some leaked objects, print basic info
-            if test_error is None and (leak_count := leak_tracker.count()):
-                print("\nItems still alive:", leak_count)
-                leak_tracker.pretty_print(debug_init=False, debug_owners=False, trace_depth=5)
-                # if too many objects leaked, print debug info
-                if leak_count > self.leak_count_limit:
-                    print("details:")
-                    leak_tracker.pretty_print(debug_init=True, debug_owners=True, trace_depth=5)
-                    raise RuntimeError(f"Too many leaked objects: {leak_count}")
-        finally:
-            leak_tracker.clear()
+
+        # if the test passed but there were some leaked objects, print basic info
+        if test_error is None and (leak_count := leak_tracker.count()):
+            print("\nItems still alive:", leak_count)
+            leak_tracker.pretty_print(debug_init=False, debug_owners=False, trace_depth=5)
+            # if too many objects leaked, print debug info
+            if leak_count > self.leak_count_limit:
+                print("details:")
+                leak_tracker.pretty_print(debug_init=True, debug_owners=True, trace_depth=5)
+                raise RuntimeError(f"Too many leaked objects: {leak_count}")
 
         for widget in self.app.topLevelWidgets():
             if widget.isVisible():


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## No issue
Related to #3065

### Description

We reset the leak track between tests so that it is easier to debug where the leaks are happening. Do this in `setUp()` rather than `tearDown()` so that we can be sure that tests start with a clean state.

For example this prevents ImageStacks that created during test collection being counted by the first test that runs.

Also limit test collection to the system test directory for system tests in github action workflows. This saves the import and search of a large number of unit test files.

### Developer Testing 

Without the change I get a leak error running
`python -m pytest -vs -rs -p no:xdist -p no:randomly -p no:repeat -p no:cov -o log_cli=true --run-system-tests -k test_no_rename_for_bad_roi_name_2_all`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] ...

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

