### PR TITLE
Do Not Autoselect Flat of Dark Log File if Found

### DIFF
--- a/mantidimaging/gui/windows/image_load_dialog/presenter.py
+++ b/mantidimaging/gui/windows/image_load_dialog/presenter.py
@@ -97,7 +97,9 @@ class LoadPresenter:
             if getattr(file_group, file_path_attr):
                 field = self.view.fields[file_type_dict[file_info].fname]
                 field.path = getattr(file_group, file_path_attr)
-                field.use = True
+                # If log if flat or dark, don't auto select to avoid issues loading sample log with angles
+                is_log = file_type_dict is log_for_file_type
+                field.use = not is_log or file_info == FILE_TYPES.SAMPLE
 
     def do_update_shutter_counts(self, field: Field, selected_file: str) -> None:
         """


### PR DESCRIPTION

<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes: N/A Flash PR

### Description

To avoid mistakingly loading flat and dark log files when loading a tomography dataset with angles, when the flat and dark log file is automatically found, do not automatically select it in the loading dialog

<!-- Add a description of the changes made. -->
Flat and Dark log files are automatically found and selected if present when loading a dataset. if the dataset has angles, this will cuase an index error as the log files will differ in the number of columns present compared to the sample log file as they understandably won't have angle data in them.

This flash PR ensures that when the flat or dark log files are automatically found, we don't select them to load.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- Flat and dark log files are automatically found, but not selected

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Flat and dark log files are automatically found, but not selected

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

No release notes needed

- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info)

