### PR TITLE
Update Miniconda actions to newer major versions for Node 24

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -42,12 +42,13 @@ jobs:
           key: ${{runner.os}}-condapkg-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml')}}
 
       - name: Setup Miniforge
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           miniforge-version: latest
           activate-environment: mantidimaging-dev
-          auto-activate-base: false
+          auto-activate: false
           use-mamba: true
+          conda-remove-defaults: true
 
       - name: Cache Miniforge environment
         uses: actions/cache@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,12 +38,13 @@ jobs:
           key: ${{runner.os}}-condapkg-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml')}}
 
       - name: Setup Miniforge
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           miniforge-version: latest
           activate-environment: mantidimaging-dev
-          auto-activate-base: false
+          auto-activate: false
           use-mamba: true
+          conda-remove-defaults: true
 
       - name: Cache Miniforge environment
         uses: actions/cache@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,12 +44,13 @@ jobs:
           key: ${{runner.os}}-condapkg-${{env.CACHE_NUMBER}}-${{steps.get-date.outputs.date}}-${{hashFiles('environment-dev.yml','conda/meta.yaml')}}
 
       - name: Setup Miniforge
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           miniforge-version: latest
           activate-environment: mantidimaging-dev
-          auto-activate-base: false
+          auto-activate: false
           use-mamba: true
+          conda-remove-defaults: true
 
       - name: Cache Miniforge environment
         uses: actions/cache@v4

--- a/docs/release_notes/next/dev-3149-Update_Miniconda_and_update_deprecated_fields
+++ b/docs/release_notes/next/dev-3149-Update_Miniconda_and_update_deprecated_fields
@@ -1,0 +1,1 @@
+#3149: Update Miniconda and update deprecated fields in the workflow yaml files. This is to ensure that the latest version of Miniconda is used and to remove any deprecated fields that may cause issues in the future which presently output warnings in workflows


### PR DESCRIPTION
Update Manjor versions for Miniconda for Node 24 readiness, replace deprecated inout  with  to remove depreciation warnings and add  in Miniconda setup to stop implicit defaults-channel warnings and keep channel selection explicit

<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3149 

### Description

<!-- Add a description of the changes made. -->

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- All warnings other than `Node.js 20 actions are deprecated.` on Job completion are no longer raised.

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] All warnings other than `Node.js 20 actions are deprecated.` on Job completion are no longer raised.

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

