### PR TITLE
Pass correct 2D vectors to create_Cone2D for cone geometry preview

### DIFF
--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -300,7 +300,7 @@ class CILRecon(BaseRecon):
             else:
                 source_pos = images.geometry.source_position
                 detector_pos = images.geometry.detector_position
-                ag = AcquisitionGeometry.create_Cone2D([0, source_pos, 0], [0, detector_pos, 0])
+                ag = AcquisitionGeometry.create_Cone2D([0, source_pos], [0, detector_pos])
 
             ag.set_panel(pixel_num_h, pixel_size=pixel_size)
             ag.set_labels(DataOrder.ASTRA_AG_LABELS)


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3082

### Description

Fixes a bug where 3D vectors were incorrectly passed to AcquisitionGeometry.create_Cone2D for cone geometry preview, causing a ValueError. Now, only 2D vectors are passed for 2D cone geometry, allowing the preview to work correctly.

### Developer Testing 

I have verified unit tests pass locally: python -m pytest -vs
Manually tested preview with cone geometry in the reconstruction window.

### Acceptance Criteria and Reviewer Testing

- [ ]  Unit tests pass locally: python -m pytest -vs
- [ ]  Preview works for cone geometry without error
- [ ]  No regression for parallel geometry preview

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

