### PR TITLE
Platform Specific Inline Code Block Custom Extension

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,2 +1,11 @@
 div.sd-card-body {font-size: 120%}
 div.sd-card-title {font-size: 300%}
+
+/* OS-specific keyboard shortcut visibility */
+.shortcut-mac     { display: none; }
+.shortcut-windows { display: none; }
+.shortcut-linux   { display: none; }
+
+.os-mac     .shortcut-mac     { display: inline; }
+.os-windows .shortcut-windows { display: inline; }
+.os-linux   .shortcut-linux   { display: inline; }

--- a/docs/_static/platform_detection.js
+++ b/docs/_static/platform_detection.js
@@ -1,0 +1,20 @@
+/**
+ * Detects the user's OS and adds a CSS class to <body>, enabling
+ * OS-specific inline code snippet display via custom.css
+ */
+
+const OS_CLASS_MAP = [
+    { match: (platform) => platform.includes("MAC"), cssClass: "os-mac" },
+    { match: (platform) => platform.includes("WIN"), cssClass: "os-windows" },
+    { match: (platform) => platform.includes("LINUX"), cssClass: "os-linux" },
+];
+const DEFAULT_OS_CLASS = "os-linux";
+
+function detectOsClass() {
+    const platform = (navigator.userAgentData?.platform ?? navigator.platform ?? "").toUpperCase();
+    return OS_CLASS_MAP.find(({ match }) => match(platform))?.cssClass ?? DEFAULT_OS_CLASS;
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    document.body.classList.add(detectOsClass());
+});

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,7 @@ sys.path.append(str((THIS_DIR.parent).resolve()))
 
 extensions.append("operations_user_doc")
 extensions.append("release_notes")
+extensions.append("platform_detection_rst_to_css_mapping")
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -106,6 +107,7 @@ todo_include_todos = True
 html_theme = 'pydata_sphinx_theme'
 
 html_css_files = ['custom.css']
+html_js_files = ['platform_detection.js']
 
 # Ensure sidebar displays only the current section's nested headings (local ToC)
 html_sidebars = {

--- a/docs/ext/platform_detection_rst_to_css_mapping.py
+++ b/docs/ext/platform_detection_rst_to_css_mapping.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+"""
+Custom Sphinx extension to render OS-specific code snippets in the documentation.
+
+Maps RST role to CSS class applied to <kbd> element.
+CSS class is toggled visible by platform_detection.js based on user's OS.
+Update JS/CSS to add new roles.
+"""
+
+from typing import Any
+
+from docutils import nodes
+from sphinx.application import Sphinx
+
+_OS_ROLES: dict[str, str] = {
+    "IsMac": "shortcut-mac",
+    "IsWindows": "shortcut-windows",
+    "IsLinux": "shortcut-linux",
+}
+
+
+def _make_os_role(css_class: str):
+    """
+    Return a Sphinx role function that renders a <kbd> for one OS
+
+    Args:
+        css_class: CSS class to apply to the <kbd> element, which will be toggle snippet vissibility
+    """
+
+    def role(_name: str, _rawtext: str, text: str, _lineno: int, _inliner: Any, **_):
+        node = nodes.raw("", f'<kbd class="shortcut {css_class}">{text}</kbd>', format="html")
+        return [node], []
+
+    return role
+
+
+def setup(app: Sphinx) -> dict:
+    """
+    Sphinx extension setup function
+
+    Args:
+        app: Sphinx application object
+    """
+    for role_name, css_class in _OS_ROLES.items():
+        app.add_role(role_name, _make_os_role(css_class))
+    return {"parallel_read_safe": True}


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #<ISSUE>

### Description

<!-- Add a description of the changes made. -->

Allow for inline code blocks to use platform specific commands. This is to work around that fact that Sphinx does not directly support this. It is only possible via code blocks with [group-tab](https://sphinx-design.readthedocs.io/en/latest/tabs.html) via [sphinx-design](https://sphinx-design.readthedocs.io/en/latest/index.html), but not inline code snippets.

Create a custom extension and supporting JS to use local platform OS to map RST to a CSS class to handle visibility of an inline code block which can be implemented as:

```rst
1. Open the Command Palette :IsMac:⌘+Shift+P :IsWindows:Ctrl+Shift+P :IsLinux:Ctrl+Shift+P and search for "Python: Select Interpreter"
```

Where whichever class is visible is shown while those that do not meet the platform criterion are hidden.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- Checked no sphinx build warnings are occur as a result of this implementation by replacing an inline code block with OS specific code blocks based on the example above for a given page and running `pixi run build-docs`
- Tested each code block is shown depending on the OS used by testing on various OS's and by swapping over maps within `docs/ext/platform_detection_rst_to_css_mapping._OS_ROLES` by checking build docs hosted locally with `pixi run serve-docs`

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Check no sphinx build warnings are occur as a result of this implementation by replacing an inline code block with OS specific code blocks based on the example above for a given page.
- [ ] Test each code block is shown depending on the OS used by testing on various OS's and by swapping over maps within `docs/ext/platform_detection_rst_to_css_mapping._OS_ROLES` - it may be good to test different OS if possible and resort to swapping the mapping if this is not possible for you. 

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [ ] Sphinx documentation has been updated

