### PR TITLE
Fix: prevent segmentation faults and mypy errors in image view widgets

### DIFF
--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from itertools import chain, tee
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from weakref import WeakSet
 
 from PyQt5.QtCore import QTimer
@@ -22,7 +22,7 @@ import numpy as np
 if TYPE_CHECKING:
     from PyQt5.QtWidgets import QWidget
 
-graveyard = []
+graveyard: list[Any] = []
 
 
 # https://docs.python.org/3/library/itertools.html?highlight=itertools#itertools.pairwise

--- a/mantidimaging/gui/widgets/spectrum_widgets/export_image_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/export_image_widget.py
@@ -2,9 +2,13 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 from PyQt5.QtWidgets import QWidget, QVBoxLayout
 import pyqtgraph as pg
+
+_graveyard: list[Any] = []
 
 
 class ExportImageViewWidget(QWidget):
@@ -19,6 +23,9 @@ class ExportImageViewWidget(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
 
         self.image_view = pg.ImageView()
+        _graveyard.append(self.image_view.view)
+        _graveyard.append(self.image_view.getRoiPlot().plotItem.vb)
+        _graveyard.append(self.image_view.getHistogramWidget().vb)
         self.image_view.ui.roiBtn.hide()
         self.image_view.ui.menuBtn.hide()
         self.image_view.ui.histogram.hide()

--- a/mantidimaging/gui/widgets/zslider/zslider.py
+++ b/mantidimaging/gui/widgets/zslider/zslider.py
@@ -2,9 +2,13 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+from typing import Any
+
 from PyQt5.QtCore import pyqtSignal, Qt
 from PyQt5.QtWidgets import QGraphicsSceneMouseEvent
 from pyqtgraph import PlotItem, InfiniteLine
+
+_graveyard: list[Any] = []
 
 
 class ZSlider(PlotItem):
@@ -24,6 +28,7 @@ class ZSlider(PlotItem):
 
     def __init__(self) -> None:
         super().__init__()
+        _graveyard.append(self.vb)
         self.setFixedHeight(40)
         self.hideAxis("left")
         self.setXRange(0, 1)

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from logging import getLogger
+from typing import Any
 
 import numpy as np
 from PyQt5.QtCore import QPoint, QRect
@@ -23,6 +24,8 @@ diff_pen = (0, 0, 200)
 
 OVERLAY_THRESHOLD = 1e-6
 OVERLAY_COLOUR_DIFFERENCE = [0, 255, 255, 255]
+
+_graveyard: list[Any] = []
 
 
 def _data_valid_for_histogram(data) -> bool:
@@ -74,6 +77,7 @@ class FilterPreviews(GraphicsLayoutWidget):
         self.nextRow()
 
         self.histogram = self.init_histogram()
+        _graveyard.append(self.histogram.vb)
 
         # Work around for https://github.com/mantidproject/mantidimaging/issues/565
         self.scene().contextMenu = [item for item in self.scene().contextMenu if "export" not in item.text().lower()]

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from logging import getLogger
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from PyQt5.QtCore import pyqtSignal, Qt, QSignalBlocker, QEvent
 from PyQt5.QtGui import QColor, QResizeEvent
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
     from mantidimaging.gui.windows.main import MainWindowView  # noqa:F401   # pragma: no cover
 
 LOG = getLogger(__name__)
+
+_graveyard: list[Any] = []
 
 
 class SpectrumROI(ROI):
@@ -134,7 +136,6 @@ class SpectrumWidget(QWidget):
         super().__init__()
 
         self.vbox = QVBoxLayout(self)
-
         self.image_widget = SpectrumProjectionWidget(main_window)
         self.image = self.image_widget.image
         self.spectrum_plot_widget = SpectrumPlotWidget()
@@ -397,6 +398,7 @@ class MIPlotItem(PlotItem):
     def __init__(self, *args, **kwds) -> None:
         super().__init__(*args, **kwds)
         self.vb = self.getViewBox()
+        _graveyard.append(self.vb)
         self.base_menu = self.getMenu()
 
         self.plot_menu = self.base_menu.addMenu("Plot Style")


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3086

### Description


~~Fix segmentation faults in spectrum viewer system tests by ensuring proper parenting and reference management for all Qt and pyqtgraph objects.~~

Used the graveyard pattern for graphics items to prevent premature deletion and double-deletion.

Verified fix by running: pytest --run-system-tests -k gui_system_spectrum_test.py
