### PR TITLE
update ROI normalisation air region when switching stacks

### DIFF
--- a/docs/release_notes/next/fix-3191-Refresh_ROI_normalisation_air_region_on_stack_change
+++ b/docs/release_notes/next/fix-3191-Refresh_ROI_normalisation_air_region_on_stack_change
@@ -1,0 +1,1 @@
+#3191: Refresh the ROI normalisation air region when the selected stack changes

--- a/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
+++ b/mantidimaging/core/operations/roi_normalisation/roi_normalisation.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from mantidimaging import helper as h
+from mantidimaging.core.fitting.bounding_box import get_bounding_box
 from mantidimaging.core.operations.base_filter import BaseFilter, FilterGroup
 from mantidimaging.core.parallel import shared as ps
 from mantidimaging.core.utility.sensible_roi import SensibleROI
@@ -16,6 +17,7 @@ from mantidimaging.gui.widgets.dataset_selector import DatasetSelectorWidgetView
 
 if TYPE_CHECKING:
     from mantidimaging.core.data import ImageStack
+    from PyQt5.QtWidgets import QWidget
 
 
 def modes() -> list[str]:
@@ -158,6 +160,19 @@ class RoiNormalisationFilter(BaseFilter):
                        region_of_interest=roi,
                        normalisation_mode=mode,
                        flat_field=flat_images)
+
+    @staticmethod
+    def on_stack_changed(filter_widget_kwargs: dict[str, QWidget], stack: ImageStack | None) -> None:
+        """
+        Refresh the air region ROI when the selected stack changes.
+        """
+        if stack is None:
+            return
+        roi_field = filter_widget_kwargs.get('roi_field')
+        if roi_field is None:
+            return
+        air_roi = get_bounding_box(stack)
+        roi_field.setText(air_roi.to_list_string())
 
     @staticmethod
     def group_name() -> FilterGroup:

--- a/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
+++ b/mantidimaging/core/operations/roi_normalisation/test/roi_normalisation_test.py
@@ -123,6 +123,38 @@ class ROINormalisationTest(unittest.TestCase):
         flat_val = mock.Mock()
         self.assertRaises(ValueError, RoiNormalisationFilter.filter_func, images_mock, roi_mock, mode_val, flat_val)
 
+    def test_on_stack_changed_updates_roi_field(self):
+        roi_mock = mock.Mock()
+        filter_widget_kwargs = {"roi_field": roi_mock}
+        stack = mock.Mock()
+        with mock.patch("mantidimaging.core.operations.roi_normalisation.roi_normalisation.get_bounding_box"
+                        ) as get_bounding_box_mock:
+            mock_roi = mock.Mock()
+            mock_roi.to_list_string.return_value = "1, 2, 3, 4"
+            get_bounding_box_mock.return_value = mock_roi
+
+            RoiNormalisationFilter.on_stack_changed(filter_widget_kwargs, stack)
+
+            self.assertEqual(get_bounding_box_mock.call_count, 1)
+            get_bounding_box_mock.assert_called_once_with(stack)
+            self.assertEqual(roi_mock.setText.call_count, 1)
+            roi_mock.setText.assert_called_once_with("1, 2, 3, 4")
+
+    def test_on_stack_changed_with_no_stack_does_nothing(self):
+        roi_mock = mock.Mock()
+        filter_widget_kwargs = {"roi_field": roi_mock}
+        RoiNormalisationFilter.on_stack_changed(filter_widget_kwargs, None)
+        self.assertEqual(roi_mock.setText.call_count, 0)
+        roi_mock.setText.assert_not_called()
+
+    def test_on_stack_changed_with_no_widget_does_nothing(self):
+        stack = mock.Mock()
+        with mock.patch("mantidimaging.core.operations.roi_normalisation.roi_normalisation.get_bounding_box"
+                        ) as get_bounding_box:
+            RoiNormalisationFilter.on_stack_changed({}, stack)
+            self.assertEqual(get_bounding_box.call_count, 0)
+            get_bounding_box.assert_not_called()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Issue Closes #3191

### Description
Added an on_stack_changed hook to the ROI Normalisation operation so the air region ROI is refreshed when the selected stack changes. This keeps the ROI bounded to the current stack in the same way as Crop Coordinates.

### Developer Testing

- [x] I have verified the new unit tests for ROI normalisation stack-change behavior.
- [ ] I have not completed a full local python -m pytest -vs run in this session.
- [x] Acceptance Criteria and Reviewer Testing
- [x]  Unit tests pass locally: python -m pytest -vs
- [x]  Verify ROI Normalisation refreshes the air region ROI after switching stacks.
- [x]  Confirm the release note is included in the next release notes build.
