### PR TITLE
Resolve Version Schema for built packages

### DIFF
--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -1,9 +1,9 @@
 schema_version: 1
 
 context:
-  version_tag: ${{ git.latest_tag(".") | default("0.0.0")}} # ratter-build --experimental
-  commit_number: ${{ git.latest_tag_distance(".")  | default("0")}} # ratter-build>=0.65 --experimental
-  version: ${{ version_tag + commit_number }}
+  version_tag: ${{ git.latest_tag(".") | default("0.0.0")}} # rattler-build --experimental
+  commit_number: ${{ git.latest_tag_distance(".") | default("0")}} # ratter-build>=0.65 --experimental
+  version: ${{ version_tag ~ (".post" ~ commit_number if commit_number > 0 else "") }}
 
 package:
   name: mantidimaging


### PR DESCRIPTION
Resolve schema for build version from V.V.V<N> to V.V.V<.post<N>> to match the version schema used previously in conda/meta.yaml

<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes: N/A Flash PR

### Description

<!-- Add a description of the changes made. -->

The [version numbers in Anaconda](https://anaconda.org/channels/mantidimaging/packages/mantidimaging/files) don't quite match what we used to have with `conda/meta.yml` prior to the rattler-build migration. Our build version seems to be `3.2.0a172` (i.e. V.V.Va1<N>` when it should be `V.V.Va1<.postN>` if we want to continue to match the version schema we have used previously to avoid possible confusion. where `.postN` will be added when the version tag is non-zero.

This PR modified the `recipe.yaml` to update the version with an if statement to check the tag version and dynamically format with `.postN`

### Developer Testing 

<!-- Describe the tests that were used to verify your changes -->
- Check Anaconda to validate version schema is correctly set when publish package is ran (i'v

### Acceptance Criteria and Reviewer Testing

<!-- Validation checks the reviewer should make and step by step instructions for how the reviewer should test including any necessary environment setup (Reviewer should tick off each check. Reviewer may also perform additional tests-->
- [ ] See comment below: https://github.com/mantidproject/mantidimaging/pull/3200#issuecomment-5132466411 and validate package visible on Anaconda

### Documentation and Additional Notes

<!-- Please un-comment any of the below checkboxes applicable for your PR. This could be updated release notes, sphinx documentation, or screenshot tests.
Please also add any additional notes that may be helpful to the reviewer here including screenshots if necessary -->

<!-- - [ ] Release Notes have been updated
- [ ] Sphinx documentation has been updated
- [ ] Screenshot tests have been updated
  - [ ] **Before merge for developer:** Resolve the change on applitools by, creating a new baseline for test and verify that the tests pass.
  - [ ] **After merge for reviewer:** Go to [Applitools compare and merge page](https://eyes.applitools.com/app/merge/), select all changes and merge dev branch to default branch
  - [ ] **After merge for reviewer:** Verify that other PR's screenshot tests do not start to fail (See [Applitools baselines](https://eyes.applitools.com/app/baselines) for more info) -->

