### PR TITLE
Spectrum viewer: Handle the case that the ROI has be deleted by the time the spectrum calc is done

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -341,6 +341,12 @@ class SpectrumViewerWindowPresenter(BasePresenter):
     def thread_cleanup(self, thread: TaskWorkerThread) -> None:
         if thread.error is not None:
             raise thread.error
+
+        roi_name = thread.kwargs["roi"].name
+        if roi_name not in self.view.spectrum_widget.roi_dict:
+            LOG.warning("Spectrum calculation thread finished, but ROI no longer exists")
+            return
+
         if self.thread.result is not None:
             self.thread_finished_processing(self.thread)
         self.view.show_visible_spectrums()


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3118

### Description

Add a check in `thread_cleanup()` that the ROI still exists.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- ...

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] ...

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

