### PR TITLE
Update environment minimum version to 2.8.0

### DIFF
--- a/docs/release_notes/next/dev-3130-update-environment-minimum-version
+++ b/docs/release_notes/next/dev-3130-update-environment-minimum-version
@@ -1,0 +1,1 @@
+#3130: Update minimum mantidimaging environment dependency to 2.8.0

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -6,7 +6,7 @@ channels:
   - algotom
   - https://software.repos.intel.com/python/conda/
 dependencies:
-  - mantidimaging>=2.5.0
+  - mantidimaging>=2.8.0
   - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774
   - numba==0.61.* # https://github.com/numba/numba/issues/10239
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ channels:
   - https://software.repos.intel.com/python/conda/
 # Dependencies that can be installed with conda should be in conda/meta.yaml
 dependencies:
-  - mantidimaging>=2.5.0
+  - mantidimaging>=2.8.0
   - conda-forge::numexpr # https://github.com/mantidproject/mantidimaging/issues/1774
   - numba==0.61.* # https://github.com/numba/numba/issues/10239
   - ipp=2021.12 # https://github.com/mantidproject/mantidimaging/issues/2354


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #3130

### Description

Updated the minimum mantidimaging dependency version from >=2.5.0 to >=2.8.0 in both environment files:


### Acceptance Criteria and Reviewer Testing

- [ ]  Unit tests pass locally: python -m pytest -vs
- [ ]  Environment creation succeeds: mamba env create -f environment.yml
- [ ]  Environment creation succeeds: mamba env create -f environment-dev.yml
- [ ]  Verify mantidimaging minimum version is >=2.8.0 in environment.yml and environment-dev.yml
- [ ]  Verify release note exists and is correctly formatted in docs/release_notes/next/dev-3130-update-environment-minimum-version

