### PR TITLE
Update Validation on Binnng ROI Changed

### DIFF
--- a/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/roi_form_widget.py
@@ -63,7 +63,7 @@ class ROIFormWidget(BaseWidget):
 
         self.bin_step_spinBox.valueChanged.connect(self._binning_changed)
         self.bin_size_spinBox.valueChanged.connect(self._binning_changed)
-        self.roi_properties_widget.roi_changed.connect(self._update_bin_size_limit)
+        self.roi_properties_widget.roi_changed.connect(self._binning_changed)
 
     def update_bin_size_limit(self) -> None:
         self._update_bin_size_limit()

--- a/mantidimaging/gui/windows/spectrum_viewer/view.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/view.py
@@ -531,6 +531,7 @@ class SpectrumViewerWindowView(BaseMainWindowView):
         self.roi_form.roi_properties_widget.set_roi_name(roi_name)
         self.roi_form.roi_properties_widget.set_roi_values(current_roi)
         self.roi_form.roi_properties_widget.enable_roi_spinboxes(True)
+        self.roi_form._binning_changed()
 
     def disable_roi_properties(self) -> None:
         self.roi_form.roi_properties_widget.set_roi_name("None selected")


### PR DESCRIPTION
Hookup  instead of  on  which already calls  so we can clear the warning of invalid bin size or step when the ROI is re-shaped to satisfy current values set. Call  in  to set value warning if ROI shape changed from valid state to invalid state based on bin size and step values after updating spinbox values since  uses a  meaning the  signal is suppressed dugin changes.

<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3092 

### Description

<!-- Add a description of the changes made. -->

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- In spectrum viewer under Image sub-tab, set bin size to 10 and step size to 5
- A warning should appear
- Reshape ROI using drag and drop to 100x100, warning should disappear
- Reshape ROI to be slightly larger and no longer satisfy step size (say 113x113) and the warning should reapear on deselection
- Repeat the above steps using Bin size and step size Spinboxes        

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Warning for step bin and step size updates on ROI change in image view and via SpinBox selection

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->


No need for release notes as minor fix that does not change underlying logic or user workflow

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

