### PR TITLE
pre-commit: use same ruff version as pixi.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         language: system
         types: [python]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.3
+    rev: v0.3.7
     hooks:
       - id: ruff
   - repo: https://github.com/pre-commit/mirrors-prettier


### PR DESCRIPTION
Solves issue with ruff per-file-ignores setting not being used in pre-commit

<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3111 

### Description

In pixi.toml we are using ruff 0.3.7, in pre-commit we had 0.3.3.

We are using the `per-file-ignores` rule with a negative match, which was introduced in [ruff 0.3.6](https://github.com/astral-sh/ruff/releases/tag/v0.3.6)

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- Run `pre-commit run --files docs/conf.py ruff`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] `pre-commit run --files docs/conf.py ruff` does not give the `INP` error (you might need to be in pixi shell, see bug report)


### Documentation and Additional Notes

Not needed

