### PR TITLE
feat(recon): add SIRT non-negativity constraint

### DIFF
--- a/docs/release_notes/next/feature-3144-add-sirt-non-negativity-constraint
+++ b/docs/release_notes/next/feature-3144-add-sirt-non-negativity-constraint
@@ -1,0 +1,1 @@
+#3144: Add ability to apply a non-negativity constraint to SIRT reconstruction.

--- a/mantidimaging/core/reconstruct/astra_recon.py
+++ b/mantidimaging/core/reconstruct/astra_recon.py
@@ -146,6 +146,8 @@ class AstraRecon(BaseRecon):
             proj_geom = astra.create_proj_geom('parallel_vec', image_width, vectors)
             cfg = astra.astra_dict(recon_params.algorithm)
             cfg['FilterType'] = recon_params.filter_name
+            if recon_params.non_negative:
+                cfg['option'] = {'MinConstraint': 0.0}
 
             with _managed_recon(sino, cfg, proj_geom, vol_geom) as (alg_id, rec_id):
                 astra.algorithm.run(alg_id, iterations=recon_params.num_iter)
@@ -182,6 +184,8 @@ class AstraRecon(BaseRecon):
 def allowed_recon_kwargs() -> dict:
     return {
         'FBP_CUDA': ['filter_name', 'filter_par'],
-        'SIRT_CUDA': ['num_iter', 'min_constraint', 'max_constraint', 'DetectorSuperSampling', 'PixelSuperSampling'],
-        'SIRT3D_CUDA': ['num_iter', 'min_constraint', 'max_constraint', 'DetectorSuperSampling', 'PixelSuperSampling']
+        'SIRT_CUDA':
+        ['num_iter', 'non_negative', 'min_constraint', 'max_constraint', 'DetectorSuperSampling', 'PixelSuperSampling'],
+        'SIRT3D_CUDA':
+        ['num_iter', 'non_negative', 'min_constraint', 'max_constraint', 'DetectorSuperSampling', 'PixelSuperSampling']
     }

--- a/mantidimaging/core/reconstruct/test/astra_recon_test.py
+++ b/mantidimaging/core/reconstruct/test/astra_recon_test.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest import mock
+
+import numpy as np
+
+from mantidimaging.core.data import ImageStack
+from mantidimaging.core.reconstruct.astra_recon import AstraRecon, allowed_recon_kwargs
+from mantidimaging.core.utility.data_containers import ProjectionAngles, ReconstructionParameters, ScalarCoR
+
+
+def test_allowed_recon_kwargs_include_non_negative_for_sirt():
+    assert "non_negative" in allowed_recon_kwargs()["SIRT_CUDA"]
+    assert "non_negative" in allowed_recon_kwargs()["SIRT3D_CUDA"]
+
+
+@mock.patch("mantidimaging.core.reconstruct.astra_recon.CudaChecker.cuda_is_present", return_value=False)
+@mock.patch("mantidimaging.core.reconstruct.astra_recon.astra.data2d.get", return_value=np.ones((2, 2)))
+@mock.patch("mantidimaging.core.reconstruct.astra_recon.astra.algorithm.run")
+@mock.patch("mantidimaging.core.reconstruct.astra_recon.astra.astra_dict",
+            side_effect=lambda algorithm: {"algorithm": algorithm})
+@mock.patch("mantidimaging.core.reconstruct.astra_recon.astra.create_proj_geom")
+@mock.patch("mantidimaging.core.reconstruct.astra_recon.astra.create_vol_geom")
+def test_single_sino_sets_min_constraint_for_non_negative_sirt(
+    create_vol_geom_mock,
+    create_proj_geom_mock,
+    astra_dict_mock,
+    algorithm_run_mock,
+    _astra_get_mock,
+    _cuda_mock,
+):
+    image_stack = ImageStack(data=np.ones((1, 2, 2), dtype=np.float32))
+    image_stack.set_projection_angles(ProjectionAngles(np.array([0.0])))
+    assert image_stack.geometry is not None
+    image_stack.geometry.cor = ScalarCoR(1.0)
+
+    recon_params = ReconstructionParameters("SIRT_CUDA", "none", num_iter=3, non_negative=True)
+
+    captured_cfg = {}
+
+    @contextmanager
+    def fake_managed_recon(_sino, cfg, _proj_geom, _vol_geom):
+        captured_cfg.update(cfg)
+        yield 1, 2
+
+    with mock.patch("mantidimaging.core.reconstruct.astra_recon._managed_recon", side_effect=fake_managed_recon):
+        AstraRecon.single_sino(image_stack, 0, recon_params)
+
+    assert captured_cfg["option"] == {"MinConstraint": 0.0}
+    astra_dict_mock.assert_called_once_with("SIRT_CUDA")
+    algorithm_run_mock.assert_called_once_with(1, iterations=3)
+    create_vol_geom_mock.assert_called_once_with((2, 2))
+    create_proj_geom_mock.assert_called_once()

--- a/mantidimaging/gui/windows/recon/test/presenter_test.py
+++ b/mantidimaging/gui/windows/recon/test/presenter_test.py
@@ -272,6 +272,34 @@ class ReconWindowPresenterTest(unittest.TestCase):
         mock_corview.return_value.exec.assert_called_once()
         assert self.view.num_iter == iters
 
+    @mock.patch("mantidimaging.gui.windows.recon.presenter.BlockQtSignals")
+    def test_do_algorithm_changed_shows_non_negative_for_sirt(self, _):
+        self.presenter.allowed_recon_kwargs = {
+            "SIRT_CUDA": ["num_iter", "non_negative", "min_constraint"],
+            "FBP_CUDA": ["filter_name"],
+        }
+        self.view.algorithm_name = "SIRT_CUDA"
+        self.presenter.do_preview_reconstruct_slice = mock.Mock()
+
+        self.presenter.do_algorithm_changed()
+
+        self.view.nonNegativeCheckBox.show.assert_called_once_with()
+        self.view.nonNegativeLabel.show.assert_called_once_with()
+
+    @mock.patch("mantidimaging.gui.windows.recon.presenter.BlockQtSignals")
+    def test_do_algorithm_changed_hides_non_negative_for_fbp(self, _):
+        self.presenter.allowed_recon_kwargs = {
+            "SIRT_CUDA": ["num_iter", "non_negative", "min_constraint"],
+            "FBP_CUDA": ["filter_name"],
+        }
+        self.view.algorithm_name = "FBP_CUDA"
+        self.presenter.do_preview_reconstruct_slice = mock.Mock()
+
+        self.presenter.do_algorithm_changed()
+
+        self.view.nonNegativeCheckBox.hide.assert_called_once_with()
+        self.view.nonNegativeLabel.hide.assert_called_once_with()
+
     @mock.patch("mantidimaging.gui.windows.recon.presenter.ReconstructWindowPresenter._update_imagestack_geometry_data")
     def test_do_cor_fit(self, _):
         self.presenter.do_preview_reconstruct_slice = mock.Mock()


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3144 

### Description

This change adds support for a non-negativity constraint in SIRT reconstructions using ASTRA. When the existing reconstruction “Non-negative” option is enabled for SIRT, the backend now forwards ASTRA’s MinConstraint = 0 setting so reconstructed values are clamped at zero.

The reconstruction window also now exposes the non-negative control for SIRT, matching the behaviour already available for other algorithms that support the option.


### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [x] Unit tests pass locally: `python -m pytest -vs`
- [x]  Confirm the SIRT reconstruction UI shows the non-negative checkbox.
- [x]  Confirm enabling non-negative reconstruction maps to ASTRA MinConstraint = 0.
- [x]  Run the focused tests for the recon window and ASTRA recon slice.


