### PR TITLE
2955 spectrum viewer map fitted params

### DIFF
--- a/docs/release_notes/next/feature-2955-map_fitted_params_over_sample_image
+++ b/docs/release_notes/next/feature-2955-map_fitted_params_over_sample_image
@@ -1,0 +1,1 @@
+#2955: Map fitted parameters over sample image, providing various control options for map visualisation and the ability to export mapped area only or mapping over sample image.

--- a/mantidimaging/core/utility/sensible_roi.py
+++ b/mantidimaging/core/utility/sensible_roi.py
@@ -107,3 +107,7 @@ class ROIBinner:
         right_edge = self.left_indexes[-1] + self.bin_size
         bottom_edge = self.top_indexes[-1] + self.bin_size
         return right_edge == self.roi.right and bottom_edge == self.roi.bottom
+
+    def get_roi_name(self, col: int, row: int) -> str:
+        """Return ROI name for bin grid position (col, row)."""
+        return f"ROI_bin:(x={col},y={row})"

--- a/mantidimaging/gui/widgets/spectrum_widgets/export_image_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_image_widget.py
@@ -2,11 +2,15 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import numpy as np
+from PyQt5.QtGui import QTransform
 from PyQt5.QtWidgets import QWidget, QVBoxLayout
 import pyqtgraph as pg
+
+if TYPE_CHECKING:
+    from mantidimaging.core.utility.sensible_roi import ROIBinner
 
 _graveyard: list[Any] = []
 
@@ -31,6 +35,11 @@ class ExportImageViewWidget(QWidget):
         self.image_view.ui.histogram.hide()
 
         layout.addWidget(self.image_view)
+
+        self.param_overlay = pg.ImageItem()
+        self.param_overlay.hide()
+        self.image_view.getView().addItem(self.param_overlay)
+
         self.clear()
 
     def update_image(self, image: np.ndarray | None, autoLevels: bool = True) -> None:
@@ -46,6 +55,33 @@ class ExportImageViewWidget(QWidget):
     def clear(self) -> None:
         """Show a blank canvas."""
         self.image_view.setImage(np.zeros((1, 1), dtype=np.float32), autoLevels=True)
+        self.image_view.ui.histogram.setImageItem(self.image_view.imageItem)
+        self.image_view.ui.histogram.hide()
+        self.param_overlay.hide()
+
+    def populate_parameter_selector(self, param_names: list[str]) -> None:
+        """Populate the parameter selector combobox with fitted parameter names"""
+        self.parent().exportSettingsWidget.populate_parameter_selector(param_names)
+
+    def show_parameter_map(self, map_array: np.ndarray, binner: ROIBinner) -> None:
+        """Display the parameter map with 50% transaparency and viridis over sample"""
+
+        self.param_overlay.setColorMap('viridis')
+        self.param_overlay.setOpacity(0.5)
+
+        # Align mapping with sample and scale to match binned resolution
+        transform = QTransform()
+        transform.translate(binner.left_indexes[0], binner.top_indexes[0])
+        transform.scale(binner.step_size, binner.step_size)
+        self.param_overlay.setImage(map_array.T, autoLevels=False)
+        self.param_overlay.setTransform(transform)
+        self.param_overlay.show()
+
+        # connect histogram to parameter values and match colourmap
+        hist = self.image_view.ui.histogram
+        hist.setImageItem(self.param_overlay)
+        hist.gradient.setColorMap(pg.colormap.get('viridis'))
+        hist.show()
 
     @property
     def image_data(self) -> np.ndarray | None:

--- a/mantidimaging/gui/widgets/spectrum_widgets/export_image_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_image_widget.py
@@ -63,9 +63,13 @@ class ExportImageViewWidget(QWidget):
         """Populate the parameter selector combobox with fitted parameter names"""
         self.parent().exportSettingsWidget.populate_parameter_selector(param_names)
 
-    def show_parameter_map(self, map_array: np.ndarray, binner: ROIBinner, opacity: float = 0.5) -> None:
+    def show_parameter_map(self,
+                           map_array: np.ndarray,
+                           binner: ROIBinner,
+                           opacity: float = 0.5,
+                           levels: tuple[float, float] = (0.0, 1.0)) -> None:
         """Display the parameter map with 50% transaparency and viridis over sample"""
-
+        lower_level, upper_level = levels
         self.param_overlay.setColorMap('viridis')
         self.param_overlay.setOpacity(opacity)
 
@@ -74,6 +78,7 @@ class ExportImageViewWidget(QWidget):
         transform.translate(binner.left_indexes[0], binner.top_indexes[0])
         transform.scale(binner.step_size, binner.step_size)
         self.param_overlay.setImage(map_array, autoLevels=True)
+        self.param_overlay.setLevels(lower_level, upper_level)
         self.param_overlay.setTransform(transform)
         self.param_overlay.show()
 
@@ -81,6 +86,7 @@ class ExportImageViewWidget(QWidget):
         hist = self.image_view.ui.histogram
         hist.setImageItem(self.param_overlay)
         hist.gradient.setColorMap(pg.colormap.get('viridis'))
+        hist.setLevels(lower_level, upper_level)
         hist.show()
 
     @property

--- a/mantidimaging/gui/widgets/spectrum_widgets/export_image_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_image_widget.py
@@ -63,17 +63,17 @@ class ExportImageViewWidget(QWidget):
         """Populate the parameter selector combobox with fitted parameter names"""
         self.parent().exportSettingsWidget.populate_parameter_selector(param_names)
 
-    def show_parameter_map(self, map_array: np.ndarray, binner: ROIBinner) -> None:
+    def show_parameter_map(self, map_array: np.ndarray, binner: ROIBinner, opacity: float = 0.5) -> None:
         """Display the parameter map with 50% transaparency and viridis over sample"""
 
         self.param_overlay.setColorMap('viridis')
-        self.param_overlay.setOpacity(0.5)
+        self.param_overlay.setOpacity(opacity)
 
         # Align mapping with sample and scale to match binned resolution
         transform = QTransform()
         transform.translate(binner.left_indexes[0], binner.top_indexes[0])
         transform.scale(binner.step_size, binner.step_size)
-        self.param_overlay.setImage(map_array.T, autoLevels=False)
+        self.param_overlay.setImage(map_array, autoLevels=True)
         self.param_overlay.setTransform(transform)
         self.param_overlay.show()
 

--- a/mantidimaging/gui/widgets/spectrum_widgets/export_image_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_image_widget.py
@@ -42,7 +42,7 @@ class ExportImageViewWidget(QWidget):
 
         self.clear()
 
-    def update_image(self, image: np.ndarray | None, autoLevels: bool = True) -> None:
+    def update_image(self, image: np.ndarray | None) -> None:
         if image is None:
             self.clear()
             return
@@ -50,7 +50,9 @@ class ExportImageViewWidget(QWidget):
         arr = np.asarray(image)
         if arr.ndim == 3 and arr.shape[0] > 0:
             arr = arr.mean(axis=0)
-        self.image_view.setImage(arr, autoLevels=autoLevels)
+        finite = arr[np.isfinite(arr)]
+        levels = (float(np.percentile(finite, 0.5)), float(np.percentile(finite, 99.5))) if finite.size else (0.0, 1.0)
+        self.image_view.setImage(arr, autoLevels=False, levels=levels)
 
     def clear(self) -> None:
         """Show a blank canvas."""
@@ -68,7 +70,7 @@ class ExportImageViewWidget(QWidget):
                            binner: ROIBinner,
                            opacity: float = 0.5,
                            levels: tuple[float, float] = (0.0, 1.0)) -> None:
-        """Display the parameter map with 50% transaparency and viridis over sample"""
+        """Display the parameter map overlay using viridis with the given opacity and colour levels."""
         lower_level, upper_level = levels
         self.param_overlay.setColorMap('viridis')
         self.param_overlay.setOpacity(opacity)
@@ -77,8 +79,8 @@ class ExportImageViewWidget(QWidget):
         transform = QTransform()
         transform.translate(binner.left_indexes[0], binner.top_indexes[0])
         transform.scale(binner.step_size, binner.step_size)
-        self.param_overlay.setImage(map_array, autoLevels=True)
-        self.param_overlay.setLevels(lower_level, upper_level)
+
+        self.param_overlay.setImage(map_array, autoLevels=False, levels=(lower_level, upper_level))
         self.param_overlay.setTransform(transform)
         self.param_overlay.show()
 

--- a/mantidimaging/gui/widgets/spectrum_widgets/export_settings_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_settings_widget.py
@@ -48,6 +48,15 @@ class FitExportFormWidget(QWidget):
                                                    "Initialised to the 95th percentile of good fits.")
         map_layout.addWidget(self.chiSquaredThresholdSpinBox)
 
+        map_layout.addWidget(QLabel("Image Export Region"))
+        self.exportContentDropdown = QComboBox()
+        self.exportContentDropdown.addItems(["Mapped region only", "Full sample image"])
+        map_layout.addWidget(self.exportContentDropdown)
+
+        self.exportMappedImageButton = QPushButton("Export Map...")
+        self.exportMappedImageButton.setEnabled(False)
+        map_layout.addWidget(self.exportMappedImageButton)
+
         outer_layout.addWidget(map_group)
 
         # Table export group
@@ -90,6 +99,7 @@ class FitExportFormWidget(QWidget):
             self.parameterDropdown.clear()
             self.parameterDropdown.addItems(param_names)
             self.parameterDropdown.setEnabled(bool(param_names))
+            self.exportMappedImageButton.setEnabled(bool(param_names))
             if param_names:
                 self.parameterDropdown.setCurrentIndex(0)
 
@@ -112,6 +122,11 @@ class FitExportFormWidget(QWidget):
         0% transparency = 100% opacity to improve intuitivenessl
         """
         return (100 - self.transparencySpinBox.value()) / 100.0
+
+    @property
+    def is_full_sample_export(self) -> bool:
+        """True when the user has selected 'Full sample image' in the Image Export Region dropdown."""
+        return self.exportContentDropdown.currentText() == "Full sample image"
 
     @property
     def selected_colour_range_mode(self) -> str:

--- a/mantidimaging/gui/widgets/spectrum_widgets/export_settings_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_settings_widget.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel, QComboBox, QPushButton
+from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QLabel, QComboBox, QPushButton, QGroupBox)
 
 
 class FitExportFormWidget(QWidget):
@@ -12,25 +12,42 @@ class FitExportFormWidget(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        layout = QVBoxLayout(self)
+        outer_layout = QVBoxLayout(self)
+
+        # Parameter map group
+        map_group = QGroupBox("Parameter Map")
+        map_layout = QVBoxLayout(map_group)
 
         self.fitAllButton = QPushButton("Fit All")
-        layout.addWidget(self.fitAllButton)
+        map_layout.addWidget(self.fitAllButton)
+
+        map_layout.addWidget(QLabel("Map Parameter"))
+        self.parameterDropdown = QComboBox()
+        self.parameterDropdown.setEnabled(False)
+        self.parameterDropdown.setPlaceholderText("Run fit to populate")
+        map_layout.addWidget(self.parameterDropdown)
+
+        outer_layout.addWidget(map_group)
+
+        # Table export group
+        table_group = QGroupBox("Table Export")
+        table_layout = QVBoxLayout(table_group)
 
         self.formatDropdown = QComboBox()
         self.formatDropdown.addItems(["CSV"])
         self.areaDropdown = QComboBox()
         self.areaDropdown.addItem("All")
 
-        layout.addWidget(QLabel("Export Format"))
-        layout.addWidget(self.formatDropdown)
-        layout.addWidget(QLabel("Export Area"))
-        layout.addWidget(self.areaDropdown)
+        table_layout.addWidget(QLabel("Export Format"))
+        table_layout.addWidget(self.formatDropdown)
+        table_layout.addWidget(QLabel("Export Area"))
+        table_layout.addWidget(self.areaDropdown)
 
         self.exportButton = QPushButton("Export")
-        layout.addWidget(self.exportButton)
+        table_layout.addWidget(self.exportButton)
 
-        layout.addStretch()
+        outer_layout.addWidget(table_group)
+        outer_layout.addStretch()
 
     def set_roi_names(self, roi_names: list[str]) -> None:
         """Update ROI dropdown list dynamically."""
@@ -42,6 +59,16 @@ class FitExportFormWidget(QWidget):
         if current in roi_names:
             self.areaDropdown.setCurrentText(current)
         self.areaDropdown.blockSignals(False)
+
+    def populate_parameter_selector(self, param_names: list[str]) -> None:
+        """Populate the parameter selector combo with fitted parameter names and enable it."""
+        self.parameterDropdown.clear()
+        self.parameterDropdown.addItems(param_names)
+        self.parameterDropdown.setEnabled(bool(param_names))
+
+    @property
+    def parameter_selected(self):
+        return self.parameterDropdown.currentTextChanged
 
     def selected_format(self) -> str:
         return self.formatDropdown.currentText()

--- a/mantidimaging/gui/widgets/spectrum_widgets/export_settings_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_settings_widget.py
@@ -35,6 +35,10 @@ class FitExportFormWidget(QWidget):
         self.transparencySpinBox.setSuffix("%")
         map_layout.addWidget(self.transparencySpinBox)
 
+        map_layout.addWidget(QLabel("Colour Range"))
+        self.colourRangeDropdown = QComboBox()
+        map_layout.addWidget(self.colourRangeDropdown)
+
         map_layout.addWidget(QLabel("chi\u00b2 threshold"))
         self.chiSquaredThresholdSpinBox = QDoubleSpinBox()
         self.chiSquaredThresholdSpinBox.setRange(0.0, 1e6)
@@ -108,6 +112,10 @@ class FitExportFormWidget(QWidget):
         0% transparency = 100% opacity to improve intuitivenessl
         """
         return (100 - self.transparencySpinBox.value()) / 100.0
+
+    @property
+    def selected_colour_range_mode(self) -> str:
+        return self.colourRangeDropdown.currentText()
 
     def selected_format(self) -> str:
         return self.formatDropdown.currentText()

--- a/mantidimaging/gui/widgets/spectrum_widgets/export_settings_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_settings_widget.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
+from PyQt5.QtCore import QSignalBlocker
 from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QLabel, QComboBox, QPushButton, QSpinBox, QDoubleSpinBox, QGroupBox)
 
 
@@ -77,10 +78,24 @@ class FitExportFormWidget(QWidget):
         self.areaDropdown.blockSignals(False)
 
     def populate_parameter_selector(self, param_names: list[str]) -> None:
-        """Populate the parameter selector combo with fitted parameter names and enable it."""
-        self.parameterDropdown.clear()
-        self.parameterDropdown.addItems(param_names)
-        self.parameterDropdown.setEnabled(bool(param_names))
+        """
+        Populate the parameter selector combo with fitted parameter names and enable it
+        after all data is written to export table
+        """
+        with QSignalBlocker(self.parameterDropdown):
+            self.parameterDropdown.clear()
+            self.parameterDropdown.addItems(param_names)
+            self.parameterDropdown.setEnabled(bool(param_names))
+            if param_names:
+                self.parameterDropdown.setCurrentIndex(0)
+
+    def set_chi2_threshold(self, value: float) -> None:
+        """
+        Set the chi2 threshold without emitting signals to avoid pre-maturely
+        updating the map display before all data is written to table
+        """
+        with QSignalBlocker(self.chiSquaredThresholdSpinBox):
+            self.chiSquaredThresholdSpinBox.setValue(value)
 
     @property
     def parameter_selected(self):

--- a/mantidimaging/gui/widgets/spectrum_widgets/export_settings_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_settings_widget.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
-from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QLabel, QComboBox, QPushButton, QGroupBox)
+from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QLabel, QComboBox, QPushButton, QSpinBox, QDoubleSpinBox, QGroupBox)
 
 
 class FitExportFormWidget(QWidget):
@@ -26,6 +26,22 @@ class FitExportFormWidget(QWidget):
         self.parameterDropdown.setEnabled(False)
         self.parameterDropdown.setPlaceholderText("Run fit to populate")
         map_layout.addWidget(self.parameterDropdown)
+
+        map_layout.addWidget(QLabel("Map Transparency (%)"))
+        self.transparencySpinBox = QSpinBox()
+        self.transparencySpinBox.setRange(0, 100)
+        self.transparencySpinBox.setValue(50)
+        self.transparencySpinBox.setSuffix("%")
+        map_layout.addWidget(self.transparencySpinBox)
+
+        map_layout.addWidget(QLabel("chi\u00b2 threshold"))
+        self.chiSquaredThresholdSpinBox = QDoubleSpinBox()
+        self.chiSquaredThresholdSpinBox.setRange(0.0, 1e6)
+        self.chiSquaredThresholdSpinBox.setDecimals(6)
+        self.chiSquaredThresholdSpinBox.setSingleStep(0.0001)
+        self.chiSquaredThresholdSpinBox.setToolTip("Pixels with reduced chi\u00b2 above threshold are masked. "
+                                                   "Initialised to the 95th percentile of good fits.")
+        map_layout.addWidget(self.chiSquaredThresholdSpinBox)
 
         outer_layout.addWidget(map_group)
 
@@ -69,6 +85,14 @@ class FitExportFormWidget(QWidget):
     @property
     def parameter_selected(self):
         return self.parameterDropdown.currentTextChanged
+
+    @property
+    def overlay_opacity(self) -> float:
+        """
+        Return overlay opacity spinbox. Opacity flipped so that
+        0% transparency = 100% opacity to improve intuitivenessl
+        """
+        return (100 - self.transparencySpinBox.value()) / 100.0
 
     def selected_format(self) -> str:
         return self.formatDropdown.currentText()

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -632,20 +632,20 @@ class SpectrumViewerWindowModel:
         @param param_name: The name of the fitted parameter to map
         @param binner: The ROIBinner used when generating for fit
         @param  chi2_threshold: Optional upper bound on rss_per_dof. Exclude fits if reduced chi2 higher than threshold
-        @return np.ndarray: 2D array of parameters (n_cols, n_rows) matching binner dimensions.
+        @return np.ndarray: 2D array of parameters (n_rows, n_cols) matching binner dimensions.
         """
         if self.fit_results is None:
             raise ValueError("No fit results available. Run 'Fit All' before building a parameter map.")
 
         n_cols, n_rows = binner.lengths()
-        param_map = np.full((n_cols, n_rows), np.nan, dtype=np.float64)
+        param_map = np.full((n_rows, n_cols), np.nan, dtype=np.float64)
 
         for col, row in np.ndindex(n_cols, n_rows):
             if (fit_result := self._good_fits_by_roi_name.get(binner.get_roi_name(col, row))) is None:
                 continue
             if chi2_threshold is not None and fit_result.rss_per_dof > chi2_threshold:
                 continue
-            param_map[col, row] = fit_result.params[param_name]
+            param_map[row, col] = fit_result.params[param_name]
 
         return param_map
 
@@ -666,7 +666,7 @@ class SpectrumViewerWindowModel:
         strategies = {
             ColourRangeMode.IQR: self._colour_levels_iqr,
             ColourRangeMode.MAD: self._colour_levels_mad,
-            ColourRangeMode.PERCENTILE: self._colour_levels_percentile,
+            ColourRangeMode.PERCENTILE: self.colour_levels_percentile,
         }
         lower, upper = strategies[mode](finite_values)
 
@@ -675,8 +675,8 @@ class SpectrumViewerWindowModel:
         return lower, upper
 
     @staticmethod
-    def _colour_levels_percentile(finite_values: np.ndarray) -> tuple[float, float]:
-        """Show only 2nd-98th percentile range"""
+    def colour_levels_percentile(finite_values: np.ndarray) -> tuple[float, float]:
+        """Return the 2nd-98th percentile range of the given finite values."""
         return float(np.percentile(finite_values, 2)), float(np.percentile(finite_values, 98))
 
     @staticmethod
@@ -695,3 +695,40 @@ class SpectrumViewerWindowModel:
         iqr = upper_quartile - lower_quartile
         return (float(max(finite_values.min(),
                           lower_quartile - 1.5 * iqr)), float(min(finite_values.max(), upper_quartile + 1.5 * iqr)))
+
+    def build_full_sample_parameter_map(self, map_array: np.ndarray, binner: ROIBinner) -> np.ndarray:
+        """
+        Create array matching sample image size filled with NaN and insert parameter map over ROI region
+        set by binner for overlaying over sample image.
+
+        Each bin occupies exactly step_size pixels in both axes to avoid edge artefacts
+        using bin_size which may be larger when bins overlap.
+
+        @param map_array: parameter map
+        @param binner: The binner used when generating the map
+        @return: Array of shape (height, width) matching the sample stack dimensions
+        """
+        img_height, img_width = self.get_image_shape()
+        full_map = np.full((img_height, img_width), np.nan, dtype=np.float32)
+        step = binner.step_size
+
+        n_cols, n_rows = binner.lengths()
+        for col, row in np.ndindex(n_cols, n_rows):
+            param_value = map_array[row, col]
+            if np.isfinite(param_value):
+                x_start = binner.left_indexes[col]
+                x_end = min(x_start + step, img_width)
+                y_start = binner.top_indexes[row]
+                y_end = min(y_start + step, img_height)
+                full_map[y_start:y_end, x_start:x_end] = np.float32(param_value)
+
+        return full_map
+
+    def save_parameter_map(self, path: Path, map_array: np.ndarray) -> None:
+        """
+        Save parameter map array to a TIFF file
+
+        @param path: File path for the TIFF
+        @param map_array: Parameter Map
+        """
+        saver.write_img(map_array, str(path))

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -52,6 +52,12 @@ class ErrorMode(Enum):
         raise ValueError(f"Unknown error mode: {value}")
 
 
+class ColourRangeMode(Enum):
+    IQR = "1.5\u00d7IQR"
+    MAD = "Median \u00b13\u00d7MAD"
+    PERCENTILE = "2nd - 98th %ile"
+
+
 class AllowedModesTypedDict(TypedDict):
     mode: ToFUnitMode
     label: str
@@ -642,3 +648,50 @@ class SpectrumViewerWindowModel:
             param_map[col, row] = fit_result.params[param_name]
 
         return param_map
+
+    def calculate_colour_levels(self, map_array: np.ndarray, mode: ColourRangeMode) -> tuple[float, float]:
+        """
+        Handle a various outlier exclusion options to handle various distributions, falling back
+        to full range if needed for IQR and percentile
+        Return (lower, upper) display levels for a parameter map based on user colour range selection
+
+        @param map_array: 2D parameter map array
+        @param mode: Colour range selection
+        @return: (lower, upper) tuple image display levels
+        """
+        finite_values = map_array[np.isfinite(map_array)]
+        if finite_values.size == 0:
+            return 0.0, 1.0
+
+        strategies = {
+            ColourRangeMode.IQR: self._colour_levels_iqr,
+            ColourRangeMode.MAD: self._colour_levels_mad,
+            ColourRangeMode.PERCENTILE: self._colour_levels_percentile,
+        }
+        lower, upper = strategies[mode](finite_values)
+
+        if lower >= upper:
+            return float(finite_values.min()), float(finite_values.max())
+        return lower, upper
+
+    @staticmethod
+    def _colour_levels_percentile(finite_values: np.ndarray) -> tuple[float, float]:
+        """Show only 2nd-98th percentile range"""
+        return float(np.percentile(finite_values, 2)), float(np.percentile(finite_values, 98))
+
+    @staticmethod
+    def _colour_levels_mad(finite_values: np.ndarray) -> tuple[float, float]:
+        """Clips to median +- 3xMAD and falls back to full range when MAD = 0 to exclude outliers"""
+        median = np.median(finite_values)
+        mad = np.median(np.abs(finite_values - median))
+        if mad == 0:
+            return float(finite_values.min()), float(finite_values.max())
+        return float(max(finite_values.min(), median - 3.0 * mad)), float(min(finite_values.max(), median + 3.0 * mad))
+
+    @staticmethod
+    def _colour_levels_iqr(finite_values: np.ndarray) -> tuple[float, float]:
+        """Clips outliers beyond 1.5xIQR to exclude outliers"""
+        lower_quartile, upper_quartile = np.percentile(finite_values, [25, 75])
+        iqr = upper_quartile - lower_quartile
+        return (float(max(finite_values.min(),
+                          lower_quartile - 1.5 * iqr)), float(min(finite_values.max(), upper_quartile + 1.5 * iqr)))

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -96,11 +96,9 @@ class SpectrumViewerWindowModel:
     def __init__(self, presenter: SpectrumViewerWindowPresenter):
         self.presenter = presenter
         self._roi_id_counter = 0
-
         self.fit_results: list[tuple[str, SpectrumFitResult]] | None = None
-
+        self._good_fits_by_roi_name: dict[str, SpectrumFitResult] = {}
         self.units = UnitConversion()
-
         self.fitting_engine = FittingEngine(ErfStepFunction())
 
     def roi_name_generator(self) -> str:
@@ -586,8 +584,45 @@ class SpectrumViewerWindowModel:
         return self.fitting_engine.find_best_fit(xvals, yvals, init_params, params_bounds=bounds)
 
     def set_fit_results(self, results: list[tuple[str, SpectrumFitResult]] | None) -> None:
+        """
+        Store filtered fit results to only good fits and create a lookup for building parameter maps
+        """
         self.fit_results = results
+        self._good_fits_by_roi_name = {
+            name: result
+            for name, result in results if result.is_good_fit
+        } if results else {}
         LOG.info("Stored fit results")
 
     def get_fit_results(self) -> list[tuple[str, SpectrumFitResult]] | None:
         return self.fit_results
+
+    def build_parameter_map(self,
+                            param_name: str,
+                            binner: ROIBinner,
+                            chi2_threshold: float | None = None) -> np.ndarray:
+        """
+        Build a 2D parameter map from stored fit results for the given parameter name.
+
+        Grid dimensions are derived from the binner sub-ROIs.
+        Fits higher than chi2_threshold excluded from map.
+
+        @param param_name: The name of the fitted parameter to map
+        @param binner: The ROIBinner used when generating for fit
+        @param  chi2_threshold: Optional upper bound on rss_per_dof. Exclude fits if reduced chi2 higher than threshold
+        @return np.ndarray: 2D array of parameters (n_cols, n_rows) matching binner dimensions.
+        """
+        if self.fit_results is None:
+            raise ValueError("No fit results available. Run 'Fit All' before building a parameter map.")
+
+        n_cols, n_rows = binner.lengths()
+        param_map = np.full((n_cols, n_rows), np.nan, dtype=np.float64)
+
+        for col, row in np.ndindex(n_cols, n_rows):
+            if (fit_result := self._good_fits_by_roi_name.get(binner.get_roi_name(col, row))) is None:
+                continue
+            if chi2_threshold is not None and fit_result.rss_per_dof > chi2_threshold:
+                continue
+            param_map[col, row] = fit_result.params[param_name]
+
+        return param_map

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -597,6 +597,22 @@ class SpectrumViewerWindowModel:
     def get_fit_results(self) -> list[tuple[str, SpectrumFitResult]] | None:
         return self.fit_results
 
+    def compute_chi2_threshold(self, percentile: float = 95.0) -> float | None:
+        """
+        Return a given percentile of good-fit rss_per_dof values, or None if unavailable.
+        Acts as a good starting point to be altered based on data and preference
+
+        @param percentile: The percentile of rss_per_dof values to return as the chi2 threshold
+        @return: The chi2 threshold value or None if no valid fit results are available
+        """
+        if self.fit_results is None:
+            return None
+        valid_chi2_values = [
+            result.rss_per_dof for _, result in self.fit_results
+            if result.is_good_fit and np.isfinite(result.rss_per_dof) and result.rss_per_dof > 0
+        ]
+        return float(np.percentile(valid_chi2_values, percentile)) if valid_chi2_values else None
+
     def build_parameter_map(self,
                             param_name: str,
                             binner: ROIBinner,

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -799,7 +799,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
                 param_names = self.model.fitting_engine.get_parameter_names()
                 self.view.exportSettingsWidget.populate_parameter_selector(param_names)
                 if (threshold := self.model.compute_chi2_threshold()) is not None:
-                    self.view.exportSettingsWidget.chiSquaredThresholdSpinBox.setValue(threshold)
+                    self.view.exportSettingsWidget.set_chi2_threshold(threshold)
+                self.view.show_image_tab()
                 self.update_parameter_map()
         else:
             self.view.show_error_dialog(str(task.error))

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -48,6 +48,11 @@ class SpectrumFitResult(NamedTuple):
     rss_per_dof: float
     status: Literal["Fitted", "Failed"]
 
+    @property
+    def is_good_fit(self) -> bool:
+        """True if the fit converged and produced valid chi2 residuals """
+        return self.status != "Failed" and np.isfinite(self.rss_per_dof)
+
 
 class SpectrumViewerWindowPresenter(BasePresenter):
     """

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Literal, NamedTuple
 from collections.abc import Iterator
 from logging import getLogger
 
+import pyqtgraph as pg
 from mantidimaging.core.fitting.fitting_engine import BoundType
 from mantidimaging.core.utility.progress_reporting.progress import Progress
 import numpy as np
@@ -21,6 +22,7 @@ from mantidimaging.gui.dialogs.async_task import start_async_task_view, TaskWork
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.windows.spectrum_viewer.model import SpectrumViewerWindowModel, SpecType, ROI_RITS, ErrorMode, \
     ToFUnitMode, allowed_modes, ColourRangeMode
+from mantidimaging.core.utility.sensible_roi import ROIBinner
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.spectrum_viewer.view import SpectrumViewerWindowView  # pragma: no cover
@@ -815,18 +817,25 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         """
         self.view.exportDataTableWidget.clear_table()
 
+    def _get_display_image(self) -> np.ndarray | None:
+        """
+        Match image in main view for backgroud in full sample parameter map
+        @return: image to use as background for mapped param export, or None if no stack is loaded
+        """
+        return (self.model.get_normalized_averaged_image()
+                if self.view.normalisation_enabled() else self.model.get_averaged_image())
+
     def update_parameter_map(self) -> None:
         """
         Update the map based on the selected parameter in the export settings.
         """
-        param_name = self.view.exportSettingsWidget.parameterDropdown.currentText()
-        if not param_name:
+        if not self.view.selected_param_name:
             return
         binner = self.view.get_binner()
-        chi2_threshold = self.view.exportSettingsWidget.chiSquaredThresholdSpinBox.value()
-        map_array = self.model.build_parameter_map(param_name, binner, chi2_threshold)
-        colour_mode = ColourRangeMode(self.view.exportSettingsWidget.selected_colour_range_mode)
+        map_array = self.model.build_parameter_map(self.view.selected_param_name, binner, self.view.chi2_threshold)
+        colour_mode = ColourRangeMode(self.view.colour_range_mode)
         levels = self.model.calculate_colour_levels(map_array, colour_mode)
+
         self.view.display_parameter_map(map_array, binner, levels)
 
     def on_map_display_settings_changed(self, value: int) -> None:
@@ -834,6 +843,83 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
     def handle_parameter_map_changed(self, param_name: str) -> None:
         self.update_parameter_map()
+
+    def handle_export_parameter_map(self) -> None:
+        """Select array shape based on export selection"""
+        if not (path := self.view.get_map_export_filename()):
+            return
+
+        fit_parameter = self.view.selected_param_name
+        binner = self.view.get_binner()
+        chi2_threshold = self.view.chi2_threshold
+        map_array = self.model.build_parameter_map(fit_parameter, binner, chi2_threshold)
+
+        if self.view.export_full_sample:
+            array_to_save = self._build_full_sample_export(map_array, binner)
+        else:
+            array_to_save = map_array
+
+        self.model.save_parameter_map(path, array_to_save)
+        LOG.info("Parameter map '%s' exported to %s", self.view.selected_param_name, path)
+
+    def _build_full_sample_export(self, map_array: np.ndarray, binner: ROIBinner) -> np.ndarray:
+        """
+        Build colour parameter map (viridis) over the sample image for export
+
+        @param map_array: 2D array of parameter values for each binned ROI
+        @param binner: ROIBinner object containing the definitions of the binned ROIs
+        @return: 3D Colour array for export matching sample shape
+        """
+        colour_mode = ColourRangeMode(self.view.colour_range_mode)
+        levels = self.model.calculate_colour_levels(map_array, colour_mode)
+        full_map = self.model.build_full_sample_parameter_map(map_array, binner)
+        display_image = self._get_display_image()
+        assert display_image is not None, "Stack must be loaded to export full sample image"
+        return self.build_composite_image(full_map, levels, self.view.overlay_opacity, sample_image=display_image)
+
+    def _normalise_background(self, sample_image: np.ndarray) -> np.ndarray:
+        """
+        Normalise sample image using percentile levels
+
+        @param sample_image: the image to be normalised
+        @return: normalised colour image
+        """
+        sample = sample_image.astype(float)
+        finite_pixels = sample[np.isfinite(sample)]
+        lower, upper = self.model.colour_levels_percentile(finite_pixels)
+        if upper > lower:
+            sample_normalised = np.clip((sample - lower) / (upper - lower), 0.0, 1.0)
+        else:
+            sample_normalised = np.zeros_like(sample)
+        return np.stack([sample_normalised] * 3, axis=-1)
+
+    def build_composite_image(self,
+                              full_map: np.ndarray,
+                              levels: tuple[float, float],
+                              opacity: float,
+                              sample_image: np.ndarray | None = None) -> np.ndarray:
+        """Colour (viridis) parameter map overlay over sample image.
+
+        @param full_map: Full-resolution float32 NaN canvas from build_full_sample_parameter_map
+        @param levels: (lower, upper) colour limits used to normalise the overlay
+        @param opacity: Overlay opacity between 0 and 1
+        @param sample_image: Background image to composite over. Pass None for map-only export.
+        @return: colour array
+        """
+        map_lower, map_upper = levels
+        fitted_pixel_mask = np.isfinite(full_map)
+        blank_background = np.zeros((*full_map.shape, 3))
+        background_rgb = self._normalise_background(sample_image) if sample_image is not None else blank_background
+
+        # only apply map to overlay over fitted pixels within levels exlcuidg outliers
+        if fitted_pixel_mask.any() and map_upper > map_lower:
+            map_normalised = np.clip((full_map - map_lower) / (map_upper - map_lower), 0.0, 1.0)
+            viridis_rgb = pg.colormap.get('viridis').map(map_normalised, mode='float')[..., :3]
+            foreground = viridis_rgb[fitted_pixel_mask]
+            background = background_rgb[fitted_pixel_mask]
+            background_rgb[fitted_pixel_mask] = opacity * foreground + (1.0 - opacity) * background
+
+        return (np.clip(background_rgb, 0.0, 1.0) * 255).astype(np.uint8)
 
     def _populate_export_table(self, results: list[tuple[str, SpectrumFitResult]]) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -798,6 +798,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             if results:
                 param_names = self.model.fitting_engine.get_parameter_names()
                 self.view.exportSettingsWidget.populate_parameter_selector(param_names)
+                if (threshold := self.model.compute_chi2_threshold()) is not None:
+                    self.view.exportSettingsWidget.chiSquaredThresholdSpinBox.setValue(threshold)
                 self.update_parameter_map()
         else:
             self.view.show_error_dialog(str(task.error))
@@ -816,9 +818,12 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         if not param_name:
             return
         binner = self.view.get_binner()
-        chi2_threshold = None  # ToDo Add Ui Control
+        chi2_threshold = self.view.exportSettingsWidget.chiSquaredThresholdSpinBox.value()
         map_array = self.model.build_parameter_map(param_name, binner, chi2_threshold)
         self.view.display_parameter_map(map_array, binner)
+
+    def on_map_display_settings_changed(self, value: int) -> None:
+        self.update_parameter_map()
 
     def handle_parameter_map_changed(self, param_name: str) -> None:
         self.update_parameter_map()

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -20,7 +20,7 @@ from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.dialogs.async_task import start_async_task_view, TaskWorkerThread
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.windows.spectrum_viewer.model import SpectrumViewerWindowModel, SpecType, ROI_RITS, ErrorMode, \
-    ToFUnitMode, allowed_modes
+    ToFUnitMode, allowed_modes, ColourRangeMode
 
 if TYPE_CHECKING:
     from mantidimaging.gui.windows.spectrum_viewer.view import SpectrumViewerWindowView  # pragma: no cover
@@ -83,6 +83,10 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         self.handle_roi_change_timer = QTimer()
         self.handle_roi_change_timer.setSingleShot(True)
         self.handle_roi_change_timer.timeout.connect(self.handle_roi_moved)
+
+    def setup_colour_range_dropdown(self) -> None:
+        """Populate colour range dropdown with available options"""
+        self.view.exportSettingsWidget.colourRangeDropdown.addItems([mode.value for mode in ColourRangeMode])
 
     def _run_fit_async(self):
         """
@@ -821,7 +825,9 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         binner = self.view.get_binner()
         chi2_threshold = self.view.exportSettingsWidget.chiSquaredThresholdSpinBox.value()
         map_array = self.model.build_parameter_map(param_name, binner, chi2_threshold)
-        self.view.display_parameter_map(map_array, binner)
+        colour_mode = ColourRangeMode(self.view.exportSettingsWidget.selected_colour_range_mode)
+        levels = self.model.calculate_colour_levels(map_array, colour_mode)
+        self.view.display_parameter_map(map_array, binner, levels)
 
     def on_map_display_settings_changed(self, value: int) -> None:
         self.update_parameter_map()

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -783,7 +783,7 @@ class SpectrumViewerWindowPresenter(BasePresenter):
     def on_fit_all_regions(self, task: TaskWorkerThread) -> None:
         """
         Callback executed when the asynchronous fitting task completes.
-        Handles errors, retrieves results, and updates the export table.
+        Handles errors, retrieves results, and updates the export table and parameter map
 
         Parameters
         ----------
@@ -794,8 +794,34 @@ class SpectrumViewerWindowPresenter(BasePresenter):
 
             self._populate_export_table(results)
             self.model.set_fit_results(results)
+
+            if results:
+                param_names = self.model.fitting_engine.get_parameter_names()
+                self.view.exportSettingsWidget.populate_parameter_selector(param_names)
+                self.update_parameter_map()
         else:
             self.view.show_error_dialog(str(task.error))
+
+    def _clear_export_table(self) -> None:
+        """
+        Clear all existing data from the export results table.
+        """
+        self.view.exportDataTableWidget.clear_table()
+
+    def update_parameter_map(self) -> None:
+        """
+        Update the map based on the selected parameter in the export settings.
+        """
+        param_name = self.view.exportSettingsWidget.parameterDropdown.currentText()
+        if not param_name:
+            return
+        binner = self.view.get_binner()
+        chi2_threshold = None  # ToDo Add Ui Control
+        map_array = self.model.build_parameter_map(param_name, binner, chi2_threshold)
+        self.view.display_parameter_map(map_array, binner)
+
+    def handle_parameter_map_changed(self, param_name: str) -> None:
+        self.update_parameter_map()
 
     def _populate_export_table(self, results: list[tuple[str, SpectrumFitResult]]) -> None:
         """

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 import unittest
 from pathlib import Path, PurePath
+from typing import Literal
 from unittest import mock
 import io
 import math
@@ -18,6 +19,7 @@ from mantidimaging.gui.windows.spectrum_viewer.model import SpecType, ErrorMode
 from mantidimaging.test_helpers.unit_test_helper import generate_images
 from mantidimaging.core.data import ImageStack
 from mantidimaging.core.utility.sensible_roi import SensibleROI, ROIBinner
+from mantidimaging.gui.windows.spectrum_viewer.presenter import SpectrumFitResult
 
 
 class CloseCheckStream(io.StringIO):
@@ -70,6 +72,28 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         mock_path = mock.create_autospec(Path, instance=True)
         mock_path.open.return_value = mock_stream
         return mock_stream, mock_path
+
+    def _make_binner(self) -> ROIBinner:
+        """Create a 2 by 2 bins at (0,0), (1,0), (0,1), (1,1)"""
+        roi = SensibleROI(left=0, top=0, right=20, bottom=20)
+        return ROIBinner(roi, step_size=10, bin_size=10)
+
+    def _set_fit_results(self,
+                         binner: ROIBinner,
+                         param_values: tuple[float, ...] = (1.0, 2.0, 3.0, 4.0),
+                         chi2s: tuple[float, ...] = (0.5, 0.5, 0.5, 0.5),
+                         statuses: tuple[Literal["Fitted", "Failed"], ...] = ("Fitted", ) * 4) -> None:
+        """Set fit results for a 2 by 2 binner and indexed as (col, row): (0,0), (1,0), (0,1), (1,1)"""
+        n_cols, n_rows = binner.lengths()
+        positions = [(col, row) for col in range(n_cols) for row in range(n_rows)]
+        roi_names = [binner.get_roi_name(col, row) for col, row in positions]
+
+        fit_results = []
+        for param_value, chi2, status in zip(param_values, chi2s, statuses, strict=True):
+            fit_results.append(
+                SpectrumFitResult(params={"sigma": param_value}, rss=chi2, rss_per_dof=chi2, status=status))
+
+        self.model.set_fit_results(list(zip(roi_names, fit_results, strict=True)))
 
     def test_set_stack(self):
         stack, _ = self._set_sample_stack()
@@ -581,3 +605,66 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
     def test_get_transmission_error_propogated_raises_runtimeerror_if_no_stack(self):
         with self.assertRaises(RuntimeError):
             self.model.get_transmission_error_propagated("roi")
+
+    def test_WHEN_fit_results_set_THEN_parameter_map_values_placed_at_correct_grid_cell(self):
+        binner = self._make_binner()
+        self._set_fit_results(binner)
+        result = self.model.build_parameter_map("sigma", binner)
+        np.testing.assert_array_equal(result, [[1.0, 3.0], [2.0, 4.0]])
+
+    def test_WHEN_fit_result_has_failed_status_THEN_corresponding_cell_is_nan(self):
+        binner = self._make_binner()
+        self._set_fit_results(binner,
+                              param_values=(99.0, 2.0, 3.0, 4.0),
+                              statuses=("Failed", "Fitted", "Fitted", "Fitted"))
+        result = self.model.build_parameter_map("sigma", binner)
+        self.assertTrue(np.isnan(result[0, 0]))
+        self.assertFalse(np.isnan(result[1, 0]))
+
+    def test_WHEN_fit_result_chi2_exceeds_threshold_THEN_corresponding_cell_is_nan(self):
+        binner = self._make_binner()
+        self._set_fit_results(binner, chi2s=(0.5, 10.0, 0.5, 0.5))
+        result = self.model.build_parameter_map("sigma", binner, chi2_threshold=1.0)
+        self.assertFalse(np.isnan(result[0, 0]))
+        self.assertTrue(np.isnan(result[1, 0]))
+
+    @parameterized.expand([
+        ("value_written_to_correct_block", [[np.nan, 7.0], [np.nan,
+                                                            np.nan]], (0, 10, 10, 20), 7.0, (0, 10, 0, 10), np.nan),
+        ("nan_leaves_pixel_block_as_nan", [[3.0, 3.0], [np.nan, 3.0]], (10, 20, 0, 10), np.nan, (0, 10, 0, 10), 3.0),
+    ])
+    def test_WHEN_build_full_sample_parameter_map_THEN(self, _, map_vals, block1, val1, block2, val2):
+        self.model.set_stack(ImageStack(np.zeros([1, 20, 20])))
+        binner = self._make_binner()
+        full_map = self.model.build_full_sample_parameter_map(np.array(map_vals, dtype=np.float64), binner)
+        y1, y2, x1, x2 = block1
+        npt.assert_array_equal(full_map[y1:y2, x1:x2], np.full((y2 - y1, x2 - x1), val1))
+        y1, y2, x1, x2 = block2
+        npt.assert_array_equal(full_map[y1:y2, x1:x2], np.full((y2 - y1, x2 - x1), val2))
+
+    def test_WHEN_build_full_sample_parameter_map_overlapping_bins_THEN_each_bin_occupies_step_size_pixels(self):
+        """Each bin writes exactly step_size pixels so no edge artefacts from overlapping bins"""
+        self.model.set_stack(ImageStack(np.zeros([1, 20, 20])))
+        binner = ROIBinner(SensibleROI(0, 0, 20, 20), step_size=5, bin_size=10)
+        map_array = np.arange(9, dtype=np.float32).reshape(3, 3)
+        full_map = self.model.build_full_sample_parameter_map(map_array, binner)
+
+        expected = np.full((20, 20), np.nan, dtype=np.float32)
+        for col, row in np.ndindex(3, 3):
+            x, y = binner.left_indexes[col], binner.top_indexes[row]
+            expected[y:y + 5, x:x + 5] = map_array[row, col]
+
+        npt.assert_array_equal(full_map, expected)
+
+    def test_WHEN_build_full_sample_parameter_map_overlapping_bins_THEN_trailing_region_is_nan(self):
+        """
+        Pixels beyond the last bin's step_size block remain NaN and aren't filled with the last bin's
+        value causing edge artifcats
+        """
+        self.model.set_stack(ImageStack(np.zeros([1, 20, 20])))
+        binner = ROIBinner(SensibleROI(0, 0, 20, 20), step_size=5, bin_size=10)
+        map_array = np.ones((3, 3), dtype=np.float32)
+        full_map = self.model.build_full_sample_parameter_map(map_array, binner)
+
+        npt.assert_array_equal(full_map[15:, :], np.full((5, 20), np.nan))
+        npt.assert_array_equal(full_map[:, 15:], np.full((20, 5), np.nan))

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest import mock
 
 import numpy as np
+import numpy.testing as npt
 from PyQt5.QtWidgets import QPushButton, QActionGroup, QGroupBox, QAction, QCheckBox, QTabWidget
 from parameterized import parameterized
 
@@ -15,9 +16,10 @@ from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.widgets.spectrum_widgets.roi_form_widget import ROIFormWidget, ROIPropertiesTableWidget, \
     ROITableWidget
 from mantidimaging.gui.windows.main import MainWindowView
-from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowView, SpectrumViewerWindowPresenter
+from mantidimaging.gui.windows.spectrum_viewer import SpectrumViewerWindowView
 from mantidimaging.gui.windows.spectrum_viewer.model import ErrorMode, ToFUnitMode, ROI_RITS, SpecType, \
     SpectrumViewerWindowModel
+from mantidimaging.gui.windows.spectrum_viewer.presenter import SpectrumViewerWindowPresenter, SpectrumFitResult
 from mantidimaging.gui.windows.spectrum_viewer.spectrum_widget import SpectrumWidget, SpectrumPlotWidget, SpectrumROI, \
     MIPlotItem
 from mantidimaging.gui.widgets.spectrum_widgets.tof_properties import ExperimentSetupFormWidget
@@ -445,3 +447,41 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         self.assertEqual(self.presenter.spectrum_mode, initial_spectrum_mode)
         self.presenter.redraw_all_rois.assert_not_called()
         self.view.display_normalise_error.assert_not_called()
+
+    def test_WHEN_normalise_background_normal_image_THEN_returns_normalised_rgb(self):
+        sample = np.array([[0.0, 128.0], [255.0, 64.0]])
+        result = self.presenter._normalise_background(sample)
+        self.assertEqual(result.shape, (2, 2, 3))
+        npt.assert_array_equal(result[..., 0], result[..., 1])
+        self.assertAlmostEqual(result[1, 0, 0], 1.0)
+        self.assertAlmostEqual(result[0, 0, 0], 0.0)
+
+    def test_WHEN_normalise_background_flat_image_THEN_returns_zeros(self):
+        sample = np.ones((3, 3)) * 5.0
+        result = self.presenter._normalise_background(sample)
+        npt.assert_array_equal(result, np.zeros((3, 3, 3)))
+
+    def test_WHEN_build_composite_image_no_sample_THEN_background_is_black(self):
+        full_map = np.full((4, 4), np.nan)
+        result = self.presenter.build_composite_image(full_map, (0.0, 1.0), opacity=1.0, sample_image=None)
+        self.assertEqual(result.shape, (4, 4, 3))
+        npt.assert_array_equal(result, np.zeros((4, 4, 3), dtype=np.uint8))
+
+    def test_WHEN_build_composite_image_opacity_zero_THEN_only_background_visible(self):
+        sample = np.ones((4, 4))
+        full_map = np.zeros((4, 4))
+        result = self.presenter.build_composite_image(full_map, (0.0, 1.0), opacity=0.0, sample_image=sample)
+        background = self.presenter._normalise_background(sample)
+        expected = (np.clip(background, 0.0, 1.0) * 255).astype(np.uint8)
+        npt.assert_array_equal(result, expected)
+
+    @parameterized.expand([
+        ("failed_status", {}, 0.0, 0.0, "Failed", False),
+        ("rss_per_dof_nan", {}, 0.0, float('nan'), "Fitted", False),
+        ("fitted_and_finite", {
+            "sigma": 1.0
+        }, 0.5, 0.5, "Fitted", True),
+    ])
+    def test_WHEN_fit_result_THEN_is_good_fit_correct(self, _, params, rss, rss_per_dof, status, expected):
+        result = SpectrumFitResult(params=params, rss=rss, rss_per_dof=rss_per_dof, status=status)
+        self.assertEqual(result.is_good_fit, expected)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -78,13 +78,10 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.spectrum = self.spectrum_widget.spectrum_plot_widget
         self.imageLayout.addWidget(self.spectrum_widget)
 
-        self.spectrum.range_changed.connect(self.presenter.handle_range_slide_moved)
-
         self.fittingDisplayWidget = FittingDisplayWidget()
         self.fittingForm = FittingFormWidgetView(self)
         self.fittingFormContainer.layout().addWidget(self.fittingForm)
 
-        self.fittingDisplayWidget.unit_changed.connect(self.presenter.handle_tof_unit_change_via_menu)
         self.fittingLayout.addWidget(self.fittingDisplayWidget)
 
         self.fitting_param_form = self.fittingForm.fitting_param_form
@@ -100,12 +97,18 @@ class SpectrumViewerWindowView(BaseMainWindowView):
 
         self.exportSettingsWidget = FitExportFormWidget()
         self.exportFormLayout.layout().addWidget(self.exportSettingsWidget)
+        self.presenter.setup_colour_range_dropdown()
+
+        self.spectrum.range_changed.connect(self.presenter.handle_range_slide_moved)
+        self.fittingDisplayWidget.unit_changed.connect(self.presenter.handle_tof_unit_change_via_menu)
         self.exportSettingsWidget.exportButton.clicked.connect(self.presenter.handle_export_table)
         self.exportSettingsWidget.fitAllButton.clicked.connect(self.presenter._run_fit_async)
         self.exportSettingsWidget.parameter_selected.connect(self.presenter.handle_parameter_map_changed)
         self.exportSettingsWidget.transparencySpinBox.valueChanged.connect(
             self.presenter.on_map_display_settings_changed)
         self.exportSettingsWidget.chiSquaredThresholdSpinBox.valueChanged.connect(
+            self.presenter.on_map_display_settings_changed)
+        self.exportSettingsWidget.colourRangeDropdown.currentIndexChanged.connect(
             self.presenter.on_map_display_settings_changed)
 
         self.spectrum_widget.roi_clicked.connect(self.presenter.handle_roi_clicked)
@@ -214,11 +217,11 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         """Switch the export display to the Image tab."""
         self.export_display_tabs.setCurrentIndex(self.export_display_tabs.indexOf(self._export_image_widget))
 
-    def display_parameter_map(self, map_array: np.ndarray, binner: ROIBinner) -> None:
+    def display_parameter_map(self, map_array: np.ndarray, binner: ROIBinner, levels: tuple[float, float]) -> None:
         """Display the parameter map on the image tab of the export view."""
         self._export_image_widget.update_image(self.spectrum_widget.image.image_item.image)
         opacity = self.exportSettingsWidget.overlay_opacity
-        self._export_image_widget.show_parameter_map(map_array, binner, opacity)
+        self._export_image_widget.show_parameter_map(map_array, binner, opacity, levels)
 
     def sync_unit_menus(self, unit_name: str) -> None:
         """Sync the checked unit in both the image and fitting tab unit menus."""

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -110,6 +110,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             self.presenter.on_map_display_settings_changed)
         self.exportSettingsWidget.colourRangeDropdown.currentIndexChanged.connect(
             self.presenter.on_map_display_settings_changed)
+        self.exportSettingsWidget.exportMappedImageButton.clicked.connect(self.presenter.handle_export_parameter_map)
 
         self.spectrum_widget.roi_clicked.connect(self.presenter.handle_roi_clicked)
         self.spectrum_widget.roi_changing.connect(self.presenter.handle_notify_roi_moved)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -103,6 +103,10 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.exportSettingsWidget.exportButton.clicked.connect(self.presenter.handle_export_table)
         self.exportSettingsWidget.fitAllButton.clicked.connect(self.presenter._run_fit_async)
         self.exportSettingsWidget.parameter_selected.connect(self.presenter.handle_parameter_map_changed)
+        self.exportSettingsWidget.transparencySpinBox.valueChanged.connect(
+            self.presenter.on_map_display_settings_changed)
+        self.exportSettingsWidget.chiSquaredThresholdSpinBox.valueChanged.connect(
+            self.presenter.on_map_display_settings_changed)
 
         self.spectrum_widget.roi_clicked.connect(self.presenter.handle_roi_clicked)
         self.spectrum_widget.roi_changing.connect(self.presenter.handle_notify_roi_moved)
@@ -209,7 +213,8 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     def display_parameter_map(self, map_array: np.ndarray, binner: ROIBinner) -> None:
         """Display the parameter map on the image tab of the export view."""
         self._export_image_widget.update_image(self.spectrum_widget.image.image_item.image)
-        self._export_image_widget.show_parameter_map(map_array, binner)
+        opacity = self.exportSettingsWidget.overlay_opacity
+        self._export_image_widget.show_parameter_map(map_array, binner, opacity)
 
     def sync_unit_menus(self, unit_name: str) -> None:
         """Sync the checked unit in both the image and fitting tab unit menus."""

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -213,6 +213,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
                 self.fittingForm.presenter.setup_fitting_model()
             if self.export_display_tabs.tabText(self.export_display_tabs.currentIndex()) == "Image":
                 self._sync_export_background()
+                self.presenter.update_parameter_map()
         self.imageTabs.setCurrentIndex(tab_index)
         self.presenter.update_unit_labels_and_menus()
         LOG.debug("Tab changed: index=%d", tab_index)
@@ -220,6 +221,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     def handle_export_change_tab(self, tab_index: int):
         if self.export_display_tabs.tabText(tab_index) == "Image":
             self._sync_export_background()
+            self.presenter.update_parameter_map()
 
     def show_image_tab(self) -> None:
         """Switch the export display to the Image tab."""

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -210,6 +210,10 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         if self.export_display_tabs.tabText(tab_index) == "Image":
             self._export_image_widget.update_image(self.spectrum_widget.image.image_item.image)
 
+    def show_image_tab(self) -> None:
+        """Switch the export display to the Image tab."""
+        self.export_display_tabs.setCurrentIndex(self.export_display_tabs.indexOf(self._export_image_widget))
+
     def display_parameter_map(self, map_array: np.ndarray, binner: ROIBinner) -> None:
         """Display the parameter map on the image tab of the export view."""
         self._export_image_widget.update_image(self.spectrum_widget.image.image_item.image)

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -102,6 +102,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.exportFormLayout.layout().addWidget(self.exportSettingsWidget)
         self.exportSettingsWidget.exportButton.clicked.connect(self.presenter.handle_export_table)
         self.exportSettingsWidget.fitAllButton.clicked.connect(self.presenter._run_fit_async)
+        self.exportSettingsWidget.parameter_selected.connect(self.presenter.handle_parameter_map_changed)
 
         self.spectrum_widget.roi_clicked.connect(self.presenter.handle_roi_clicked)
         self.spectrum_widget.roi_changing.connect(self.presenter.handle_notify_roi_moved)
@@ -204,6 +205,11 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     def handle_export_change_tab(self, tab_index: int):
         if self.export_display_tabs.tabText(tab_index) == "Image":
             self._export_image_widget.update_image(self.spectrum_widget.image.image_item.image)
+
+    def display_parameter_map(self, map_array: np.ndarray, binner: ROIBinner) -> None:
+        """Display the parameter map on the image tab of the export view."""
+        self._export_image_widget.update_image(self.spectrum_widget.image.image_item.image)
+        self._export_image_widget.show_parameter_map(map_array, binner)
 
     def sync_unit_menus(self, unit_name: str) -> None:
         """Sync the checked unit in both the image and fitting tab unit menus."""

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -199,29 +199,55 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.set_roi_properties()
         self.presenter.initial_roi_calc()
 
+    def _sync_export_background(self) -> None:
+        """Copy current image main spectrum view to the export widget"""
+        self._export_image_widget.update_image(self.spectrum_widget.image.image_item.image)
+
+    def get_export_background_image(self) -> np.ndarray | None:
+        return self._export_image_widget.image_data
+
     def handle_change_tab(self, tab_index: int):
         if self.formTabs.tabText(tab_index) == "Export":
             if self.exportDataTableWidget.model.rowCount() == 0:
                 self.fittingForm.presenter.setup_fitting_model()
             if self.export_display_tabs.tabText(self.export_display_tabs.currentIndex()) == "Image":
-                self._export_image_widget.update_image(self.spectrum_widget.image.image_item.image)
+                self._sync_export_background()
         self.imageTabs.setCurrentIndex(tab_index)
         self.presenter.update_unit_labels_and_menus()
         LOG.debug("Tab changed: index=%d", tab_index)
 
     def handle_export_change_tab(self, tab_index: int):
         if self.export_display_tabs.tabText(tab_index) == "Image":
-            self._export_image_widget.update_image(self.spectrum_widget.image.image_item.image)
+            self._sync_export_background()
 
     def show_image_tab(self) -> None:
         """Switch the export display to the Image tab."""
         self.export_display_tabs.setCurrentIndex(self.export_display_tabs.indexOf(self._export_image_widget))
 
+    @property
+    def selected_param_name(self) -> str:
+        return self.exportSettingsWidget.parameterDropdown.currentText()
+
+    @property
+    def chi2_threshold(self) -> float:
+        return self.exportSettingsWidget.chiSquaredThresholdSpinBox.value()
+
+    @property
+    def export_full_sample(self) -> bool:
+        return self.exportSettingsWidget.is_full_sample_export
+
+    @property
+    def overlay_opacity(self) -> float:
+        return self.exportSettingsWidget.overlay_opacity
+
+    @property
+    def colour_range_mode(self) -> str:
+        return self.exportSettingsWidget.selected_colour_range_mode
+
     def display_parameter_map(self, map_array: np.ndarray, binner: ROIBinner, levels: tuple[float, float]) -> None:
         """Display the parameter map on the image tab of the export view."""
-        self._export_image_widget.update_image(self.spectrum_widget.image.image_item.image)
-        opacity = self.exportSettingsWidget.overlay_opacity
-        self._export_image_widget.show_parameter_map(map_array, binner, opacity, levels)
+        self._sync_export_background()
+        self._export_image_widget.show_parameter_map(map_array, binner, self.overlay_opacity, levels)
 
     def sync_unit_menus(self, unit_name: str) -> None:
         """Sync the checked unit in both the image and fitting tab unit menus."""
@@ -271,12 +297,24 @@ class SpectrumViewerWindowView(BaseMainWindowView):
     def get_normalise_stack(self) -> UUID | None:
         return self.normaliseStackSelector.current()
 
+    def _get_save_filename(self, title: str, file_filter: str) -> Path | None:
+        """Open a save-file dialog and return the chosen path, or None if cancelled"""
+        path, _ = QFileDialog.getSaveFileName(self, title, "", file_filter)
+        return Path(path) if path else None
+
     def get_csv_filename(self) -> Path | None:
-        path = QFileDialog.getSaveFileName(self, "Save CSV file", "", "CSV file (*.csv)")[0]
-        if path:
-            return Path(path)
-        else:
-            return None
+        return self._get_save_filename("Save CSV file", "CSV file (*.csv)")
+
+    def get_map_export_filename(self) -> Path | None:
+        """
+        Open a save-file dialog for the parameter map export
+
+        @return: path.tiff or None is cancelled
+        """
+        export_path = self._get_save_filename("Export Parameter Map", "TIFF (*.tiff *.tif)")
+        if export_path and export_path.suffix.lower() not in (".tiff", ".tif"):
+            export_path = export_path.with_suffix(".tiff")
+        return export_path
 
     def get_rits_export_directory(self) -> Path | None:
         """
@@ -289,14 +327,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
             return None
 
     def get_rits_export_filename(self) -> Path | None:
-        """
-        Get the path to save the RITS file too
-        """
-        path = QFileDialog.getSaveFileName(self, "Save DAT file", "", "DAT file (*.dat)")[0]
-        if path:
-            return Path(path)
-        else:
-            return None
+        return self._get_save_filename("Save DAT file", "DAT file (*.dat)")
 
     def set_image(self, image_data: np.ndarray, autoLevels: bool = True) -> None:
         self.spectrum_widget.image.setImage(image_data, autoLevels=autoLevels)


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2955 

### Description

<!-- Add a description of the changes made. -->
- Create 2D mapping overlay of fit per parameter over sample image in Export Image view
- Allow for user control of mapping opacity to control if fit parameter map or sample is more visible
- Add 3 outlier colour range selections (1.5xIQR, Median+-3XMAD and lower and upper 2 percent clipping to improve parameter overlay visibility when more extreme outliers exist
- Allow user selected chi2 threshold to filter fit quality in parameter map overlay where if values are less than threshold, they are displayed as NaN/transparent
- Added export of mapped area only and mapped area over sample image. Mapped area only can be loaded in MI while mapped area over sample area include default viridis colouring, so not able to be loaded into MI, but useful for presentations

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`, `pixi run test-cpu` or `pixi run test-gpu`
- Parameter overlay mapped image displayed by default on completion of "Fit All"
- Parameter overlay shows viridis colour map
- ROI shape and position correctly mapped over sample image in Export Tab Image view
- ROI shape and position correctly mapped over sample image in "Full Sample image" exported Image
- "Full sample image" exported matches opacity, colour range and chi2 threshold in Spectrum Viewer Export tab Image View
- "Full sample image" exported image shows full sample shape and mapped parameters using OS image viewer
- "Mapped Region only" matches current parameter selection  in Spectrum Viewer Export tab Image View
- "Mapped Region only" possible to open in Mantid Imaging
- IQR, MAD and percentile Colour ranges correctly update colour range upper lower and upper bounds of fitted parameter map overlay (IQR and MAD should be the most accurate)

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Parameter overlay mapped image displayed by default on completion of "Fit All"
- [ ] Parameter overlay shows viridis colour map
- [ ] ROI shape and position correctly mapped over sample image in Export Tab Image view
- [ ] ROI shape and position correctly mapped over sample image in "Full Sample image" exported Image
- [ ] "Full sample image" exported matches opacity, colour range and chi2 threshold in Spectrum Viewer Export tab Image View
- [ ] "Full sample image" exported image shows full sample shape and mapped parameters using OS image viewer
- [ ] "Mapped Region only" matches current parameter selection  in Spectrum Viewer Export tab Image View
- [ ] "Mapped Region only" possible to open in Mantid Imaging
- [ ] IQR, MAD and percentile Colour ranges correctly update colour range upper lower and upper bounds of fitted parameter map overlay (IQR and MAD should be the most accurate)

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [ ] Release Notes have been updated
<!-- - [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

**Fitted Parameter Map over Export Image view:**
<img width="1725" height="1031" alt="image" src="https://github.com/user-attachments/assets/a98d4430-e68f-43cf-9165-094410674275" />

**Exported Full Sample Map Image:**
<img width="1156" height="993" alt="image" src="https://github.com/user-attachments/assets/3767fe28-160e-40ff-b657-220570428f9b" />


**Exported Mapped Parameters only loaded into Mantid Imaging:**
<img width="1446" height="987" alt="image" src="https://github.com/user-attachments/assets/ca88d8ba-1ff9-4db9-b739-95805a35e7ed" />

