### PR TITLE
Operations: Fix Crop Coordinates ROI not updating when switching between stacks

### DIFF
--- a/docs/release_notes/next/fix-3115-Fix_rescale_and_autocrop_in_crop_coordinates_operation
+++ b/docs/release_notes/next/fix-3115-Fix_rescale_and_autocrop_in_crop_coordinates_operation
@@ -1,0 +1,1 @@
+#3115: Add ROI validation for crop coordinates when switching stacks

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -170,6 +170,9 @@ class FiltersWindowPresenter(BasePresenter):
                 if isinstance(widget, DatasetSelectorWidgetView):
                     widget._handle_loaded_datasets_changed()
 
+        if self.view.get_selected_filter() == CROP_COORDINATES and "roi_field" in self.model.filter_widget_kwargs:
+            self.init_roi_field(self.model.filter_widget_kwargs["roi_field"])
+
         self.do_update_previews()
 
     def set_preview_image_index(self, image_idx: int):

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -462,6 +462,29 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.presenter.init_roi_field(mock_roi_field)
         assert_called_once_with(mock_roi_field.setText, "0, 0, 100, 100")
 
+    @mock.patch("mantidimaging.gui.windows.operations.presenter.get_bounding_box")
+    def test_init_roi_field_called_with_auto_bounding_box_on_different_stacks(self, mock_bounding_box):
+        mock_roi_field = mock.Mock()
+
+        first_stack = mock.Mock()
+        first_stack.data = np.ones((2, 201, 201))
+
+        second_stack = mock.Mock()
+        second_stack.data = np.ones((2, 143, 140))
+
+        mock_bounding_box.side_effect = [SensibleROI(0, 0, 100, 100), SensibleROI(0, 0, 80, 70)]
+
+        self.presenter.stack = first_stack
+        self.presenter.init_roi_field(mock_roi_field)
+
+        self.presenter.stack = second_stack
+        self.presenter.init_roi_field(mock_roi_field)
+
+        expected_calls = [mock.call("0, 0, 100, 100"), mock.call("0, 0, 80, 70")]
+        mock_roi_field.setText.assert_has_calls(expected_calls)
+
+        assert mock_bounding_box.call_count == 2
+
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter._do_apply_filter_sync')
     def test_negative_values_found_in_twelve_or_less_ranges(self, do_apply_filter_sync_mock):
         self.presenter.view.safeApply.isChecked.return_value = False

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -17,8 +17,8 @@ from mantidimaging.core.operation_history.const import OPERATION_HISTORY, OPERAT
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.operations import FiltersWindowPresenter
-from mantidimaging.gui.windows.operations.presenter import REPEAT_FLAT_FIELDING_MSG, FLAT_FIELDING, _find_nan_change, \
-    _group_consecutive_values, FLAT_FIELD_REGION
+from mantidimaging.gui.windows.operations.presenter import CROP_COORDINATES, REPEAT_FLAT_FIELDING_MSG, \
+    FLAT_FIELDING ,_find_nan_change, _group_consecutive_values, FLAT_FIELD_REGION
 from mantidimaging.test_helpers.unit_test_helper import assert_called_once_with, generate_images
 from mantidimaging.core.data import ImageStack
 
@@ -462,28 +462,23 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.presenter.init_roi_field(mock_roi_field)
         assert_called_once_with(mock_roi_field.setText, "0, 0, 100, 100")
 
-    @mock.patch("mantidimaging.gui.windows.operations.presenter.get_bounding_box")
-    def test_init_roi_field_called_with_auto_bounding_box_on_different_stacks(self, mock_bounding_box):
+    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter.init_roi_field')
+    def test_set_stack_initialises_roi_for_crop_coordinates(self, mock_init_roi_field):
         mock_roi_field = mock.Mock()
 
-        first_stack = mock.Mock()
-        first_stack.data = np.ones((2, 201, 201))
+        self.view.get_selected_filter.return_value = CROP_COORDINATES
+        self.presenter.model.filter_widget_kwargs = {"roi_field": mock_roi_field}
 
-        second_stack = mock.Mock()
-        second_stack.data = np.ones((2, 143, 140))
+        stack = mock.Mock(
+            name="test_stack",
+            shape=(2, 201, 201),
+            num_images=2,
+            num_sinograms=201,
+        )
+        with mock.patch("mantidimaging.gui.windows.operations.presenter.BlockQtSignals"):
+            self.presenter.set_stack(stack)
 
-        mock_bounding_box.side_effect = [SensibleROI(0, 0, 100, 100), SensibleROI(0, 0, 80, 70)]
-
-        self.presenter.stack = first_stack
-        self.presenter.init_roi_field(mock_roi_field)
-
-        self.presenter.stack = second_stack
-        self.presenter.init_roi_field(mock_roi_field)
-
-        expected_calls = [mock.call("0, 0, 100, 100"), mock.call("0, 0, 80, 70")]
-        mock_roi_field.setText.assert_has_calls(expected_calls)
-
-        assert mock_bounding_box.call_count == 2
+        mock_init_roi_field.assert_called_once_with(mock_roi_field)
 
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter._do_apply_filter_sync')
     def test_negative_values_found_in_twelve_or_less_ranges(self, do_apply_filter_sync_mock):

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -462,19 +462,15 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         self.presenter.init_roi_field(mock_roi_field)
         assert_called_once_with(mock_roi_field.setText, "0, 0, 100, 100")
 
+    @mock.patch("mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter.do_update_previews")
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter.init_roi_field')
-    def test_set_stack_initialises_roi_for_crop_coordinates(self, mock_init_roi_field):
+    def test_set_stack_initialises_roi_for_crop_coordinates(self, mock_init_roi_field, mock_do_update_previews):
         mock_roi_field = mock.Mock()
 
         self.view.get_selected_filter.return_value = CROP_COORDINATES
         self.presenter.model.filter_widget_kwargs = {"roi_field": mock_roi_field}
 
-        stack = mock.Mock(
-            name="test_stack",
-            shape=(2, 201, 201),
-            num_images=2,
-            num_sinograms=201,
-        )
+        stack = mock.Mock(num_images=2)
         with mock.patch("mantidimaging.gui.windows.operations.presenter.BlockQtSignals"):
             self.presenter.set_stack(stack)
 


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3115 

### Description

- Added validation within `set_stacks` to refresh the ROI field using the current stack if the currently selected filter is Crop Coordinates, and the ROI field exists.
- Added a test for  `roi_field_called_with_auto_bounding_box_on_different_stacks`

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- I have verified the test `roi_field_called_with_auto_bounding_box_on_different_stacks` passes locally. Tested using the debugger as well to check if the variables were returning expected results.

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
#### ROI within FoV steps:
- [ ] Load two datasets, one with a larger (x, y) axis than the other.
- [ ] Open the Crop coordinates operation and select the larger stack
- [ ] Resize the ROI to be larger than the smaller stack and click okay, but don't apply the change
- [ ] Using the stack selector, select the smaller sample
- [ ] Open up the ROI editor view
- [ ] The ROI should be within the FoV of the imagestack 

#### Auto-crop is re-activated when switching between stacks when multiple datasets are loaded:
- [ ] Load two datasets, one with a larger (x, y) axis than the other.
- [ ] Open the Crop coordinates operation and open ROI editor - autocrop will work as expected
- [ ] Using the stack selector, select the smaller sample
- [ ] Open up the ROI editor view and confirm that the autocrop updates correctly


### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

