### PR TITLE
fix: handle IndexError in averaged image toggle

### DIFF
--- a/docs/release_notes/next/fix-3116-Main-Window-Toggle-Averaged-Image
+++ b/docs/release_notes/next/fix-3116-Main-Window-Toggle-Averaged-Image
@@ -1,0 +1,1 @@
+#3126: Add stack shape validation checks on stack modification to Spectrum Viewer to resolve shape mismatch Value Errors being raised when stack is normalised in spectrum viewer and cropped in operations window, making the normalisation invalid as stack shapes must be identical.

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -318,9 +318,10 @@ class MIImageView(ImageView, BadDataOverlay, AutoColorMenu):
     def default_roi(self) -> None | list[int]:
         # Recommend an ROI that covers the top left quadrant
         # However set min dimensions to avoid an ROI that is so small it's difficult to work with
-        if self.image_data is None:
+        if self.image_data is None or self.image_data.ndim < 2:
             return None
         min_size = 20
-        roi_width = max(round(self.image_data.shape[2] / 2), min_size)
-        roi_height = max(round(self.image_data.shape[1] / 2), min_size)
+        height, width = self.image_data.shape[-2:]
+        roi_width = max(round(width / 2), min_size)
+        roi_height = max(round(height / 2), min_size)
         return [0, 0, roi_width, roi_height]


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3116

### Description

Handle cases where image data has fewer than 3 dimensions in default_roi by using self.image_data.ndim and self.image_data.shape directly. This prevents IndexError when toggling the averaged image view via the right-click menu 

### Steps To Reproduce

<!--- Please provide detailed steps for reproducing this issue. -->
* Load Tomography sample into MI
* Right click image view >> toggle averaged image
* See CLI logs returning index error

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Unit tests pass locally: `python -m pytest -vs`
- [x] Toggling averaged image view via right-click menu does not raise IndexError in CLI



