### PR TITLE
Actions: Add timeout for build/publish package step

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -143,6 +143,7 @@ jobs:
         with:
           label: unstable
           token: ${{ secrets.ANACONDA_API_TOKEN_MANTIDIMAGING }}
+        timeout-minutes: 120
 
       - name: Show disk space at end
         if: ${{ !cancelled() }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -140,6 +140,7 @@ jobs:
         with:
           label: unstable
           token: ${{ secrets.ANACONDA_API_TOKEN_MANTIDIMAGING }}
+        timeout-minutes: 120
 
       - name: Show disk space at end
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Issue work on #3131 

### Description
This does not solve the issue, but is still useful.

If the package build hangs, then timeout within the job at 120 minutes, rather than waiting for to hit the GHA timeout at 6 hours. This means we logs get recorded properly, and avoids wasting time.

A good build should take about 10 minutes. But from local testing on Windows I have seen it take 45. 120 minutes should be enough that it succeeds if it just being slow.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- ...

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] ...

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

