### PR TITLE
Default image export stack selection to the currently selected stack …

### DIFF
--- a/docs/release_notes/next/feature-3180-default_selected_stack_in_image_save_dialog
+++ b/docs/release_notes/next/feature-3180-default_selected_stack_in_image_save_dialog
@@ -1,0 +1,1 @@
+#3180: Default image export stack selection to the currently selected stack in the main window tree when available

--- a/mantidimaging/gui/windows/main/image_save_dialog.py
+++ b/mantidimaging/gui/windows/main/image_save_dialog.py
@@ -25,9 +25,9 @@ def sort_by_tomo_and_recon(stack_id: StackId):
 
 
 class ImageSaveDialog(BaseDialogView):
-    selected_stack = uuid.UUID | None
+    selected_stack: uuid.UUID | None
 
-    def __init__(self, parent, stack_list):
+    def __init__(self, parent, stack_list, selected_stack_uuid: uuid.UUID | None = None):
         super().__init__(parent, 'gui/ui/image_save_dialog.ui')
 
         self.browseButton.clicked.connect(lambda: select_directory(self.savePath, "Browse"))
@@ -50,6 +50,9 @@ class ImageSaveDialog(BaseDialogView):
             self.stack_uuids, user_friendly_names = zip(*user_friendly_stack_list, strict=True)
 
             self.stackNames.addItems(user_friendly_names)
+
+            if selected_stack_uuid in self.stack_uuids:
+                self.stackNames.setCurrentIndex(self.stack_uuids.index(selected_stack_uuid))
 
         self.selected_stack = None
 

--- a/mantidimaging/gui/windows/main/presenter.py
+++ b/mantidimaging/gui/windows/main/presenter.py
@@ -545,11 +545,11 @@ class MainWindowPresenter(BasePresenter):
 
     def _select_tree_widget_item(self, tree_widget_item: QTreeWidgetItem) -> None:
         """
-        Clears the existing selection on the dataset tree view and selects a given item.
+        Clears the existing selection on the dataset tree view and sets a given current item.
         :param tree_widget_item: The item to select.
         """
         self.view.dataset_tree_widget.clearSelection()
-        tree_widget_item.setSelected(True)
+        self.view.dataset_tree_widget.setCurrentItem(tree_widget_item)
 
     @staticmethod
     def _remove_recon_item_from_tree_view(recon_group, uuid_remove: uuid.UUID) -> bool:

--- a/mantidimaging/gui/windows/main/test/Image_save_test.py
+++ b/mantidimaging/gui/windows/main/test/Image_save_test.py
@@ -43,3 +43,29 @@ class SaveDialogQtTest(unittest.TestCase):
         self.assertEqual(mwsd.stack_uuids[0], stack_list[4].id)
         # the Tomo stack is 2nd choice
         self.assertEqual(mwsd.stack_uuids[1], stack_list[3].id)
+
+    def test_init_uses_selected_stack_as_default(self):
+        stack_list = [
+            StackId(uuid.uuid4(), "Stack 1"),
+            StackId(uuid.uuid4(), "Stack 2"),
+            StackId(uuid.uuid4(), "Stack 3"),
+        ]
+        selected_stack_id = stack_list[1].id
+        mwsd = ImageSaveDialog(None, stack_list, selected_stack_uuid=selected_stack_id)
+
+        self.assertEqual(mwsd.stackNames.currentIndex(), 1)
+        self.assertEqual(mwsd.stack_uuids[mwsd.stackNames.currentIndex()], selected_stack_id)
+
+    def test_init_falls_back_to_existing_default_when_selected_stack_not_present(self):
+        stack_list = [
+            StackId(uuid.uuid4(), "Stack 1"),
+            StackId(uuid.uuid4(), "Stack 2"),
+            StackId(uuid.uuid4(), "Stack 3"),
+            StackId(uuid.uuid4(), "Stack Tomo"),
+            StackId(uuid.uuid4(), "Stack Recon"),
+        ]
+        mwsd = ImageSaveDialog(None, stack_list, selected_stack_uuid=uuid.uuid4())
+
+        # Existing behavior defaults to Recon/Tomo preference sorting.
+        self.assertEqual(mwsd.stack_uuids[0], stack_list[4].id)
+        self.assertEqual(mwsd.stackNames.currentIndex(), 0)

--- a/mantidimaging/gui/windows/main/test/presenter_test.py
+++ b/mantidimaging/gui/windows/main/test/presenter_test.py
@@ -575,8 +575,8 @@ class MainWindowPresenterTest(unittest.TestCase):
     def test_select_tree_widget_item(self):
         tree_widget_item = mock.Mock()
         self.presenter._select_tree_widget_item(tree_widget_item)
-        tree_widget_item.setSelected.assert_called_once_with(True)
         self.view.dataset_tree_widget.clearSelection.assert_called_once()
+        self.view.dataset_tree_widget.setCurrentItem.assert_called_once_with(tree_widget_item)
 
     def test_select_top_level_item(self):
         self.view.dataset_tree_widget.topLevelItemCount.return_value = 1
@@ -585,7 +585,7 @@ class MainWindowPresenterTest(unittest.TestCase):
 
         self.presenter._set_tree_view_selection_with_id(mock_id)
         self.view.dataset_tree_widget.clearSelection.assert_called_once()
-        mock_top_level_item.setSelected.assert_called_once_with(True)
+        self.view.dataset_tree_widget.setCurrentItem.assert_called_once_with(mock_top_level_item)
 
     def test_select_stack_item(self):
         mock_stack_widget = mock.Mock()
@@ -602,7 +602,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.notify(Notification.TAB_CLICKED, stack=mock_stack_widget)
 
         self.view.dataset_tree_widget.clearSelection.assert_called_once()
-        mock_stack_item.setSelected.assert_called_once_with(True)
+        self.view.dataset_tree_widget.setCurrentItem.assert_called_once_with(mock_stack_item)
 
     def test_select_recon_item(self):
         mock_recon_widget = mock.Mock()
@@ -622,7 +622,7 @@ class MainWindowPresenterTest(unittest.TestCase):
         self.presenter.notify(Notification.TAB_CLICKED, stack=mock_recon_widget)
 
         self.view.dataset_tree_widget.clearSelection.assert_called_once()
-        mock_recon_item.setSelected.assert_called_once_with(True)
+        self.view.dataset_tree_widget.setCurrentItem.assert_called_once_with(mock_recon_item)
 
     def test_all_stack_ids(self):
         mixed_stacks = [generate_images() for _ in range(5)]

--- a/mantidimaging/gui/windows/main/test/view_test.py
+++ b/mantidimaging/gui/windows/main/test/view_test.py
@@ -414,7 +414,7 @@ class MainWindowViewTest(unittest.TestCase):
     @mock.patch("mantidimaging.gui.windows.main.view.ImageSaveDialog")
     def test_show_image_save_dialog(self, image_save_dialog_mock):
         self.view.show_image_save_dialog()
-        image_save_dialog_mock.assert_called_once_with(self.view, self.view.stack_list)
+        image_save_dialog_mock.assert_called_once_with(self.view, self.view.stack_list, None)
         image_save_dialog_mock.return_value.show.assert_called_once()
 
     @mock.patch("mantidimaging.gui.windows.main.view.NexusSaveDialog")

--- a/mantidimaging/gui/windows/main/view.py
+++ b/mantidimaging/gui/windows/main/view.py
@@ -496,7 +496,7 @@ class MainWindowView(BaseMainWindowView):
                               new_name=new_dataset_name)
 
     def show_image_save_dialog(self) -> None:
-        self.image_save_dialog = ImageSaveDialog(self, self.stack_list)
+        self.image_save_dialog = ImageSaveDialog(self, self.stack_list, self.selected_stack_from_tree)
         self.image_save_dialog.show()
 
     def show_nexus_save_dialog(self) -> None:
@@ -577,6 +577,23 @@ class MainWindowView(BaseMainWindowView):
     @property
     def stack_list(self) -> list[StackId]:
         return self.presenter.stack_visualiser_list
+
+    @property
+    def selected_stack_from_tree(self) -> uuid.UUID | None:
+        selected_id = self._tree_item_id(self.dataset_tree_widget.currentItem())
+        if selected_id is None:
+            return None
+
+        if selected_id in self.presenter.all_stack_ids:
+            return selected_id
+
+        return None
+
+    @staticmethod
+    def _tree_item_id(item: QTreeWidgetItem | None) -> uuid.UUID | None:
+        if isinstance(item, QTreeDatasetWidgetItem):
+            return item.id
+        return None
 
     @property
     def stack_names(self) -> list[str]:


### PR DESCRIPTION
…in the main window tree when available

<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3180

### Description

This change improves export safety and usability by defaulting the Save Images dialog to the stack currently selected in the main window tree, when that selection is a valid stack.


### Acceptance Criteria and Reviewer Testing

- [ ]  Unit tests pass locally: python -m pytest -vs
- [ ]  Selecting a stack in the tree makes it the default in Save Images (including Recon/Spectrum workflows)
- [ ]  With no valid stack selected, fallback default remains Recon/Tomo preference
