### PR TITLE
Spectrum Viewer: Fix Export Table not clearing properly when Fitting Model is changed

### DIFF
--- a/docs/release_notes/next/fix-3078-fix_export_table_not_updating_on_changing_fitting_model
+++ b/docs/release_notes/next/fix-3078-fix_export_table_not_updating_on_changing_fitting_model
@@ -1,0 +1,1 @@
+#3078: Fixes a bug where the export table headers were not updating on changing the fitting model.

--- a/mantidimaging/gui/windows/spectrum_viewer/fitting_form.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/fitting_form.py
@@ -184,6 +184,7 @@ class FittingFormWidgetPresenter:
         self.setup_fitting_model()
 
     def setup_fitting_model(self) -> None:
+        self.spectrum_viewer.exportDataTableWidget.clear_table()
         param_names = self.model.fitting_engine.get_parameter_names()
         self.view.fitting_param_form.set_parameters(param_names)
         self.spectrum_viewer.exportDataTableWidget.set_parameters(param_names)

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -787,17 +787,10 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         if task.was_successful():
             results = task.result
 
-            self._clear_export_table()
             self._populate_export_table(results)
             self.model.set_fit_results(results)
         else:
             self.view.show_error_dialog(str(task.error))
-
-    def _clear_export_table(self) -> None:
-        """
-        Clear all existing data from the export results table.
-        """
-        self.view.exportDataTableWidget.clear_table()
 
     def _populate_export_table(self, results: list[tuple[str, SpectrumFitResult]]) -> None:
         """


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3078

### Description

- Updated the current implementation of `setup_fitting_model` to clear all the export table data when the fitting model is updated.
- Removed clearing export table as part of running  fit on all regions as it was redundant after updating `setup_fitting_model`

<!-- Add a description of the changes made. -->

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- These changes have been tested manually but it would be useful to add a test on this in the future

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Upload an appropriate dataset in MantidImaging I used (python -m mantidimaging --path C:\Programming\Mantid_Data\small_fe\small_fe\sample)
- [ ]  Open the Spectrum Viewer and select the Image Mode
- [ ]  Select a region
- [ ]  Select a Fitting Function
- [ ]  Switch to the Export tab and check if the headers are as expected (params of the selected fitting model)
- [ ] Run Fit All 
- [ ] Select another Fitting function and switch to the Export tab to see if the data from previous fit is cleared and the headers are updated according to the new fitting model
- [ ] Validate the same with ROI Mode

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [x] Release Notes have been updated


