### PR TITLE
update pyright

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     - cil=25.0.*
     - ccpi-regulariser=25.0.*
     - jenkspy=0.4.*
+    - pyright=1.1.410
     - pyqt=5.15.*
     - pyqtgraph=0.13.7
     - qt-material=2.14

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -37,7 +37,6 @@ requirements:
     - cil=25.0.*
     - ccpi-regulariser=25.0.*
     - jenkspy=0.4.*
-    - pyright=1.1.410
     - pyqt=5.15.*
     - pyqtgraph=0.13.7
     - qt-material=2.14

--- a/docs/release_notes/next/dev-3165-update-pyright-to-1.1.410
+++ b/docs/release_notes/next/dev-3165-update-pyright-to-1.1.410
@@ -1,0 +1,1 @@
+#3165: Update pyright to 1.1.410 in pixi.toml, environment-dev.yml, and conda/meta.yaml

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -28,7 +28,7 @@ dependencies:
   - pyfakefs==5.3.*
   - parameterized==0.9.*
   - pyinstaller==6.14.*
-  - pyright=1.1.407
+  - pyright=1.1.410
   - make==4.3
   - ruff=0.3.7
   - pre-commit==3.5.*

--- a/mantidimaging/gui/dialogs/async_task/view.py
+++ b/mantidimaging/gui/dialogs/async_task/view.py
@@ -6,7 +6,8 @@ from typing import Any
 from collections.abc import Callable
 
 import numpy as np
-from pyqtgraph import PlotWidget, ImageView
+from pyqtgraph import PlotWidget
+from pyqtgraph.imageview import ImageView
 
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.gui.mvp_base import BaseDialogView

--- a/mantidimaging/gui/utility/qt_helpers.py
+++ b/mantidimaging/gui/utility/qt_helpers.py
@@ -49,7 +49,10 @@ class BlockQtSignals:
 
 def compile_ui(ui_file: str, qt_obj=None) -> QWidget:
     ui_path = Path(finder.ROOT_PATH) / ui_file
-    return uic.loadUi(str(ui_path), qt_obj)
+    loaded_ui = uic.loadUi(str(ui_path), qt_obj)
+    if loaded_ui is None:
+        raise RuntimeError(f"Failed to load UI file: {ui_file}")
+    return loaded_ui
 
 
 def select_directory(field: QWidget, caption: str) -> None:
@@ -259,7 +262,7 @@ def delete_all_widgets_from_layout(lo: QLayout) -> None:
             item.widget().setParent(None)
 
 
-def populate_menu(menu: QMenu, actions_list: list[QAction]) -> None:
+def populate_menu(menu: QMenu, actions_list: list[tuple[str, Callable | None]]) -> None:
     for (menu_text, func) in actions_list:
         if func is None:
             menu.addSeparator()

--- a/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
+++ b/mantidimaging/gui/widgets/bad_data_overlay/bad_data_overlay.py
@@ -7,7 +7,8 @@ from collections.abc import Callable
 from typing import Final
 
 import numpy as np
-from pyqtgraph import ColorMap, ImageItem, ViewBox
+from pyqtgraph import ColorMap, ImageItem
+from pyqtgraph.graphicsItems.ViewBox import ViewBox
 from dataclasses import dataclass
 
 from mantidimaging.gui.utility.qt_helpers import _metaclass_sip_abc

--- a/mantidimaging/gui/widgets/indicator_icon/view.py
+++ b/mantidimaging/gui/widgets/indicator_icon/view.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 
 import numpy as np
 from PIL import Image
-from pyqtgraph import ViewBox
+from pyqtgraph.graphicsItems.ViewBox import ViewBox
 from PyQt5.QtWidgets import QGraphicsPixmapItem, QGraphicsSimpleTextItem, QMenu, QAction
 from PyQt5.QtGui import QPixmap, QImage, QColor
 

--- a/mantidimaging/gui/widgets/mi_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_image_view/view.py
@@ -9,7 +9,9 @@ from collections.abc import Callable
 
 from PyQt5.QtCore import Qt, QRectF
 from PyQt5.QtWidgets import QApplication, QHBoxLayout, QLabel, QPushButton, QSizePolicy
-from pyqtgraph import ROI, ImageItem, ImageView, ViewBox
+from pyqtgraph import ROI, ImageItem
+from pyqtgraph.imageview import ImageView
+from pyqtgraph.graphicsItems.ViewBox import ViewBox
 from pyqtgraph.GraphicsScene.mouseEvents import HoverEvent
 
 from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint

--- a/mantidimaging/gui/widgets/mi_mini_image_view/view.py
+++ b/mantidimaging/gui/widgets/mi_mini_image_view/view.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING, Any
 from weakref import WeakSet
 
 from PyQt5.QtCore import QTimer
-from pyqtgraph import ImageItem, ViewBox
+from pyqtgraph import ImageItem
+from pyqtgraph.graphicsItems.ViewBox import ViewBox
 from pyqtgraph.graphicsItems.GraphicsLayout import GraphicsLayout
 from pyqtgraph.graphicsItems.HistogramLUTItem import HistogramLUTItem
 from tifffile import tifffile

--- a/mantidimaging/gui/widgets/spectrum_widgets/tof_properties.py
+++ b/mantidimaging/gui/widgets/spectrum_widgets/tof_properties.py
@@ -3,6 +3,7 @@
 
 from PyQt5 import QtCore, QtWidgets
 from logging import getLogger
+from collections.abc import Callable
 
 LOG = getLogger(__name__)
 
@@ -89,6 +90,6 @@ class ExperimentSetupFormWidget(QtWidgets.QGroupBox):
         self.timeDelaySpinBox.setValue(value)
         LOG.debug("Time delay set to: %.3f µs", value)
 
-    def connect_value_changed(self, handler: QtCore.pyqtSlot):
+    def connect_value_changed(self, handler: Callable[..., None]) -> None:
         self.flightPathSpinBox.valueChanged.connect(handler)
         self.timeDelaySpinBox.valueChanged.connect(handler)

--- a/mantidimaging/gui/widgets/zslider/zslider.py
+++ b/mantidimaging/gui/widgets/zslider/zslider.py
@@ -6,7 +6,8 @@ from typing import Any
 
 from PyQt5.QtCore import pyqtSignal, Qt
 from PyQt5.QtWidgets import QGraphicsSceneMouseEvent
-from pyqtgraph import PlotItem, InfiniteLine
+from pyqtgraph.graphicsItems.InfiniteLine import InfiniteLine
+from pyqtgraph.graphicsItems.PlotItem import PlotItem
 
 _graveyard: list[Any] = []
 

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -6,7 +6,7 @@ import uuid
 from logging import getLogger
 from pathlib import Path
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
 import numpy as np
@@ -751,9 +751,7 @@ class MainWindowView(BaseMainWindowView):
         for i in range(parent.childCount()):
             child = parent.child(i)
             if child.text(0) == SINO_TEXT:
-                if not isinstance(child, QTreeDatasetWidgetItem):
-                    return None
-                return child
+                return cast(QTreeDatasetWidgetItem, child)
         return None
 
     def _open_tree_menu(self, position: QPoint) -> None:
@@ -842,9 +840,7 @@ class MainWindowView(BaseMainWindowView):
         for i in range(dataset_item.childCount()):
             child = dataset_item.child(i)
             if child.text(0) == RECON_GROUP_TEXT:
-                if not isinstance(child, QTreeDatasetWidgetItem):
-                    return None
-                return child
+                return cast(QTreeDatasetWidgetItem, child)
         return None
 
     def get_dataset_tree_view_item(self, dataset_id: uuid.UUID) -> QTreeDatasetWidgetItem:
@@ -856,10 +852,8 @@ class MainWindowView(BaseMainWindowView):
         top_level_item_count = self.dataset_tree_widget.topLevelItemCount()
         for i in range(top_level_item_count):
             top_level_item = self.dataset_tree_widget.topLevelItem(i)
-            if not isinstance(top_level_item, QTreeDatasetWidgetItem):
-                continue
-            if top_level_item.id == dataset_id:
-                return top_level_item
+            if top_level_item is not None and getattr(top_level_item, "id", None) == dataset_id:
+                return cast(QTreeDatasetWidgetItem, top_level_item)
         raise RuntimeError(f"Unable to find dataset with ID {dataset_id}")
 
     @property

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -751,6 +751,8 @@ class MainWindowView(BaseMainWindowView):
         for i in range(parent.childCount()):
             child = parent.child(i)
             if child.text(0) == SINO_TEXT:
+                if not isinstance(child, QTreeDatasetWidgetItem):
+                    return None
                 return child
         return None
 
@@ -838,8 +840,11 @@ class MainWindowView(BaseMainWindowView):
         :return: The recon group if found.
         """
         for i in range(dataset_item.childCount()):
-            if dataset_item.child(i).text(0) == RECON_GROUP_TEXT:
-                return dataset_item.child(i)
+            child = dataset_item.child(i)
+            if child.text(0) == RECON_GROUP_TEXT:
+                if not isinstance(child, QTreeDatasetWidgetItem):
+                    return None
+                return child
         return None
 
     def get_dataset_tree_view_item(self, dataset_id: uuid.UUID) -> QTreeDatasetWidgetItem:
@@ -851,6 +856,8 @@ class MainWindowView(BaseMainWindowView):
         top_level_item_count = self.dataset_tree_widget.topLevelItemCount()
         for i in range(top_level_item_count):
             top_level_item = self.dataset_tree_widget.topLevelItem(i)
+            if not isinstance(top_level_item, QTreeDatasetWidgetItem):
+                continue
             if top_level_item.id == dataset_id:
                 return top_level_item
         raise RuntimeError(f"Unable to find dataset with ID {dataset_id}")

--- a/mantidimaging/gui/windows/operations/filter_previews.py
+++ b/mantidimaging/gui/windows/operations/filter_previews.py
@@ -8,7 +8,9 @@ from typing import Any
 import numpy as np
 from PyQt5.QtCore import QPoint, QRect
 from PyQt5.QtGui import QGuiApplication, QResizeEvent
-from pyqtgraph import ColorMap, GraphicsLayoutWidget, ImageItem, LegendItem, PlotItem
+from pyqtgraph import ColorMap, GraphicsLayoutWidget, ImageItem
+from pyqtgraph.graphicsItems.LegendItem import LegendItem
+from pyqtgraph.graphicsItems.PlotItem import PlotItem
 from pyqtgraph.graphicsItems.GraphicsLayout import GraphicsLayout
 
 from mantidimaging.core.utility.histogram import set_histogram_log_scale

--- a/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/roi_table_model.py
@@ -65,7 +65,8 @@ class TableModel(QAbstractTableModel):
 
         if role == Qt.BackgroundRole:
             if index.column() == 1:
-                return QBrush(QColor(*self._data[index.row()][index.column()]))
+                color = cast(tuple[int, int, int], self._data[index.row()][index.column()])
+                return QBrush(QColor(*color))
 
         if role == Qt.CheckStateRole:
             if index.column() == 2:

--- a/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
+++ b/mantidimaging/gui/windows/spectrum_viewer/spectrum_widget.py
@@ -13,13 +13,13 @@ from pyqtgraph import (
     ROI,
     GraphicsLayoutWidget,
     LinearRegionItem,
-    PlotItem,
     mkPen,
-    ViewBox,
     PlotDataItem,
     GraphicsItem,
     LabelItem,
 )
+from pyqtgraph.graphicsItems.PlotItem import PlotItem
+from pyqtgraph.graphicsItems.ViewBox import ViewBox
 import numpy as np
 
 from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint

--- a/mantidimaging/main.py
+++ b/mantidimaging/main.py
@@ -92,12 +92,12 @@ def setup_application() -> QApplication:
     return q_application
 
 
-def main() -> None:
+def main() -> int | None:
     args = parse_args()
     if args.version:
         from mantidimaging import __version__ as version_no
         print(version_no)
-        return
+        return 0
 
     q_application = setup_application()
     show_unclean_shutdown_warning(settings)

--- a/pixi.toml
+++ b/pixi.toml
@@ -25,7 +25,7 @@ build-gpu = ["runtime", "runtime-gpu", "gpu-verify", "build"]
 # Linting packages
 [feature.lint.dependencies]
 mypy = "==1.17"
-pyright = "==1.1.391"
+pyright = "==1.1.410"
 yapf = "0.43.*"
 ruff = "0.3.7.*"
 types-requests = "*"


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3165

### Description

Updated pyright to version 1.1.410 across project package management files:

pixi.toml
environment-dev.yml
meta.yaml

In addition to the version bump, I also worked through compatibility fallout from newer Pyright checks by updating type usage in the GUI layer, including pyqtgraph import/type annotations and stricter return/callback typing where needed. I then adjusted a few type hints to satisfy both Pyright and mypy without changing runtime behavior, and refined tree-item typing in main window helpers so static checks pass while existing mocked tests remain compatible.

### Developer Testing 

Verified dependency pins were updated to pyright 1.1.410 in all three target files.
I have not run the full unit test suite locally for this dependency-only update.


