### PR TITLE
system tests: delete main_window in tearDown()

### DIFF
--- a/mantidimaging/gui/test/gui_system_base.py
+++ b/mantidimaging/gui/test/gui_system_base.py
@@ -61,6 +61,7 @@ class GuiSystemBase(unittest.TestCase):
                    max_retry=60,
                    message="Main window did not close within 3 seconds")
         self.assertDictEqual(self.main_window.presenter.model.datasets, {})
+        del self.main_window
 
         # if self._outcome.result._excinfo is None then there were no AssertionErrors during the test
         test_error = self._outcome.result._excinfo  # type: ignore

--- a/mantidimaging/gui/test/gui_system_liveviewer_test.py
+++ b/mantidimaging/gui/test/gui_system_liveviewer_test.py
@@ -35,7 +35,6 @@ class TestGuiLiveViewer(GuiSystemBase):
     def tearDown(self) -> None:
         self._close_image_stacks()
         super().tearDown()
-        self.assertFalse(self.main_window.isVisible())
 
     def test_open_close_intensity_profile(self):
         self.assertEqual(self.live_viewer_window.splitter.sizes()[1], 0)

--- a/mantidimaging/gui/test/gui_system_loading_test.py
+++ b/mantidimaging/gui/test/gui_system_loading_test.py
@@ -32,7 +32,6 @@ class TestGuiSystemLoading(GuiSystemBase):
         self._close_image_stacks()
         self._check_datasets_consistent()
         super().tearDown()
-        self.assertFalse(self.main_window.isVisible())
 
     @mock.patch("mantidimaging.gui.windows.main.MainWindowView._get_file_name")
     def _load_images(self, mocked_select_file):

--- a/mantidimaging/gui/test/gui_system_operations_test.py
+++ b/mantidimaging/gui/test/gui_system_operations_test.py
@@ -74,7 +74,6 @@ class TestGuiSystemOperations(GuiSystemBase):
         QTest.qWait(SHOW_DELAY)
         self._close_image_stacks()
         super().tearDown()
-        self.assertFalse(self.main_window.isVisible())
 
     @staticmethod
     def _get_operation_parameter_widget(form: QFormLayout, param_name: str) -> QWidget:

--- a/mantidimaging/gui/test/gui_system_reconstruction_test.py
+++ b/mantidimaging/gui/test/gui_system_reconstruction_test.py
@@ -42,7 +42,6 @@ class TestGuiSystemReconstruction(GuiSystemBase):
         self._close_image_stacks()
         self.mock_show_error_dialog.assert_not_called()
         super().tearDown()
-        self.assertFalse(self.main_window.isVisible())
 
     def test_correlate(self):
         expected_initial_cor = 64.0

--- a/mantidimaging/gui/test/gui_system_spectrum_test.py
+++ b/mantidimaging/gui/test/gui_system_spectrum_test.py
@@ -43,7 +43,6 @@ class TestGuiSpectrumViewer(GuiSystemBase):
         wait_until(lambda: len(self.spectrum_window.presenter.roi_to_process_queue) == 0, max_retry=600)
         self._close_image_stacks()
         super().tearDown()
-        self.assertFalse(self.main_window.isVisible())
 
     def _property_box_name(self):
         box_title = self.spectrum_window.roi_form.roi_properties_widget.group_box.title()

--- a/mantidimaging/gui/test/gui_system_windows_test.py
+++ b/mantidimaging/gui/test/gui_system_windows_test.py
@@ -13,7 +13,6 @@ class TestGuiSystemWindows(GuiSystemBase):
     def tearDown(self) -> None:
         self._close_image_stacks()
         super().tearDown()
-        self.assertFalse(self.main_window.isVisible())
 
     def test_main_window_shows(self):
         self.assertTrue(self.main_window.isVisible())


### PR DESCRIPTION
## Issue related to #3086 

This does not fix the issue, but will make debugging simpler in some cases

### Description

This means the destructor happens in the `tearDown()` of the current test, rather than during the `setUp()` of the following test. There may be cases were this makes issues easier to find.

The `self.assertFalse(self.main_window.isVisible())` are not needed any more as there is a `wait_until()` in the top `tearDone()` 


### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- ...

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] ...

### Documentation and Additional Notes

Not needed