### PR TITLE
3007 distance units for geometry

### DIFF
--- a/mantidimaging/core/data/geometry.py
+++ b/mantidimaging/core/data/geometry.py
@@ -46,6 +46,9 @@ class Geometry(AcquisitionGeometry):
         """
         super().__init__()
 
+        self._source_position_mm: float = 0.0
+        self._detector_position_mm: float = 0.0
+
         if type == GeometryType.PARALLEL3D:
             parallel_3d = self.create_Parallel3D(*args, units=units, **kwargs)
             self.config = parallel_3d.config
@@ -59,6 +62,7 @@ class Geometry(AcquisitionGeometry):
 
         self.set_panel(num_pixels=num_pixels, pixel_size=pixel_size)
         self.set_angles(angles=angles, angle_unit=angle_unit)
+        self.set_source_detector_positions(source_position[1], detector_position[1])
 
     def set_geometry_from_cor_tilt(self, cor: ScalarCoR, tilt: float) -> None:
         """
@@ -150,23 +154,31 @@ class Geometry(AcquisitionGeometry):
         else:
             return GeometryType.CONE3D
 
-    def set_source_detector_positions(self, source_pos: float, detector_pos: float) -> None:
-        if source_pos != 0 and self.type == GeometryType.CONE3D:
-            self.config.system.source.position = [0, source_pos, 0]
+    def set_source_detector_positions(self, source_pos_mm: float, detector_pos_mm: float) -> None:
+        self._source_position_mm = source_pos_mm
+        self._detector_position_mm = detector_pos_mm
+        pixel_size_mm = self.config.panel.pixel_size[0]
+        source_pos_px = source_pos_mm / pixel_size_mm
+        detector_pos_px = detector_pos_mm / pixel_size_mm
+        if source_pos_px != 0 and self.type == GeometryType.CONE3D:
+            self.config.system.source.position = [0, source_pos_px, 0]
+        if detector_pos_px != 0 and self.type == GeometryType.CONE3D:
+            self.config.system.detector.position = [0, detector_pos_px, 0]
 
-        if detector_pos != 0 and self.type == GeometryType.CONE3D:
-            self.config.system.detector.position = [0, detector_pos, 0]
+    @property
+    def source_position_mm(self) -> float:
+        return self._source_position_mm
+
+    @property
+    def detector_position_mm(self) -> float:
+        return self._detector_position_mm
 
     @property
     def source_position(self) -> float:
-        source_pos = 0
-        if self.type == GeometryType.CONE3D:
-            source_pos = self.config.system.source.position[1]
-        return source_pos
+        pixel_size_mm = self.config.panel.pixel_size[0]
+        return self._source_position_mm / pixel_size_mm
 
     @property
     def detector_position(self) -> float:
-        detector_pos = 0
-        if self.type == GeometryType.CONE3D:
-            detector_pos = self.config.system.detector.position[1]
-        return detector_pos
+        pixel_size_mm = self.config.panel.pixel_size[0]
+        return self._detector_position_mm / pixel_size_mm

--- a/mantidimaging/core/utility/test/unit_conversion_test.py
+++ b/mantidimaging/core/utility/test/unit_conversion_test.py
@@ -52,3 +52,13 @@ class UnitConversionTest(unittest.TestCase):
     def test_WHEN_tof_converted_to_us_THEN_us_data_returned(self):
         us_data = unit_conversion.UnitConversion(self.tof_data).tof_seconds_to_us()
         assert_array_almost_equal(us_data, np.array([1000000., 2000000., 3000000., 5000000., 8000000., 9000000.]))
+
+    def test_WHEN_convert_distance_from_mm_to_m_THEN_returns_expected_value(self):
+        self.assertEqual(unit_conversion.convert_distance(1500.0, "mm", "m"), 1.5)
+
+    def test_WHEN_convert_distance_from_m_to_mm_THEN_returns_expected_value(self):
+        self.assertEqual(unit_conversion.convert_distance(2.0, "m", "mm"), 2000.0)
+
+    def test_WHEN_convert_distance_with_unknown_unit_THEN_raises_error(self):
+        with self.assertRaises(ValueError):
+            unit_conversion.convert_distance(1.0, "cm", "mm")

--- a/mantidimaging/core/utility/unit_conversion.py
+++ b/mantidimaging/core/utility/unit_conversion.py
@@ -5,6 +5,21 @@ from __future__ import annotations
 import numpy as np
 
 
+def convert_distance(value: float, from_unit: str, to_unit: str) -> float:
+    conversion_factors = {
+        "mm": 1.0,
+        "m": 1000.0,
+    }
+
+    if from_unit not in conversion_factors:
+        raise ValueError(f"Unknown unit: {from_unit}")
+    if to_unit not in conversion_factors:
+        raise ValueError(f"Unknown unit: {to_unit}")
+
+    value_mm = value * conversion_factors[from_unit]
+    return value_mm / conversion_factors[to_unit]
+
+
 class UnitConversion:
     # target_to_camera_dist = 56 m taken from https://scripts.iucr.org/cgi-bin/paper?S1600576719001730
     neutron_mass: float = 1.674927211e-27  # [kg]

--- a/mantidimaging/gui/windows/geometry/presenter.py
+++ b/mantidimaging/gui/windows/geometry/presenter.py
@@ -12,6 +12,7 @@ from mantidimaging.core.data import ImageStack
 from mantidimaging.core.data.geometry import GeometryType
 from mantidimaging.core.data.imagestack import StackNotFoundError
 from mantidimaging.core.utility.data_containers import ScalarCoR, ProjectionAngles
+from mantidimaging.core.utility.unit_conversion import convert_distance
 from mantidimaging.gui.mvp_base import BasePresenter
 from mantidimaging.gui.windows.geometry.model import GeometryWindowModel
 
@@ -82,12 +83,18 @@ class GeometryWindowPresenter(BasePresenter):
         mi_cor = stack.geometry.cor.value
         mi_tilt = stack.geometry.tilt
 
+        # Geometry distances are stored internally in mm
+        src_unit = self.view.source_position_unit
+        det_unit = self.view.detector_position_unit
+        src_val = convert_distance(stack.geometry.source_position_mm, "mm", src_unit)
+        det_val = convert_distance(stack.geometry.detector_position_mm, "mm", det_unit)
+
         self.view.type = geometry_type
         self.view.angles = angle_range
         self.view.rotation_axis = mi_cor
         self.view.tilt = mi_tilt
-        self.view.source_position = stack.geometry.source_position
-        self.view.detector_position = stack.geometry.detector_position
+        self.view.source_position = src_val
+        self.view.detector_position = det_val
 
     def set_default_new_parameters(self, stack: ImageStack) -> None:
         default_cor = stack.width / 2
@@ -96,22 +103,23 @@ class GeometryWindowPresenter(BasePresenter):
         self.view.new_tilt = .0
         self.view.new_min_angle = 0
         self.view.new_max_angle = 360
-        # Source and detector positions cannot be 0
-        self.view.new_source_position = -1.
-        self.view.new_detector_position = 1.
+        self.view.new_source_position = -100.
+        self.view.new_detector_position = 100.
 
     def handle_parameter_updates(self) -> None:
         updated_cor = ScalarCoR(self.view.rotation_axis)
         updated_tilt = self.view.tilt
 
-        updated_source_pos = self.view.source_position
-        updated_detector_pos = self.view.detector_position
-
         stack = self._get_current_stack_with_assert()
         assert stack.geometry is not None
 
+        src_unit = self.view.source_position_unit
+        det_unit = self.view.detector_position_unit
+        src_val_mm = convert_distance(self.view.source_position, src_unit, "mm")
+        det_val_mm = convert_distance(self.view.detector_position, det_unit, "mm")
+
         stack.geometry.set_geometry_from_cor_tilt(updated_cor, updated_tilt)
-        stack.geometry.set_source_detector_positions(updated_source_pos, updated_detector_pos)
+        stack.geometry.set_source_detector_positions(src_val_mm, det_val_mm)
 
         self.refresh_plot(stack)
         # Notify main window that stack was modified (so recon window can update COR/Tilt)
@@ -136,6 +144,12 @@ class GeometryWindowPresenter(BasePresenter):
         new_source_position = self.view.new_source_position
         new_detector_position = self.view.new_detector_position
 
+        # Convert source/detector positions from selected units to mm
+        src_unit = self.view.new_source_position_unit
+        det_unit = self.view.new_detector_position_unit
+        src_val_mm = convert_distance(new_source_position, src_unit, "mm")
+        det_val_mm = convert_distance(new_detector_position, det_unit, "mm")
+
         new_angles = ProjectionAngles(
             np.linspace(np.deg2rad(new_min_angle), np.deg2rad(new_max_angle), stack.num_projections))
 
@@ -146,7 +160,7 @@ class GeometryWindowPresenter(BasePresenter):
         stack.create_geometry(new_angles, geometry_type)
         assert stack.geometry is not None
         stack.geometry.set_geometry_from_cor_tilt(new_cor, new_tilt)
-        stack.geometry.set_source_detector_positions(new_source_position, new_detector_position)
+        stack.geometry.set_source_detector_positions(src_val_mm, det_val_mm)
 
         self.main_window.presenter.add_projection_angles_to_sample(stack.id, new_angles)
 

--- a/mantidimaging/gui/windows/geometry/test/presenter_test.py
+++ b/mantidimaging/gui/windows/geometry/test/presenter_test.py
@@ -42,6 +42,10 @@ class GeometryWindowPresenterTest(unittest.TestCase):
         self.view.new_max_angle = 0
         self.view.current_stack = self.uuid
         self.view.conversion_type = "Parallel 3D"
+        self.view.source_position_unit = "mm"
+        self.view.detector_position_unit = "mm"
+        self.view.new_source_position_unit = "mm"
+        self.view.new_detector_position_unit = "mm"
 
     def reset_new_stack(self):
         self.data = ImageStack(data=np.ndarray(shape=(128, 10, 128), dtype=np.float32))

--- a/mantidimaging/gui/windows/geometry/test/presenter_test.py
+++ b/mantidimaging/gui/windows/geometry/test/presenter_test.py
@@ -87,3 +87,37 @@ class GeometryWindowPresenterTest(unittest.TestCase):
         self.presenter.handle_parameter_updates()
         self.assertAlmostEqual(self.data.geometry.cor.value, test_cor, places=10)
         self.assertAlmostEqual(self.data.geometry.tilt, test_tilt, places=10)
+
+    def test_update_parameters_converts_internal_mm_to_displayed_m(self):
+        self.presenter.handle_create_new_geometry()
+        assert self.data.geometry is not None
+        self.data.geometry.set_source_detector_positions(-1500.0, 2500.0)
+        self.view.source_position_unit = "m"
+        self.view.detector_position_unit = "m"
+        self.presenter.update_parameters(self.data)
+        self.assertEqual(self.view.source_position, -1.5)
+        self.assertEqual(self.view.detector_position, 2.5)
+
+    def test_handle_parameter_updates_converts_displayed_m_to_internal_mm(self):
+        self.presenter.handle_create_new_geometry()
+        assert self.data.geometry is not None
+        self.view.source_position_unit = "m"
+        self.view.detector_position_unit = "m"
+        self.view.source_position = -1.25
+        self.view.detector_position = 3.75
+        self.presenter.handle_parameter_updates()
+        self.assertEqual(self.data.geometry.source_position_mm, -1250.0)
+        self.assertEqual(self.data.geometry.detector_position_mm, 3750.0)
+        self.presenter.update_parameters(self.data)
+        self.assertEqual(self.view.source_position, -1.25)
+        self.assertEqual(self.view.detector_position, 3.75)
+
+    def test_create_new_geometry_converts_m_inputs_to_internal_mm(self):
+        self.view.new_source_position_unit = "m"
+        self.view.new_detector_position_unit = "m"
+        self.view.new_source_position = -2.0
+        self.view.new_detector_position = 4.0
+        self.presenter.handle_create_new_geometry()
+        assert self.data.geometry is not None
+        self.assertEqual(self.data.geometry.source_position_mm, -2000.0)
+        self.assertEqual(self.data.geometry.detector_position_mm, 4000.0)

--- a/mantidimaging/gui/windows/geometry/view.py
+++ b/mantidimaging/gui/windows/geometry/view.py
@@ -438,3 +438,43 @@ class GeometryWindowView(BaseMainWindowView):
     @property
     def conversion_type(self) -> str:
         return self.conversionTypeSelector.currentText()
+
+    @property
+    def source_position_unit(self) -> str:
+        return self.sourcePosUnitSelector.currentText()
+
+    @source_position_unit.setter
+    def source_position_unit(self, value: str) -> None:
+        idx = self.sourcePosUnitSelector.findText(value)
+        if idx != -1:
+            self.sourcePosUnitSelector.setCurrentIndex(idx)
+
+    @property
+    def detector_position_unit(self) -> str:
+        return self.detectorPosUnitSelector.currentText()
+
+    @detector_position_unit.setter
+    def detector_position_unit(self, value: str) -> None:
+        idx = self.detectorPosUnitSelector.findText(value)
+        if idx != -1:
+            self.detectorPosUnitSelector.setCurrentIndex(idx)
+
+    @property
+    def new_source_position_unit(self) -> str:
+        return self.newSourcePosUnitSelector.currentText()
+
+    @new_source_position_unit.setter
+    def new_source_position_unit(self, value: str) -> None:
+        idx = self.newSourcePosUnitSelector.findText(value)
+        if idx != -1:
+            self.newSourcePosUnitSelector.setCurrentIndex(idx)
+
+    @property
+    def new_detector_position_unit(self) -> str:
+        return self.newDetectorPosUnitSelector.currentText()
+
+    @new_detector_position_unit.setter
+    def new_detector_position_unit(self, value: str) -> None:
+        idx = self.newDetectorPosUnitSelector.findText(value)
+        if idx != -1:
+            self.newDetectorPosUnitSelector.setCurrentIndex(idx)

--- a/mantidimaging/gui/windows/geometry/view.py
+++ b/mantidimaging/gui/windows/geometry/view.py
@@ -87,6 +87,14 @@ class GeometryWindowView(BaseMainWindowView):
         self.conversionTypeSelector = QComboBox()
         self.convertGeometryButton = QPushButton("Convert")
 
+        # Unit selectors for geometry data display
+        self.pixelSizeUnitSelector = QComboBox()
+        self.pixelSizeUnitSelector.addItems(["pixels", "mm", "m"])
+        self.sourcePosUnitSelector = QComboBox()
+        self.sourcePosUnitSelector.addItems(["pixels", "mm", "m"])
+        self.detectorPosUnitSelector = QComboBox()
+        self.detectorPosUnitSelector.addItems(["pixels", "mm", "m"])
+
         # New Geometry page
 
         self.geomTypeSelector = QComboBox()
@@ -98,6 +106,14 @@ class GeometryWindowView(BaseMainWindowView):
         self.newSourcePosBox = CustomRangeSpinBox()
         self.newDetectorPosBox = CustomRangeSpinBox()
         self.createGeometryButton = QPushButton("Create Geometry")
+
+        # Unit selectors for new geometry
+        self.newPixelSizeUnitSelector = QComboBox()
+        self.newPixelSizeUnitSelector.addItems(["pixels", "mm", "m"])
+        self.newSourcePosUnitSelector = QComboBox()
+        self.newSourcePosUnitSelector.addItems(["pixels", "mm", "m"])
+        self.newDetectorPosUnitSelector = QComboBox()
+        self.newDetectorPosUnitSelector.addItems(["pixels", "mm", "m"])
 
         self.figureCanvas = FigureCanvas()
 
@@ -154,8 +170,22 @@ class GeometryWindowView(BaseMainWindowView):
         data_display_group_layout.addRow(QLabel("Angles:"), self.angleDisplay)
         data_display_group_layout.addRow(QLabel("COR:"), self.corSpinBox)
         data_display_group_layout.addRow(QLabel("Tilt:"), self.tiltSpinBox)
-        data_display_group_layout.addRow(QLabel("Source Pos:"), self.sourcePosBox)
-        data_display_group_layout.addRow(QLabel("Detector Pos:"), self.detectorPosBox)
+
+        # Source position with unit selector
+        source_pos_widget = QWidget()
+        source_pos_layout = QHBoxLayout(source_pos_widget)
+        source_pos_layout.setContentsMargins(0, 0, 0, 0)
+        source_pos_layout.addWidget(self.sourcePosBox)
+        source_pos_layout.addWidget(self.sourcePosUnitSelector)
+        data_display_group_layout.addRow(QLabel("Source Pos:"), source_pos_widget)
+
+        # Detector position with unit selector
+        detector_pos_widget = QWidget()
+        detector_pos_layout = QHBoxLayout(detector_pos_widget)
+        detector_pos_layout.setContentsMargins(0, 0, 0, 0)
+        detector_pos_layout.addWidget(self.detectorPosBox)
+        detector_pos_layout.addWidget(self.detectorPosUnitSelector)
+        data_display_group_layout.addRow(QLabel("Detector Pos:"), detector_pos_widget)
 
         self.deleteGeometryButton = QPushButton("Delete Geometry")
         data_display_group_layout.addRow(self.deleteGeometryButton)
@@ -221,8 +251,22 @@ class GeometryWindowView(BaseMainWindowView):
         new_params_layout.addRow(QLabel(""), self.loadAnglesButton)
         new_params_layout.addRow(QLabel("COR:"), self.newCorSpinBox)
         new_params_layout.addRow(QLabel("Tilt:"), self.newTiltSpinBox)
-        new_params_layout.addRow(QLabel("Source Position:"), self.newSourcePosBox)
-        new_params_layout.addRow(QLabel("Detector Position:"), self.newDetectorPosBox)
+
+        # Source position with unit selector
+        new_source_pos_widget = QWidget()
+        new_source_pos_layout = QHBoxLayout(new_source_pos_widget)
+        new_source_pos_layout.setContentsMargins(0, 0, 0, 0)
+        new_source_pos_layout.addWidget(self.newSourcePosBox)
+        new_source_pos_layout.addWidget(self.newSourcePosUnitSelector)
+        new_params_layout.addRow(QLabel("Source Position:"), new_source_pos_widget)
+
+        # Detector position with unit selector
+        new_detector_pos_widget = QWidget()
+        new_detector_pos_layout = QHBoxLayout(new_detector_pos_widget)
+        new_detector_pos_layout.setContentsMargins(0, 0, 0, 0)
+        new_detector_pos_layout.addWidget(self.newDetectorPosBox)
+        new_detector_pos_layout.addWidget(self.newDetectorPosUnitSelector)
+        new_params_layout.addRow(QLabel("Detector Position:"), new_detector_pos_widget)
 
         return new_params_group
 

--- a/mantidimaging/gui/windows/geometry/view.py
+++ b/mantidimaging/gui/windows/geometry/view.py
@@ -38,6 +38,7 @@ else:
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 
 from mantidimaging.gui.mvp_base import BaseMainWindowView
+from mantidimaging.core.utility.unit_conversion import convert_distance
 from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
 from mantidimaging.gui.windows.geometry.presenter import GeometryWindowPresenter
 
@@ -88,15 +89,14 @@ class GeometryWindowView(BaseMainWindowView):
         self.convertGeometryButton = QPushButton("Convert")
 
         # Unit selectors for geometry data display
-        self.pixelSizeUnitSelector = QComboBox()
-        self.pixelSizeUnitSelector.addItems(["pixels", "mm", "m"])
         self.sourcePosUnitSelector = QComboBox()
-        self.sourcePosUnitSelector.addItems(["pixels", "mm", "m"])
+        self.sourcePosUnitSelector.addItems(["mm", "m"])
         self.detectorPosUnitSelector = QComboBox()
-        self.detectorPosUnitSelector.addItems(["pixels", "mm", "m"])
+        self.detectorPosUnitSelector.addItems(["mm", "m"])
+        self.lastSourcePositionUnit = "mm"
+        self.lastDetectorPositionUnit = "mm"
 
         # New Geometry page
-
         self.geomTypeSelector = QComboBox()
         self.minAngleSpinBox = CustomRangeSpinBox(-360, 360)
         self.maxAngleSpinBox = CustomRangeSpinBox(-360, 360)
@@ -108,13 +108,10 @@ class GeometryWindowView(BaseMainWindowView):
         self.createGeometryButton = QPushButton("Create Geometry")
 
         # Unit selectors for new geometry
-        self.newPixelSizeUnitSelector = QComboBox()
-        self.newPixelSizeUnitSelector.addItems(["pixels", "mm", "m"])
         self.newSourcePosUnitSelector = QComboBox()
-        self.newSourcePosUnitSelector.addItems(["pixels", "mm", "m"])
+        self.newSourcePosUnitSelector.addItems(["mm", "m"])
         self.newDetectorPosUnitSelector = QComboBox()
-        self.newDetectorPosUnitSelector.addItems(["pixels", "mm", "m"])
-
+        self.newDetectorPosUnitSelector.addItems(["mm", "m"])
         self.figureCanvas = FigureCanvas()
 
     def _init_layout(self) -> None:
@@ -125,6 +122,25 @@ class GeometryWindowView(BaseMainWindowView):
         central_layout.addWidget(self._build_plot_visualiser())
 
         self.setCentralWidget(central_container)
+
+    def _on_unit_selector_changed(self):
+        if not self.presenter:
+            return
+        stack = self.presenter._get_current_stack_with_assert()
+        if not stack or not stack.geometry:
+            return
+        new_src_unit = self.source_position_unit
+        src_val_new_unit = convert_distance(self.source_position, self.lastSourcePositionUnit, new_src_unit)
+        self.sourcePosBox.blockSignals(True)
+        self.source_position = src_val_new_unit
+        self.sourcePosBox.blockSignals(False)
+        self.lastSourcePositionUnit = new_src_unit
+        new_det_unit = self.detector_position_unit
+        det_val_new_unit = convert_distance(self.detector_position, self.lastDetectorPositionUnit, new_det_unit)
+        self.detectorPosBox.blockSignals(True)
+        self.detector_position = det_val_new_unit
+        self.detectorPosBox.blockSignals(False)
+        self.lastDetectorPositionUnit = new_det_unit
 
     def _build_left_pane(self) -> QWidget:
         left_container = QWidget()
@@ -145,9 +161,8 @@ class GeometryWindowView(BaseMainWindowView):
 
     def _build_geometry_pages_widget(self) -> QWidget:
         self.geometryPagesWidget.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
-
-        self.geometryPagesWidget.addWidget(self._build_geometry_data_display_page())  # page 0 (Geometry exists)
-        self.geometryPagesWidget.addWidget(self._build_new_geometry_page())  # page 1 (Geometry doesn't exist)
+        self.geometryPagesWidget.addWidget(self._build_geometry_data_display_page())
+        self.geometryPagesWidget.addWidget(self._build_new_geometry_page())
 
         return self.geometryPagesWidget
 
@@ -305,6 +320,8 @@ class GeometryWindowView(BaseMainWindowView):
         self.convertGeometryButton.clicked.connect(self.presenter.handle_convert_geometry)
 
         self.deleteGeometryButton.clicked.connect(self.presenter.handle_delete_geometry)
+        self.sourcePosUnitSelector.currentIndexChanged.connect(self._on_unit_selector_changed)
+        self.detectorPosUnitSelector.currentIndexChanged.connect(self._on_unit_selector_changed)
 
     def set_widget_stack_page(self, index: int) -> None:
         self.geometryPagesWidget.setCurrentIndex(index)


### PR DESCRIPTION
## Issue
Closes #3007

### Description

Adds SI unit support for geometry source and detector distances.

Changes include:
- Replacing pixel-based UI distances with `mm` and `m`
- Refactoring distance conversion into a single helper
- Updating geometry creation/update flows to use SI values
- Removing pixel units from geometry selectors
- Preventing recursive UI updates during unit switching

### Developer Testing

- I have verified unit tests pass locally: `python -m pytest -vs`
- Verified geometry distances update correctly when switching between `mm` and `m`
- Verified geometry creation and updates work correctly

### Acceptance Criteria and Reviewer Testing

- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Verify geometry distances can be entered in `mm` and `m`
- [ ] Verify unit switching updates values correctly
- [ ] Verify geometry creation and updates still work correctly

### Documentation and Additional Notes

- No documentation changes required