### PR TITLE
System tests for Spectrum Viewer Fitting

### DIFF
--- a/docs/release_notes/next/feature-3080-System-tests-for-Spectrum-Viewer-Fitting
+++ b/docs/release_notes/next/feature-3080-System-tests-for-Spectrum-Viewer-Fitting
@@ -1,0 +1,1 @@
+#3080: Added System tests for Spectrum Viewer Fitting

--- a/mantidimaging/gui/test/gui_system_spectrum_test.py
+++ b/mantidimaging/gui/test/gui_system_spectrum_test.py
@@ -255,3 +255,49 @@ class TestGuiSpectrumViewer(GuiSystemBase):
         self.spectrum_window.export_display_tabs.setCurrentIndex(1)
         spec_stack = self.main_window.get_stack(self.spectrum_window.presenter.current_stack_uuid)
         assert_array_equal(spec_stack.data.mean(axis=0), self.spectrum_window._export_image_widget.image_data)
+
+    def test_bragg_edge_workflow(self):
+        QTest.mouseClick(self.spectrum_window.roi_form.addBtn, Qt.MouseButton.LeftButton)
+        QTest.qWait(SHORT_DELAY)
+        roi_name = 'roi_1'
+        self.assertIn(roi_name, self.spectrum_window.spectrum_widget.roi_dict)
+        self.spectrum_window.formTabs.setCurrentIndex(1)
+        QTest.qWait(SHORT_DELAY)
+        QTest.mouseClick(self.spectrum_window.fittingForm.fitting_param_form.from_roi_button, Qt.MouseButton.LeftButton)
+        QTest.mouseClick(self.spectrum_window.fittingForm.run_fit_button, Qt.MouseButton.LeftButton)
+        QTest.qWait(SHORT_DELAY)
+        QTest.mouseClick(self.spectrum_window.exportSettingsWidget.fitAllButton, Qt.MouseButton.LeftButton)
+        wait_until(lambda: self.spectrum_window.exportDataTableWidget.model.rowCount() >= 1)
+        self.assertGreaterEqual(self.spectrum_window.exportDataTableWidget.model.rowCount(), 1)
+        fit_results = self.spectrum_window.presenter.model.get_fit_results()
+        self.assertIsNotNone(fit_results)
+        self.assertTrue(any(name == roi_name for name, _ in fit_results))
+        roi_fit_result = next(result for name, result in fit_results if name == roi_name)
+        param_names = self.spectrum_window.presenter.model.fitting_engine.get_parameter_names()
+        self.assertTrue(param_names)
+        self.assertTrue(all(param_name in roi_fit_result.params for param_name in param_names))
+        self.assertTrue(any(np.isfinite(roi_fit_result.params[param_name]) for param_name in param_names))
+
+    def test_fit_multiple_rois(self):
+        roi_names = []
+        for i in range(1, 4):
+            QTest.mouseClick(self.spectrum_window.roi_form.addBtn, Qt.MouseButton.LeftButton)
+            QTest.qWait(SHORT_DELAY)
+            roi_names.append(f'roi_{i}')
+            self.assertIn(f'roi_{i}', self.spectrum_window.spectrum_widget.roi_dict)
+        self.spectrum_window.formTabs.setCurrentIndex(1)
+        QTest.qWait(SHORT_DELAY)
+        QTest.mouseClick(self.spectrum_window.exportSettingsWidget.fitAllButton, Qt.MouseButton.LeftButton)
+        wait_until(lambda: self.spectrum_window.exportDataTableWidget.model.rowCount() >= len(roi_names))
+        self.assertGreaterEqual(self.spectrum_window.exportDataTableWidget.model.rowCount(), len(roi_names))
+        fit_results = self.spectrum_window.presenter.model.get_fit_results()
+        self.assertIsNotNone(fit_results)
+        fit_result_names = [name for name, _ in fit_results]
+        for roi_name in roi_names:
+            self.assertIn(roi_name, fit_result_names)
+        export_names = [
+            self.spectrum_window.exportDataTableWidget.model.item(row, 0).text()
+            for row in range(self.spectrum_window.exportDataTableWidget.model.rowCount())
+        ]
+        for roi_name in roi_names:
+            self.assertIn(roi_name, export_names)


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes  #3080

### Description

Added new system tests for the Spectrum Viewer:

test_fit_multiple_rois: Verifies that fitting works correctly when multiple ROIs are added, and that results are present for each ROI.
test_bragg_edge_workflow: Simulates the Bragg edge workflow, including ROI creation, fitting, and parameter map generation.


### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ]  New system tests for multiple ROIs and Bragg edge workflow are present and passing.

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

