### PR TITLE
3203 release prep clean

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -42,9 +42,9 @@ authors:
     orcid: https://orcid.org/0000-0002-7495-8655
 title: "Mantid Imaging"
 abstract: "Mantid Imaging is a graphical toolkit for performing 3D reconstruction of neutron tomography data.  It provides an easy-to-use graphical interface to a wide range of pre/post-processing operations, tilt correction and reconstruction algorithms, accommodating for tomography users with varying data complexity and image analysis background knowledge. It utilises a flexible plugin system that allows easy integration of external software, and has allowed us to re-use software widely known in the neutron tomography community."
-version: "3.1.0"
+version: "3.1.1"
 doi: 10.5281/zenodo.4728059
-date-released: 2026-04-16
+date-released: 2026-08-03
 license: "GPL-3.0-or-later"
 repository-code: https://github.com/mantidproject/mantidimaging
 url: https://mantidproject.github.io/mantidimaging

--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -1,11 +1,16 @@
 [
   {
-    "name": "v3.1.0 (dev)",
-    "version": "3.1.0a1",
+    "name": "v3.1.1 (dev)",
+    "version": "3.1.1a1",
     "url": "/mantidimaging/"
   },
   {
-    "name": "v3.1.0 (stable)",
+    "name": "v3.1.1 (stable)",
+    "version": "3.1.1",
+    "url": "/mantidimaging/3.1.1"
+  },
+  {
+    "name": "v3.1.0",
     "version": "3.1.0",
     "url": "/mantidimaging/3.1.0"
   },

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,6 +57,6 @@ For more information, see the :ref:`overview`.
    Anaconda Package <https://anaconda.org/mantidimaging/mantidimaging>
 
 Please cite as:
-Akello-Egwel, Dolica; Alhassan, Hussam; Allen, Jack; Baust, Rachel; Cornal, James; Gigg, Martyn; Ioannide, Despina; Jones, Samuel; Kulan, Rasmia; Meigh, Ashley; Nixon, Daniel; Stock, Samuel; Sullivan, Michael; Tasev, Dimitar; Taylor, Will; Tygier, Sam. (2026). Mantid Imaging (3.1.0), Zenodo https://doi.org/10.5281/zenodo.4728059
+Akello-Egwel, Dolica; Alhassan, Hussam; Allen, Jack; Baust, Rachel; Cornal, James; Gigg, Martyn; Ioannide, Despina; Jones, Samuel; Kulan, Rasmia; Meigh, Ashley; Nixon, Daniel; Stock, Samuel; Sullivan, Michael; Tasev, Dimitar; Taylor, Will; Tygier, Sam. (2026). Mantid Imaging (3.1.1), Zenodo https://doi.org/10.5281/zenodo.4728059
 
 (See `Zenodo <https://doi.org/10.5281/zenodo.4728059>`_ for citing specific versions).


### PR DESCRIPTION
<!-- Close or ref the associated ticket, e.g.  -->
## Issue Closes #
This PR prepares release metadata and documentation references for version 3.1.1.

Changes included:

- Updated CITATION.cff:
- version from 3.1.0 to 3.1.1
- date-released to 2026-08-03

- Updated docs/conf.py:
- release set to 3.1.1 (removed alpha tag)

- Updated docs/index.rst:
- citation version updated to 3.1.1

- Updated docs/_static/version_switcher.json:
- added v3.1.1 (stable) pointing to /mantidimaging/3.1.1
- updated dev entry to v3.1.1 (dev) with version 3.1.1a1
- removed Stable label from v3.1.0 entry
 

### Acceptance Criteria and Reviewer Testing

- [ ]  Unit tests pass locally: python -m pytest -vs
- [ ]  CITATION.cff shows version 3.1.1 and date-released 2026-08-03
- [ ]  conf.py release value is 3.1.1
- [ ]  index.rst citation line references Mantid Imaging (3.1.1)
- [ ]  version_switcher.json contains:
- [ ]  v3.1.1 (dev) with version 3.1.1a1 and url /mantidimaging/
- [ ]  v3.1.1 (stable) with version 3.1.1 and url /mantidimaging/3.1.1
- [ ]  v3.1.0 entry without Stable label
- [ ]  Build docs and verify version switcher renders expected options

SSUE>

### Description

This PR prepares release metadata and documentation references for version 3.1.1.

Changes included:

- Updated CITATION.cff:
- version from 3.1.0 to 3.1.1
- date-released to 2026-08-03

- Updated docs/conf.py:
- release set to 3.1.1 (removed alpha tag)

- Updated docs/index.rst:
- citation version updated to 3.1.1

- Updated docs/_static/version_switcher.json:
- added v3.1.1 (stable) pointing to /mantidimaging/3.1.1
- updated dev entry to v3.1.1 (dev) with version 3.1.1a1
- removed Stable label from v3.1.0 entry
 

### Acceptance Criteria and Reviewer Testing

- [ ]  Unit tests pass locally: python -m pytest -vs
- [ ]  CITATION.cff shows version 3.1.1 and date-released 2026-08-03
- [ ]  conf.py release value is 3.1.1
- [ ]  index.rst citation line references Mantid Imaging (3.1.1)
- [ ]  version_switcher.json contains:
- [ ]  v3.1.1 (dev) with version 3.1.1a1 and url /mantidimaging/
- [ ]  v3.1.1 (stable) with version 3.1.1 and url /mantidimaging/3.1.1
- [ ]  v3.1.0 entry without Stable label
- [ ]  Build docs and verify version switcher renders expected options


