### PR TITLE
Reconstruction Window: Remove maximum projection angle field

### DIFF
--- a/mantidimaging/core/utility/data_containers.py
+++ b/mantidimaging/core/utility/data_containers.py
@@ -103,7 +103,6 @@ class ReconstructionParameters:
     alpha: float = 0.0
     gamma: float = 1.0
     non_negative: bool = False
-    max_projection_angle: float = 360.0
     beam_hardening_coefs: list[float] | None = None
     stochastic: bool = False
     projections_per_subset: int = 50

--- a/mantidimaging/gui/ui/recon_window.ui
+++ b/mantidimaging/gui/ui/recon_window.ui
@@ -646,13 +646,6 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="maxProjAngleLabel">
-                    <property name="text">
-                     <string>Maximum projection angle</string>
-                    </property>
-                   </widget>
-                  </item>
                   <item row="1" column="0">
                    <widget class="QLabel" name="algorithmNameLabel">
                     <property name="text">
@@ -776,16 +769,6 @@
                    <widget class="QLabel" name="stochasticLabel">
                     <property name="text">
                      <string>Stochastic</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
-                   <widget class="QDoubleSpinBox" name="maxProjAngleSpinBox">
-                    <property name="maximum">
-                     <double>9999.000000000000000</double>
-                    </property>
-                    <property name="value">
-                     <double>360.000000000000000</double>
                     </property>
                    </widget>
                   </item>

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -178,9 +178,6 @@ class ReconstructWindowViewTest(unittest.TestCase):
     def test_slope_property(self):
         self.assertEqual(self.view.slope, 0)
 
-    def test_max_proj_angle(self):
-        self.assertEqual(self.view.max_proj_angle, 360)
-
     def test_algorithm_name(self):
         self.assertIn(self.view.algorithm_name, ["gridrec", "FBP_CUDA"])
 

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -68,7 +68,7 @@ class ReconstructWindowView(BaseMainWindowView):
 
     reconTab: QWidget
 
-    maxProjAngleSpinBox: QDoubleSpinBox
+    #maxProjAngleSpinBox: QDoubleSpinBox
     algorithmNameComboBox: QComboBox
     filterNameComboBox: QComboBox
     numIterSpinBox: QSpinBox
@@ -233,8 +233,6 @@ class ReconstructWindowView(BaseMainWindowView):
         self.stackSelector.stack_selected_uuid.connect(lambda: self.presenter.notify(PresN.SET_CURRENT_STACK))
         self.stackSelector.select_eligible_stack()
 
-        self.maxProjAngleSpinBox.valueChanged.connect(
-            lambda: self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE))  # type: ignore
         self.algorithmNameComboBox.currentTextChanged.connect(
             lambda: self.presenter.notify(PresN.ALGORITHM_CHANGED))  # type: ignore
         self.presenter.notify(PresN.ALGORITHM_CHANGED)
@@ -419,9 +417,9 @@ class ReconstructWindowView(BaseMainWindowView):
     def slope(self, value: float) -> None:
         self.resultSlopeSpinBox.setValue(value)
 
-    @property
-    def max_proj_angle(self) -> float:
-        return self.maxProjAngleSpinBox.value()
+    # @property
+    # def max_proj_angle(self) -> float:
+    #     return self.maxProjAngleSpinBox.value()
 
     @property
     def algorithm_name(self) -> str:
@@ -502,7 +500,6 @@ class ReconstructWindowView(BaseMainWindowView):
                                         non_negative=self.non_negative,
                                         stochastic=self.stochastic,
                                         projections_per_subset=self.projections_per_subset,
-                                        max_projection_angle=self.max_proj_angle,
                                         regularisation_percent=self.regularisation_percent,
                                         regulariser=self.regulariser,
                                         beam_hardening_coefs=self.beam_hardening_coefs)

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -68,7 +68,6 @@ class ReconstructWindowView(BaseMainWindowView):
 
     reconTab: QWidget
 
-    #maxProjAngleSpinBox: QDoubleSpinBox
     algorithmNameComboBox: QComboBox
     filterNameComboBox: QComboBox
     numIterSpinBox: QSpinBox
@@ -416,10 +415,6 @@ class ReconstructWindowView(BaseMainWindowView):
     @slope.setter
     def slope(self, value: float) -> None:
         self.resultSlopeSpinBox.setValue(value)
-
-    # @property
-    # def max_proj_angle(self) -> float:
-    #     return self.maxProjAngleSpinBox.value()
 
     @property
     def algorithm_name(self) -> str:


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #1851 

### Description

Removed the `Maximum projection angle` field from the reconstruction window along with any of its references. This is not required anymore as now there is no case where the value is used. If there is a geometry that is used instead of the value, if there is not a geometry then recon won't work.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- I have manually tested with datasets with and without geometry to see if removing `Maximum projection angle` had an impact  on them in the reconstruction window.

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Open Mantid Imaging and navigate to the reconstruction window
- [ ] Confirm that the reconstruction window does not have the `Maximum projection angle` field.

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

