### PR TITLE
Add Example Neutron Datasets to Documentation

### DIFF
--- a/docs/release_notes/next/feature-2880-Add-Example-Neutron-Datasets-to-Documentation
+++ b/docs/release_notes/next/feature-2880-Add-Example-Neutron-Datasets-to-Documentation
@@ -1,0 +1,1 @@
+#2880: Add Example Neutron Datasets to Documentation

--- a/docs/user_docs/reference/dataset.rst
+++ b/docs/user_docs/reference/dataset.rst
@@ -1,0 +1,121 @@
+.. _dataset:
+
+Example Neutron Datasets
+========================
+
+This page provides example neutron (and related) datasets for use with Mantid Imaging.
+These datasets are intended to help users quickly get started with visualization,
+corrections, and reconstruction workflows.
+
+The datasets listed here are small, open-access, or synthetic where possible, and are
+suitable for tutorials, testing, and continuous integration (CI) workflows.
+
+Overview
+--------
+
+The datasets included or referenced here are designed to:
+
+- Demonstrate visualization in Mantid Imaging
+- Show typical correction workflows (dark/flat correction, normalization, etc.)
+- Provide reproducible examples for tutorials and testing
+
+Test Datasets Repository
+------------------------
+
+A small collection of test datasets is available via GitHub:
+
+https://github.com/mantidproject/mantidimaging-data
+
+This repository currently includes:
+
+- **Neutron tomography of a flower**
+
+  - Acquired at IMAT at ISIS Neutron and Muon Source
+  - Format: TIFF image stack
+  - Suitable for:
+
+    - Basic visualization
+    - Reconstruction workflows
+    - Testing correction pipelines
+
+- **X-ray tomography of a wire sample**
+
+  - Acquired at beamline i13 at Diamond Light Source
+  - Format: NXTomo (NeXus) file
+  - Useful for:
+
+    - Testing NeXus file handling
+    - Comparing neutron vs X-ray workflows
+
+These datasets are intentionally small to allow fast download and use in CI environments.
+
+Recommended Open Datasets
+-------------------------
+
+A larger collection of open-access tomography datasets is available via Zenodo:
+
+https://zenodo.org/collection/user-ccpi
+
+Recommended neutron datasets include:
+
+**Lego Man Neutron Tomography Dataset**
+
+- DOI: https://doi.org/10.5281/zenodo.17814677
+- Description:
+
+  A neutron tomography dataset of a Lego figure, acquired with both equidistant
+  and golden angle sampling strategies.
+
+- Use cases:
+
+  - Reconstruction algorithm comparison
+  - Sampling strategy studies
+  - Visualization examples
+
+**Aluminium Cylinder – Flexible Neutron Tomography Dataset**
+
+- DOI: https://doi.org/10.5281/zenodo.18956581
+- Description:
+
+  A flexible neutron tomography dataset acquired with multiple exposure times and
+  a highly composite number of projection angles.
+
+- Use cases:
+
+  - Studying trade-offs between exposure time and number of projections
+  - Optimizing acquisition strategies
+  - Testing reconstruction robustness
+
+**Cone Beam CT Dataset**
+
+- DOI: https://doi.org/10.5281/zenodo.11397266
+- Description:
+
+  X-ray cone-beam CT dataset of a walnut acquired at multiple dose levels.
+  Includes TIFF projections and scan metadata describing scan geometry and parameters.
+
+- Use cases:
+
+  - Testing cone-beam reconstruction workflows
+  - Exploring dose vs image quality trade-offs
+  - Practicing correction steps (dark/flat field)
+
+
+Internal ISIS Datasets
+----------------------
+
+Additional datasets are available internally via the ISIS Data Analysis
+as a Service `Ada <https://ada.stfc.ac.uk/login>`_ system.
+
+- Location:
+
+  ``/mnt/ceph/auxiliary/tomography/example_data``
+
+- Access:
+
+  Available to ISIS users and STFC staff
+
+- Notes:
+
+  - See :ref:`getting-started-with-ada` in **Tutorials** if you're new to using Ada.
+

--- a/docs/user_docs/reference/dataset.rst
+++ b/docs/user_docs/reference/dataset.rst
@@ -32,7 +32,7 @@ This repository currently includes:
 
   - Acquired at IMAT at ISIS Neutron and Muon Source
   - Format: TIFF image stack
-  - Suitable for:
+  - Use cases:
 
     - Basic visualization
     - Reconstruction workflows
@@ -42,7 +42,7 @@ This repository currently includes:
 
   - Acquired at beamline i13 at Diamond Light Source
   - Format: NXTomo (NeXus) file
-  - Useful for:
+  - Use cases:
 
     - Testing NeXus file handling
     - Comparing neutron vs X-ray workflows
@@ -61,6 +61,7 @@ Recommended neutron datasets include:
 **Lego Man Neutron Tomography Dataset**
 
 - DOI: https://doi.org/10.5281/zenodo.17814677
+- Format: TIFF projection images + metadata
 - Description:
 
   A neutron tomography dataset of a Lego figure, acquired with both equidistant
@@ -75,6 +76,7 @@ Recommended neutron datasets include:
 **Aluminium Cylinder – Flexible Neutron Tomography Dataset**
 
 - DOI: https://doi.org/10.5281/zenodo.18956581
+- Format: TIFF projection images + metadata
 - Description:
 
   A flexible neutron tomography dataset acquired with multiple exposure times and
@@ -89,6 +91,7 @@ Recommended neutron datasets include:
 **Cone Beam CT Dataset**
 
 - DOI: https://doi.org/10.5281/zenodo.11397266
+- Format: TIFF projection images + metadata
 - Description:
 
   X-ray cone-beam CT dataset of a walnut acquired at multiple dose levels.
@@ -101,7 +104,7 @@ Recommended neutron datasets include:
   - Practicing correction steps (dark/flat field)
 
 
-Internal ISIS Datasets
+Internal ISIS Example Datasets
 ----------------------
 
 Additional datasets are available internally via the ISIS Data Analysis
@@ -115,7 +118,7 @@ as a Service `Ada <https://ada.stfc.ac.uk/login>`_ system.
 
   Available to ISIS users and STFC staff
 
-- Notes:
+.. note::
 
   - See :ref:`getting-started-with-ada` in **Tutorials** if you're new to using Ada.
 

--- a/docs/user_docs/reference/dataset.rst
+++ b/docs/user_docs/reference/dataset.rst
@@ -105,7 +105,7 @@ Recommended neutron datasets include:
 
 
 Internal ISIS Example Datasets
-----------------------
+------------------------------
 
 Additional datasets are available internally via the ISIS Data Analysis
 as a Service `Ada <https://ada.stfc.ac.uk/login>`_ system.
@@ -120,5 +120,5 @@ as a Service `Ada <https://ada.stfc.ac.uk/login>`_ system.
 
 .. note::
 
-  - See :ref:`getting-started-with-ada` in **Tutorials** if you're new to using Ada.
+  - See the :doc:`Using Mantid Imaging on IDAaaS <../tutorials/installation>` guide if you're new to using Ada.
 

--- a/docs/user_docs/reference/dataset.rst
+++ b/docs/user_docs/reference/dataset.rst
@@ -120,5 +120,5 @@ as a Service `Ada <https://ada.stfc.ac.uk/login>`_ system.
 
 .. note::
 
-  - See the :doc:`Using Mantid Imaging on IDAaaS <../tutorials/installation>` guide if you're new to using Ada.
+  - See the :ref:`installing-idaaas` guide if you're new to using Ada.
 

--- a/docs/user_docs/reference/index.rst
+++ b/docs/user_docs/reference/index.rst
@@ -6,6 +6,7 @@ Reference
 .. toctree::
    :maxdepth: 2
 
+   dataset
    ../../../support
    ../../../api
    ../../../release_notes/next

--- a/docs/user_docs/tutorials/quick_start_guides/quick_start_guides.rst
+++ b/docs/user_docs/tutorials/quick_start_guides/quick_start_guides.rst
@@ -10,4 +10,7 @@ This quick start guide will help you get started with the main features of the a
 - For a step-by-step guide on tomographic reconstruction, see the :doc:`Tomography Workflow Guide <tomography_workflow_guide>`.
 - For an example of time of flight analysis and using the spectrum viewer, see the :doc:`Time of Flight Workflow Guide <time_of_flight_workflow_guide>`.
 
+Example datasets for trying out these workflows are available in the
+:ref:`Example Neutron Datasets <dataset>`.
+
 For more details, please refer to the full documentation.


### PR DESCRIPTION
## Issue Closes #2880

### Description

Added example neutron datasets to the Mantid Imaging documentation. This includes:

- A new datasets page with links to small test datasets and recommended open datasets
- Descriptions of datasets for visualization, correction workflows, and reconstruction
- Inclusion of internal ISIS (Ada) datasets for training and testing
- Added reference to datasets page in the Quick Start Guides
- Added a cone beam CT dataset example (Zenodo)

These changes improve accessibility for new users and provide reproducible examples for tutorials and testing.

### Developer Testing 

- I have verified unit tests pass locally: `python -m pytest -vs`
- Built documentation locally and confirmed no Sphinx warnings/errors
- Verified all dataset links resolve correctly
- Checked new pages render correctly in the docs

### Acceptance Criteria and Reviewer Testing

- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Documentation builds without warnings
- [ ] Dataset links (GitHub, Zenodo, Ada note) are correct
- [ ] Quick Start page correctly links to datasets page
- [ ] New datasets page renders and formatting is consistent

### Documentation and Additional Notes

- [x] Sphinx documentation has been updated

This PR adds documentation only (no code changes). Focus is on improving onboarding and usability for new users by providing accessible example datasets.
