### PR TITLE
Operations:  Add Generic hook with polymorphic dispatch for on stack change

### DIFF
--- a/docs/release_notes/next/dev-3152-polymorphic_stack_hook
+++ b/docs/release_notes/next/dev-3152-polymorphic_stack_hook
@@ -1,0 +1,1 @@
+#3152: Add a polymorphic on_stack_changed hook and refactor code accordingly

--- a/docs/release_notes/next/dev-3152-polymorphic_stack_hook
+++ b/docs/release_notes/next/dev-3152-polymorphic_stack_hook
@@ -1,1 +1,1 @@
-#3152: Add a polymorphic on_stack_changed hook and refactor code accordingly
+#3152: Adds support for filters to respond to stack changes, allowing filter settings to update automatically based on the selected data.

--- a/mantidimaging/core/operations/base_filter.py
+++ b/mantidimaging/core/operations/base_filter.py
@@ -114,6 +114,20 @@ class BaseFilter:
             raise ValueError(f"Selected stack for {msg} does not exist") from exc
         return stack
 
+    @staticmethod
+    def on_stack_changed(filter_widget_kwargs: dict[str, Any], stack: ImageStack | None) -> None:
+        """
+        Optional hook for filters that need to refresh UI state when the selected stack changes.
+
+        :param filter_widget_kwargs: The widgets registered for the active filter.
+        :param stack: The newly selected stack, or None when selection is cleared.
+        """
+        widget = filter_widget_kwargs.get("stack_selector")
+        if widget is not None:
+            widget.set_current_stack(stack)
+
+        return
+
 
 def raise_not_implemented(function_name):
     raise NotImplementedError(f"Required method '{function_name}' not implemented for filter")

--- a/mantidimaging/core/operations/base_filter.py
+++ b/mantidimaging/core/operations/base_filter.py
@@ -115,17 +115,13 @@ class BaseFilter:
         return stack
 
     @staticmethod
-    def on_stack_changed(filter_widget_kwargs: dict[str, Any], stack: ImageStack | None) -> None:
+    def on_stack_changed(filter_widget_kwargs: dict[str, QWidget], stack: ImageStack | None) -> None:
         """
         Optional hook for filters that need to refresh UI state when the selected stack changes.
 
         :param filter_widget_kwargs: The widgets registered for the active filter.
         :param stack: The newly selected stack, or None when selection is cleared.
         """
-        widget = filter_widget_kwargs.get("stack_selector")
-        if widget is not None:
-            widget.set_current_stack(stack)
-
         return
 
 

--- a/mantidimaging/core/operations/crop_coords/crop_coords.py
+++ b/mantidimaging/core/operations/crop_coords/crop_coords.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from mantidimaging import helper as h
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
@@ -11,6 +11,7 @@ from mantidimaging.core.parallel import utility as pu
 from mantidimaging.core.utility.progress_reporting import Progress
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.utility.qt_helpers import Type
+from mantidimaging.core.fitting.bounding_box import get_bounding_box
 
 if TYPE_CHECKING:
     from mantidimaging.core.data import ImageStack
@@ -93,6 +94,19 @@ class CropCoordinatesFilter(BaseFilter):
             return partial(CropCoordinatesFilter.filter_func, region_of_interest=roi)
         except Exception as exc:
             raise ValueError(f"The provided ROI string is invalid! Error: {exc}") from exc
+
+    @staticmethod
+    def on_stack_changed(filter_widget_kwargs: dict[str, Any], stack: ImageStack | None) -> None:
+
+        if stack is None:
+            return
+
+        roi_field = filter_widget_kwargs.get("roi_field")
+        if roi_field is None:
+            return
+
+        crop_roi = get_bounding_box(stack)
+        roi_field.setText(crop_roi.to_list_string())
 
     @staticmethod
     def group_name() -> FilterGroup:

--- a/mantidimaging/core/operations/crop_coords/crop_coords.py
+++ b/mantidimaging/core/operations/crop_coords/crop_coords.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from mantidimaging import helper as h
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
@@ -15,7 +15,7 @@ from mantidimaging.core.fitting.bounding_box import get_bounding_box
 
 if TYPE_CHECKING:
     from mantidimaging.core.data import ImageStack
-    from PyQt5.QtWidgets import QLineEdit
+    from PyQt5.QtWidgets import QLineEdit, QWidget
 
 
 class CropCoordinatesFilter(BaseFilter):
@@ -96,7 +96,10 @@ class CropCoordinatesFilter(BaseFilter):
             raise ValueError(f"The provided ROI string is invalid! Error: {exc}") from exc
 
     @staticmethod
-    def on_stack_changed(filter_widget_kwargs: dict[str, Any], stack: ImageStack | None) -> None:
+    def on_stack_changed(filter_widget_kwargs: dict[str, QWidget], stack: ImageStack | None) -> None:
+        """
+        Update the ROI field with the bounding box of the newly selected stack.
+        """
 
         if stack is None:
             return

--- a/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
+++ b/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
@@ -65,17 +65,17 @@ class CropCoordsTest(unittest.TestCase):
         with mock.patch(
                 "mantidimaging.core.operations.crop_coords.crop_coords.get_bounding_box") as get_bounding_box_mock:
             mock_roi = mock.Mock()
-            mock_roi.to_list_string.return_value = "[1, 2, 3, 4]"
+            mock_roi.to_list_string.return_value = "1, 2, 3, 4"
             get_bounding_box_mock.return_value = mock_roi
 
             CropCoordinatesFilter.on_stack_changed(filter_widget_kwargs, stack)
 
             get_bounding_box_mock.assert_called_once_with(stack)
-            roi_mock.setText.assert_called_once_with("[1, 2, 3, 4]")
+            roi_mock.setText.assert_called_once_with("1, 2, 3, 4")
 
-    def test_on_stack_changed_with_no_stack_or_no_widget_does_nothing(self):
+    def test_on_stack_changed_with_no_stack_does_nothing(self):
         """
-        Test that on_stack_changed does nothing when stack or ROI field is missing
+        Test that on_stack_changed does nothing when stack is missing
         """
         roi_mock = mock.Mock()
         filter_widget_kwargs = {"roi_field": roi_mock}
@@ -84,10 +84,15 @@ class CropCoordsTest(unittest.TestCase):
 
         roi_mock.setText.assert_not_called()
 
-        roi_mock.reset_mock()
+    def test_on_stack_changed_with_no_widget_does_nothing(self):
+        """
+        Test that on_stack_changed does nothing when widget is missing
+        """
+        stack = mock.Mock()
 
-        CropCoordinatesFilter.on_stack_changed({}, mock.Mock())
-        roi_mock.setText.assert_not_called()
+        with mock.patch("mantidimaging.core.operations.crop_coords.crop_coords.get_bounding_box") as get_bounding_box:
+            CropCoordinatesFilter.on_stack_changed({}, stack)
+            get_bounding_box.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
+++ b/mantidimaging/core/operations/crop_coords/test/crop_coords_test.py
@@ -53,6 +53,42 @@ class CropCoordsTest(unittest.TestCase):
         self.assertRaises(ValueError, CropCoordinatesFilter.execute_wrapper, roi_mock)
         roi_mock.text.assert_called_once()
 
+    def test_on_stack_changed_updates_roi_field(self):
+        """
+        Test that on_stack_changed retrieves the bounding box from the stack and updates the ROI field text
+        """
+        roi_mock = mock.Mock()
+
+        filter_widget_kwargs = {"roi_field": roi_mock}
+        stack = mock.Mock()
+
+        with mock.patch(
+                "mantidimaging.core.operations.crop_coords.crop_coords.get_bounding_box") as get_bounding_box_mock:
+            mock_roi = mock.Mock()
+            mock_roi.to_list_string.return_value = "[1, 2, 3, 4]"
+            get_bounding_box_mock.return_value = mock_roi
+
+            CropCoordinatesFilter.on_stack_changed(filter_widget_kwargs, stack)
+
+            get_bounding_box_mock.assert_called_once_with(stack)
+            roi_mock.setText.assert_called_once_with("[1, 2, 3, 4]")
+
+    def test_on_stack_changed_with_no_stack_or_no_widget_does_nothing(self):
+        """
+        Test that on_stack_changed does nothing when stack or ROI field is missing
+        """
+        roi_mock = mock.Mock()
+        filter_widget_kwargs = {"roi_field": roi_mock}
+
+        CropCoordinatesFilter.on_stack_changed(filter_widget_kwargs, None)
+
+        roi_mock.setText.assert_not_called()
+
+        roi_mock.reset_mock()
+
+        CropCoordinatesFilter.on_stack_changed({}, mock.Mock())
+        roi_mock.setText.assert_not_called()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -169,9 +169,7 @@ class FiltersWindowPresenter(BasePresenter):
                 widget = self.view.filterPropertiesLayout.itemAt(row_id).widget()
                 if isinstance(widget, DatasetSelectorWidgetView):
                     widget._handle_loaded_datasets_changed()
-
-        if self.view.get_selected_filter() == CROP_COORDINATES and "roi_field" in self.model.filter_widget_kwargs:
-            self.init_roi_field(self.model.filter_widget_kwargs["roi_field"])
+        self.model.selected_filter.on_stack_changed(self.model.filter_widget_kwargs, self.stack)
 
         self.do_update_previews()
 
@@ -202,12 +200,11 @@ class FiltersWindowPresenter(BasePresenter):
         filter_widget_kwargs = register_func(self.view.filterPropertiesLayout, self.view.auto_update_triggered.emit,
                                              self.view)
 
-        if filter_name == CROP_COORDINATES:
-            self.init_roi_field(filter_widget_kwargs["roi_field"])
-        elif filter_name == ROI_NORMALISATION:
+        if filter_name == ROI_NORMALISATION:
             self.init_air_field(filter_widget_kwargs["roi_field"])
 
         self.model.setup_filter(filter_name, filter_widget_kwargs)
+        self.model.selected_filter.on_stack_changed(self.model.filter_widget_kwargs, self.stack)
         self.view.clear_notification_dialog()
         self.view.previews.link_before_after_histogram_scales(self.model.link_histograms())
 
@@ -332,10 +329,9 @@ class FiltersWindowPresenter(BasePresenter):
                 self.view.show_operation_completed(self.model.selected_filter.filter_name)
 
                 selected_filter = self.view.get_selected_filter()
-                if selected_filter == CROP_COORDINATES:
-                    self.init_roi_field(self.model.filter_widget_kwargs["roi_field"])
-                elif selected_filter == FLAT_FIELDING and negative_stacks:
+                if selected_filter == FLAT_FIELDING and negative_stacks:
                     self._show_negative_values_error(negative_stacks)
+                self.model.selected_filter.on_stack_changed(self.model.filter_widget_kwargs, self.stack)
 
                 self.sync_histogram_levels()
             else:

--- a/mantidimaging/gui/windows/operations/presenter.py
+++ b/mantidimaging/gui/windows/operations/presenter.py
@@ -36,7 +36,6 @@ APPLY_TO_180_MSG = "Operations applied to the sample are also automatically appl
 FLAT_FIELDING = "Flat-fielding"
 FLAT_FIELD_REGION = [-0.2, 1.2]
 
-CROP_COORDINATES = "Crop Coordinates"
 ROI_NORMALISATION = "ROI Normalisation"
 
 if TYPE_CHECKING:

--- a/mantidimaging/gui/windows/operations/test/presenter_test.py
+++ b/mantidimaging/gui/windows/operations/test/presenter_test.py
@@ -17,7 +17,7 @@ from mantidimaging.core.operation_history.const import OPERATION_HISTORY, OPERAT
 from mantidimaging.core.utility.sensible_roi import SensibleROI
 from mantidimaging.gui.windows.main import MainWindowView
 from mantidimaging.gui.windows.operations import FiltersWindowPresenter
-from mantidimaging.gui.windows.operations.presenter import CROP_COORDINATES, REPEAT_FLAT_FIELDING_MSG, \
+from mantidimaging.gui.windows.operations.presenter import REPEAT_FLAT_FIELDING_MSG, \
     FLAT_FIELDING ,_find_nan_change, _group_consecutive_values, FLAT_FIELD_REGION
 from mantidimaging.test_helpers.unit_test_helper import assert_called_once_with, generate_images
 from mantidimaging.core.data import ImageStack
@@ -463,18 +463,19 @@ class FiltersWindowPresenterTest(unittest.TestCase):
         assert_called_once_with(mock_roi_field.setText, "0, 0, 100, 100")
 
     @mock.patch("mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter.do_update_previews")
-    @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter.init_roi_field')
-    def test_set_stack_initialises_roi_for_crop_coordinates(self, mock_init_roi_field, mock_do_update_previews):
-        mock_roi_field = mock.Mock()
+    @mock.patch("mantidimaging.gui.windows.operations.presenter.BlockQtSignals")
+    def test_set_stack_calls_selected_filter_on_stack_changed(self, mock_block_signals, mock_do_update_previews):
+        mock_filter = mock.Mock()
+        mock_filter.on_stack_changed = mock.Mock()
 
-        self.view.get_selected_filter.return_value = CROP_COORDINATES
-        self.presenter.model.filter_widget_kwargs = {"roi_field": mock_roi_field}
+        self.presenter.model.selected_filter = mock_filter
+        self.presenter.model.filter_widget_kwargs = {"roi_field": mock.Mock()}
 
-        stack = mock.Mock(num_images=2)
-        with mock.patch("mantidimaging.gui.windows.operations.presenter.BlockQtSignals"):
-            self.presenter.set_stack(stack)
+        stack = mock.Mock()
+        stack.num_sinograms = 2
+        self.presenter.set_stack(stack)
 
-        mock_init_roi_field.assert_called_once_with(mock_roi_field)
+        mock_filter.on_stack_changed.assert_called_once_with(self.presenter.model.filter_widget_kwargs, stack)
 
     @mock.patch('mantidimaging.gui.windows.operations.presenter.FiltersWindowPresenter._do_apply_filter_sync')
     def test_negative_values_found_in_twelve_or_less_ranges(self, do_apply_filter_sync_mock):


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3152 

### Description

- Added a `on_stack_changed` hook for filters that require refreshing UI states when the selected stack changes.
- Refactored `presenter.py` to make use of the hook through `self.model.selected_filter.on_stack_changed(self.model.filter_widget_kwargs, self.stack)` instead of checking against `CROP_COORDINATES` filter and removed its declaration.
- Added `test_set_stack_calls_selected_filter_on_stack_changed` which replaces the previous one by moving the assertion from checking that the presenter directly initialises the ROI UI to verifying that it correctly delegates stack changes to the active filter through the `on_stack_changed` hook.
- Added `test_on_stack_changed_updates_roi_field` to verify `on_stack_changed` gets the bounding box from the stack and updates the ROI field text accordingly. (NOTE: The `crop_coords.crop_coords` path is intentional because the package and module have identical names, so Python resolves it by first importing the package and then accessing the module inside it.)
- Added `test_on_stack_changed_with_no_stack_or_no_widget_does_nothing` to verify the case when there is no stack or no widget present `on_stack_changed` doesn't do anything.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- I added logs `within `set_stack`, `do_register_active_filter` and `_post_filter` during development to verify the functions were called as expected when crop coordinates operation was applied on different datasets.
- I have verified the tests I have added pass locally with:
   - `pytest mantidimaging/gui/windows/operations/test/presenter_test.py::FiltersWindowPresenterTest::test_set_stack_calls_selected_filter_on_stack_changed`
   - `pytest mantidimaging/core/operations/crop_coords/test/crop_coords_test.py::CropCoordsTest::test_on_stack_changed_updates_roi_field` 
   - `pytest mantidimaging/core/operations/crop_coords/test/crop_coords_test.py::CropCoordsTest::test_on_stack_changed_with_no_stack_or_no_widget_does_nothing`
   - Tested against the initial bug fix [3145](https://github.com/mantidproject/mantidimaging/pull/3145) and I can verify that the crop coordinates operation worked as expected.
  

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] Newly added tests pass locally: 
   - [ ] `pytest mantidimaging/gui/windows/operations/test/presenter_test.py::FiltersWindowPresenterTest::test_set_stack_calls_selected_filter_on_stack_changed`
   - [ ] `pytest mantidimaging/core/operations/crop_coords/test/crop_coords_test.py::CropCoordsTest::test_on_stack_changed_updates_roi_field` 
   - [ ] `pytest mantidimaging/core/operations/crop_coords/test/crop_coords_test.py::CropCoordsTest::test_on_stack_changed_with_no_stack_or_no_widget_does_nothing`
- Following cases give expected results
 #### ROI within FoV steps:
- [ ] Load two datasets, one with a larger (x, y) axis than the other.
- [ ] Open the Crop coordinates operation and select the larger stack
- [ ] Resize the ROI to be larger than the smaller stack and click okay, but don't apply the change
- [ ] Using the stack selector, select the smaller sample
- [ ] Open up the ROI editor view
- [ ] The ROI should be within the FoV of the imagestack 

#### Auto-crop is re-activated when switching between stacks when multiple datasets are loaded:
- [ ] Load two datasets, one with a larger (x, y) axis than the other.
- [ ] Open the Crop coordinates operation and open ROI editor - autocrop will work as expected
- [ ] Using the stack selector, select the smaller sample
- [ ] Open up the ROI editor view and confirm that the autocrop updates correctly
