### PR TITLE
dev-3186: add PyCharm IDE setup docs for contributors

### DIFF
--- a/docs/developer_docs/how-to-guides/index.rst
+++ b/docs/developer_docs/how-to-guides/index.rst
@@ -11,6 +11,7 @@ Specific guides for common development tasks.
 
    command.rst
    vsc_setup.rst
+   pycharm_setup.rst
    debugging.rst
    testing.rst
    release.rst

--- a/docs/developer_docs/how-to-guides/pycharm_setup.rst
+++ b/docs/developer_docs/how-to-guides/pycharm_setup.rst
@@ -1,0 +1,67 @@
+PyCharm
+=======
+
+Overview
+--------
+This page is aimed at developers who use `PyCharm <https://www.jetbrains.com/pycharm/download/>`_ as their integrated development environment (IDE) for Mantid Imaging development.
+
+It includes:
+
+- Opening the Mantid Imaging project in PyCharm
+- Configuring the project interpreter
+- Optional save and formatting settings
+
+How-to Guides
+=============
+
+How to open and prepare PyCharm for Mantid Imaging development
+--------------------------------------------------------------
+
+Prerequisites
+~~~~~~~~~~~~~
+Before starting, ensure you have:
+
+1. An installed copy of `PyCharm <https://www.jetbrains.com/pycharm/download/>`_
+2. A clone of the `Mantid Imaging repository <https://github.com/mantidproject/mantidimaging>`_
+3. A configured Mantid Imaging developer environment (see :ref:`getting-started` guide)
+
+Opening the project
+~~~~~~~~~~~~~~~~~~~
+1. Open PyCharm
+2. Click ``Open`` on the welcome screen (or ``File -> Open``)
+3. Select your local ``mantidimaging`` source directory
+
+PyCharm will index the project and detect Python files automatically.
+
+.. _selecting-pycharm-python-interpreter:
+
+Selecting the Python interpreter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1. Open ``File -> Settings`` (Windows/Linux) or ``PyCharm -> Settings`` (macOS)
+2. Navigate to ``Project: mantidimaging -> Python Interpreter``
+3. Click ``Add Interpreter`` and select the environment that matches your Mantid Imaging developer setup (for example, ``mantidimaging-dev``)
+4. Apply the changes
+
+Verify that the selected interpreter is correct by checking the interpreter shown in the status bar and by opening the Python Console in PyCharm.
+
+If you are using Pixi, select the interpreter from the local Pixi environment in ``.pixi/envs/dev``.
+
+How to configure save behavior
+------------------------------
+PyCharm saves files automatically in most workflows (for example when switching windows or running code). To tune this behavior:
+
+1. Open ``File -> Settings -> Appearance & Behavior -> System Settings``
+2. Enable or adjust the save options for your preferred workflow
+
+How to disable auto-format on save
+----------------------------------
+PyCharm can run formatting actions automatically on save using ``Actions on Save``.
+
+1. Open ``File -> Settings -> Tools -> Actions on Save``
+2. Disable actions such as ``Reformat code`` and ``Optimize imports`` if you do not want automatic formatting on save
+
+See Also
+========
+- :ref:`pycharm_plugins` - A list of required and recommended plugins and settings for PyCharm.
+- :ref:`pycharm-keyboard-shortcuts` - Commonly used keyboard shortcuts in PyCharm for efficient coding and navigation.
+- :ref:`debugging-python-tests` - A guide on setting up and using the debugger for Python development.

--- a/docs/developer_docs/reference/index.rst
+++ b/docs/developer_docs/reference/index.rst
@@ -10,3 +10,4 @@ Reference
    ../../api
    ../../release_notes/next
    vsc_extensions
+   pycharm_plugins

--- a/docs/developer_docs/reference/pycharm_plugins.rst
+++ b/docs/developer_docs/reference/pycharm_plugins.rst
@@ -1,0 +1,88 @@
+.. _pycharm_plugins:
+
+PyCharm Plugins and Keybindings
+===============================
+
+Plugins can be installed from the `JetBrains Marketplace <https://plugins.jetbrains.com/>`_ or through ``Settings -> Plugins`` in PyCharm.
+
+Required Plugins
+----------------
+
+Python Development
+~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+    :widths: 25 75
+    :header-rows: 1
+
+    * - Plugin
+      - Purpose
+    * - `Python (bundled with PyCharm) <https://www.jetbrains.com/help/pycharm/installing-uninstalling-and-enabling-disabling-plugins.html>`_
+      - Core Python editing, navigation, refactoring, and debugging support.
+    * - `Ruff <https://plugins.jetbrains.com/plugin/20574-ruff>`_
+      - Integrates Ruff linting and formatting checks into the IDE.
+
+Recommended Plugins
+-------------------
+
+Code Reviews
+~~~~~~~~~~~~
+
+.. list-table::
+    :widths: 25 75
+    :header-rows: 1
+
+    * - Plugin
+      - Purpose
+    * - `GitHub <https://plugins.jetbrains.com/plugin/7499-github>`_
+      - Enables pull request and issue integration directly from PyCharm.
+
+Markdown and Documentation
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+    :widths: 25 75
+    :header-rows: 1
+
+    * - Plugin
+      - Purpose
+    * - `Markdown <https://plugins.jetbrains.com/plugin/7793-markdown>`_
+      - Improves Markdown editing and preview when writing documentation and release notes.
+
+.. _pycharm-keyboard-shortcuts:
+
+Keybindings
+-----------
+PyCharm provides a wide range of keyboard shortcuts for actions such as search, navigation, and run/debug.
+
+Commonly used keybindings
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :widths: 25 25 25 25
+   :header-rows: 1
+
+   * - Function
+     - Linux
+     - macOS
+     - Windows
+   * - Search in Files
+     - Ctrl+Shift+F
+     - Cmd+Shift+F
+     - Ctrl+Shift+F
+   * - Find Action
+     - Ctrl+Shift+A
+     - Cmd+Shift+A
+     - Ctrl+Shift+A
+   * - Open File
+     - Ctrl+Shift+N
+     - Cmd+Shift+O
+     - Ctrl+Shift+N
+   * - Run
+     - Shift+F10
+     - Control+R
+     - Shift+F10
+   * - Debug
+     - Shift+F9
+     - Control+D
+     - Shift+F9

--- a/docs/release_notes/next/dev-3186-Create_Developer_IDE_Environment_Setup_Documentation_for_PyCharm
+++ b/docs/release_notes/next/dev-3186-Create_Developer_IDE_Environment_Setup_Documentation_for_PyCharm
@@ -1,0 +1,1 @@
+#3186: Add developer documentation for configuring PyCharm as an IDE for Mantid Imaging, including setup steps and recommended plugins/keybindings.


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3186 

### Description

This change improves contributor onboarding by adding dedicated PyCharm IDE setup documentation for Mantid Imaging, aligned with the existing VS Code guidance so developers get a consistent experience regardless of editor choice. The new content explains how to open the project, select the correct Python interpreter for the development environment, configure save and format-on-save behavior, and use recommended plugins and keybindings. Together, these updates make it easier for new contributors to get productive quickly, reduce setup friction, and standardize local development practices across the team.