### PR TITLE
When theres no ROIs, disable fitting buttons and plot empty spectrum

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/fitting_form.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/fitting_form.py
@@ -115,8 +115,9 @@ class FittingFormWidgetPresenter:
     def handle_activated(self) -> None:
         LOG.warning("Fitting form activated")
         self.update_roi_dropdown()
-        if (self.spectrum_viewer.presenter.export_mode == ExportMode.ROI_MODE
-                and self.view.roiSelectionWidget.current_roi_name == ''):
+        roi_names = self.spectrum_viewer.presenter.get_roi_names()
+        mode = self.spectrum_viewer.presenter.export_mode
+        if mode == ExportMode.ROI_MODE and not roi_names:
             self.fitting_display_widget.update_plot(np.array([]), np.array([]))
             self.set_binning()
             self.view.run_fit_button.setEnabled(False)

--- a/mantidimaging/gui/windows/spectrum_viewer/fitting_form.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/fitting_form.py
@@ -115,13 +115,22 @@ class FittingFormWidgetPresenter:
     def handle_activated(self) -> None:
         LOG.warning("Fitting form activated")
         self.update_roi_dropdown()
-        self.update_roi_on_fitting_thumbnail()
-        self.set_spectrum()
-        self.set_default_fitting_region()
-        self.set_binning()
-        if self.first_activation:
-            self.setup_fitting_model()
-            self.first_activation = False
+        if (self.spectrum_viewer.presenter.export_mode == ExportMode.ROI_MODE
+                and self.view.roiSelectionWidget.current_roi_name == ''):
+            self.fitting_display_widget.update_plot(np.array([]), np.array([]))
+            self.set_binning()
+            self.view.run_fit_button.setEnabled(False)
+            self.view.fitting_param_form.from_roi_button.setEnabled(False)
+        else:
+            self.update_roi_on_fitting_thumbnail()
+            self.set_spectrum()
+            self.set_default_fitting_region()
+            self.set_binning()
+            self.view.run_fit_button.setEnabled(True)
+            self.view.fitting_param_form.from_roi_button.setEnabled(True)
+            if self.first_activation:
+                self.setup_fitting_model()
+                self.first_activation = False
 
     def handle_roi_selection_changes(self) -> None:
         self.update_roi_on_fitting_thumbnail()

--- a/mantidimaging/gui/windows/spectrum_viewer/fitting_form.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/fitting_form.py
@@ -115,8 +115,10 @@ class FittingFormWidgetPresenter:
     def handle_activated(self) -> None:
         LOG.warning("Fitting form activated")
         self.update_roi_dropdown()
-        if (self.spectrum_viewer.presenter.export_mode == ExportMode.ROI_MODE
-                and self.view.roiSelectionWidget.current_roi_name == ''):
+        roi_names = self.spectrum_viewer.presenter.get_roi_names()
+        roi_names.remove("rits_roi")
+        mode = self.spectrum_viewer.presenter.export_mode
+        if mode == ExportMode.ROI_MODE and not roi_names:
             self.fitting_display_widget.update_plot(np.array([]), np.array([]))
             self.set_binning()
             self.view.run_fit_button.setEnabled(False)


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3123

### Description

There are now checks when the Fitting Tab is activated so that when we are in ROI mode and all ROIs have been deleted from the table, an empty spectrum is plotted and the "From ROI" and "Run All Fit" buttons are disabled as there is no data to fit against.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- ...

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Load in data and open Spectrum Viewer
- [ ] With an ROI activate, open the Fitting Tab and check that it behaves as normal.
- [ ] Go back to the Image Tab and delete the ROI so that the table is completely empty
- [ ] Go to the Fitting Tab and check that the ROI Selection Widget is empty, and that the relevant buttons are disabled.
- [ ] Add an ROI and go back to the Fitting Tab, check that everything is enabled as usual.
