### PR TITLE
Fix docs publish empty commit on release branches

### DIFF
--- a/.github/actions/publish-docs/action.yml
+++ b/.github/actions/publish-docs/action.yml
@@ -29,8 +29,8 @@ runs:
         mkdir -p ${dir_name}
         cp -a ../docs/build/html/* ${dir_name}
         md5sum ${dir_name}/index.html # if no index then there must have been a problem
-        if [ "$(git status --porcelain | wc -l)" -gt "0" ] ; then
           git add ${dir_name}
+          if ! git diff --cached --quiet -- ${dir_name} ; then
           git commit -m "Update documentation"
           git push
         else

--- a/.github/actions/publish-docs/action.yml
+++ b/.github/actions/publish-docs/action.yml
@@ -29,8 +29,8 @@ runs:
         mkdir -p ${dir_name}
         cp -a ../docs/build/html/* ${dir_name}
         md5sum ${dir_name}/index.html # if no index then there must have been a problem
-          git add ${dir_name}
-          if ! git diff --cached --quiet -- ${dir_name} ; then
+        git add ${dir_name}
+        if ! git diff --cached --quiet -- ${dir_name} ; then
           git commit -m "Update documentation"
           git push
         else

--- a/docs/release_notes/next/fix-2757-docs-release-publish-empty-commit
+++ b/docs/release_notes/next/fix-2757-docs-release-publish-empty-commit
@@ -1,0 +1,1 @@
+#2757: Fix release branch documentation publishing failing when no files change in the versioned docs directory


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2757.

### Description

Fix docs publish empty commit on release branches
Stage the target docs directory before checking for changes in the publish-docs action, and only commit when that staged directory has a diff. This avoids release branch docs jobs failing when the gh-pages worktree has unrelated changes but the versioned docs output is unchanged.
