### PR TITLE
Update Environment Versions to 3.1.0

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,12 +1,12 @@
 name: mantidimaging-dev
 channels:
-  - mantidimaging/label/unstable
+  - mantidimaging/label/main
   - conda-forge
   - ccpi
   - algotom
   - https://software.repos.intel.com/python/conda/
 dependencies:
-  - mantidimaging>=2.5.0
+  - mantidimaging>=3.1.0, <3.2.0
   - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774
   - numba==0.61.* # https://github.com/numba/numba/issues/10239
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -1,13 +1,13 @@
-name: mantidimaging-nightly
+name: mantidimaging
 channels:
-  - mantidimaging/label/unstable
+  - mantidimaging/label/main
   - conda-forge
   - ccpi
   - algotom
   - https://software.repos.intel.com/python/conda/
 # Dependencies that can be installed with conda should be in conda/meta.yaml
 dependencies:
-  - mantidimaging>=2.5.0
+  - mantidimaging>=3.1.0, <3.2.0
   - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774
   - numba==0.61.* # https://github.com/numba/numba/issues/10239
   - ipp=2021.12 # https://github.com/mantidproject/mantidimaging/issues/2354


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3102 

### Description

Updates `environment.yml` and `environment-dev.yml`

### Testing 

Check versions are now 3.1.0

### Acceptance Criteria 

- Versions are now 3.1.0 in environment files
- Check that install succeeds with: `mamba env create -f environment.yml` 
- Check that install succeeds with: `mamba env create -f environment-dev.yml`

### Documentation

N/A

