### PR TITLE
3158 Resolve CoR Refinement Inflated Values and Plot CoR Values Over Sample Image

### DIFF
--- a/docs/release_notes/next/fix-3158-resolve_inflated_cor_refinement_and_plot_cor_values
+++ b/docs/release_notes/next/fix-3158-resolve_inflated_cor_refinement_and_plot_cor_values
@@ -1,0 +1,1 @@
+#3158: Resolve inflated CoR values caused when manually refining a given CoR where the tilt was double calculated and incorporate tests to try and avoid the re-implementation of this issue. Additionally, to improve CoR value clarity, plot the CoR values over the sample image.

--- a/mantidimaging/core/data/geometry.py
+++ b/mantidimaging/core/data/geometry.py
@@ -92,6 +92,19 @@ class Geometry(AcquisitionGeometry):
         cor = (gradient * slice_idx) + self.cor.value
         return ScalarCoR(cor)
 
+    def set_cor_at_slice_index(self, slice_idx: int, cor: ScalarCoR) -> None:
+        """
+        Sets geometry.cor from a COR value measured at a specific slice index.
+
+        Back-calculatethe COR at slice 0 so that get_cor_at_slice_index(slice_idx)
+        returns the given cor value at the given slice_idx when the tilt is taken into account.
+
+        :param slice_idx: The slice index the COR was measured at
+        :param cor: The COR value at that slice index
+        """
+        gradient = -tan(radians(self.tilt))
+        self.cor = ScalarCoR(cor.value - gradient * slice_idx)
+
     def get_all_cors(self) -> list[ScalarCoR]:
         """
         Returns all cors across How many cors will be generated,

--- a/mantidimaging/core/data/test/geometry_test.py
+++ b/mantidimaging/core/data/test/geometry_test.py
@@ -164,6 +164,20 @@ class GeometryTest(unittest.TestCase):
         self.assertAlmostEqual(cil_offset, expected_cil_offset, places=6)
         self.assertAlmostEqual(cil_angle, tilt, places=6)
 
+    @parameterized.expand([
+        ("zero_tilt_mid_slice", 0.0, 255, ScalarCoR(128.0)),
+        ("positive_tilt_mid_slice", 1.5, 255, ScalarCoR(130.0)),
+        ("negative_tilt_mid_slice", -2.3, 100, ScalarCoR(120.0)),
+        ("large_tilt", 5.0, 400, ScalarCoR(250.0)),
+    ])
+    def test_set_cor_at_slice_index_inverts_set_to_get_original_cor(self, _, tilt, slice_idx, cor_at_slice):
+        geometry = Geometry(TEST_ANGLES, num_pixels=(512, 512))
+        geometry.tilt = tilt
+        geometry.set_cor_at_slice_index(slice_idx, cor_at_slice)
+        result = geometry.get_cor_at_slice_index(slice_idx)
+
+        self.assertAlmostEqual(result.value, cor_at_slice.value, places=6)
+
     def test_geometry_type(self):
         """
         Tests that the correct geometry type is returned.

--- a/mantidimaging/core/rotation/data_model.py
+++ b/mantidimaging/core/rotation/data_model.py
@@ -117,6 +117,10 @@ class CorTiltDataModel:
         return [float(p.cor) for p in self._points]
 
     @property
+    def points(self) -> list[Point]:
+        return list(self._points)
+
+    @property
     def gradient(self) -> Slope:
         if self._cached_gradient is not None:
             return Slope(self._cached_gradient)

--- a/mantidimaging/gui/dialogs/cor_inspection/model.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/model.py
@@ -84,7 +84,7 @@ class CORInspectionDialogModel:
     def _recon_cor_preview(self, image: ImageType) -> np.ndarray:
         assert (self.images.geometry is not None)
         assert self.proj_angles is not None
-        self.images.geometry.cor = ScalarCoR(self.cor(image))
+        self.images.geometry.set_cor_at_slice_index(self.slice_idx, ScalarCoR(self.cor(image)))
         return self.reconstructor.single_sino(self.images, self.slice_idx, self.recon_params)
 
     def _recon_iters_preview(self, image: ImageType) -> np.ndarray:

--- a/mantidimaging/gui/dialogs/cor_inspection/model.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/model.py
@@ -82,10 +82,20 @@ class CORInspectionDialogModel:
             return self.centre_value + self.step
 
     def _recon_cor_preview(self, image: ImageType) -> np.ndarray:
-        assert (self.images.geometry is not None)
+        """
+        Reconstructs a preview of the rotation centre for the given image
+        Ensures geometry is preserved on exit, even if the reconstruction fails
+        """
+        assert self.images.geometry is not None
         assert self.proj_angles is not None
+
+        original = self.images.geometry.get_cor_at_slice_index(self.slice_idx)
         self.images.geometry.set_cor_at_slice_index(self.slice_idx, ScalarCoR(self.cor(image)))
-        return self.reconstructor.single_sino(self.images, self.slice_idx, self.recon_params)
+
+        try:
+            return self.reconstructor.single_sino(self.images, self.slice_idx, self.recon_params)
+        finally:
+            self.images.geometry.set_cor_at_slice_index(self.slice_idx, original)
 
     def _recon_iters_preview(self, image: ImageType) -> np.ndarray:
         assert self.proj_angles is not None

--- a/mantidimaging/gui/dialogs/cor_inspection/test/model_test.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/test/model_test.py
@@ -117,3 +117,19 @@ class CORInspectionDialogModelTest(unittest.TestCase):
         m.recon_preview(ImageType.CURRENT)
         replace_mock.assert_called_once_with(m.recon_params, num_iter=100)
         m.reconstructor.single_sino.assert_called_once_with(m.images, m.slice_idx, replace_mock.return_value)
+
+    def test_recon_cor_preview_does_not_inflate_cor_with_tilt(self):
+        slice_idx = 5
+        cor_at_slice = ScalarCoR(20.0)
+        tilt = 2.0  # extreme tilt so gradient * slice_idx is measurable reflecting how #3158 was first discovered.
+
+        images = generate_images_with_geometry(360)
+        images.geometry.tilt = tilt
+
+        model = CORInspectionDialogModel(images, slice_idx, cor_at_slice,
+                                         ReconstructionParameters('FBP_CUDA', 'ram-lak'), False)
+        model.reconstructor = Mock()
+        model.recon_preview(ImageType.CURRENT)
+
+        result = images.geometry.get_cor_at_slice_index(slice_idx)
+        self.assertAlmostEqual(result.value, cor_at_slice.value, places=6)

--- a/mantidimaging/gui/dialogs/cor_inspection/test/model_test.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/test/model_test.py
@@ -2,10 +2,12 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+import contextlib
 import unittest
 from unittest.mock import Mock, patch
 
 import numpy.testing as npt
+from parameterized import parameterized
 
 from mantidimaging.core.utility.data_containers import ScalarCoR, ReconstructionParameters
 from mantidimaging.gui.dialogs.cor_inspection import CORInspectionDialogModel
@@ -108,6 +110,26 @@ class CORInspectionDialogModelTest(unittest.TestCase):
         self.assertEqual(m.centre_value, 75)
         self.assertEqual(m.step, 25)
 
+    @parameterized.expand([
+        ("success", None),
+        ("failure", RuntimeError("recon failed")),
+    ])
+    def test_recon_cor_preview_restores_geometry_on_(self, _name, recon_side_effect):
+        images = generate_images_with_geometry(360)
+        slice_idx = 5
+        # get CoR before model construction to match pre-dialog geometry state
+        original_cor = images.geometry.get_cor_at_slice_index(slice_idx)
+        recon_parameters = ReconstructionParameters("FBP_CUDA", "ram-lak")
+
+        model = CORInspectionDialogModel(images, slice_idx, ScalarCoR(20), recon_parameters, False)
+        model.reconstructor = Mock()
+        model.reconstructor.single_sino.side_effect = recon_side_effect
+
+        with contextlib.suppress(RuntimeError):
+            model.recon_preview(ImageType.LESS)
+
+        self.assertEqual(images.geometry.get_cor_at_slice_index(slice_idx).value, original_cor.value)
+
     @patch('mantidimaging.gui.dialogs.cor_inspection.model.replace')
     def test_recon_iters_preview(self, replace_mock):
         images = generate_images_with_geometry(360)
@@ -126,10 +148,13 @@ class CORInspectionDialogModelTest(unittest.TestCase):
         images = generate_images_with_geometry(360)
         images.geometry.tilt = tilt
 
-        model = CORInspectionDialogModel(images, slice_idx, cor_at_slice,
-                                         ReconstructionParameters('FBP_CUDA', 'ram-lak'), False)
+        recon_params = ReconstructionParameters('FBP_CUDA', 'ram-lak')
+        model = CORInspectionDialogModel(images, slice_idx, cor_at_slice, recon_params, False)
         model.reconstructor = Mock()
-        model.recon_preview(ImageType.CURRENT)
 
-        result = images.geometry.get_cor_at_slice_index(slice_idx)
-        self.assertAlmostEqual(result.value, cor_at_slice.value, places=6)
+        geometry = images.geometry
+        with patch.object(geometry, "set_cor_at_slice_index", wraps=geometry.set_cor_at_slice_index) as mock_set_cor:
+            model.recon_preview(ImageType.CURRENT)
+
+        preview_cor = mock_set_cor.call_args_list[0].args[1]
+        self.assertAlmostEqual(preview_cor.value, cor_at_slice.value, places=6)

--- a/mantidimaging/gui/dialogs/cor_inspection/view.py
+++ b/mantidimaging/gui/dialogs/cor_inspection/view.py
@@ -30,7 +30,7 @@ class CORInspectionDialogView(BaseDialogView):
 
     def __init__(self, parent, images: ImageStack, slice_index: int, initial_cor: ScalarCoR,
                  recon_params: ReconstructionParameters, iters_mode: bool):
-        super().__init__(parent, 'gui/ui/cor_inspection_dialog.ui')
+        super().__init__(None, 'gui/ui/cor_inspection_dialog.ui')
         self.iters_mode = iters_mode
 
         if self.iters_mode:

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -20,7 +20,7 @@ class ReconImagesView(GraphicsLayoutWidget):
     def __init__(self, parent):
         super().__init__(parent)
         self.parent = parent
-        self._selected_cor_row = -1
+        self._selected_cor_row: int = -1  # Default to no row selected
         self._scatter_rows: list[int] = []
         self._scatter_cors: list[float] = []
         self._scatter_slice_indices: list[int] = []
@@ -147,24 +147,30 @@ class ReconImagesView(GraphicsLayoutWidget):
         self._scatter_rows = list(range(len(slice_indices)))
         self._refresh_cor_scatter()
 
-    def _make_spot(self, cor: float, slice_idx: int) -> dict:
+    def set_selected_cor_row(self, row: int) -> None:
+        self._selected_cor_row = row
+        self._refresh_cor_scatter()
+
+    def _make_spot(self, cor: float, slice_idx: int, row: int) -> dict:
         """
-        Create CoR spot
+        Create CoR spot and update its appearance based on whether it is selected or not
 
         :param cor: CoR value
         :param slice_idx: slice index
+        :param row: row index
         :return: dict of spot parameters
         """
+        selected = row == self._selected_cor_row
         return {
             'pos': (cor, slice_idx),
-            'pen': self._normal_pen,
-            'brush': self._normal_brush,
+            'pen': self._selected_pen if selected else self._normal_pen,
+            'brush': self._selected_brush if selected else self._normal_brush,
         }
 
     def _refresh_cor_scatter(self) -> None:
-        """Update scatter plot with current CoR"""
-        cor_table_data = zip(self._scatter_cors, self._scatter_slice_indices, strict=True)
-        spots = [self._make_spot(cor, slice_idx) for cor, slice_idx in cor_table_data]
+        """Update scatter plot with current CoR by creating a list of spots and setting them to the scatter plot item"""
+        cor_table_data = zip(self._scatter_cors, self._scatter_slice_indices, self._scatter_rows, strict=True)
+        spots = [self._make_spot(cor, slice_idx, row) for cor, slice_idx, row in cor_table_data]
         self.cor_scatter.setData(spots=spots, symbol='x', size=14, tip=None)
 
     def show_cor_line(self, tilt: Degrees, pos: float) -> None:

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -16,6 +16,7 @@ from mantidimaging.gui.widgets.mi_mini_image_view.view import MIMiniImageView
 
 class ReconImagesView(GraphicsLayoutWidget):
     sigSliceIndexChanged = QtCore.pyqtSignal(int)
+    sigCorPointClicked = QtCore.pyqtSignal(int)
 
     def __init__(self, parent):
         super().__init__(parent)
@@ -34,11 +35,18 @@ class ReconImagesView(GraphicsLayoutWidget):
         self.imageview_projection.viewbox.addItem(self.slice_line)
         self.tilt_line = InfiniteLine(pos=1024, angle=90, pen=(255, 0, 0, 255), movable=False)
         self._normal_pen = mkPen((255, 255, 0, 255), width=1)
+        self._hover_pen = mkPen((0, 255, 255, 255), width=3)
         self._selected_pen = mkPen((0, 255, 0, 255), width=2)
         self._normal_brush = mkBrush(255, 255, 0, 200)
         self._selected_brush = mkBrush(0, 255, 0, 200)
-        self.cor_scatter = ScatterPlotItem(symbol='x', size=14, pen=self._normal_pen, tip=None)
+        self.cor_scatter = ScatterPlotItem(symbol='x',
+                                           size=14,
+                                           pen=self._normal_pen,
+                                           hoverable=True,
+                                           hoverPen=self._hover_pen)
+        self.cor_scatter.sigHovered.connect(self._on_cor_scatter_hovered)
         self.imageview_projection.viewbox.addItem(self.cor_scatter)
+        self.cor_scatter.sigClicked.connect(self._on_cor_scatter_clicked)
         self.recon_line_profile = LineProfilePlot(self.imageview_recon)
 
         self.addItem(self.imageview_projection, 0, 0)
@@ -163,6 +171,7 @@ class ReconImagesView(GraphicsLayoutWidget):
         selected = row == self._selected_cor_row
         return {
             'pos': (cor, slice_idx),
+            'data': row,
             'pen': self._selected_pen if selected else self._normal_pen,
             'brush': self._selected_brush if selected else self._normal_brush,
         }
@@ -172,6 +181,15 @@ class ReconImagesView(GraphicsLayoutWidget):
         cor_table_data = zip(self._scatter_cors, self._scatter_slice_indices, self._scatter_rows, strict=True)
         spots = [self._make_spot(cor, slice_idx, row) for cor, slice_idx, row in cor_table_data]
         self.cor_scatter.setData(spots=spots, symbol='x', size=14, tip=None)
+
+    def _on_cor_scatter_clicked(self, plot, spots, ev) -> None:
+        if spots:
+            row_index_from_cor_spot = spots[0].data()
+            self.sigCorPointClicked.emit(row_index_from_cor_spot)
+
+    def _on_cor_scatter_hovered(self, plot: ScatterPlotItem, points: list) -> None:
+        if plot_canvas := plot.getViewWidget():
+            plot_canvas.setCursor(QtCore.Qt.OpenHandCursor if points else QtCore.Qt.ArrowCursor)
 
     def show_cor_line(self, tilt: Degrees, pos: float) -> None:
         if not isnan(tilt.value):  # is isnan it means there is no tilt, i.e. the line is vertical

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -5,7 +5,7 @@ from math import isnan
 
 import numpy as np
 from PyQt5 import QtCore
-from pyqtgraph import GraphicsLayoutWidget, InfiniteLine
+from pyqtgraph import GraphicsLayoutWidget, InfiniteLine, ScatterPlotItem, mkBrush, mkPen
 
 from mantidimaging.core.utility.close_enough_point import CloseEnoughPoint
 from mantidimaging.core.utility.data_containers import Degrees
@@ -20,6 +20,11 @@ class ReconImagesView(GraphicsLayoutWidget):
     def __init__(self, parent):
         super().__init__(parent)
         self.parent = parent
+        self._selected_cor_row = -1
+        self._scatter_rows: list[int] = []
+        self._scatter_cors: list[float] = []
+        self._scatter_slice_indices: list[int] = []
+        self._tilt_value: float = 0.0
 
         self.imageview_projection = MIMiniImageView(name="Projection", parent=parent)
         self.imageview_sinogram = MIMiniImageView(name="Sinogram", parent=parent)
@@ -28,6 +33,12 @@ class ReconImagesView(GraphicsLayoutWidget):
         self.slice_line = InfiniteLine(pos=1024, angle=0, movable=True)
         self.imageview_projection.viewbox.addItem(self.slice_line)
         self.tilt_line = InfiniteLine(pos=1024, angle=90, pen=(255, 0, 0, 255), movable=False)
+        self._normal_pen = mkPen((255, 255, 0, 255), width=1)
+        self._selected_pen = mkPen((0, 255, 0, 255), width=2)
+        self._normal_brush = mkBrush(255, 255, 0, 200)
+        self._selected_brush = mkBrush(0, 255, 0, 200)
+        self.cor_scatter = ScatterPlotItem(symbol='x', size=14, pen=self._normal_pen, tip=None)
+        self.imageview_projection.viewbox.addItem(self.cor_scatter)
         self.recon_line_profile = LineProfilePlot(self.imageview_recon)
 
         self.addItem(self.imageview_projection, 0, 0)
@@ -121,6 +132,40 @@ class ReconImagesView(GraphicsLayoutWidget):
         """
         if self.tilt_line.scene() is not None:
             self.imageview_projection.viewbox.removeItem(self.tilt_line)
+
+    def update_cor_table_points(self, slice_indices: list[int], cors: list[float], tilt: float = 0.0) -> None:
+        """
+        Updates the CoR scatter points on the projection preview and the tilt line if there is a tilt
+
+        :param slice_indices: list of slice indices for the CoR points
+        :param cors: list of CoR values for the CoR points
+        :param tilt: tilt value for the tilt line, if there is a tilt
+        """
+        self._tilt_value = tilt
+        self._scatter_cors = cors
+        self._scatter_slice_indices = slice_indices
+        self._scatter_rows = list(range(len(slice_indices)))
+        self._refresh_cor_scatter()
+
+    def _make_spot(self, cor: float, slice_idx: int) -> dict:
+        """
+        Create CoR spot
+
+        :param cor: CoR value
+        :param slice_idx: slice index
+        :return: dict of spot parameters
+        """
+        return {
+            'pos': (cor, slice_idx),
+            'pen': self._normal_pen,
+            'brush': self._normal_brush,
+        }
+
+    def _refresh_cor_scatter(self) -> None:
+        """Update scatter plot with current CoR"""
+        cor_table_data = zip(self._scatter_cors, self._scatter_slice_indices, strict=True)
+        spots = [self._make_spot(cor, slice_idx) for cor, slice_idx in cor_table_data]
+        self.cor_scatter.setData(spots=spots, symbol='x', size=14, tip=None)
 
     def show_cor_line(self, tilt: Degrees, pos: float) -> None:
         if not isnan(tilt.value):  # is isnan it means there is no tilt, i.e. the line is vertical

--- a/mantidimaging/gui/windows/recon/image_view.py
+++ b/mantidimaging/gui/windows/recon/image_view.py
@@ -183,13 +183,13 @@ class ReconImagesView(GraphicsLayoutWidget):
         self.cor_scatter.setData(spots=spots, symbol='x', size=14, tip=None)
 
     def _on_cor_scatter_clicked(self, plot, spots, ev) -> None:
-        if spots:
+        if len(spots):
             row_index_from_cor_spot = spots[0].data()
             self.sigCorPointClicked.emit(row_index_from_cor_spot)
 
     def _on_cor_scatter_hovered(self, plot: ScatterPlotItem, points: list) -> None:
         if plot_canvas := plot.getViewWidget():
-            plot_canvas.setCursor(QtCore.Qt.OpenHandCursor if points else QtCore.Qt.ArrowCursor)
+            plot_canvas.setCursor(QtCore.Qt.OpenHandCursor if len(points) else QtCore.Qt.ArrowCursor)
 
     def show_cor_line(self, tilt: Degrees, pos: float) -> None:
         if not isnan(tilt.value):  # is isnan it means there is no tilt, i.e. the line is vertical

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -33,13 +33,22 @@ class ReconstructWindowViewTest(unittest.TestCase):
     def setUp(self, _) -> None:
         self.main_window = MockMainWindow()
         with mock.patch("mantidimaging.gui.windows.recon.view.ReconImagesView") as mock_riv:
-            self.image_view = mock.create_autospec(ReconImagesView, sigSliceIndexChanged=mock.Mock(), instance=True)
+            self.image_view = mock.create_autospec(ReconImagesView,
+                                                   sigSliceIndexChanged=mock.Mock(),
+                                                   sigCorPointClicked=mock.Mock(),
+                                                   instance=True)
             mock_riv.side_effect = [self.image_view]
             self.view = ReconstructWindowView(self.main_window)
 
         self.view.presenter = self.presenter = mock.Mock()
+        self._real_cor_table_model = self.view.cor_table_model
         self.view.tableView = self.tableView = mock.Mock()
+        self.view.tableView.model.return_value._points = []
         self.view.autoFindMethod = self.autoFindMethod = mock.Mock()
+
+        selection_model_mock = mock.Mock()
+        selection_model_mock.selectedRows.return_value = []
+        self.tableView.selectionModel = mock.Mock(return_value=selection_model_mock)
 
     def test_remove_selected_cor(self):
         assert self.view.remove_selected_cor() == self.tableView.removeSelectedRows.return_value
@@ -125,6 +134,26 @@ class ReconstructWindowViewTest(unittest.TestCase):
         self.view.update_sinogram(image_data)
         self.image_view.update_sinogram.assert_called_once_with(image_data)
 
+    def test_update_cor_scatter_with_no_points_passes_empty_lists(self):
+        self.tableView.model.return_value._points = []
+        self.view._update_cor_scatter()
+        self.image_view.update_cor_table_points.assert_called_once_with([], [], self.view.tilt)
+
+    def test_update_cor_scatter_passes_points_to_image_view(self):
+        slice_indices = [78, 125]
+        cors = [115.215625, 114.8578125]
+        tilt = 0.26
+
+        point_1 = mock.Mock(slice_index=slice_indices[0], cor=cors[0])
+        point_2 = mock.Mock(slice_index=slice_indices[1], cor=cors[1])
+
+        self.tableView.model.return_value._points = [point_1, point_2]
+        self.view.resultTiltSpinBox.setValue(tilt)
+        self.image_view.update_cor_table_points.assert_not_called()
+        self.view._update_cor_scatter()
+
+        self.image_view.update_cor_table_points.assert_called_once_with(slice_indices, cors, tilt)
+
     def test_update_recon_preview_no_hist(self):
         image_data = mock.Mock()
         self.view.update_recon_hist_needed = False
@@ -168,6 +197,11 @@ class ReconstructWindowViewTest(unittest.TestCase):
 
         self.tableView.model.return_value.appendNewRow.assert_called_once_with(row, slice_index, cor)
         self.tableView.selectRow.assert_called_once_with(row)
+
+    def test_layout_changed_updates_cor_scatter(self):
+        self.image_view.update_cor_table_points.reset_mock()
+        self._real_cor_table_model.layoutChanged.emit()
+        self.image_view.update_cor_table_points.assert_called()
 
     def test_rotation_centre_property(self):
         self.assertEqual(self.view.rotation_centre, 0)

--- a/mantidimaging/gui/windows/recon/test/view_test.py
+++ b/mantidimaging/gui/windows/recon/test/view_test.py
@@ -43,7 +43,7 @@ class ReconstructWindowViewTest(unittest.TestCase):
         self.view.presenter = self.presenter = mock.Mock()
         self._real_cor_table_model = self.view.cor_table_model
         self.view.tableView = self.tableView = mock.Mock()
-        self.view.tableView.model.return_value._points = []
+        self.view.tableView.model.return_value.points = []
         self.view.autoFindMethod = self.autoFindMethod = mock.Mock()
 
         selection_model_mock = mock.Mock()
@@ -135,7 +135,7 @@ class ReconstructWindowViewTest(unittest.TestCase):
         self.image_view.update_sinogram.assert_called_once_with(image_data)
 
     def test_update_cor_scatter_with_no_points_passes_empty_lists(self):
-        self.tableView.model.return_value._points = []
+        self.tableView.model.return_value.points = []
         self.view._update_cor_scatter()
         self.image_view.update_cor_table_points.assert_called_once_with([], [], self.view.tilt)
 
@@ -147,7 +147,7 @@ class ReconstructWindowViewTest(unittest.TestCase):
         point_1 = mock.Mock(slice_index=slice_indices[0], cor=cors[0])
         point_2 = mock.Mock(slice_index=slice_indices[1], cor=cors[1])
 
-        self.tableView.model.return_value._points = [point_1, point_2]
+        self.tableView.model.return_value.points = [point_1, point_2]
         self.view.resultTiltSpinBox.setValue(tilt)
         self.image_view.update_cor_table_points.assert_not_called()
         self.view._update_cor_scatter()

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -232,6 +232,7 @@ class ReconstructWindowView(BaseMainWindowView):
                 button.setEnabled(item.isValid())
 
         self.tableView.selectionModel().currentRowChanged.connect(on_row_change)  # type: ignore
+        self.image_view.sigCorPointClicked.connect(self.tableView.selectRow)
 
         # Update initial UI state
         self.on_table_row_count_change()
@@ -346,7 +347,7 @@ class ReconstructWindowView(BaseMainWindowView):
 
     def _update_cor_scatter(self) -> None:
         """Updates the COR scatter points on the projection preview"""
-        points = self.cor_table_model._points
+        points = self.cor_table_model.points
         slice_indices = [point.slice_index for point in points]
         cors = [point.cor for point in points]
         selected_rows = self.tableView.selectionModel().selectedRows()

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -177,12 +177,16 @@ class ReconstructWindowView(BaseMainWindowView):
         self.cor_table_model.rowsRemoved.connect(self.on_table_row_count_change)  # type: ignore
         self.cor_table_model.modelReset.connect(self.on_table_row_count_change)  # type: ignore
 
+        self.cor_table_model.rowsRemoved.connect(self._update_cor_scatter)  # type: ignore
+        self.cor_table_model.layoutChanged.connect(self._update_cor_scatter)  # type: ignore
+
         # Update previews when data in table changes
         def on_data_change(tl, br, _):
             # Should we auto fit on data change?
             if self.tableView.model().num_points >= 2:
                 self.presenter.notify(PresN.COR_FIT)
             self.presenter.notify(PresN.UPDATE_PROJECTION)
+            self._update_cor_scatter()
             if tl == br and tl.column() == Column.CENTRE_OF_ROTATION.value:
                 mdl = self.tableView.model()
                 slice_idx = mdl.data(mdl.index(tl.row(), Column.SLICE_INDEX.value))
@@ -336,6 +340,13 @@ class ReconstructWindowView(BaseMainWindowView):
 
     def update_sinogram(self, image_data) -> None:
         self.image_view.update_sinogram(image_data)
+
+    def _update_cor_scatter(self) -> None:
+        """Updates the COR scatter points on the projection preview"""
+        points = self.cor_table_model._points
+        slice_indices = [point.slice_index for point in points]
+        cors = [point.cor for point in points]
+        self.image_view.update_cor_table_points(slice_indices, cors, self.tilt)
 
     def is_auto_update_preview(self) -> bool:
         return self.previewAutoUpdate.isChecked()

--- a/mantidimaging/gui/windows/recon/view.py
+++ b/mantidimaging/gui/windows/recon/view.py
@@ -218,10 +218,13 @@ class ReconstructWindowView(BaseMainWindowView):
                 slice_idx = row_data.slice_index
                 cor = row_data.cor
                 self.presenter.set_row(item.row())
+                self.image_view.set_selected_cor_row(item.row())
                 self.presenter.set_last_cor(cor)
                 self.presenter.set_preview_slice_idx(slice_idx)
                 self.image_view.slice_line.setPos(slice_idx)
                 self.presenter.notify(PresN.RECONSTRUCT_PREVIEW_SLICE)
+            else:
+                self.image_view.set_selected_cor_row(-1)  # No row selected
 
             # Only allow buttons which act on selected row to be clicked when a valid
             # row is selected
@@ -346,7 +349,10 @@ class ReconstructWindowView(BaseMainWindowView):
         points = self.cor_table_model._points
         slice_indices = [point.slice_index for point in points]
         cors = [point.cor for point in points]
+        selected_rows = self.tableView.selectionModel().selectedRows()
+        selected_row = selected_rows[0].row() if selected_rows else -1  # -1 means no row selected
         self.image_view.update_cor_table_points(slice_indices, cors, self.tilt)
+        self.image_view.set_selected_cor_row(selected_row)
 
     def is_auto_update_preview(self) -> bool:
         return self.previewAutoUpdate.isChecked()


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3158 

### Description

<!-- Add a description of the changes made. -->
* Resolve CoR refinement inflated values by preventing double calculating of tilt to be applied and create appropriate tests with the intention of avoiding CoR inflation going forward.
* Allow manual CoR refinement dialog window to be moveable and resizeable.
* Plot CoR values over sample image to improve CoR value visibility.

<img width="1490" height="906" alt="image" src="https://github.com/user-attachments/assets/95085586-71c7-4df1-bcb5-2328db32d7e0" />


### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- Manually tested by comparing with `main` that CoR refinement is not inflated by applying the same steps to the same dataset and comparing the output and validating the failure of `test_recon_cor_preview_does_not_inflate_cor_with_tilt` if introduce in `main` branch.
- Checked CoR spot selection updates table of CoR row selection and vice versa.

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] CoR values are no longer inflated by the double calculation of tilt when compared to `main` when performing manual refinement. You can check this via visual comparison with a large tilt, via debug statements and / or by adding `mantidimaging/gui/dialogs/cor_inspection/test/model_test.test_recon_cor_preview_does_not_inflate_cor_with_tilt()` to the main branch and validating a failure. 
- [ ] Check CoR spot selection updates table of CoR row selection and vice versa.

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

- [ ] Release Notes have been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info)

