### PR TITLE
[CI/CD] Developer Tools: Enable pre-commit hooks to use pixi environments & add feature tasks for checking license and release notes format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,10 @@ repos:
         types: [python]
         files: ^mantidimaging/
         pass_filenames: false
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.0
+    hooks:
+      - id: prettier
+        files: \.(json|ya?ml)$
+        exclude: ^conda/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,6 @@ repos:
         entry: pixi run -e dev check-licenses
         language: system
         types: [python]
-        files: ^mantidimaging/
 
       - id: check-release-notes-format
         name: Check Release Notes Format
@@ -24,38 +23,37 @@ repos:
       - id: yapf
         name: yapf
         description: Checks that all files pass yapf checks
-        entry: pixi run -e dev yapf
+        entry: pixi run -e lint yapf-staged-base
         language: system
         types: [python]
         files: ^mantidimaging/
-        pass_filenames: false
+        pass_filenames: true
 
       - id: mypy
         name: mypy
         description: Checks that all files pass mypy checks
-        entry: pixi run -e dev mypy
+        entry: pixi run -e dev mypy-staged-base
         language: system
         types: [python]
         files: ^mantidimaging/
-        pass_filenames: false
+        pass_filenames: true
 
       - id: pyright
         name: pyright
         description: Checks that all files pass pyright checks
-        entry: pixi run -e dev pyright
+        entry: pixi run -e dev pyright-staged-base
         language: system
         types: [python]
-        files: ^mantidimaging/
-        pass_filenames: false
+        pass_filenames: true
 
       - id: ruff
         name: ruff
         description: Checks that all files pass ruff checks
-        entry: pixi run -e dev ruff
+        entry: pixi run -e lint ruff-staged-base
         language: system
         types: [python]
         files: ^mantidimaging/
-        pass_filenames: false
+        pass_filenames: true
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,49 +4,55 @@ repos:
     hooks:
       - id: end-of-file-fixer
         types: [python]
-  - repo: https://github.com/google/yapf
-    rev: v0.43.0
-    hooks:
-      - id: yapf
   - repo: local
     hooks:
       - id: check-licenses
         name: Check Licenses
         description: Checks that all files have correct copyright licenses
-        entry: python -m CheckLicensesInFiles
-        language: python
+        entry: pixi run -e dev check-licenses
+        language: system
         types: [python]
-  - repo: local
-    hooks:
+        files: ^mantidimaging/
+
       - id: check-release-notes-format
         name: Check Release Notes Format
         description: Validate release note filename and contents format before commit
-        entry: python  -m CheckReleaseNoteFormat
-        language: python
+        entry: pixi run -e dev check-release-notes-format
+        language: system
         files: ^docs/release_notes/next/
-        additional_dependencies: [requests]
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.17.1"
-    hooks:
-      - id: mypy
+
+      - id: yapf
+        name: yapf
+        description: Checks that all files pass yapf checks
+        entry: pixi run -e dev yapf
+        language: system
+        types: [python]
         files: ^mantidimaging/
-        args: [--ignore-missing-imports]
-        additional_dependencies: [types-docutils, types-PyYAML, types-requests]
-  - repo: local
-    hooks:
+        pass_filenames: false
+
+      - id: mypy
+        name: mypy
+        description: Checks that all files pass mypy checks
+        entry: pixi run -e dev mypy
+        language: system
+        types: [python]
+        files: ^mantidimaging/
+        pass_filenames: false
+
       - id: pyright
         name: pyright
         description: Checks that all files pass pyright checks
-        entry: pyright
+        entry: pixi run -e dev pyright
         language: system
         types: [python]
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.7
-    hooks:
+        files: ^mantidimaging/
+        pass_filenames: false
+
       - id: ruff
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0
-    hooks:
-      - id: prettier
-        files: \.(json|ya?ml)$
-        exclude: ^conda/
+        name: ruff
+        description: Checks that all files pass ruff checks
+        entry: pixi run -e dev ruff
+        language: system
+        types: [python]
+        files: ^mantidimaging/
+        pass_filenames: false

--- a/docs/developer_docs/how-to-guides/testing.rst
+++ b/docs/developer_docs/how-to-guides/testing.rst
@@ -63,7 +63,7 @@ Mantid Imaging uses `pre-commit <https://pre-commit.com/>`_ to run pre-commit ho
 
 To enable pre-commit hooks, you must manually install them by running::
 
-    pre-commit install
+    pixi run -e dev setup-pre-commit
 
 Once installed, the hooks will execute automatically with every commit.
 
@@ -78,7 +78,7 @@ Unit testing
 
 Unit tests can be run using `pytest <https://docs.pytest.org/>`_, e.g.::
 
-    make pytest
+    pixi run test-base
 
 For options such as running a subset of tests, see `PyTest Docs <https://docs.pytest.org/en/stable/usage.html>`_.
 
@@ -89,18 +89,20 @@ Static analysis
 Mantid Imaging uses several tools to ensure high code quality and consistency:
 
 - `mypy <http://mypy-lang.org/>`_: Enforces type correctness to catch potential type errors early.
+- `pyright <https://github.com/microsoft/pyright>`_: Performs fast static type analysis with advanced type inference to identify potential type issues and improve type safety.
 - `ruff <https://beta.ruff.rs/docs/>`_: Checks for common syntax and style issues to maintain clean, readable code.
 - `yapf <https://github.com/google/yapf>`_: Formats code according to PEP 8 standards, ensuring consistent style.
 
 These tools can be run collectively with:
 
-- :code:`make check`: Runs all static analysis tools together for a comprehensive check.
+- :code:`pixi run lint-all`: Runs all static analysis tools together for a comprehensive check.
 
 Or individually for specific tasks:
 
-- :code:`make mypy`: Perform static type checks.
-- :code:`make ruff`: Lint the code for syntax and style issues.
-- :code:`make yapf`: Automatically format code according to PEP 8.
+- :code:`pixi run mypy`: Perform static type checks.
+- :code:`pixi run pyright`: Run Pyright's static type analysis with additional type inference checks.
+- :code:`pixi run ruff`: Lint the code for syntax and style issues.
+- :code:`pixi run yapf`: Automatically format code according to PEP 8.
 
 
 GUI Screenshot Testing

--- a/docs/release_notes/next/dev-2967-enable-pre_commit_hooks_to_use_pixi
+++ b/docs/release_notes/next/dev-2967-enable-pre_commit_hooks_to_use_pixi
@@ -1,0 +1,1 @@
+#2967: Enable pre-commit hooks to use pixi, add pixi tasks for checking licenses,release notes format and pre-commit install, and update documentation.

--- a/pixi.toml
+++ b/pixi.toml
@@ -252,7 +252,9 @@ description = "Run screenshot tests (GPU)"
 mypy-base = { cmd = "python -m mypy --ignore-missing-imports $SOURCE_DIRS", description = "Run mypy type checks (fail on error)" }
 pyright-base = { cmd = "python -m pyright", description = "Run pyright type checks (fail on error)" }
 yapf-base = { cmd = "python -m yapf --parallel --diff --recursive $SOURCE_DIRS", description = "Check code formatting with yapf (fail on error)" }
+yapf-staged-base = { cmd = "python -m yapf --parallel --diff", description = "Check formatting of staged files with yapf (for pre-commit)" }  
 ruff-base = { cmd = "ruff check $SOURCE_DIRS", description = "Run ruff linter (fail on error)" }
+ruff-staged-base = { cmd = "ruff check", description = "Run ruff on staged files (for pre-commit)" }
 
 # Base linting tasks - CONTINUE ON ERROR (with || true)
 mypy-base-continue = { cmd = "python -m mypy --ignore-missing-imports $SOURCE_DIRS || true", description = "Run mypy type checks (continue on error)" }
@@ -268,6 +270,8 @@ build-docs-base = { cmd = "python -c 'import shutil; shutil.rmtree(\"docs/api\",
 build-docs-headless-base = { cmd = "python -c 'import shutil; shutil.rmtree(\"docs/api\", ignore_errors=True)' && sphinx-apidoc -f -M -e -T -d 3 mantidimaging '**/test' '**/test_helpers' '**/eyes_tests' '**/tests' 'mantidimaging/ipython' -o docs/api/ && sphinx-build -b html docs/ docs/build/html", cwd = ".", env = { QT_QPA_PLATFORM = "offscreen" }, description = "Base task to build Sphinx documentation in headless mode" }
 serve-docs-base = { cmd = "python -m http.server 8000", cwd = "docs/build/html", description = "Base task to serve built documentation on http://localhost:8000" }
 release-notes-base = { cmd = "python setup.py release_notes", description = "Base task to generate release notes" }
+mypy-staged-base = { cmd = "python -m mypy --ignore-missing-imports", description = "Run mypy on staged files (for pre-commit)" }  
+pyright-staged-base = { cmd = "python -m pyright", description = "Run pyright on staged files (for pre-commit)" }  
 check-licenses = { cmd = "python -m CheckLicensesInFiles" }
 check-release-notes-format = { cmd = "python -m CheckReleaseNoteFormat" }
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -271,6 +271,8 @@ release-notes-base = { cmd = "python setup.py release_notes", description = "Bas
 check-licenses = { cmd = "python -m CheckLicensesInFiles" }
 check-release-notes-format = { cmd = "python -m CheckReleaseNoteFormat" }
 
+setup-pre-commit = { cmd = "pre-commit install", description = "Install the Git pre-commit hook" }
+
 [tasks]
 #Run Mantid Imaging Application
 MI-base = { cmd = "python -m mantidimaging", description = "Base task to launch Mantid Imaging GUI (used by other tasks)" }

--- a/pixi.toml
+++ b/pixi.toml
@@ -268,6 +268,8 @@ build-docs-base = { cmd = "python -c 'import shutil; shutil.rmtree(\"docs/api\",
 build-docs-headless-base = { cmd = "python -c 'import shutil; shutil.rmtree(\"docs/api\", ignore_errors=True)' && sphinx-apidoc -f -M -e -T -d 3 mantidimaging '**/test' '**/test_helpers' '**/eyes_tests' '**/tests' 'mantidimaging/ipython' -o docs/api/ && sphinx-build -b html docs/ docs/build/html", cwd = ".", env = { QT_QPA_PLATFORM = "offscreen" }, description = "Base task to build Sphinx documentation in headless mode" }
 serve-docs-base = { cmd = "python -m http.server 8000", cwd = "docs/build/html", description = "Base task to serve built documentation on http://localhost:8000" }
 release-notes-base = { cmd = "python setup.py release_notes", description = "Base task to generate release notes" }
+check-licenses = { cmd = "python -m CheckLicensesInFiles" }
+check-release-notes-format = { cmd = "python -m CheckReleaseNoteFormat" }
 
 [tasks]
 #Run Mantid Imaging Application


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #2967 

### Description

- Updated `.pre-commit-config.yaml` with pre-commits using pixi's environment instead of creating their own isolated ones.
- Updated `pixi.toml` with the following tasks:
  - `check-license` to run `python -m CheckLicensesInFiles`.
  - `check-release-notes-format` to run `python -m CheckReleaseNoteFormat`.
  - `setup-pre-commit` to run `pre-commit install`.
- Updated documentation to:
  - run `pixi run -e dev setup-pre-commit` for enabling pre-commit hooks instead of `pre-commit install`.
  - run `pixi run test-base` for running unit tests instead of `make pytest`.
  - add tool description for `pyright`.
  - specify running the tools collectively with `pixi run lint-all` rather than `make check`.
  - specify pixi command for running the tools individually.

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- I have verified unit tests pass locally: `python -m pytest -vs`.
- I have verified clean commits passing.
- I have verified committing with formatting issues fails.

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] Unit tests pass locally: `python -m pytest -vs`.
- [ ] Validate clean commits pass as expected.
- [ ] Validate commits with formatting issues fail as expected.
- [ ] Validate the documentation is updated correctly.

### Documentation and Additional Notes
There was no task added for `end-of-file-fixer` and `prettier` as they are self-contained hooks. Unlike Python tooling they dont duplicate configuration from `pixi.toml` so moving them to Pixi wouldn't really simplify maintenance.

