### PR TITLE
Rattler-build: Fix version mismatch between built package and GUI

### DIFF
--- a/conda/build.bat
+++ b/conda/build.bat
@@ -1,3 +1,4 @@
+echo ===== BUILD.BAT STARTED =====
 python conda\make_versions.py
 python -m pip install --ignore-installed .
 del mantidimaging\versions.py

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,3 +1,4 @@
+echo ===== BUILD.SH STARTED =====
 python conda/make_versions.py
 python -m pip install --ignore-installed .
 rm mantidimaging/versions.py

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -13,7 +13,6 @@ source:
   path: ..
 
 build:
-  script: pip install . -vv
   python:
     entry_points:
       - mantidimaging = mantidimaging.main:main

--- a/docs/release_notes/next/feature-3136-migrate_to_rattler-build
+++ b/docs/release_notes/next/feature-3136-migrate_to_rattler-build
@@ -1,0 +1,1 @@
+#3136: Migrate to rattler-build for package building

--- a/docs/release_notes/next/fix-3182-fix_version_mismatch_between_generated_recipe_and_gui
+++ b/docs/release_notes/next/fix-3182-fix_version_mismatch_between_generated_recipe_and_gui
@@ -1,0 +1,1 @@
+#3182: Fix version mismatch between the generated recipe and gui


### PR DESCRIPTION


<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3182 

### Description

- Renamed `bld.bat` to `build.bat` as rattler-build defaults to that file name. [detailed here](https://rattler-build.prefix.dev/latest/build_script/)
- Added echos to both `build.bat` and `build.sh` to better understand their executions when built.
- Removed the script section from `recipe.yaml` as by default, rattler-Build uses a `build.sh` file on Unix (macOS and Linux) and a `build.bat` file on Windows, if they exist in the same folder as the recipe.yaml file. (which it does for mantidimaging) [ref](https://rattler-build.prefix.dev/latest/reference/recipe_file/#script)
- Added release notes

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`
- I can verify that following the steps below was reflecting the updated version.

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`
- [ ] run `rattler-build build -r conda/recipe.yaml --experimental --output-dir output/unstable --config-file conda/recipe_config.toml`
- [ ] rename the `mantidimaging-3.2.0a186-h9490d1a_0.conda` to `mantidimaging-3.2.0a186-h9490d1a_0.zip` and unzip.
- [ ] unzip the `tar` file in `C:\Programming\mantidimaging\output\unstable\win-64\pkg-mantidimaging-3.2.0a186-h9490d1a_0.tar.zst`
- [ ] check if the `versions.py` file reflect the generated version in `C:\Programming\mantidimaging\output\unstable\win-64\mantidimaging-3.2.0a186-h9490d1a_0 - Copy\pkg-mantidimaging-3.2.0a186-h9490d1a_0\Lib\site-packages\mantidimaging`
- [ ] create an environment and launch Mantid Imaging from `C:\Programming\mantidimaging\output\unstable\win-64\mantidimaging-3.2.0a186-h9490d1a_0 - Copy\pkg-mantidimaging-3.2.0a186-h9490d1a_0\Lib\site-packages\mantidimaging` to validate the GUI shows the updated version.

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

