### PR TITLE
Prevent IndexError in spectrum viewer when dataset contains no NaNs

### DIFF
--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -323,21 +323,18 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         queue = self.roi_to_process_queue
         mask = self.image_nan_mask_dict
         roi_name = list(queue.keys())[0]
+        data = mask[roi_name]
         chunk_size = 100
-        if chunk_size > 0:
-            nanInds = np.argwhere(np.isnan(mask[roi_name]))
-            if nanInds.size == 0:
-                # No NaNs found, return safe defaults
-                chunk_start, chunk_end = 0, -1
-            else:
-                chunk_start = int(nanInds[0, 0])
-                if len(nanInds) > chunk_size:
-                    chunk_end = int(nanInds[chunk_size, 0])
-                else:
-                    chunk_end = int(nanInds[-1, 0]) + 1
+        if data is None or data.size == 0:
+            return 0, 0
+        nan_positions = np.flatnonzero(np.isnan(data))
+        if nan_positions.size == 0:
+            return 0, data.shape[0]
+        chunk_start = int(nan_positions[0])
+        if nan_positions.size >= chunk_size:
+            chunk_end = int(nan_positions[chunk_size - 1]) + 1
         else:
-            chunk_start, chunk_end = (0, -1)
-
+            chunk_end = int(nan_positions[-1]) + 1
         return chunk_start, chunk_end
 
     def handle_roi_moved(self) -> None:

--- a/mantidimaging/gui/windows/spectrum_viewer/presenter.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/presenter.py
@@ -326,11 +326,15 @@ class SpectrumViewerWindowPresenter(BasePresenter):
         chunk_size = 100
         if chunk_size > 0:
             nanInds = np.argwhere(np.isnan(mask[roi_name]))
-            chunk_start = int(nanInds[0, 0])
-            if len(nanInds) > chunk_size:
-                chunk_end = int(nanInds[chunk_size, 0])
+            if nanInds.size == 0:
+                # No NaNs found, return safe defaults
+                chunk_start, chunk_end = 0, -1
             else:
-                chunk_end = int(nanInds[-1, 0]) + 1
+                chunk_start = int(nanInds[0, 0])
+                if len(nanInds) > chunk_size:
+                    chunk_end = int(nanInds[chunk_size, 0])
+                else:
+                    chunk_end = int(nanInds[-1, 0]) + 1
         else:
             chunk_start, chunk_end = (0, -1)
 


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3127


### Description

Fixes an IndexError in the Spectrum Viewer caused by attempting to access elements of an empty array when no NaNs are present in the dataset.

Previously, np.argwhere(np.isnan(...)) could return an empty array, and the code would still attempt to access nanInds[0, 0], leading to a crash.

Changes

- Replaced np.argwhere with np.flatnonzero for simpler and safer 1D indexing
- Added a guard for empty or None datasets
- Explicitly handle the case where no NaNs are present by returning the full data range
- Fixed chunk boundary calculation to avoid off-by-one errors
- Removed reliance on ambiguous sentinel values (e.g. -1)
- 