### PR TITLE
Add documentaion of MI use in reasearch

### DIFF
--- a/docs/release_notes/next/dev-2597-Add_documentation_of_MI_use_cases
+++ b/docs/release_notes/next/dev-2597-Add_documentation_of_MI_use_cases
@@ -1,0 +1,1 @@
+#2597: Add documentation of Mantid Imaging in research

--- a/docs/release_notes/next/fix-3126-normalise_stack_shape_mismatch_handling
+++ b/docs/release_notes/next/fix-3126-normalise_stack_shape_mismatch_handling
@@ -1,0 +1,1 @@
+#3126: Add stack shape validation checks on stack modification to Spectrum Viewer to resolve shape mismatch Value Errors being raised when stack is normalised in spectrum viewer and cropped in operations window, making the normalisation invalid as stack shapes must be identical.

--- a/docs/user_docs/reference/index.rst
+++ b/docs/user_docs/reference/index.rst
@@ -9,3 +9,4 @@ Reference
    ../../../support
    ../../../api
    ../../../release_notes/next
+   mi_in_research

--- a/docs/user_docs/reference/mi_in_research.rst
+++ b/docs/user_docs/reference/mi_in_research.rst
@@ -1,0 +1,33 @@
+.. _mi_in_research:
+
+Mantid Imaging in Research
+==========================
+
+This page highlights research that has used and credited Mantid Imaging, featuring journal articles, PhD theses, and other scientific contributions demonstrating its use in practice.
+
+Journal Articles
+----------------
+Explore journal publications showcasing how Mantid Imaging has been applied in scientific studies across a range of research areas.
+
+Tomography and Reconstruction
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- `Tomographic reconstruction with Mantid Imaging <https://iopscience.iop.org/article/10.1088/1742-6596/2605/1/012017>`_
+- `Crystalline phase discriminating neutron tomography using advanced reconstruction methods <https://iopscience.iop.org/article/10.1088/1361-6463/ac02f9>`_
+- `Neutron tomography reveals extensive modern modification in Iron Age Iranian swords <https://linkinghub.elsevier.com/retrieve/pii/S0305440324000864>`_
+
+Engineering and Material Science
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- `Exploring spatial resolution enhancements on IMAT for steel corrosion studies <https://www.sciencedirect.com/science/article/pii/S0168900225000853?via%3Dihub>`_
+- `The application of neutron imaging to examine ethene hydrogenation over a carbon-supported palladium catalyst <https://www.nature.com/articles/s41598-025-91179-6>`_
+
+PhD Theses
+----------
+A collection of doctoral theses that have applied Mantid Imaging in research, demonstrating its use in advanced academic studies and specialised scientific applications.
+
+Energy-Resolved / Diffraction Imaging
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- `Diffraction-based energy-resolved neutron imaging of rechargeable batteries under operation <https://orbit.dtu.dk/en/publications/diffraction-based-energy-resolved-neutron-imaging-of-rechargeable/>`_
+
+

--- a/mantidimaging/gui/windows/spectrum_viewer/model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/model.py
@@ -151,6 +151,8 @@ class SpectrumViewerWindowModel:
         tof_slice = slice(self.tof_range[0], self.tof_range[1] + 1)
         sample_data = self._stack.data[tof_slice].mean(axis=0)
         norm_data = self._normalise_stack.data[tof_slice].mean(axis=0)
+        if sample_data.shape != norm_data.shape:
+            return None
         normalized_image = np.divide(sample_data, norm_data, out=np.zeros_like(sample_data), where=norm_data != 0)
         shutter_correction = self.get_shuttercount_normalised_correction_parameter()
         normalized_image /= shutter_correction

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -111,6 +111,8 @@ class SpectrumViewerWindowPresenter(BasePresenter):
             except RuntimeError:
                 norm_stack = None
             self.model.set_normalise_stack(norm_stack)
+        self.view.set_normalise_error(self.model.normalise_issue())
+        self.handle_button_enabled()
         self.model.set_tof_unit_mode_for_stack()
         self.model.spectrum_cache.clear()
         sample_roi = SensibleROI.from_list([0, 0, *self.model.get_image_shape()])
@@ -242,9 +244,23 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         return None if stack_id is None else self.main_window.get_dataset_id_from_stack_uuid(stack_id)
 
     def update_displayed_image(self, autoLevels: bool = True) -> None:
-        """Fetches the correct image (normalized or not) and updates the display."""
-        averaged_image = (self.model.get_normalized_averaged_image()
-                          if self.view.normalisation_enabled() else self.model.get_averaged_image())
+        """
+        Fetches the correct image (normalized or not) and updates the display
+
+        If normalisation is enabled, but no longer valud due to changes to image stacks,
+        the normalisation error message will be updated and the unnormalised image will be shown
+        until the issue is resolved.
+
+        :param autoLevels: Whether to automatically set the levels of the displayed image, or keep them fixed.
+        :return: None
+        """
+        averaged_image = self.model.get_averaged_image()
+        if self.view.normalisation_enabled():
+            normalised = self.model.get_normalized_averaged_image()
+            if normalised is None:
+                self.view.set_normalise_error(self.model.normalise_issue())
+            else:
+                averaged_image = normalised
         if averaged_image is None:
             image_shape = self.model.get_image_shape()
             averaged_image = np.zeros(image_shape, dtype=np.float32)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/model_test.py
@@ -146,6 +146,12 @@ class SpectrumViewerWindowModelTest(unittest.TestCase):
         expected_value = (self.model._stack.data.mean() / self.model._normalise_stack.data.mean()) / 2.0
         self.assertAlmostEqual(av_img[0, 0], expected_value, places=7)
 
+    def test_WHEN_normalise_stack_shape_differs_THEN_get_normalized_averaged_image_returns_none(self):
+        self.model.set_stack(ImageStack(np.ones([10, 11, 12])))
+        self.model.set_normalise_stack(ImageStack(np.ones([10, 5, 6])))
+        result = self.model.get_normalized_averaged_image()
+        self.assertIsNone(result)
+
     def test_get_spectrum(self):
         stack, spectrum = self._set_sample_stack()
         roi = SensibleROI(left=0, top=0, right=12, bottom=11)

--- a/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/test/presenter_test.py
@@ -485,6 +485,19 @@ class SpectrumViewerWindowPresenterTest(unittest.TestCase):
         result = self.presenter._normalise_background(sample)
         npt.assert_array_equal(result, np.zeros((3, 3, 3)))
 
+    def test_WHEN_normalised_image_is_none_THEN_averaged_image_used_and_error_set(self):
+        self.view.normalisation_enabled.return_value = True
+        self.presenter.model.get_normalized_averaged_image = mock.Mock(return_value=None)
+        self.presenter.model.get_averaged_image = mock.Mock(return_value=np.zeros((5, 5)))
+        self.presenter.model.normalise_issue = mock.Mock(return_value="Stack shapes must match")
+
+        self.presenter.update_displayed_image()
+
+        self.view.set_normalise_error.assert_called_once_with("Stack shapes must match")
+        self.view.set_image.assert_called_once_with(mock.ANY, autoLevels=True)
+        called_image = self.view.set_image.call_args[0][0]
+        np.testing.assert_array_equal(called_image, np.zeros((5, 5)))
+
     def test_WHEN_build_composite_image_no_sample_THEN_background_is_black(self):
         full_map = np.full((4, 4), np.nan)
         result = self.presenter.build_composite_image(full_map, (0.0, 1.0), opacity=1.0, sample_image=None)


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2597 

### Description

Added a `Mantid Imaging in Research` section within the `Reference` subsection in User docs. The section includes categorised journal articles and PhD thesis that have used and credited Mantid Imaging.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- ...

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] from the source directory, `make build-docs`
- [ ] `cd docs/build/html`
- [ ] `python -m http.server 8000`
- [ ] In a browser of your choosing, navigate to: http://0.0.0.0:8000/developer_docs/how-to-guides/testing.html (localhost:8000 worked for me)
- [ ] Validate that you can see all the instructions and all the links mentioned are correct.

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

