### PR TITLE
Fix headless system-test matplotlib backend

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from collections import Counter
 
+import matplotlib
 import pytest
 from PyQt5 import QtCore
 from PyQt5.QtGui import QFont
@@ -30,16 +31,24 @@ skipped_tests = []
 
 
 def pytest_collection_modifyitems(config, items):
+    qt_platform = None
     if config.getoption("--run-system-tests"):
         allowed_markers.append(pytest.mark.system.mark)
-        os.environ["QT_QPA_PLATFORM"] = "minimal"
+        qt_platform = "offscreen"
     if config.getoption("--run-system-tests-show"):
         allowed_markers.append(pytest.mark.system.mark)
-        os.environ["QT_QPA_PLATFORM"] = ""
+        qt_platform = ""
     if config.getoption("--run-eyes-tests"):
         allowed_markers.append(pytest.mark.eyes.mark)
     if config.getoption("--run-unit-tests") or len(allowed_markers) == 0:
         allowed_markers.append(pytest.mark.unit.mark)
+    if qt_platform is not None:
+        os.environ["QT_QPA_PLATFORM"] = qt_platform
+    if os.environ.get("QT_QPA_PLATFORM") in ["offscreen", "minimal"]:
+        matplotlib.use("Agg")
+    else:
+        matplotlib.use("Qt5Agg")
+
     for item in items:
         if "gui_system" in item.nodeid:
             item.add_marker(pytest.mark.system)

--- a/mantidimaging/gui/windows/geometry/view.py
+++ b/mantidimaging/gui/windows/geometry/view.py
@@ -4,8 +4,6 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 from PyQt5.QtCore import pyqtSignal
-
-import os
 from uuid import UUID
 
 from PyQt5.QtWidgets import (
@@ -24,17 +22,10 @@ from PyQt5.QtWidgets import (
     QStyle,
 )
 
-import matplotlib
 from matplotlib import pyplot
 from matplotlib.figure import Figure
 
 from mantidimaging.core.data.geometry import GeometryType
-
-if os.environ.get('QT_QPA_PLATFORM') == 'offscreen':
-    matplotlib.use('Agg')
-else:
-    matplotlib.use('Qt5Agg')
-
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 
 from mantidimaging.gui.mvp_base import BaseMainWindowView


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2926 

### Description

Fixes headless system-test crashes by setting matplotlib backend during pytest collection (after test flags are applied), not at geometry view import time.

### Developer Testing 

Agg for QT_QPA_PLATFORM = offscreen or minimal
Qt5Agg otherwise

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ]  With DISPLAY unset + --run-system-tests, tests do not fail at import with Qt5Agg headless error
- [ ] offscreen/minimal selects Agg backend
s baselines](https://eyes.applitools.com/app/baselines) for more info) -->

