### PR TITLE
Refactor SPDHG reconstruction to use a sampler instead of the depreca…

### DIFF
--- a/docs/release_notes/next/dev-3174-SPDHG_sampler_for_deprecated_prob
+++ b/docs/release_notes/next/dev-3174-SPDHG_sampler_for_deprecated_prob
@@ -1,0 +1,1 @@
+#3174: Refactor SPDHG reconstruction to use a sampler instead of the deprecated `prob` argument.

--- a/mantidimaging/core/reconstruct/cil_recon.py
+++ b/mantidimaging/core/reconstruct/cil_recon.py
@@ -14,6 +14,7 @@ import numpy as np
 
 from cil.framework import AcquisitionData, AcquisitionGeometry, ImageGeometry, BlockGeometry, BlockDataContainer
 from cil.optimisation.algorithms import PDHG, SPDHG, Algorithm
+from cil.optimisation.utilities.sampler import Sampler
 from cil.optimisation.operators import GradientOperator, BlockOperator
 from cil.optimisation.operators import SymmetrisedGradientOperator, ZeroOperator, IdentityOperator
 
@@ -323,7 +324,8 @@ class CILRecon(BaseRecon):
             if recon_params.stochastic:
                 reg_percent = recon_params.regularisation_percent
                 probs = [(1 - reg_percent / 100) / num_subsets] * num_subsets + [reg_percent / 100]
-                algo = SPDHG(f=F, g=G, operator=K, prob=probs, update_objective_interval=update_objective_interval)
+                sampler = Sampler.random_with_replacement(len(K), prob=probs)
+                algo = SPDHG(f=F, g=G, operator=K, sampler=sampler, update_objective_interval=update_objective_interval)
             else:
                 normK = K.norm()
                 sigma = 1
@@ -429,7 +431,8 @@ class CILRecon(BaseRecon):
             if recon_params.stochastic:
                 reg_percent = recon_params.regularisation_percent
                 probs = [(1 - reg_percent / 100) / num_subsets] * num_subsets + [reg_percent / 100]
-                algo = SPDHG(f=F, g=G, operator=K, prob=probs, update_objective_interval=update_objective_interval)
+                sampler = Sampler.random_with_replacement(len(K), prob=probs)
+                algo = SPDHG(f=F, g=G, operator=K, sampler=sampler, update_objective_interval=update_objective_interval)
             else:
                 normK = K.norm()
                 sigma = 1


### PR DESCRIPTION
…ted `prob` argument.

<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes  #3174

### Description

Refactored SPDHG reconstruction to use Sampler.random_with_replacement(..., prob=probs) instead of passing the deprecated prob argument directly to SPDHG. Updated both stochastic reconstruction paths in cil_recon.py and fixed the Sampler import to use cil.optimisation.utilities.sampler.


### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ]  Stochastic SPDHG reconstruction still runs with the expected subset probabilities
- [ ] No deprecated prob argument is passed to SPDHG

### Documentation and Additional Notes

<!-- - [ ] Release Notes have been updated

